### PR TITLE
feat(core,backend,web): show connected Google accounts as separate calendar sections

### DIFF
--- a/packages/backend/src/common/services/sync-service/connection-state.translation.test.ts
+++ b/packages/backend/src/common/services/sync-service/connection-state.translation.test.ts
@@ -137,7 +137,7 @@ describe("selectPrimaryGoogleConnection", () => {
 });
 
 describe("toGoogleSyncConnectionSummary", () => {
-  it("maps id, state, timestamps, and account email only", () => {
+  it("maps id, state, timestamps, account email, and the connection's own product state", () => {
     const record = {
       ...connection("delayed", "workOverdue"),
       id: "c-summary",
@@ -156,6 +156,9 @@ describe("toGoogleSyncConnectionSummary", () => {
       lastSyncedAt: "2026-07-24T10:00:00.000Z",
       lastHealthyAt: "2026-07-23T10:00:00.000Z",
       accountEmail: "user@example.com",
+      // This connection's own state, so the browser can render one account's
+      // status without knowing sync's vocabulary. delayed maps to ATTENTION.
+      connectionState: "ATTENTION",
     });
   });
 });

--- a/packages/backend/src/common/services/sync-service/connection-state.translation.ts
+++ b/packages/backend/src/common/services/sync-service/connection-state.translation.ts
@@ -120,5 +120,13 @@ export function toGoogleSyncConnectionSummary(
     lastSyncedAt: connection.lastSyncedAt,
     lastHealthyAt: connection.lastHealthyAt,
     accountEmail: connection.account.email,
+    // This connection's own product state, so the browser can render one
+    // account's status and reconnect without knowing sync's vocabulary. The
+    // top-level `connectionState` stays the precedence winner across all
+    // connections; this is deliberately per-connection and may differ.
+    connectionState: translateConnection(
+      connection.state,
+      connection.stateReason,
+    ),
   };
 }

--- a/packages/backend/src/common/services/sync-service/google-connection-status.test.ts
+++ b/packages/backend/src/common/services/sync-service/google-connection-status.test.ts
@@ -117,7 +117,7 @@ describe("resolveGoogleConnectionFromSync", () => {
     });
   });
 
-  it("returns a null summary when Sync is unavailable", async () => {
+  it("returns a null summary and no connections when Sync is unavailable", async () => {
     const client = clientReturning({
       ok: false,
       error: { kind: "unavailable", correlationId: "corr-1" },
@@ -125,7 +125,52 @@ describe("resolveGoogleConnectionFromSync", () => {
 
     expect(await resolveGoogleConnectionFromSync(client, principal)).toEqual({
       connectionState: "ATTENTION",
+      connections: [],
       connection: null,
     });
+  });
+
+  it("summarizes every connection, in the order sync returned them", async () => {
+    const client = clientReturning({
+      ok: true,
+      value: {
+        connections: [
+          {
+            ...connection("healthy", null),
+            id: "c-first",
+            account: {
+              providerAccountId: "a1",
+              email: "first@example.com",
+              displayName: null,
+            },
+          },
+          {
+            ...connection("actionRequired", "authorizationRevoked"),
+            id: "c-second",
+            account: {
+              providerAccountId: "a2",
+              email: "second@example.com",
+              displayName: null,
+            },
+          },
+        ],
+      },
+      correlationId: "corr-1",
+    });
+
+    const result = await resolveGoogleConnectionFromSync(client, principal);
+
+    expect(
+      result.connections.map((summary) => [
+        summary.accountEmail,
+        summary.connectionState,
+      ]),
+    ).toEqual([
+      ["first@example.com", "HEALTHY"],
+      ["second@example.com", "RECONNECT_REQUIRED"],
+    ]);
+    // The singular summary stays the precedence winner (the broken account),
+    // which is deliberately NOT the first connection here.
+    expect(result.connection?.id).toBe("c-second");
   });
 });

--- a/packages/backend/src/common/services/sync-service/google-connection-status.ts
+++ b/packages/backend/src/common/services/sync-service/google-connection-status.ts
@@ -17,6 +17,10 @@ const logger = Logger("app:google-connection-status");
 
 export interface GoogleConnectionFromSync {
   connectionState: GoogleConnectionState;
+  // Every connected account, in the order sync returned them (connection
+  // order), so the browser can render one section per account. Empty on
+  // none / outage.
+  connections: GoogleSyncConnectionSummary[];
   // Primary Sync connection summary for the browser (null when none / outage).
   connection: GoogleSyncConnectionSummary | null;
 }
@@ -41,6 +45,7 @@ export async function resolveGoogleConnectionFromSync(
     const primary = selectPrimaryGoogleConnection(connections);
     return {
       connectionState: toGoogleConnectionState(connections),
+      connections: connections.map(toGoogleSyncConnectionSummary),
       connection: primary ? toGoogleSyncConnectionSummary(primary) : null,
     };
   }
@@ -49,5 +54,5 @@ export async function resolveGoogleConnectionFromSync(
     `Sync connection status unavailable (${result.error.kind}); reporting ATTENTION ` +
       `[correlationId=${result.error.correlationId}]`,
   );
-  return { connectionState: "ATTENTION", connection: null };
+  return { connectionState: "ATTENTION", connections: [], connection: null };
 }

--- a/packages/backend/src/user/services/user-metadata.service.ts
+++ b/packages/backend/src/user/services/user-metadata.service.ts
@@ -13,6 +13,7 @@ import { type GetUserMetadataResponse } from "@backend/user/types/user.types";
 
 type GoogleMetadataAssessment = {
   connectionState: GoogleConnectionState;
+  connections?: GoogleSyncConnectionSummary[];
   connection?: GoogleSyncConnectionSummary | null;
 };
 
@@ -123,18 +124,17 @@ class UserMetadataService {
       };
     }
 
-    const { connectionState, connection } =
+    const { connectionState, connections, connection } =
       await this.assessGoogleMetadata(userId);
 
-    // Cast: SuperTokens JSONObject's index signature doesn't accept our nested
-    // google.connection summary type even though every field is JSON-safe.
     return {
       ...metadata,
       google: {
         connectionState,
+        ...(connections !== undefined ? { connections } : {}),
         ...(connection !== undefined ? { connection } : {}),
       },
-    } as UserMetadata;
+    };
   };
 }
 

