### PR TITLE
feat(web): let the user choose which calendar new events go to

### DIFF
--- a/packages/web/src/__tests__/utils/state/reset-stores.ts
+++ b/packages/web/src/__tests__/utils/state/reset-stores.ts
@@ -10,6 +10,7 @@ import {
   useUserMetadataStore,
 } from "@web/auth/state/user-metadata.store";
 import { resetCalendarVisibilityStoreForTests } from "@web/calendars/calendar-visibility.store";
+import { resetDefaultCalendarStoreForTests } from "@web/calendars/default-calendar.store";
 import { useFeedbackStore } from "@web/components/Feedback/feedback.store";
 import { useReleaseNotesPromptStore } from "@web/components/ReleaseNotesPrompt/release-notes-prompt.store";
 import { useWelcomeGuideStore } from "@web/components/WelcomeModal/welcome.guide.store";
@@ -50,6 +51,7 @@ const storeResets: StoreReset[] = [
   // Storage itself is cleared by resetBrowserState() (test-lifecycle.ts)
   // before this runs; this just resyncs the module-singleton store to match.
   resetCalendarVisibilityStoreForTests,
+  resetDefaultCalendarStoreForTests,
   // Lives on window.__weekInteractionMotionActive, which survives across
   // test files (the preload reuses one jsdom window). A test that starts a
   // real drag and never completes it would otherwise leave every later

--- a/packages/web/src/calendars/calendar.util.test.ts
+++ b/packages/web/src/calendars/calendar.util.test.ts
@@ -87,4 +87,115 @@ describe("getDefaultTargetCalendar", () => {
   it("returns undefined when there is no calendar at all", () => {
     expect(getDefaultTargetCalendar([])).toBeUndefined();
   });
+
+  it("honors the user's starred calendar over the derived default", () => {
+    const primaryGoogle = makeCalendar({
+      provider: "google",
+      isPrimary: true,
+      id: "507f1f77bcf86cd799439012" as Calendar["id"],
+    });
+    const starred = makeCalendar({
+      provider: "google",
+      isPrimary: false,
+      id: "507f1f77bcf86cd799439013" as Calendar["id"],
+    });
+
+    expect(
+      getDefaultTargetCalendar([primaryGoogle, starred], {
+        preferredCalendarId: starred.id,
+      }),
+    ).toBe(starred);
+  });
+
+  it("lets the local calendar be starred explicitly", () => {
+    const local = makeCalendar({ provider: "local" });
+    const primaryGoogle = makeCalendar({
+      provider: "google",
+      isPrimary: true,
+      id: "507f1f77bcf86cd799439012" as Calendar["id"],
+    });
+
+    expect(
+      getDefaultTargetCalendar([local, primaryGoogle], {
+        preferredCalendarId: local.id,
+      }),
+    ).toBe(local);
+  });
+
+  it("falls back to the derived default when the starred calendar is gone", () => {
+    const primaryGoogle = makeCalendar({
+      provider: "google",
+      isPrimary: true,
+      id: "507f1f77bcf86cd799439012" as Calendar["id"],
+    });
+
+    expect(
+      getDefaultTargetCalendar([primaryGoogle], {
+        preferredCalendarId: "507f1f77bcf86cd799439099",
+      }),
+    ).toBe(primaryGoogle);
+  });
+
+  it("falls back when the starred calendar is no longer writable", () => {
+    const primaryGoogle = makeCalendar({
+      provider: "google",
+      isPrimary: true,
+      id: "507f1f77bcf86cd799439012" as Calendar["id"],
+    });
+    const demoted = makeCalendar({
+      provider: "google",
+      id: "507f1f77bcf86cd799439013" as Calendar["id"],
+      capabilities: {
+        canReadAvailability: true,
+        canReadDetails: true,
+        canWrite: false,
+        canManage: false,
+        canWatchEvents: true,
+      },
+    });
+
+    expect(
+      getDefaultTargetCalendar([primaryGoogle, demoted], {
+        preferredCalendarId: demoted.id,
+      }),
+    ).toBe(primaryGoogle);
+  });
+
+  it("picks the oldest-connected account's primary when two accounts each have one", () => {
+    // Both are primary and writable, so without connection order this is a
+    // coin flip decided by array position.
+    const newerAccountPrimary = makeCalendar({
+      provider: "google",
+      isPrimary: true,
+      accountEmail: "new@example.com",
+      id: "507f1f77bcf86cd799439012" as Calendar["id"],
+    });
+    const olderAccountPrimary = makeCalendar({
+      provider: "google",
+      isPrimary: true,
+      accountEmail: "old@example.com",
+      id: "507f1f77bcf86cd799439013" as Calendar["id"],
+    });
+
+    expect(
+      getDefaultTargetCalendar([newerAccountPrimary, olderAccountPrimary], {
+        accountEmailOrder: ["old@example.com", "new@example.com"],
+      }),
+    ).toBe(olderAccountPrimary);
+  });
+
+  it("still resolves when the connection order names an account with no primary", () => {
+    const primary = makeCalendar({
+      provider: "google",
+      isPrimary: true,
+      accountEmail: "new@example.com",
+      id: "507f1f77bcf86cd799439012" as Calendar["id"],
+    });
+
+    expect(
+      getDefaultTargetCalendar([primary], {
+        accountEmailOrder: ["old@example.com", "new@example.com"],
+      }),
+    ).toBe(primary);
+  });
 });

--- a/packages/web/src/calendars/calendar.util.ts
+++ b/packages/web/src/calendars/calendar.util.ts
@@ -1,21 +1,56 @@
 import { type Calendar } from "@core/types/calendar.contracts";
 
-// The default create target is the primary writable Google calendar,
-// falling back to the local calendar when there is no such Google calendar
-// (offline/anonymous mode, or a Google account with no primary writer access).
 export function getLocalCalendar(calendars: Calendar[]): Calendar | undefined {
   return calendars.find((calendar) => calendar.provider === "local");
 }
 
+export interface DefaultTargetCalendarOptions {
+  /**
+   * The calendar the user starred as their default. Ignored when it names a
+   * calendar that is gone or no longer writable, so a stale preference
+   * degrades to the derived default instead of breaking event creation.
+   */
+  preferredCalendarId?: string | null;
+  /**
+   * Connected account emails in connection order. With two accounts, both
+   * have a primary calendar, so "first primary wins" would pick whichever
+   * happened to sort first; this makes the oldest-connected account win.
+   */
+  accountEmailOrder?: readonly string[];
+}
+
+const isWritableGoogleCalendar = (calendar: Calendar): boolean =>
+  calendar.provider === "google" && calendar.capabilities.canWrite;
+
+/**
+ * Where a new event lands: the user's starred default if it is still usable,
+ * else the primary calendar of the oldest-connected account, else the local
+ * calendar (offline/anonymous mode, or a Google account with no primary the
+ * user can write to).
+ */
 export function getDefaultTargetCalendar(
   calendars: Calendar[],
+  options: DefaultTargetCalendarOptions = {},
 ): Calendar | undefined {
-  const primaryGoogle = calendars.find(
-    (calendar) =>
-      calendar.provider === "google" &&
-      calendar.isPrimary &&
-      calendar.capabilities.canWrite,
-  );
+  const { preferredCalendarId, accountEmailOrder = [] } = options;
 
-  return primaryGoogle ?? getLocalCalendar(calendars);
+  const preferred = preferredCalendarId
+    ? calendars.find((calendar) => calendar.id === preferredCalendarId)
+    : undefined;
+  // The local calendar is a valid explicit choice even though it is not a
+  // writable *Google* calendar.
+  if (preferred?.capabilities.canWrite) {
+    return preferred;
+  }
+
+  const primaries = calendars.filter(
+    (calendar) => calendar.isPrimary && isWritableGoogleCalendar(calendar),
+  );
+  const byConnectionOrder = accountEmailOrder
+    .map((email) =>
+      primaries.find((calendar) => calendar.accountEmail === email),
+    )
+    .find(Boolean);
+
+  return byConnectionOrder ?? primaries[0] ?? getLocalCalendar(calendars);
 }

--- a/packages/web/src/calendars/default-calendar.store.test.ts
+++ b/packages/web/src/calendars/default-calendar.store.test.ts
@@ -1,0 +1,56 @@
+import { type CalendarId } from "@core/types/domain-primitives";
+import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
+import { persistentBrowserStore } from "@web/common/storage/browser-key-value.store";
+import {
+  getStoredDefaultCalendarId,
+  resetDefaultCalendarStoreForTests,
+  setDefaultCalendarId,
+} from "./default-calendar.store";
+import { beforeEach, describe, expect, it, spyOn } from "bun:test";
+
+const calendarId = (value: string) => value as CalendarId;
+
+describe("default-calendar.store", () => {
+  beforeEach(() => {
+    persistentBrowserStore.remove(STORAGE_KEYS.DEFAULT_CALENDAR_ID);
+    resetDefaultCalendarStoreForTests();
+  });
+
+  it("has no default until one is chosen", () => {
+    expect(getStoredDefaultCalendarId()).toBeNull();
+  });
+
+  it("persists the chosen calendar and reads it back after a reload", () => {
+    expect(setDefaultCalendarId(calendarId("cal-1"))).toBe(true);
+
+    expect(getStoredDefaultCalendarId()).toBe("cal-1");
+    expect(persistentBrowserStore.get(STORAGE_KEYS.DEFAULT_CALENDAR_ID)).toBe(
+      "cal-1",
+    );
+
+    // A fresh page load re-reads storage rather than the in-memory value.
+    resetDefaultCalendarStoreForTests();
+    expect(getStoredDefaultCalendarId()).toBe("cal-1");
+  });
+
+  it("clears the preference when passed null", () => {
+    setDefaultCalendarId(calendarId("cal-1"));
+
+    expect(setDefaultCalendarId(null)).toBe(true);
+    expect(getStoredDefaultCalendarId()).toBeNull();
+    expect(
+      persistentBrowserStore.get(STORAGE_KEYS.DEFAULT_CALENDAR_ID),
+    ).toBeNull();
+  });
+
+  it("leaves the store untouched when the storage write fails", () => {
+    setDefaultCalendarId(calendarId("cal-1"));
+    const setSpy = spyOn(persistentBrowserStore, "set").mockReturnValue(false);
+
+    expect(setDefaultCalendarId(calendarId("cal-2"))).toBe(false);
+    // Reporting cal-2 here would show the user a preference that did not stick.
+    expect(getStoredDefaultCalendarId()).toBe("cal-1");
+
+    setSpy.mockRestore();
+  });
+});

--- a/packages/web/src/calendars/default-calendar.store.ts
+++ b/packages/web/src/calendars/default-calendar.store.ts
@@ -1,0 +1,79 @@
+import { useSyncExternalStore } from "react";
+import { type CalendarId } from "@core/types/domain-primitives";
+import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
+import { persistentBrowserStore } from "@web/common/storage/browser-key-value.store";
+import {
+  createExternalStore,
+  subscribeToStorageKey,
+} from "@web/common/utils/external-store.util";
+
+/**
+ * The calendar new events are created on, chosen by the user via the star on
+ * a calendar row. Client-owned, mirroring the hidden-calendar-ids store: one
+ * localStorage key is the source of truth, and this makes changes to it
+ * observable.
+ *
+ * Wart, named: the preference lives on this device only, so it does not roam
+ * across browsers. A server-side preference can supersede it later without a
+ * migration - an unknown or stale id already falls back to the derived
+ * default (see getDefaultTargetCalendar).
+ */
+
+function readDefaultCalendarId(): string | null {
+  const raw = persistentBrowserStore.get(STORAGE_KEYS.DEFAULT_CALENDAR_ID);
+  return raw && raw.trim().length > 0 ? raw : null;
+}
+
+const defaultCalendarIdStore = createExternalStore<string | null>(
+  readDefaultCalendarId(),
+);
+
+function refreshFromStorage(): void {
+  defaultCalendarIdStore.set(readDefaultCalendarId());
+}
+
+/**
+ * Persist + broadcast the chosen default calendar; pass null to clear it and
+ * fall back to the derived default. Returns false (leaving the store
+ * untouched) when the storage write fails, so callers can surface a failure
+ * rather than showing a preference that did not stick.
+ */
+export function setDefaultCalendarId(calendarId: CalendarId | null): boolean {
+  const saved =
+    calendarId === null
+      ? persistentBrowserStore.remove(STORAGE_KEYS.DEFAULT_CALENDAR_ID)
+      : persistentBrowserStore.set(
+          STORAGE_KEYS.DEFAULT_CALENDAR_ID,
+          calendarId,
+        );
+
+  if (saved) defaultCalendarIdStore.set(calendarId);
+  return saved;
+}
+
+function subscribe(onChange: () => void): () => void {
+  const unsubscribeStore = defaultCalendarIdStore.subscribe(onChange);
+  const unsubscribeStorage = subscribeToStorageKey(
+    STORAGE_KEYS.DEFAULT_CALENDAR_ID,
+    refreshFromStorage,
+  );
+
+  return () => {
+    unsubscribeStore();
+    unsubscribeStorage();
+  };
+}
+
+export function useDefaultCalendarId(): string | null {
+  return useSyncExternalStore(subscribe, defaultCalendarIdStore.get);
+}
+
+/** Read outside React (event handlers, non-hook utilities). */
+export function getStoredDefaultCalendarId(): string | null {
+  return defaultCalendarIdStore.get();
+}
+
+/** Test-only: resyncs the in-memory store from storage. */
+export function resetDefaultCalendarStoreForTests(): void {
+  refreshFromStorage();
+}

--- a/packages/web/src/calendars/useDefaultTargetCalendar.ts
+++ b/packages/web/src/calendars/useDefaultTargetCalendar.ts
@@ -1,0 +1,42 @@
+import { useMemo } from "react";
+import { type Calendar } from "@core/types/calendar.contracts";
+import {
+  selectGoogleSyncConnections,
+  useUserMetadataStore,
+} from "@web/auth/state/user-metadata.store";
+import { getDefaultTargetCalendar } from "@web/calendars/calendar.util";
+import { useDefaultCalendarId } from "@web/calendars/default-calendar.store";
+
+/**
+ * The calendar a new event should land on: the user's starred default when
+ * it is still usable, else the primary calendar of the oldest-connected
+ * account, else the local calendar.
+ *
+ * Wraps getDefaultTargetCalendar with the two reactive inputs every caller
+ * needs - the stored preference and the connected accounts in connection
+ * order - so a change to either re-renders the caller.
+ */
+export function useDefaultTargetCalendar(
+  calendars: Calendar[],
+): Calendar | undefined {
+  const preferredCalendarId = useDefaultCalendarId();
+  const accountEmailOrder = useConnectedAccountEmails();
+
+  return getDefaultTargetCalendar(calendars, {
+    preferredCalendarId,
+    accountEmailOrder,
+  });
+}
+
+/** Connected account emails in connection order (oldest first). */
+export function useConnectedAccountEmails(): string[] {
+  const connections = useUserMetadataStore(selectGoogleSyncConnections);
+
+  return useMemo(
+    () =>
+      connections
+        .map((connection) => connection.accountEmail)
+        .filter((email): email is string => Boolean(email)),
+    [connections],
+  );
+}

--- a/packages/web/src/common/constants/storage.constants.ts
+++ b/packages/web/src/common/constants/storage.constants.ts
@@ -11,7 +11,10 @@ type StorageKey =
   | "compass.view.sidebar-open"
   // S39 A2: client-owned calendar visibility (default visible). Device-local,
   // matching other compass.* prefs — not synced across browsers.
-  | "compass.calendars.hidden-ids";
+  | "compass.calendars.hidden-ids"
+  // Which calendar new events are created on. Device-local like the rest;
+  // an unknown or stale id falls back to the derived default.
+  | "compass.calendars.default-id";
 
 export const STORAGE_KEYS: Record<
   | "AUTH"
@@ -24,7 +27,8 @@ export const STORAGE_KEYS: Record<
   | "SIDEBAR_WIDTH"
   | "SIDEBAR_OPEN"
   | "THEME"
-  | "HIDDEN_CALENDAR_IDS",
+  | "HIDDEN_CALENDAR_IDS"
+  | "DEFAULT_CALENDAR_ID",
   StorageKey
 > = {
   AUTH: "compass.auth",
@@ -41,4 +45,5 @@ export const STORAGE_KEYS: Record<
   SIDEBAR_OPEN: "compass.view.sidebar-open",
   THEME: "compass.theme",
   HIDDEN_CALENDAR_IDS: "compass.calendars.hidden-ids",
+  DEFAULT_CALENDAR_ID: "compass.calendars.default-id",
 } as const;

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarList.test.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarList.test.tsx
@@ -17,6 +17,7 @@ import { BaseApi } from "@web/api/base/base.api";
 import { userMetadataActions } from "@web/auth/state/user-metadata.store";
 import { calendarQueryKeys } from "@web/calendars/calendar.query";
 import { isCalendarHidden } from "@web/calendars/calendar-visibility.storage";
+import { getStoredDefaultCalendarId } from "@web/calendars/default-calendar.store";
 import { persistentBrowserStore } from "@web/common/storage/browser-key-value.store";
 import { createObjectIdString } from "@web/common/utils/id/object-id.util";
 import { eventQueryKeys } from "@web/events/queries/event.query.keys";
@@ -472,6 +473,83 @@ describe("CalendarList", () => {
         ).queryByText("Compass"),
       ).not.toBeInTheDocument();
     }
