### PR TITLE
feat(sync,web): let a connected user add another Google account

### DIFF
--- a/packages/sync/src/providers/google/google-auth.adapter.test.ts
+++ b/packages/sync/src/providers/google/google-auth.adapter.test.ts
@@ -127,6 +127,23 @@ describe("GoogleAuthAdapter", () => {
       expect(options.scope).toEqual([...GOOGLE_SCOPES]);
       expect(url).toContain("state=opaque-state");
     });
+
+    it("forces the account chooser when adding an account", () => {
+      const client = new FakeGoogleClient();
+      const { adapter } = adapterWith(client);
+
+      adapter.buildAuthorizationUrl({
+        state: "opaque-state",
+        redirectUri: "https://staging.example.com/sync/google",
+        selectAccount: true,
+      });
+
+      // Without select_account, a browser signed into one Google account
+      // re-authorizes that same account and the user never gets to pick.
+      // consent must stay so the exchange still returns a refresh token.
+      expect(client.authUrlOptions[0].prompt).toBe("select_account consent");
+      expect(client.authUrlOptions[0].access_type).toBe("offline");
+    });
   });
 
   describe("exchangeAuthorizationCode", () => {

--- a/packages/sync/src/providers/google/google-auth.adapter.ts
+++ b/packages/sync/src/providers/google/google-auth.adapter.ts
@@ -62,12 +62,19 @@ export class GoogleAuthAdapter implements ProviderAuthAdapter {
     this.#makeClient = makeClient;
   }
 
-  buildAuthorizationUrl(input: { state: string; redirectUri: string }): string {
+  buildAuthorizationUrl(input: {
+    state: string;
+    redirectUri: string;
+    selectAccount?: boolean;
+  }): string {
     return this.#makeClient(input.redirectUri).generateAuthUrl({
       // offline + consent guarantees a refresh token even on re-authorization,
-      // which Google otherwise omits after the first consent.
+      // which Google otherwise omits after the first consent. select_account
+      // additionally forces the chooser, so adding an account cannot silently
+      // re-authorize the one already connected. Google takes the prompt as a
+      // space-delimited list.
       access_type: "offline",
-      prompt: "consent",
+      prompt: input.selectAccount ? "select_account consent" : "consent",
       include_granted_scopes: true,
       scope: [...GOOGLE_SCOPES],
       state: input.state,

--- a/packages/sync/src/providers/provider-auth.port.ts
+++ b/packages/sync/src/providers/provider-auth.port.ts
@@ -38,6 +38,11 @@ export interface ProviderAuthAdapter {
   buildAuthorizationUrl(input: {
     readonly state: string;
     readonly redirectUri: string;
+    // Ask the provider to show its account chooser. Set when the principal is
+    // adding an account alongside ones it already has: without it a provider
+    // with one signed-in session silently re-authorizes that same account, so
+    // the user never gets to pick the account they meant to add.
+    readonly selectAccount?: boolean;
   }): string;
 
   // Exchange an authorization code for durable credentials and account

--- a/packages/sync/src/server/connection.routes.db.test.ts
+++ b/packages/sync/src/server/connection.routes.db.test.ts
@@ -71,8 +71,16 @@ const testConfig = (overrides: Partial<SyncConfig> = {}): SyncConfig =>
 class FakeAuthAdapter implements ProviderAuthAdapter {
   readonly provider = "google" as const;
   revoked: string[] = [];
-  authorizations: Array<{ state: string; redirectUri: string }> = [];
-  buildAuthorizationUrl(input: { state: string; redirectUri: string }): string {
+  authorizations: Array<{
+    state: string;
+    redirectUri: string;
+    selectAccount?: boolean;
+  }> = [];
+  buildAuthorizationUrl(input: {
+    state: string;
+    redirectUri: string;
+    selectAccount?: boolean;
+  }): string {
     this.authorizations.push(input);
     return `https://consent.example.com/?state=${input.state}`;
   }
@@ -487,6 +495,49 @@ describe("POST /internal/connections/begin", () => {
     expect(verified.ok && verified.payload.principalId).toBe(principalId);
     expect(verified.ok && verified.payload.tenantId).toBe(tenantId);
     expect(verified.ok && verified.payload.connectionId).toBeNull();
+  });
+
+  it("does not force the account chooser for a principal's first connection", async () => {
+    await startService(activeConfig(), adapter);
+
+    await begin(objectId(), objectId());
+
+    // Nothing to choose between yet, and the chooser is an extra click.
+    expect(adapter.authorizations[0].selectAccount).toBe(false);
+  });
+
+  it("forces the account chooser when the principal already has a connection", async () => {
+    const tenantId = objectId();
+    const principalId = objectId();
+    await seedConnection(
+      connections,
+      tenantId,
+      principalId,
+      "first@example.com",
+    );
+    await startService(activeConfig(), adapter);
+
+    await begin(tenantId, principalId);
+
+    // Otherwise Google re-authorizes the connected account and nothing
+    // appears to happen.
+    expect(adapter.authorizations[0].selectAccount).toBe(true);
+  });
+
+  it("never forces the account chooser on reconnect (it is account-pinned)", async () => {
+    const tenantId = objectId();
+    const principalId = objectId();
+    const existing = await seedConnection(
+      connections,
+      tenantId,
+      principalId,
+      "reconnect@example.com",
+    );
+    await startService(activeConfig(), adapter);
+
+    await begin(tenantId, principalId, { connectionId: existing._id });
+
+    expect(adapter.authorizations[0].selectAccount).toBe(false);
   });
 
   it("binds the state to an owned connection for reconnect", async () => {

--- a/packages/sync/src/server/connection.routes.ts
+++ b/packages/sync/src/server/connection.routes.ts
@@ -474,6 +474,27 @@ export function registerConnectionRoutes(
         connectionId = parsed.data;
       }
 
+      // A fresh connect by a principal that already has connections is an
+      // add-account: show the provider's account chooser so the user can pick
+      // a different account instead of silently re-authorizing the connected
+      // one. Reconnect is account-pinned and must never show the chooser. A
+      // lookup failure here only costs the chooser, so it does not fail the
+      // request.
+      let selectAccount = false;
+      if (connectionId === null) {
+        try {
+          const existing = await new ProviderConnectionRepository(
+            deps.mongo.db,
+          ).listByPrincipal(auth.tenantId, auth.principalId);
+          selectAccount = existing.length > 0;
+        } catch (error) {
+          logger.warn(
+            "Failed to count connections for the account chooser",
+            redactedCause(error),
+          );
+        }
+      }
+
       const state = signOAuthState(deps.stateSecret, {
         tenantId: auth.tenantId,
         principalId: auth.principalId,
@@ -483,6 +504,7 @@ export function registerConnectionRoutes(
       const authorizationUrl = deps.authAdapter.buildAuthorizationUrl({
         state,
         redirectUri: `${deps.callbackBaseUrl}${OAUTH_CALLBACK_PATH}`,
+        selectAccount,
       });
       res.status(Status.OK).json({ authorizationUrl });
     },

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarList.test.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarList.test.tsx
@@ -54,15 +54,18 @@ const actualUseConnectGoogle = (
 let isConnectGoogleMocked = true;
 // Mirrors the real hook's one behavior these tests depend on: scoping to a
 // connection reports that account's own state. (The real scoping is covered
-// directly in useConnectGoogle.scope.test.tsx.)
-const mockUseConnectGoogle = mock(
-  (options?: Parameters<typeof actualUseConnectGoogle>[0]) => ({
-    commandAction: null,
-    isAvailable: true,
-    isConnecting: false,
-    state: options?.connection?.connectionState ?? ("NOT_CONNECTED" as const),
-  }),
-);
+// directly in useConnectGoogle.scope.test.tsx.) Restored in beforeEach, since
+// a test that swaps in mockReturnValue would otherwise poison later ones.
+const defaultUseConnectGoogle = (
+  options?: Parameters<typeof actualUseConnectGoogle>[0],
+) => ({
+  commandAction: null,
+  connect: mock(),
+  isAvailable: true,
+  isConnecting: false,
+  state: options?.connection?.connectionState ?? ("NOT_CONNECTED" as const),
+});
+const mockUseConnectGoogle = mock(defaultUseConnectGoogle);
 mock.module("@web/auth/google/hooks/useConnectGoogle/useConnectGoogle", () => ({
   useConnectGoogle: (...args: Parameters<typeof actualUseConnectGoogle>) =>
     isConnectGoogleMocked
@@ -159,6 +162,7 @@ const renderCalendarList = (
 
 describe("CalendarList", () => {
   beforeEach(() => {
+    mockUseConnectGoogle.mockImplementation(defaultUseConnectGoogle);
     mockUseSession.mockReturnValue({
       authenticated: true,
       setAuthenticated: () => {},
@@ -549,6 +553,40 @@ describe("CalendarList", () => {
 
     expect(
       screen.queryByRole("button", { name: /where new events go/ }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("offers to add another account once one is connected", async () => {
+    const connect = mock();
+    mockUseConnectGoogle.mockReturnValue({
+      commandAction: null,
+      connect,
+      isAvailable: true,
+      isConnecting: false,
+      state: "HEALTHY" as const,
+    });
+
+    const user = userEvent.setup({ delay: null });
+    renderCalendarList([makeCalendar({ name: "Work" })]);
+
+    await user.click(screen.getByRole("button", { name: "Add account" }));
+    expect(connect).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not offer to add an account before the first one is connected", () => {
+    // The header's own Connect action covers this case.
+    mockUseConnectGoogle.mockReturnValue({
+      commandAction: null,
+      connect: mock(),
+      isAvailable: true,
+      isConnecting: false,
+      state: "NOT_CONNECTED" as const,
+    });
+
+    renderCalendarList([makeCalendar({ name: "Compass", provider: "local" })]);
+
+    expect(
+      screen.queryByRole("button", { name: "Add account" }),
     ).not.toBeInTheDocument();
   });
 

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarList.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarList.tsx
@@ -90,7 +90,7 @@ interface Props {
 
 export const CalendarList: FC<Props> = ({ Header = CalendarListHeader }) => {
   const { authenticated } = useSession();
-  const { isAvailable, state } = useConnectGoogle();
+  const { connect, isAvailable, isConnecting, state } = useConnectGoogle();
   const { data, isPending, isError, refetch } = useCalendarsQuery();
   const { toggleCalendarVisibility, failureAnnouncement } =
     useCalendarVisibility();
@@ -158,6 +158,22 @@ export const CalendarList: FC<Props> = ({ Header = CalendarListHeader }) => {
       ) : (
         renderRows(calendars)
       )}
+
+      {/* Adding a second account is only meaningful once the first one is
+          connected; before that the header's own Connect action covers it. */}
+      {authenticated &&
+      isAvailable &&
+      (state === "HEALTHY" || state === "IMPORTING") ? (
+        <button
+          aria-busy={isConnecting || undefined}
+          className="c-focus-ring mt-3 rounded-xs px-1 py-0.5 text-accent text-xs hover:brightness-110 disabled:pointer-events-none disabled:opacity-60"
+          disabled={isConnecting}
+          onClick={connect}
+          type="button"
+        >
+          {isConnecting ? "Opening Google…" : "Add account"}
+        </button>
+      ) : null}
 
       <span aria-live="polite" className="sr-only" role="status">
         {failureAnnouncement}


### PR DESCRIPTION
## What

First user-visible slice of multi-account support: connecting a second Google account.

- **Sidebar affordance.** An "Add account" action appears at the bottom of the calendar list once a first account is connected and Google connection is available. Before that, the header's own Connect action already covers it, so the button stays hidden.
- **Account chooser.** `buildAuthorizationUrl` gained an optional `selectAccount`, which sends Google `prompt=select_account consent` instead of `consent`. The begin route sets it when the request is a fresh connect (no `connectionId`) by a principal that already has a connection.

Without the chooser, a browser signed into a single Google account re-authorizes that same account and nothing appears to happen. `consent` is kept alongside it so the exchange still returns a refresh token.

Reconnect stays account-pinned and never shows the chooser. Re-picking an already-connected account resumes it rather than duplicating it, which the connection store's per-account uniqueness already guaranteed; the begin-route tests now pin that the chooser flag follows the same rule.

A failure counting existing connections only costs the chooser, so it logs and continues rather than failing the request.

## Not in this PR

Disconnecting an account, and the guard rejecting an account that is another Compass user's login identity, follow in the next one.

## Tests

- Adapter: `select_account consent` when adding, plain `consent` otherwise, `offline` access preserved in both.
- Begin route: no chooser for a principal's first connection; chooser when it already has one; never on reconnect.
- Sidebar: the action appears and calls connect when an account is connected; absent when none is.
- Full sync (765) and web (1618) suites green; `bun run type-check` and biome clean.

## Verification

The end-to-end flow (chooser, second import, both accounts' events on the grid) needs a real second Google account and is part of the staging soak before this reaches production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)