--- a/packages/core/src/types/user.types.ts
+++ b/packages/core/src/types/user.types.ts
@@ -33,18 +33,26 @@ export type GoogleConnectionState =
   | "HEALTHY"
   | "ATTENTION";
 
-// Sync-backed primary connection summary for the browser (S41). Present only
-// when connection routing is delegated to Sync. IDs/timestamps/state only —
-// never credentials or event content. Plain strings so the payload stays a
+// Sync-backed connection summary for the browser (S41). Present only when
+// connection routing is delegated to Sync. IDs/timestamps/state only — never
+// credentials or event content. Plain strings so the payload stays a
 // SuperTokens JSONObject (no Zod brands on the metadata wire).
-export interface GoogleSyncConnectionSummary {
+// A type alias, not an interface: only aliases get the implicit index
+// signature that lets these values sit inside SuperTokens' JSONObject
+// metadata payload without a cast at every call site.
+export type GoogleSyncConnectionSummary = {
   id: string;
   state: string;
   stateReason: string | null;
   lastSyncedAt: string | null;
   lastHealthyAt: string | null;
   accountEmail: string | null;
-}
+  // This one connection's own product state, translated server-side from its
+  // sync state/reason. The browser renders per-account status and reconnect
+  // from it directly, so sync's state vocabulary stays on the server. Optional
+  // so a summary cached by an older tab still parses.
+  connectionState?: GoogleConnectionState;
+};
 
 // Intersection (not extends): SuperTokens JSONObject's string index signature
 // rejects a nested `google.connection` object on an interface extends clause,
@@ -57,6 +65,10 @@ export type UserMetadata = SupertokensUserMetadata.JSONObject & {
   };
   google?: {
     connectionState?: GoogleConnectionState;
+    // Every connected provider account, in connection order. The singular
+    // `connection` below stays as the precedence-winning derivation of this
+    // list, for the top-level banner and for tabs holding older metadata.
+    connections?: GoogleSyncConnectionSummary[];
     connection?: GoogleSyncConnectionSummary | null;
   };
 };