+  });
+
+  it("stars the calendar new events go to, and moves the star on click", async () => {
+    const primary = makeCalendar({ name: "Personal", isPrimary: true });
+    const side = makeCalendar({ name: "Side project" });
+
+    const user = userEvent.setup({ delay: null });
+    renderCalendarList([primary, side]);
+
+    // The derived default (the primary) starts starred.
+    expect(
+      screen.getByRole("button", {
+        name: "primary is where new events go. Select again to undo.",
+      }),
+    ).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Make Side project where new events go",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(getStoredDefaultCalendarId()).toBe(side.id);
+    });
+    expect(
+      screen.getByRole("button", {
+        name: "Side project is where new events go. Select again to undo.",
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("clears the preference when the starred calendar is starred again", async () => {
+    const primary = makeCalendar({ name: "Personal", isPrimary: true });
+    const side = makeCalendar({ name: "Side project" });
+
+    const user = userEvent.setup({ delay: null });
+    renderCalendarList([primary, side]);
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Make Side project where new events go",
+      }),
+    );
+    await waitFor(() => {
+      expect(getStoredDefaultCalendarId()).toBe(side.id);
+    });
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Side project is where new events go. Select again to undo.",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(getStoredDefaultCalendarId()).toBeNull();
+    });
+    // Back to the derived default.
+    expect(
+      screen.getByRole("button", {
+        name: "primary is where new events go. Select again to undo.",
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("offers no star on a calendar the user cannot write to", () => {
+    const readOnly = makeCalendar({
+      name: "Team",
+      access: "reader",
+      capabilities: getCalendarCapabilities("reader"),
+    });
+
+    renderCalendarList([readOnly]);
+
+    expect(
+      screen.queryByRole("button", { name: /where new events go/ }),
+    ).not.toBeInTheDocument();
   });
 
   it("shows a loading state while calendars are pending", () => {

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarList.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarList.tsx
@@ -1,3 +1,4 @@
+import { StarIcon } from "@phosphor-icons/react";
 import { type FC } from "react";
 import { type Calendar } from "@core/types/calendar.contracts";
 import { type GoogleSyncConnectionSummary } from "@core/types/user.types";
@@ -8,7 +9,9 @@ import {
   useUserMetadataStore,
 } from "@web/auth/state/user-metadata.store";
 import { useCalendarsQuery } from "@web/calendars/calendar.query";
+import { setDefaultCalendarId } from "@web/calendars/default-calendar.store";
 import { useCalendarVisibility } from "@web/calendars/useCalendarVisibility";
+import { useDefaultTargetCalendar } from "@web/calendars/useDefaultTargetCalendar";
 import { AccountSectionHeader } from "./AccountSectionHeader";
 import { CalendarListHeader } from "./CalendarListHeader";
 
@@ -96,6 +99,7 @@ export const CalendarList: FC<Props> = ({ Header = CalendarListHeader }) => {
   const calendars = sortCalendars(
     (data ?? []).filter((calendar) => calendar.isActive),
   );
+  const defaultTargetCalendarId = useDefaultTargetCalendar(calendars)?.id;
   const { groups, ungrouped } = groupCalendarsByAccount(calendars, connections);
   const showAccountSections = groups.length > 1;
 
@@ -104,6 +108,7 @@ export const CalendarList: FC<Props> = ({ Header = CalendarListHeader }) => {
       {rows.map((calendar) => (
         <CalendarRow
           calendar={calendar}
+          isDefaultTarget={calendar.id === defaultTargetCalendarId}
           key={calendar.id}
           onToggle={toggleCalendarVisibility}
         />
@@ -163,8 +168,9 @@ export const CalendarList: FC<Props> = ({ Header = CalendarListHeader }) => {
 
 const CalendarRow: FC<{
   calendar: Calendar;
+  isDefaultTarget: boolean;
   onToggle: (calendarId: Calendar["id"], isVisible: boolean) => void;
-}> = ({ calendar, onToggle }) => {
+}> = ({ calendar, isDefaultTarget, onToggle }) => {
   // The heading above the row already names the account (the list heading with
   // one account, the section heading with several), so a primary calendar's
   // row reads "primary" instead of repeating it. The anonymous local sentinel
@@ -176,11 +182,11 @@ const CalendarRow: FC<{
       : calendar.name;
 
   return (
-    <li>
+    <li className="group/row flex min-w-0 items-center gap-1">
       <button
         aria-label={`${calendar.isVisible ? "Hide" : "Show"} ${displayName} calendar`}
         aria-pressed={calendar.isVisible}
-        className="c-focus-ring group flex w-full min-w-0 items-center gap-2 rounded px-1 py-0.5 text-left text-text text-xs hover:bg-surface-panel"
+        className="c-focus-ring group flex min-w-0 flex-1 items-center gap-2 rounded px-1 py-0.5 text-left text-text text-xs hover:bg-surface-panel"
         onClick={() => onToggle(calendar.id, !calendar.isVisible)}
         type="button"
       >
@@ -196,6 +202,44 @@ const CalendarRow: FC<{
         />
         <span className="min-w-0 flex-1 truncate">{displayName}</span>
       </button>
+      {calendar.capabilities.canWrite ? (
+        <DefaultCalendarStar
+          calendar={calendar}
+          displayName={displayName}
+          isDefaultTarget={isDefaultTarget}
+        />
+      ) : null}
     </li>
   );
 };
+
+/**
+ * Marks one calendar as where new events go. Starring another calendar moves
+ * the default; starring the current default clears it, falling back to the
+ * derived default. Only offered on calendars the user can write to.
+ */
+const DefaultCalendarStar: FC<{
+  calendar: Calendar;
+  displayName: string;
+  isDefaultTarget: boolean;
+}> = ({ calendar, displayName, isDefaultTarget }) => (
+  <button
+    aria-label={
+      isDefaultTarget
+        ? `${displayName} is where new events go. Select again to undo.`
+        : `Make ${displayName} where new events go`
+    }
+    aria-pressed={isDefaultTarget}
+    className={`c-focus-ring shrink-0 rounded px-1 py-0.5 text-xs hover:bg-surface-panel ${
+      isDefaultTarget
+        ? "text-accent"
+        : // Kept discoverable without cluttering every row: revealed on hover
+          // or keyboard focus, and always present for assistive tech.
+          "text-text-muted opacity-0 focus-visible:opacity-100 group-hover/row:opacity-100"
+    }`}
+    onClick={() => setDefaultCalendarId(isDefaultTarget ? null : calendar.id)}
+    type="button"
+  >
+    <StarIcon aria-hidden weight={isDefaultTarget ? "fill" : "regular"} />
+  </button>
+);

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
@@ -10,7 +10,7 @@ import { type CalendarId } from "@core/types/domain-primitives";
 import dayjs from "@core/util/date/dayjs";
 import { useGoogleUiState } from "@web/auth/google/hooks/useConnectGoogle/useGoogleUiState";
 import { useCalendarsQuery } from "@web/calendars/calendar.query";
-import { getDefaultTargetCalendar } from "@web/calendars/calendar.util";
+import { useDefaultTargetCalendar } from "@web/calendars/useDefaultTargetCalendar";
 import { type GridEvent } from "@web/common/types/web.event.types";
 import { onViewCommand } from "@web/common/utils/dom/view-command-bus";
 import {
@@ -66,7 +66,7 @@ export function DayCalendarGrid() {
     useCalendarsQuery();
   // Seed shortcuts with the form's default create target, not day-column order.
   const defaultTargetCalendarId =
-    getDefaultTargetCalendar(calendars)?.id ?? null;
+    useDefaultTargetCalendar(calendars)?.id ?? null;
   const {
     allDayEvents,
     events: dayEvents,

--- a/packages/web/src/views/Forms/EventForm/CalendarSelect/CalendarSelect.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/CalendarSelect/CalendarSelect.test.tsx
@@ -8,8 +8,11 @@ import {
   type CalendarId,
   CalendarIdSchema,
 } from "@core/types/domain-primitives";
+import { type GoogleSyncConnectionSummary } from "@core/types/user.types";
 import { createStoreWrapper } from "@web/__tests__/render-with-store";
+import { userMetadataActions } from "@web/auth/state/user-metadata.store";
 import { calendarQueryKeys } from "@web/calendars/calendar.query";
+import { setDefaultCalendarId } from "@web/calendars/default-calendar.store";
 import { createObjectIdString } from "@web/common/utils/id/object-id.util";
 import { CalendarSelect } from "@web/views/Forms/EventForm/CalendarSelect/CalendarSelect";
 import { beforeEach, describe, expect, it, mock } from "bun:test";
@@ -30,16 +33,34 @@ const makeCalendar = (overrides: Partial<Calendar> = {}): Calendar => ({
   ...overrides,
 });
 
+const makeConnection = (accountEmail: string): GoogleSyncConnectionSummary => ({
+  id: createObjectIdString(),
+  state: "healthy",
+  stateReason: null,
+  lastSyncedAt: null,
+  lastHealthyAt: null,
+  accountEmail,
+  connectionState: "HEALTHY",
+});
+
 const renderCalendarSelect = (
   calendars: Calendar[],
   {
     value = null,
     onChange = mock(),
+    connections,
   }: {
     value?: CalendarId | null;
     onChange?: (id: CalendarId) => void;
+    connections?: GoogleSyncConnectionSummary[];
   } = {},
 ) => {
+  if (connections) {
+    userMetadataActions.set({
+      google: { connectionState: "HEALTHY", connections },
+    });
+  }
+
   const { queryClient, wrapper } = createStoreWrapper();
   queryClient.setQueryData(calendarQueryKeys.all, calendars);
 
@@ -198,5 +219,91 @@ describe("CalendarSelect", () => {
       "aria-describedby",
       "event-form-error-calendarId",
     );
+  });
+
+  it("names each option's account when two accounts are connected", async () => {
+    // Both accounts have a calendar called "Work" with a primary; without the
+    // account the two options would be indistinguishable.
+    const work = makeCalendar({
+      name: "Work",
+      isPrimary: true,
+      accountEmail: "ahab@pequod.com",
+    });
+    const personal = makeCalendar({
+      name: "Work",
+      isPrimary: true,
+      accountEmail: "ahab@gmail.com",
+    });
+
+    renderCalendarSelect([work, personal], {
+      connections: [
+        makeConnection("ahab@pequod.com"),
+        makeConnection("ahab@gmail.com"),
+      ],
+    });
+    await openDropdown();
+
+    expect(
+      screen.getByRole("option", { name: "Work (primary) on ahab@pequod.com" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("option", { name: "Work (primary) on ahab@gmail.com" }),
+    ).toBeInTheDocument();
+  });
+
+  it("leaves option labels alone with a single account", async () => {
+    const work = makeCalendar({
+      name: "Work",
+      isPrimary: true,
+      accountEmail: "ahab@pequod.com",
+    });
+
+    renderCalendarSelect([work], {
+      connections: [makeConnection("ahab@pequod.com")],
+    });
+    await openDropdown();
+
+    expect(
+      screen.getByRole("option", { name: "Work (primary)" }),
+    ).toBeInTheDocument();
+  });
+
+  it("keeps each account's calendars together, oldest-connected account first", async () => {
+    const newer = makeCalendar({
+      name: "Aardvark",
+      accountEmail: "new@example.com",
+    });
+    const older = makeCalendar({
+      name: "Zebra",
+      accountEmail: "old@example.com",
+    });
+
+    renderCalendarSelect([newer, older], {
+      connections: [
+        makeConnection("old@example.com"),
+        makeConnection("new@example.com"),
+      ],
+    });
+    await openDropdown();
+
+    // Alphabetically "Aardvark" sorts first, but it belongs to the newer
+    // account, so it comes second.
+    expect(
+      screen.getAllByRole("option").map((option) => option.textContent),
+    ).toEqual(["Zebraold@example.com", "Aardvarknew@example.com"]);
+  });
+
+  it("displays the user's starred calendar as the default target", async () => {
+    const primary = makeCalendar({ name: "Personal", isPrimary: true });
+    const starred = makeCalendar({ name: "Side project" });
+    setDefaultCalendarId(starred.id);
+
+    renderCalendarSelect([primary, starred], { value: null });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("combobox", { name: "Calendar: Side project" }),
+      ).toBeInTheDocument();
+    });
   });
 });

--- a/packages/web/src/views/Forms/EventForm/CalendarSelect/CalendarSelect.tsx
+++ b/packages/web/src/views/Forms/EventForm/CalendarSelect/CalendarSelect.tsx
@@ -11,7 +11,10 @@ import { useRef, useState } from "react";
 import { type Calendar } from "@core/types/calendar.contracts";
 import { type CalendarId } from "@core/types/domain-primitives";
 import { useCalendarsQuery } from "@web/calendars/calendar.query";
-import { getDefaultTargetCalendar } from "@web/calendars/calendar.util";
+import {
+  useConnectedAccountEmails,
+  useDefaultTargetCalendar,
+} from "@web/calendars/useDefaultTargetCalendar";
 
 interface CalendarSelectProps {
   value: CalendarId | null;
@@ -32,15 +35,42 @@ const getWritableCalendars = (calendars: Calendar[]): Calendar[] =>
 
 // Primary first (it's the default target), then alphabetical - mirrors
 // CalendarList's sort so the same calendar lands in the same relative
-// position across the sidebar list and this picker.
-const sortWritableCalendars = (calendars: Calendar[]): Calendar[] =>
-  [...calendars].sort((a, b) => {
+// position across the sidebar list and this picker. With several accounts
+// connected, calendars are additionally kept together by account, in
+// connection order, so the list reads as one block per account.
+const sortWritableCalendars = (
+  calendars: Calendar[],
+  accountEmailOrder: readonly string[],
+): Calendar[] => {
+  const accountRank = (calendar: Calendar): number => {
+    const index = calendar.accountEmail
+      ? accountEmailOrder.indexOf(calendar.accountEmail)
+      : -1;
+    // Unknown account or no account (the local calendar) sorts last.
+    return index === -1 ? accountEmailOrder.length : index;
+  };
+
+  return [...calendars].sort((a, b) => {
+    const rankDelta = accountRank(a) - accountRank(b);
+    if (rankDelta !== 0) return rankDelta;
     if (a.isPrimary !== b.isPrimary) return a.isPrimary ? -1 : 1;
     return a.name.localeCompare(b.name);
   });
+};
 
 const calendarOptionLabel = (calendar: Calendar): string =>
   calendar.isPrimary ? `${calendar.name} (primary)` : calendar.name;
+
+// With two accounts connected, each has its own primary and its own calendar
+// named e.g. "Work", so an option needs its account to be unambiguous. With
+// one account the label is already unique and stays as it was.
+const calendarOptionDescription = (
+  calendar: Calendar,
+  showAccount: boolean,
+): string =>
+  showAccount && calendar.accountEmail
+    ? `${calendarOptionLabel(calendar)} on ${calendar.accountEmail}`
+    : calendarOptionLabel(calendar);
 
 /**
  * Labeled calendar picker for NEW/DUPLICATE event forms (writable calendars
@@ -62,9 +92,18 @@ export const CalendarSelect = ({
   id,
 }: CalendarSelectProps) => {
   const { data } = useCalendarsQuery();
+  const accountEmailOrder = useConnectedAccountEmails();
   const writableCalendars = sortWritableCalendars(
     getWritableCalendars(data ?? []),
+    accountEmailOrder,
   );
+  // Only disambiguate by account when there is something to disambiguate.
+  const showAccount =
+    new Set(
+      writableCalendars
+        .map((calendar) => calendar.accountEmail)
+        .filter(Boolean),
+    ).size > 1;
   const [isOpen, setIsOpen] = useState(false);
   const [activeIndex, setActiveIndex] = useState<number | null>(null);
   const listRef = useRef<Array<HTMLElement | null>>([]);
@@ -76,7 +115,7 @@ export const CalendarSelect = ({
   // display default - it doesn't write to the draft until the user actually
   // picks something. useSaveEventForm.ts/useDraftActions.ts fall back to the
   // same default target at submit time if the user never touches this.
-  const defaultCalendar = getDefaultTargetCalendar(writableCalendars) ?? null;
+  const defaultCalendar = useDefaultTargetCalendar(writableCalendars) ?? null;
   const displayedCalendar = selectedCalendar ?? defaultCalendar;
   const displayedIndex = displayedCalendar
     ? writableCalendars.findIndex(
@@ -126,7 +165,7 @@ export const CalendarSelect = ({
 
   const dropdownId = "calendar-select-dropdown";
   const buttonLabel = displayedCalendar
-    ? `Calendar: ${calendarOptionLabel(displayedCalendar)}`
+    ? `Calendar: ${calendarOptionDescription(displayedCalendar, showAccount)}`
     : "Calendar";
 
   const hasError = Boolean(error);
@@ -201,6 +240,7 @@ export const CalendarSelect = ({
                   active: isActive,
                 })}
                 role="option"
+                aria-label={calendarOptionDescription(calendar, showAccount)}
                 aria-selected={isSelected}
                 tabIndex={isActive ? 0 : -1}
                 className={classNames(
@@ -217,6 +257,14 @@ export const CalendarSelect = ({
                 <span className="min-w-0 flex-1 truncate">
                   {calendarOptionLabel(calendar)}
                 </span>
+                {showAccount && calendar.accountEmail ? (
+                  <span
+                    className="min-w-0 shrink truncate text-text-muted"
+                    translate="no"
+                  >
+                    {calendar.accountEmail}
+                  </span>
+                ) : null}
               </div>
             );
           })}

--- a/packages/web/src/views/Forms/hooks/useSaveEventForm.ts
+++ b/packages/web/src/views/Forms/hooks/useSaveEventForm.ts
@@ -1,6 +1,6 @@
 import { useCallback, useState } from "react";
 import { useCalendarsQuery } from "@web/calendars/calendar.query";
-import { getDefaultTargetCalendar } from "@web/calendars/calendar.util";
+import { useDefaultTargetCalendar } from "@web/calendars/useDefaultTargetCalendar";
 import { RecurringEventUpdateScope } from "@web/common/types/web.event.types";
 import { type GridEventDraft } from "@web/events/event-draft.types";
 import { parseGridEventDraft } from "@web/events/grid-event-draft.adapter";
@@ -12,6 +12,7 @@ export function useSaveEventForm() {
   const closeEventForm = useCloseEventForm();
   const { create, replace } = useEventMutations();
   const { data: calendars } = useCalendarsQuery();
+  const defaultTargetCalendarId = useDefaultTargetCalendar(calendars ?? [])?.id;
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
 
   const clearFieldErrors = useCallback(() => {
@@ -32,9 +33,7 @@ export function useSaveEventForm() {
         // Respects a calendar the user explicitly chose via CalendarSelect;
         // only an untouched draft (calendarId still null) falls back to the
         // default target calendar.
-        const calendarId =
-          draft.values.calendarId ??
-          getDefaultTargetCalendar(calendars ?? [])?.id;
+        const calendarId = draft.values.calendarId ?? defaultTargetCalendarId;
         if (!calendarId) {
           setFieldErrors({ calendarId: "Calendar is required" });
           return;
@@ -75,7 +74,13 @@ export function useSaveEventForm() {
         closeEventForm();
       }
     },
-    [calendars, clearFieldErrors, closeEventForm, create, replace],
+    [
+      defaultTargetCalendarId,
+      clearFieldErrors,
+      closeEventForm,
+      create,
+      replace,
+    ],
   );
 
   return { saveEventForm, fieldErrors, clearFieldErrors };

--- a/packages/web/src/views/Week/components/Draft/hooks/actions/useDraftActions.ts
+++ b/packages/web/src/views/Week/components/Draft/hooks/actions/useDraftActions.ts
@@ -3,7 +3,7 @@ import { type RecurrenceScope } from "@core/types/event-command.contracts";
 import { devAlert } from "@core/util/app.util";
 import dayjs, { type Dayjs } from "@core/util/date/dayjs";
 import { useCalendarsQuery } from "@web/calendars/calendar.query";
-import { getDefaultTargetCalendar } from "@web/calendars/calendar.util";
+import { useDefaultTargetCalendar } from "@web/calendars/useDefaultTargetCalendar";
 import { type PartialMouseEvent } from "@web/common/types/util.types";
 import { RecurringEventUpdateScope } from "@web/common/types/web.event.types";
 import { repositionDraftByKeyboard as applyDraftKeyboardReposition } from "@web/common/utils/draft/reposition-draft-by-keyboard.util";
@@ -54,6 +54,7 @@ export const useDraftActions = (
 ) => {
   const mutations = useEventMutations();
   const { data: calendars } = useCalendarsQuery();
+  const defaultTargetCalendarId = useDefaultTargetCalendar(calendars ?? [])?.id;
   const { activity, isDrafting } = useDraftStore(selectDraftStatus)!;
 
   const {
@@ -163,9 +164,7 @@ export const useDraftActions = (
           // Respects a calendar the user explicitly chose via CalendarSelect;
           // only an untouched draft (calendarId still null) falls back to the
           // default target calendar.
-          const calendarId =
-            draft.values.calendarId ??
-            getDefaultTargetCalendar(calendars ?? [])?.id;
+          const calendarId = draft.values.calendarId ?? defaultTargetCalendarId;
           if (!calendarId) return;
 
           const parsed = parseGridEventDraft({
@@ -206,7 +205,7 @@ export const useDraftActions = (
       }
     },
     [
-      calendars,
+      defaultTargetCalendarId,
       determineSubmitAction,
       discard,
       isFormOpenBeforeDragging,

--- a/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcuts.ts
+++ b/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcuts.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect } from "react";
 import { type Dayjs } from "@core/util/date/dayjs";
 import { useCalendarsQuery } from "@web/calendars/calendar.query";
-import { getDefaultTargetCalendar } from "@web/calendars/calendar.util";
+import { useDefaultTargetCalendar } from "@web/calendars/useDefaultTargetCalendar";
 import { onViewCommand } from "@web/common/utils/dom/view-command-bus";
 import {
   createAlldayDraft,
@@ -52,7 +52,7 @@ export const useWeekShortcuts = ({
   const { data: calendars = [], isPending: isCalendarsPending } =
     useCalendarsQuery();
   const defaultTargetCalendarId =
-    getDefaultTargetCalendar(calendars)?.id ?? null;
+    useDefaultTargetCalendar(calendars)?.id ?? null;
   const {
     actions: { repositionDraftByKeyboard },
   } = useDraftContext();


### PR DESCRIPTION
## What

With several Google accounts connected, every account has its own primary calendar, so the old "first primary wins" lookup picked whichever happened to sort first. This makes the create target explicit and unambiguous.

**Where new events go**, in order:
1. The calendar the user starred in the sidebar, if it still exists and is writable.
2. The primary calendar of the oldest-connected account.
3. The local calendar.

A starred calendar that is deleted or turns read-only falls back to the derived default rather than breaking event creation.

**Starring** is a button on each writable calendar row, revealed on hover or keyboard focus and always present for assistive tech. Starring another calendar moves the default; starring the current one clears the preference and returns to the derived default.

**The event form's calendar picker** keeps each account's calendars together in connection order and names the account on each option when more than one is connected, so two calendars both reading "Work (primary)" are no longer indistinguishable. With one account the labels are unchanged.

The preference is one localStorage key beside the existing calendar-visibility preferences. Named wart, in a comment: it is per device and does not roam across browsers. A server-side preference can supersede it later without a migration, since an unknown id already falls back to the derived default.

All five callers of the old `getDefaultTargetCalendar` now go through one `useDefaultTargetCalendar` hook, so the preference and the connection order stay reactive in every one.

## Tests

- Resolution precedence: starred beats derived; the local calendar can be starred explicitly; a missing or newly read-only starred calendar falls back; the oldest-connected account's primary wins over another account's; connection order naming an account with no primary still resolves.
- Store: persists and survives a reload; clearing returns null; a failed storage write leaves the store untouched rather than showing a preference that did not stick.
- Sidebar: the default target starts starred, the star moves on click, starring again clears it, and read-only calendars offer no star.
- Picker: options name their account with two accounts and stay unchanged with one; each account's calendars stay together with the oldest-connected first; the starred calendar shows as the displayed default.
- Full web suite (1616) green; `bun run type-check` and biome clean (the two remaining biome warnings are pre-existing in DescriptionEditor.tsx).

🤖 Generated with [Claude Code](https://claude.com/claude-code)