--- a/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.scope.test.tsx
+++ b/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.scope.test.tsx
@@ -1,0 +1,118 @@
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { type GoogleSyncConnectionSummary } from "@core/types/user.types";
+import { createStoreWrapper } from "@web/__tests__/render-with-store";
+import { AuthApi } from "@web/api/auth.api";
+import { userMetadataActions } from "@web/auth/state/user-metadata.store";
+import { useConnectGoogle } from "./useConnectGoogle";
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
+
+// Reconnecting one of several accounts must rebind consent to THAT account's
+// connection, and report that account's own state - not the precedence-winning
+// one the top-level banner shows.
+
+const connection = (
+  overrides: Partial<GoogleSyncConnectionSummary>,
+): GoogleSyncConnectionSummary => ({
+  id: "connection-primary",
+  state: "actionRequired",
+  stateReason: "authorizationRevoked",
+  lastSyncedAt: null,
+  lastHealthyAt: null,
+  accountEmail: "primary@example.com",
+  connectionState: "RECONNECT_REQUIRED",
+  ...overrides,
+});
+
+const renderScoped = (scoped?: GoogleSyncConnectionSummary) => {
+  const { wrapper } = createStoreWrapper();
+  return renderHook(
+    () => useConnectGoogle(scoped ? { connection: scoped } : undefined),
+    { wrapper },
+  );
+};
+
+describe("useConnectGoogle account scoping", () => {
+  beforeEach(() => {
+    userMetadataActions.set({
+      google: {
+        connectionState: "RECONNECT_REQUIRED",
+        connection: connection({}),
+        connections: [
+          connection({}),
+          connection({
+            id: "connection-healthy",
+            state: "healthy",
+            stateReason: null,
+            accountEmail: "second@example.com",
+            connectionState: "HEALTHY",
+          }),
+        ],
+      },
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    userMetadataActions.clear();
+  });
+
+  it("reports the scoped account's own state, not the aggregate", () => {
+    const healthy = connection({
+      id: "connection-healthy",
+      state: "healthy",
+      stateReason: null,
+      accountEmail: "second@example.com",
+      connectionState: "HEALTHY",
+    });
+
+    // The aggregate is RECONNECT_REQUIRED because the other account is broken.
+    expect(renderScoped().result.current.state).toBe("RECONNECT_REQUIRED");
+    expect(renderScoped(healthy).result.current.state).toBe("HEALTHY");
+  });
+
+  it("binds reconnect to the scoped account's connection id", async () => {
+    const broken = connection({
+      id: "connection-second",
+      accountEmail: "second@example.com",
+    });
+    const beginSpy = spyOn(AuthApi, "beginGoogleConnection").mockResolvedValue({
+      // A hash target: the hook navigates to whatever URL it gets back, and
+      // jsdom implements only hash navigation (a real URL logs a noisy
+      // "Not implemented: navigation" error). The assertion is on the request,
+      // not the redirect.
+      authorizationUrl: "#consent",
+    });
+
+    const { result } = renderScoped(broken);
+    act(() => result.current.connect());
+
+    await waitFor(() => {
+      expect(beginSpy).toHaveBeenCalledWith({
+        connectionId: "connection-second",
+      });
+    });
+
+    beginSpy.mockRestore();
+  });
+
+  it("falls back to the precedence-winning connection when unscoped", async () => {
+    const beginSpy = spyOn(AuthApi, "beginGoogleConnection").mockResolvedValue({
+      // A hash target: the hook navigates to whatever URL it gets back, and
+      // jsdom implements only hash navigation (a real URL logs a noisy
+      // "Not implemented: navigation" error). The assertion is on the request,
+      // not the redirect.
+      authorizationUrl: "#consent",
+    });
+
+    const { result } = renderScoped();
+    act(() => result.current.connect());
+
+    await waitFor(() => {
+      expect(beginSpy).toHaveBeenCalledWith({
+        connectionId: "connection-primary",
+      });
+    });
+
+    beginSpy.mockRestore();
+  });
+});

--- a/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.ts
+++ b/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.ts
@@ -1,6 +1,7 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { type ConnectionId } from "@core/types/sync/identity.contracts";
+import { type GoogleSyncConnectionSummary } from "@core/types/user.types";
 import { AuthApi } from "@web/api/auth.api";
 import {
   refreshGoogleSync,
@@ -23,10 +24,26 @@ import { type UseConnectGoogleResult } from "./useConnectGoogle.types";
 import { getGoogleConnectionConfig } from "./useConnectGoogle.util";
 import { useGoogleUiState } from "./useGoogleUiState";
 
-export const useConnectGoogle = (): UseConnectGoogleResult => {
+export interface UseConnectGoogleOptions {
+  /**
+   * Scope the hook to one connected account: its own state drives the action
+   * and status, and reconnect rebinds consent to that connection rather than
+   * the precedence-winning one. Omit for the aggregate (whole-user) view.
+   */
+  connection?: GoogleSyncConnectionSummary | null;
+}
+
+export const useConnectGoogle = (
+  options?: UseConnectGoogleOptions,
+): UseConnectGoogleResult => {
   const isAvailable = useIsConnectGoogleAvailable();
-  const state = useGoogleUiState();
-  const syncConnection = useUserMetadataStore(selectGoogleSyncConnection);
+  const aggregateState = useGoogleUiState();
+  const primaryConnection = useUserMetadataStore(selectGoogleSyncConnection);
+  const scopedConnection = options?.connection;
+  const syncConnection = scopedConnection ?? primaryConnection;
+  // A scoped connection reports its own product state; fall back to the
+  // aggregate when it predates that field.
+  const state = scopedConnection?.connectionState ?? aggregateState;
   const queryClient = useQueryClient();
   const [isConnecting, setIsConnecting] = useState(false);
   // Sync guard so rapid re-clicks before React re-renders cannot start a

--- a/packages/web/src/auth/state/user-metadata.store.ts
+++ b/packages/web/src/auth/state/user-metadata.store.ts
@@ -82,3 +82,17 @@ export const selectGoogleSyncConnection = (
   state: UserMetadataState,
 ): GoogleSyncConnectionSummary | null =>
   state.current?.google?.connection ?? null;
+
+// Stable identity so the selector below never hands the store a fresh array
+// (which would re-render on every state change; see the note above the hook).
+const NO_CONNECTIONS: GoogleSyncConnectionSummary[] = [];
+
+/**
+ * Every connected provider account, in connection order. Empty when metadata
+ * hasn't loaded, no account is connected, or the payload predates the plural
+ * field.
+ */
+export const selectGoogleSyncConnections = (
+  state: UserMetadataState,
+): GoogleSyncConnectionSummary[] =>
+  state.current?.google?.connections ?? NO_CONNECTIONS;

--- a/packages/web/src/components/Sidebar/CalendarList/AccountSectionHeader.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/AccountSectionHeader.tsx
@@ -1,0 +1,82 @@
+import { type FC } from "react";
+import { type GoogleSyncConnectionSummary } from "@core/types/user.types";
+import { useConnectGoogle } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle";
+import {
+  formatLastSyncedLabel,
+  getGoogleSyncStatus,
+} from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle.util";
+import { type SyncStatusVariant } from "@web/calendars/sync-status.types";
+
+// Status is conveyed as text, never colour alone, so the variant class is
+// decoration on top of a message that already says what is happening.
+const SYNC_STATUS_VARIANT_CLASSNAME: Record<SyncStatusVariant, string> = {
+  syncing: "c-sync-text-wave",
+  healthy: "text-text",
+  warning: "text-warning",
+  error: "text-error",
+};
+
+/**
+ * Heading for one connected account's calendars: the account email, that
+ * account's own sync status, and its own reconnect/refresh action. Rendered
+ * only when more than one account is connected - with a single account the
+ * calendar list heading already carries all of this.
+ */
+export const AccountSectionHeader: FC<{
+  accountEmail: string;
+  connection: GoogleSyncConnectionSummary | undefined;
+}> = ({ accountEmail, connection }) => {
+  const { commandAction, isAvailable, isConnecting, isRefreshing, state } =
+    useConnectGoogle({ connection });
+  const syncStatus = getGoogleSyncStatus(state, connection);
+  const isSyncing = syncStatus?.variant === "syncing";
+  const lastSyncedLabel =
+    syncStatus?.variant === "healthy"
+      ? formatLastSyncedLabel(connection?.lastSyncedAt)
+      : null;
+  const actionLabel =
+    commandAction == null
+      ? null
+      : isConnecting
+        ? "Reconnecting…"
+        : isRefreshing
+          ? "Refreshing…"
+          : commandAction.label;
+
+  return (
+    <div className="mb-1.5">
+      <h3
+        className={`mb-0.5 min-w-0 truncate font-semibold text-xs leading-none ${
+          isSyncing ? "c-sync-text-wave" : "text-text"
+        }`}
+        translate="no"
+      >
+        {accountEmail}
+      </h3>
+      {syncStatus ? (
+        <p
+          aria-live="polite"
+          className={`text-xs ${SYNC_STATUS_VARIANT_CLASSNAME[syncStatus.variant]}`}
+          role="status"
+        >
+          {syncStatus.text}
+        </p>
+      ) : null}
+      {lastSyncedLabel ? (
+        <p className="text-text-muted text-xs">{lastSyncedLabel}</p>
+      ) : null}
+      {isAvailable && commandAction != null && actionLabel != null ? (
+        <button
+          aria-busy={isConnecting || isRefreshing || undefined}
+          aria-label={`${actionLabel} for ${accountEmail}`}
+          className="c-focus-ring mt-1 rounded-xs px-1.5 py-0.5 text-accent text-xs hover:brightness-110 disabled:pointer-events-none disabled:opacity-60"
+          disabled={isConnecting || isRefreshing}
+          onClick={commandAction.onSelect}
+          type="button"
+        >
+          {actionLabel}
+        </button>
+      ) : null}
+    </div>
+  );
+};

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarList.test.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarList.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import {
   type Calendar,
@@ -8,11 +8,13 @@ import {
   CalendarIdSchema,
   TimeZoneSchema,
 } from "@core/types/domain-primitives";
+import { type GoogleSyncConnectionSummary } from "@core/types/user.types";
 import { createStoreWrapper } from "@web/__tests__/render-with-store";
 import { toNormalizedEventQueryData } from "@web/__tests__/utils/event-query-test-data";
 import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
 import { type ApiRequestConfig } from "@web/api/api.types";
 import { BaseApi } from "@web/api/base/base.api";
+import { userMetadataActions } from "@web/auth/state/user-metadata.store";
 import { calendarQueryKeys } from "@web/calendars/calendar.query";
 import { isCalendarHidden } from "@web/calendars/calendar-visibility.storage";
 import { persistentBrowserStore } from "@web/common/storage/browser-key-value.store";
@@ -49,12 +51,17 @@ const actualUseConnectGoogle = (
   await import("@web/auth/google/hooks/useConnectGoogle/useConnectGoogle")
 ).useConnectGoogle;
 let isConnectGoogleMocked = true;
-const mockUseConnectGoogle = mock(() => ({
-  commandAction: null,
-  isAvailable: true,
-  isConnecting: false,
-  state: "NOT_CONNECTED" as const,
-}));
+// Mirrors the real hook's one behavior these tests depend on: scoping to a
+// connection reports that account's own state. (The real scoping is covered
+// directly in useConnectGoogle.scope.test.tsx.)
+const mockUseConnectGoogle = mock(
+  (options?: Parameters<typeof actualUseConnectGoogle>[0]) => ({
+    commandAction: null,
+    isAvailable: true,
+    isConnecting: false,
+    state: options?.connection?.connectionState ?? ("NOT_CONNECTED" as const),
+  }),
+);
 mock.module("@web/auth/google/hooks/useConnectGoogle/useConnectGoogle", () => ({
   useConnectGoogle: (...args: Parameters<typeof actualUseConnectGoogle>) =>
     isConnectGoogleMocked
@@ -104,14 +111,40 @@ const makeCalendar = (overrides: Partial<Calendar> = {}): Calendar => ({
   ...overrides,
 });
 
+const makeConnection = (
+  accountEmail: string,
+  overrides: Partial<GoogleSyncConnectionSummary> = {},
+): GoogleSyncConnectionSummary => ({
+  id: createObjectIdString(),
+  state: "healthy",
+  stateReason: null,
+  lastSyncedAt: null,
+  lastHealthyAt: null,
+  accountEmail,
+  connectionState: "HEALTHY",
+  ...overrides,
+});
+
 const renderCalendarList = (
   calendars: Calendar[],
-  { authenticated = true }: { authenticated?: boolean } = {},
+  {
+    authenticated = true,
+    connections,
+  }: {
+    authenticated?: boolean;
+    connections?: GoogleSyncConnectionSummary[];
+  } = {},
 ) => {
   mockUseSession.mockReturnValue({
     authenticated,
     setAuthenticated: () => {},
   });
+
+  if (connections) {
+    userMetadataActions.set({
+      google: { connectionState: "HEALTHY", connections },
+    });
+  }
 
   const { queryClient, wrapper } = createStoreWrapper();
   queryClient.setQueryData(calendarQueryKeys.all, calendars);
@@ -298,6 +331,147 @@ describe("CalendarList", () => {
     await waitFor(() => {
       expect(toggle.getAttribute("aria-pressed")).toBe("true");
     });
+  });
+
+  it("groups calendars under a labelled section per account when two are connected", () => {
+    const work = makeCalendar({
+      name: "Work",
+      accountEmail: "ahab@pequod.com",
+    });
+    const personal = makeCalendar({
+      name: "Personal",
+      accountEmail: "ahab@gmail.com",
+    });
+
+    renderCalendarList([work, personal], {
+      connections: [
+        makeConnection("ahab@pequod.com"),
+        makeConnection("ahab@gmail.com"),
+      ],
+    });
+
+    expect(
+      screen.getByRole("region", { name: "Calendars for ahab@pequod.com" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("region", { name: "Calendars for ahab@gmail.com" }),
+    ).toBeInTheDocument();
+    // Each account's calendars live under its own section, not one flat list.
+    expect(
+      within(
+        screen.getByRole("region", { name: "Calendars for ahab@pequod.com" }),
+      ).getByText("Work"),
+    ).toBeInTheDocument();
+    expect(
+      within(
+        screen.getByRole("region", { name: "Calendars for ahab@gmail.com" }),
+      ).getByText("Personal"),
+    ).toBeInTheDocument();
+  });
+
+  it("orders sections by connection order, not calendar order", () => {
+    const gmail = makeCalendar({
+      name: "Personal",
+      accountEmail: "ahab@gmail.com",
+    });
+    const work = makeCalendar({
+      name: "Work",
+      accountEmail: "ahab@pequod.com",
+    });
+
+    renderCalendarList([gmail, work], {
+      // pequod connected first, so its section comes first even though the
+      // gmail calendar sorts ahead of it by name.
+      connections: [
+        makeConnection("ahab@pequod.com"),
+        makeConnection("ahab@gmail.com"),
+      ],
+    });
+
+    const headings = screen
+      .getAllByRole("heading", { level: 3 })
+      .map((heading) => heading.textContent);
+    expect(headings).toEqual(["ahab@pequod.com", "ahab@gmail.com"]);
+  });
+
+  it("gives each account its own status line", () => {
+    const work = makeCalendar({
+      name: "Work",
+      accountEmail: "ahab@pequod.com",
+    });
+    const personal = makeCalendar({
+      name: "Personal",
+      accountEmail: "ahab@gmail.com",
+    });
+
+    renderCalendarList([work, personal], {
+      connections: [
+        makeConnection("ahab@pequod.com"),
+        // One broken account must not be hidden behind the healthy one.
+        makeConnection("ahab@gmail.com", {
+          state: "actionRequired",
+          stateReason: "authorizationRevoked",
+          connectionState: "RECONNECT_REQUIRED",
+        }),
+      ],
+    });
+
+    const healthy = within(
+      screen.getByRole("region", { name: "Calendars for ahab@pequod.com" }),
+    );
+    const broken = within(
+      screen.getByRole("region", { name: "Calendars for ahab@gmail.com" }),
+    );
+    expect(healthy.getByRole("status").textContent).toBe("Calendar connected");
+    expect(broken.getByRole("status").textContent).toBe(
+      "Calendar needs reconnecting",
+    );
+  });
+
+  it("keeps the flat list with a single connected account", () => {
+    // The list heading already names the sole account, so a labelled section
+    // would just repeat it.
+    const work = makeCalendar({
+      name: "Work",
+      accountEmail: "ahab@pequod.com",
+    });
+
+    renderCalendarList([work], {
+      connections: [makeConnection("ahab@pequod.com")],
+    });
+
+    expect(
+      screen.queryByRole("region", { name: /Calendars for/ }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("Work")).toBeInTheDocument();
+  });
+
+  it("leaves the local calendar outside the account sections", () => {
+    const work = makeCalendar({
+      name: "Work",
+      accountEmail: "ahab@pequod.com",
+    });
+    const personal = makeCalendar({
+      name: "Personal",
+      accountEmail: "ahab@gmail.com",
+    });
+    const local = makeCalendar({ name: "Compass", provider: "local" });
+
+    renderCalendarList([work, personal, local], {
+      connections: [
+        makeConnection("ahab@pequod.com"),
+        makeConnection("ahab@gmail.com"),
+      ],
+    });
+
+    expect(screen.getByText("Compass")).toBeInTheDocument();
+    for (const email of ["ahab@pequod.com", "ahab@gmail.com"]) {
+      expect(
+        within(
+          screen.getByRole("region", { name: `Calendars for ${email}` }),
+        ).queryByText("Compass"),
+      ).not.toBeInTheDocument();
+    }
   });
 
   it("shows a loading state while calendars are pending", () => {

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarList.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarList.tsx
@@ -1,9 +1,15 @@
 import { type FC } from "react";
 import { type Calendar } from "@core/types/calendar.contracts";
+import { type GoogleSyncConnectionSummary } from "@core/types/user.types";
 import { useSession } from "@web/auth/compass/session/useSession";
 import { useConnectGoogle } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle";
+import {
+  selectGoogleSyncConnections,
+  useUserMetadataStore,
+} from "@web/auth/state/user-metadata.store";
 import { useCalendarsQuery } from "@web/calendars/calendar.query";
 import { useCalendarVisibility } from "@web/calendars/useCalendarVisibility";
+import { AccountSectionHeader } from "./AccountSectionHeader";
 import { CalendarListHeader } from "./CalendarListHeader";
 
 // Primary calendars first, then alphabetical by name; the local calendar
@@ -19,6 +25,61 @@ function sortCalendars(calendars: Calendar[]): Calendar[] {
   });
 }
 
+interface AccountGroup {
+  accountEmail: string;
+  connection: GoogleSyncConnectionSummary | undefined;
+  calendars: Calendar[];
+}
+
+/**
+ * Bucket calendars by the account they belong to, in connection order, with
+ * anything lacking an account email (the local calendar) left ungrouped.
+ *
+ * Grouping only earns its keep once a second account exists: with one account
+ * the list heading already names it, so a single labelled section would just
+ * repeat the heading. Callers render the flat list whenever this returns
+ * fewer than two groups.
+ */
+export function groupCalendarsByAccount(
+  calendars: Calendar[],
+  connections: GoogleSyncConnectionSummary[],
+): { groups: AccountGroup[]; ungrouped: Calendar[] } {
+  const groups: AccountGroup[] = [];
+  const byEmail = new Map<string, AccountGroup>();
+  const ungrouped: Calendar[] = [];
+
+  // Seed in connection order so accounts appear oldest-connected first,
+  // regardless of the order calendars came back in.
+  for (const connection of connections) {
+    const { accountEmail } = connection;
+    if (!accountEmail || byEmail.has(accountEmail)) continue;
+    const group: AccountGroup = { accountEmail, connection, calendars: [] };
+    byEmail.set(accountEmail, group);
+    groups.push(group);
+  }
+
+  for (const calendar of calendars) {
+    const { accountEmail } = calendar;
+    if (!accountEmail) {
+      ungrouped.push(calendar);
+      continue;
+    }
+    let group = byEmail.get(accountEmail);
+    if (!group) {
+      // A calendar whose account has no connection summary yet (metadata and
+      // the calendar list can load a moment apart). Still give it a section.
+      group = { accountEmail, connection: undefined, calendars: [] };
+      byEmail.set(accountEmail, group);
+      groups.push(group);
+    }
+    group.calendars.push(calendar);
+  }
+
+  // An account can be connected before its calendars have imported; an empty
+  // section would render a heading with nothing under it.
+  return { groups: groups.filter((g) => g.calendars.length > 0), ungrouped };
+}
+
 interface Props {
   /** Test seam only: lets list tests stub the account header's auth/sync hooks. */
   Header?: FC;
@@ -30,9 +91,24 @@ export const CalendarList: FC<Props> = ({ Header = CalendarListHeader }) => {
   const { data, isPending, isError, refetch } = useCalendarsQuery();
   const { toggleCalendarVisibility, failureAnnouncement } =
     useCalendarVisibility();
+  const connections = useUserMetadataStore(selectGoogleSyncConnections);
 
   const calendars = sortCalendars(
     (data ?? []).filter((calendar) => calendar.isActive),
+  );
+  const { groups, ungrouped } = groupCalendarsByAccount(calendars, connections);
+  const showAccountSections = groups.length > 1;
+
+  const renderRows = (rows: Calendar[]) => (
+    <ul className="flex flex-col gap-1.5">
+      {rows.map((calendar) => (
+        <CalendarRow
+          calendar={calendar}
+          key={calendar.id}
+          onToggle={toggleCalendarVisibility}
+        />
+      ))}
+    </ul>
   );
 
   return (
@@ -58,55 +134,68 @@ export const CalendarList: FC<Props> = ({ Header = CalendarListHeader }) => {
             ? "Connect Google to see your calendars."
             : "No calendars yet."}
         </p>
+      ) : showAccountSections ? (
+        <div className="flex flex-col gap-3">
+          {groups.map((group) => (
+            <section
+              aria-label={`Calendars for ${group.accountEmail}`}
+              key={group.accountEmail}
+            >
+              <AccountSectionHeader
+                accountEmail={group.accountEmail}
+                connection={group.connection}
+              />
+              {renderRows(group.calendars)}
+            </section>
+          ))}
+          {ungrouped.length > 0 ? renderRows(ungrouped) : null}
+        </div>
       ) : (
-        <ul className="flex flex-col gap-1.5">
-          {calendars.map((calendar) => {
-            // The header already shows the primary calendar's name (the account
-            // email), so its row reads "primary" instead. The anonymous local
-            // sentinel is also isPrimary, but a lone "primary" row under a
-            // "Temporary account" header reads wrong - keep its own name.
-            const displayName =
-              calendar.isPrimary && calendar.provider !== "local"
-                ? "primary"
-                : calendar.name;
-            const calendarRow = (
-              <>
-                <span
-                  aria-hidden
-                  className="size-3.5 shrink-0 rounded-full border-2 transition-[background-color,border-color] motion-reduce:transition-none"
-                  style={{
-                    backgroundColor: calendar.isVisible
-                      ? calendar.backgroundColor
-                      : "transparent",
-                    borderColor: calendar.backgroundColor,
-                  }}
-                />
-                <span className="min-w-0 flex-1 truncate">{displayName}</span>
-              </>
-            );
-
-            return (
-              <li key={calendar.id}>
-                <button
-                  aria-label={`${calendar.isVisible ? "Hide" : "Show"} ${displayName} calendar`}
-                  aria-pressed={calendar.isVisible}
-                  className="c-focus-ring group flex w-full min-w-0 items-center gap-2 rounded px-1 py-0.5 text-left text-text text-xs hover:bg-surface-panel"
-                  onClick={() =>
-                    toggleCalendarVisibility(calendar.id, !calendar.isVisible)
-                  }
-                  type="button"
-                >
-                  {calendarRow}
-                </button>
-              </li>
-            );
-          })}
-        </ul>
+        renderRows(calendars)
       )}
 
       <span aria-live="polite" className="sr-only" role="status">
         {failureAnnouncement}
       </span>
     </section>
+  );
+};
+
+const CalendarRow: FC<{
+  calendar: Calendar;
+  onToggle: (calendarId: Calendar["id"], isVisible: boolean) => void;
+}> = ({ calendar, onToggle }) => {
+  // The heading above the row already names the account (the list heading with
+  // one account, the section heading with several), so a primary calendar's
+  // row reads "primary" instead of repeating it. The anonymous local sentinel
+  // is also isPrimary, but a lone "primary" row under a "Temporary account"
+  // header reads wrong - keep its own name.
+  const displayName =
+    calendar.isPrimary && calendar.provider !== "local"
+      ? "primary"
+      : calendar.name;
+
+  return (
+    <li>
+      <button
+        aria-label={`${calendar.isVisible ? "Hide" : "Show"} ${displayName} calendar`}
+        aria-pressed={calendar.isVisible}
+        className="c-focus-ring group flex w-full min-w-0 items-center gap-2 rounded px-1 py-0.5 text-left text-text text-xs hover:bg-surface-panel"
+        onClick={() => onToggle(calendar.id, !calendar.isVisible)}
+        type="button"
+      >
+        <span
+          aria-hidden
+          className="size-3.5 shrink-0 rounded-full border-2 transition-[background-color,border-color] motion-reduce:transition-none"
+          style={{
+            backgroundColor: calendar.isVisible
+              ? calendar.backgroundColor
+              : "transparent",
+            borderColor: calendar.backgroundColor,
+          }}
+        />
+        <span className="min-w-0 flex-1 truncate">{displayName}</span>
+      </button>
+    </li>
   );
 };


### PR DESCRIPTION
## What

Prepares the sidebar for more than one connected Google account.

- **User metadata carries every connection**, not just the precedence-winning one: `google.connections` is the full list in connection order. The existing singular `google.connection` stays as the precedence-winning derivation for the top-level banner and for tabs holding older metadata.
- **Each summary reports its own product state.** `GoogleSyncConnectionSummary.connectionState` is translated server-side from that connection's sync state/reason, so the browser can render one account's status without learning sync's vocabulary. The top-level state stays worst-wins across all accounts and may differ.
- **`useConnectGoogle` accepts an optional account scope.** Scoped to a connection, it reports that account's state and rebinds reconnect to that connection id instead of the precedence winner.
- **The calendar list groups by account** once two are connected: one labelled region per account email, each with its own status line and reconnect action. The local calendar stays outside the sections.

With a single connected account nothing changes: the list heading already names it, so the flat list renders exactly as before and a lone labelled section would only repeat the heading.

Also drops a now-unneeded `as UserMetadata` cast: `GoogleSyncConnectionSummary` became a type alias rather than an interface, which gives it the implicit index signature SuperTokens' `JSONObject` metadata payload requires.

## Tests

- Grouping: two labelled regions, each holding its own account's calendars; sections ordered by connection order rather than calendar order; per-account status lines (one healthy account beside one needing reconnect); local calendar left ungrouped; single account keeps the flat list.
- Hook scoping: reports the scoped account's state instead of the aggregate; reconnect binds the scoped connection id; unscoped falls back to the precedence winner.
- Backend: summary carries the per-connection state; every connection is summarized in sync's order while the singular summary stays the precedence winner; outage yields an empty list.
- Full web (1596), backend (323), and sync suites green; `bun run type-check` and biome clean.

## Verification

Ran the app locally and confirmed the single-account path is unregressed: no account sections, no section headings, the calendar row intact, no console errors. The grouped path needs a signed-in session with two real Google accounts, so its live verification comes with the add-account flow; here it is covered by the component tests above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)