### PR TITLE
feat(backend,web): let a user disconnect one Google account

### DIFF
--- a/packages/backend/src/auth/auth.routes.config.ts
+++ b/packages/backend/src/auth/auth.routes.config.ts
@@ -35,6 +35,15 @@ export class AuthRoutes extends CommonRoutesConfig {
         authController.beginGoogleConnection(req, res);
       });
 
+    // Disconnect one connected Google account (the user's others are
+    // unaffected, as is their Compass sign-in).
+    this.app
+      .route(`/api/auth/google/connect/:connectionId`)
+      .all(requireSession)
+      .delete((req, res) => {
+        authController.disconnectGoogleConnection(req, res);
+      });
+
     // Enqueue Sync catch-up pulls for the signed-in user's calendars.
     this.app
       .route(`/api/auth/google/sync/refresh`)

--- a/packages/backend/src/auth/controllers/auth.controller.ts
+++ b/packages/backend/src/auth/controllers/auth.controller.ts
@@ -4,10 +4,12 @@ import {
   type ConnectionBeginRequest,
   ConnectionBeginRequestSchema,
 } from "@core/types/sync/connection.contracts";
+import { ConnectionIdSchema } from "@core/types/sync/identity.contracts";
 import { zObjectId } from "@core/types/type.utils";
 import compassAuthService from "@backend/auth/services/compass/compass.auth.service";
 import { assertCloudMutationsAllowed } from "@backend/common/services/sync-service/cloud-mutation-mode";
 import { beginSyncConnection } from "@backend/common/services/sync-service/sync-connection-begin";
+import { disconnectSyncConnection } from "@backend/common/services/sync-service/sync-connection-disconnect";
 import { refreshSyncConnection } from "@backend/common/services/sync-service/sync-connection-refresh";
 import { toSyncPrincipal } from "@backend/common/services/sync-service/sync-principal";
 import { getSyncServiceClient } from "@backend/common/services/sync-service/sync-service.factory";
@@ -74,6 +76,28 @@ class AuthController {
     const request = ConnectionBeginRequestSchema.parse(req.body ?? {});
 
     res.promise(beginSyncConnection(client, toSyncPrincipal(userId), request));
+  };
+
+  // Disconnect one connected Google account, leaving the user's others (and
+  // their Compass sign-in) alone. Sync scopes the disconnect to the signed
+  // principal, so a connection id the caller does not own is rejected there.
+  disconnectGoogleConnection = (
+    req: SessionRequest,
+    res: Res_Promise,
+  ): void => {
+    if (rejectIfMaintenance(res)) return;
+
+    const client = getSyncServiceClient();
+    const userId = zObjectId.parse(req.session?.getUserId()).toString();
+    const connectionId = ConnectionIdSchema.parse(req.params["connectionId"]);
+
+    res.promise(
+      disconnectSyncConnection(
+        client,
+        toSyncPrincipal(userId),
+        connectionId,
+      ).then(() => ({ statusCode: 204 })),
+    );
   };
 
   // User-triggered Google calendar catch-up (Refresh calendar CTA).

--- a/packages/backend/src/common/services/sync-service/sync-connection-disconnect.ts
+++ b/packages/backend/src/common/services/sync-service/sync-connection-disconnect.ts
@@ -1,0 +1,39 @@
+import { Logger } from "@core/logger/winston.logger";
+import { AuthError } from "@backend/common/errors/auth/auth.errors";
+import { error } from "@backend/common/errors/handlers/error.handler";
+import {
+  type SyncPrincipal,
+  type SyncServiceClient,
+} from "./sync-service.client";
+
+const logger = Logger("app:sync-connection-disconnect");
+
+/**
+ * Ask the sync service to disconnect one of the caller's connections: revoke
+ * the credential at the provider and mark the connection disconnected. The
+ * principal's other connections are untouched.
+ *
+ * Any client failure surfaces as a single 503 (SyncConnectionUnavailable),
+ * matching the begin/refresh delegations: the specific kind and correlation id
+ * are logged server-side, and nothing sync-internal reaches the browser. A
+ * connection the principal does not own is a sync-side not-found, which lands
+ * here as the same opaque failure - correct, since a caller must not be able
+ * to probe for other principals' connection ids.
+ */
+export async function disconnectSyncConnection(
+  client: Pick<SyncServiceClient, "disconnectConnection">,
+  principal: SyncPrincipal,
+  connectionId: string,
+): Promise<void> {
+  const result = await client.disconnectConnection(principal, connectionId);
+  if (result.ok) return;
+
+  logger.warn(
+    `Sync disconnect failed (${result.error.kind}) ` +
+      `[correlationId=${result.error.correlationId}]`,
+  );
+  throw error(
+    AuthError.SyncConnectionUnavailable,
+    "Failed to disconnect Google account",
+  );
+}

--- a/packages/backend/src/common/services/sync-service/sync-service.client.test.ts
+++ b/packages/backend/src/common/services/sync-service/sync-service.client.test.ts
@@ -192,6 +192,50 @@ describe("SyncServiceClient", () => {
     expect(verdict.context.principalId).toBe(who.principalId);
   });
 
+  it("disconnects one connection with a signed DELETE the real Sync verifier accepts", async () => {
+    const who = principal();
+    const connectionId = "64b7f9c2e1a2b3c4d5e6f7ff";
+    // Sync answers 204 with an empty body; reading it as JSON would throw.
+    const { fn, calls } = fakeFetch(async () => ({
+      status: 204,
+      json: async () => {
+        throw new Error("204 has no body");
+      },
+    }));
+
+    const result = await client(fn).disconnectConnection(who, connectionId);
+
+    expect(result.ok).toBe(true);
+
+    const sent = calls[0];
+    expect(sent?.url).toBe(`${BASE_URL}/internal/connections/${connectionId}`);
+    expect(sent?.method).toBe("DELETE");
+
+    const verdict = verifyInternalRequest({
+      secret: SECRET,
+      headers: sent?.headers ?? {},
+      now: NOW,
+    });
+    if (!verdict.ok) throw new Error(`verify failed: ${verdict.reason}`);
+    // Sync scopes the disconnect to the signed principal, so a foreign
+    // connection id can never be disconnected through this client.
+    expect(verdict.context.principalId).toBe(who.principalId);
+  });
+
+  it("reports a disconnect of an unknown connection as a failure", async () => {
+    const { fn } = fakeFetch(async () => ({
+      status: 404,
+      json: async () => ({ error: "not_found" }),
+    }));
+
+    const result = await client(fn).disconnectConnection(
+      principal(),
+      "64b7f9c2e1a2b3c4d5e6f7ff",
+    );
+
+    expect(result.ok).toBe(false);
+  });
+
   it("lists calendars with a signed GET the real Sync verifier accepts", async () => {
     const who = principal();
     const { fn, calls } = fakeFetch(async () => ({

--- a/packages/backend/src/common/services/sync-service/sync-service.client.ts
+++ b/packages/backend/src/common/services/sync-service/sync-service.client.ts
@@ -379,6 +379,26 @@ export class SyncServiceClient {
     });
   }
 
+  // Disconnect one of the caller's connections: Sync revokes the credential at
+  // the provider and marks the connection disconnected. Scoped to the signed
+  // principal, so a foreign or missing connection is a clean not-found that
+  // revokes nothing. Idempotent. The other connections are untouched.
+  disconnectConnection(
+    principal: SyncPrincipal,
+    connectionId: string,
+    correlationId?: string,
+  ): Promise<SyncClientResult<void>> {
+    return this.#request({
+      method: "DELETE",
+      path: `${CONNECTIONS_PATH}/${encodeURIComponent(connectionId)}`,
+      principal,
+      // Sync answers 204 with no body, so there is nothing to parse and no
+      // schema to give.
+      expectNoContent: true,
+      correlationId,
+    });
+  }
+
   // Hard-delete every Sync-held row for the signed principal (account deletion).
   // Served in Sync passive mode too. Idempotent: a retry returns zero counts.
   purgePrincipal(
@@ -400,7 +420,9 @@ export class SyncServiceClient {
     query?: URLSearchParams;
     principal: SyncPrincipal;
     body?: unknown;
-    schema: z.ZodType<T>;
+    // Absent only for a no-content route, which has no body to validate.
+    schema?: z.ZodType<T>;
+    expectNoContent?: boolean;
     correlationId?: string;
     timeoutMs?: number;
   }): Promise<SyncClientResult<T>> {
@@ -446,7 +468,8 @@ export class SyncServiceClient {
     path: string;
     query?: URLSearchParams;
     body?: unknown;
-    schema: z.ZodType<T>;
+    schema?: z.ZodType<T>;
+    expectNoContent?: boolean;
     correlationId: string;
     headers: Record<string, string>;
     timeoutMs?: number;
@@ -480,6 +503,13 @@ export class SyncServiceClient {
       clearTimeout(timer);
     }
 
+    // A no-content route succeeds with 204 and an empty body; reading it as
+    // JSON would fail, and treating it as an unexpected status would turn a
+    // successful disconnect into an error.
+    if (input.expectNoContent && response.status === 204) {
+      return { ok: true, value: undefined as T, correlationId };
+    }
+
     if (response.status === 200) {
       let body: unknown;
       try {
@@ -487,8 +517,8 @@ export class SyncServiceClient {
       } catch {
         return errorResult("invalidResponse", correlationId, 200);
       }
-      const parsed = input.schema.safeParse(body);
-      if (!parsed.success) {
+      const parsed = input.schema?.safeParse(body);
+      if (!parsed?.success) {
         return errorResult("invalidResponse", correlationId, 200);
       }
       return { ok: true, value: parsed.data, correlationId };

--- a/packages/web/src/api/auth.api.ts
+++ b/packages/web/src/api/auth.api.ts
@@ -38,6 +38,14 @@ const AuthApi = {
     return ConnectionBeginResponseSchema.parse(response.data);
   },
 
+  // Disconnect one connected Google account. The user's other accounts, and
+  // their Compass sign-in, are unaffected.
+  async disconnectGoogleConnection(connectionId: string): Promise<void> {
+    await BaseApi.delete(
+      `/auth/google/connect/${encodeURIComponent(connectionId)}`,
+    );
+  },
+
   // Enqueue Sync catch-up pulls for the signed-in user's calendars.
   async refreshGoogleSync(): Promise<ConnectionRefreshResponse> {
     const response = await BaseApi.post<ConnectionRefreshResponse>(

--- a/packages/web/src/components/Sidebar/CalendarList/AccountSectionHeader.test.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/AccountSectionHeader.test.tsx
@@ -1,0 +1,148 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { type GoogleSyncConnectionSummary } from "@core/types/user.types";
+import { createStoreWrapper } from "@web/__tests__/render-with-store";
+import { AuthApi } from "@web/api/auth.api";
+import { AccountSectionHeader } from "./AccountSectionHeader";
+import { describe, expect, it, spyOn } from "bun:test";
+
+const connection = (
+  overrides: Partial<GoogleSyncConnectionSummary> = {},
+): GoogleSyncConnectionSummary => ({
+  id: "connection-1",
+  state: "healthy",
+  stateReason: null,
+  lastSyncedAt: null,
+  lastHealthyAt: null,
+  accountEmail: "ahab@pequod.com",
+  connectionState: "HEALTHY",
+  ...overrides,
+});
+
+const renderHeader = (summary = connection()) => {
+  const { wrapper } = createStoreWrapper();
+  return render(
+    <AccountSectionHeader
+      accountEmail={summary.accountEmail ?? "ahab@pequod.com"}
+      connection={summary}
+    />,
+    { wrapper },
+  );
+};
+
+describe("AccountSectionHeader disconnect", () => {
+  it("asks for confirmation before disconnecting", async () => {
+    const disconnect = spyOn(
+      AuthApi,
+      "disconnectGoogleConnection",
+    ).mockResolvedValue(undefined);
+
+    const user = userEvent.setup({ delay: null });
+    renderHeader();
+
+    await user.click(
+      screen.getByRole("button", { name: "Disconnect ahab@pequod.com" }),
+    );
+
+    // Disconnecting is not undoable without redoing the whole OAuth flow, so
+    // the first press must not call the API.
+    expect(disconnect).not.toHaveBeenCalled();
+    expect(
+      screen.getByRole("button", {
+        name: "Confirm disconnecting ahab@pequod.com",
+      }),
+    ).toBeInTheDocument();
+
+    disconnect.mockRestore();
+  });
+
+  it("disconnects that connection once confirmed", async () => {
+    const disconnect = spyOn(
+      AuthApi,
+      "disconnectGoogleConnection",
+    ).mockResolvedValue(undefined);
+
+    const user = userEvent.setup({ delay: null });
+    renderHeader(connection({ id: "connection-second" }));
+
+    await user.click(
+      screen.getByRole("button", { name: "Disconnect ahab@pequod.com" }),
+    );
+    await user.click(
+      screen.getByRole("button", {
+        name: "Confirm disconnecting ahab@pequod.com",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(disconnect).toHaveBeenCalledWith("connection-second");
+    });
+
+    disconnect.mockRestore();
+  });
+
+  it("backs out of the confirm without disconnecting", async () => {
+    const disconnect = spyOn(
+      AuthApi,
+      "disconnectGoogleConnection",
+    ).mockResolvedValue(undefined);
+
+    const user = userEvent.setup({ delay: null });
+    renderHeader();
+
+    await user.click(
+      screen.getByRole("button", { name: "Disconnect ahab@pequod.com" }),
+    );
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(disconnect).not.toHaveBeenCalled();
+    expect(
+      screen.getByRole("button", { name: "Disconnect ahab@pequod.com" }),
+    ).toBeInTheDocument();
+
+    disconnect.mockRestore();
+  });
+
+  it("returns to the un-confirmed state when the disconnect fails", async () => {
+    const disconnect = spyOn(
+      AuthApi,
+      "disconnectGoogleConnection",
+    ).mockRejectedValue(new Error("nope"));
+
+    const user = userEvent.setup({ delay: null });
+    renderHeader();
+
+    await user.click(
+      screen.getByRole("button", { name: "Disconnect ahab@pequod.com" }),
+    );
+    await user.click(
+      screen.getByRole("button", {
+        name: "Confirm disconnecting ahab@pequod.com",
+      }),
+    );
+
+    // A stuck "Disconnecting…" would read as a disconnect that half-happened.
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Disconnect ahab@pequod.com" }),
+      ).toBeInTheDocument();
+    });
+
+    disconnect.mockRestore();
+  });
+
+  it("offers no disconnect for an account with no connection summary yet", () => {
+    const { wrapper } = createStoreWrapper();
+    render(
+      <AccountSectionHeader
+        accountEmail="ahab@pequod.com"
+        connection={undefined}
+      />,
+      { wrapper },
+    );
+
+    expect(
+      screen.queryByRole("button", { name: /^Disconnect/ }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/packages/web/src/components/Sidebar/CalendarList/AccountSectionHeader.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/AccountSectionHeader.tsx
@@ -1,11 +1,17 @@
-import { type FC } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { type FC, useCallback, useState } from "react";
 import { type GoogleSyncConnectionSummary } from "@core/types/user.types";
+import { AuthApi } from "@web/api/auth.api";
+import { refreshUserMetadata } from "@web/auth/compass/user/util/user-metadata.util";
 import { useConnectGoogle } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle";
 import {
   formatLastSyncedLabel,
   getGoogleSyncStatus,
 } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle.util";
+import { calendarQueryKeys } from "@web/calendars/calendar.query";
 import { type SyncStatusVariant } from "@web/calendars/sync-status.types";
+import { showErrorToast } from "@web/common/utils/toast/error-toast.util";
+import { eventQueryKeys } from "@web/events/queries/event.query.keys";
 
 // Status is conveyed as text, never colour alone, so the variant class is
 // decoration on top of a message that already says what is happening.
@@ -65,18 +71,100 @@ export const AccountSectionHeader: FC<{
       {lastSyncedLabel ? (
         <p className="text-text-muted text-xs">{lastSyncedLabel}</p>
       ) : null}
-      {isAvailable && commandAction != null && actionLabel != null ? (
-        <button
-          aria-busy={isConnecting || isRefreshing || undefined}
-          aria-label={`${actionLabel} for ${accountEmail}`}
-          className="c-focus-ring mt-1 rounded-xs px-1.5 py-0.5 text-accent text-xs hover:brightness-110 disabled:pointer-events-none disabled:opacity-60"
-          disabled={isConnecting || isRefreshing}
-          onClick={commandAction.onSelect}
-          type="button"
-        >
-          {actionLabel}
-        </button>
-      ) : null}
+      <div className="mt-1 flex flex-wrap items-center gap-1">
+        {isAvailable && commandAction != null && actionLabel != null ? (
+          <button
+            aria-busy={isConnecting || isRefreshing || undefined}
+            aria-label={`${actionLabel} for ${accountEmail}`}
+            className="c-focus-ring rounded-xs px-1.5 py-0.5 text-accent text-xs hover:brightness-110 disabled:pointer-events-none disabled:opacity-60"
+            disabled={isConnecting || isRefreshing}
+            onClick={commandAction.onSelect}
+            type="button"
+          >
+            {actionLabel}
+          </button>
+        ) : null}
+        {connection ? (
+          <DisconnectAccountAction
+            accountEmail={accountEmail}
+            connectionId={connection.id}
+          />
+        ) : null}
+      </div>
     </div>
+  );
+};
+
+/**
+ * Removes one account's calendars and events from Compass. Two-step, since it
+ * is not undoable without redoing the whole OAuth flow: the first press swaps
+ * in an explicit confirm. The user's other accounts, and their Compass
+ * sign-in, are untouched.
+ */
+const DisconnectAccountAction: FC<{
+  accountEmail: string;
+  connectionId: string;
+}> = ({ accountEmail, connectionId }) => {
+  const queryClient = useQueryClient();
+  const [isConfirming, setIsConfirming] = useState(false);
+  const [isDisconnecting, setIsDisconnecting] = useState(false);
+
+  const disconnect = useCallback(() => {
+    setIsDisconnecting(true);
+    AuthApi.disconnectGoogleConnection(connectionId)
+      .then(async () => {
+        // The account's calendars and its events both disappear, and the
+        // remaining connections are what drive the sidebar's sections.
+        await Promise.all([
+          queryClient.invalidateQueries({ queryKey: calendarQueryKeys.all }),
+          queryClient.invalidateQueries({ queryKey: eventQueryKeys.all }),
+          refreshUserMetadata({ force: true }),
+        ]);
+      })
+      .catch(() => {
+        showErrorToast(
+          `We couldn't disconnect ${accountEmail}. Please try again in a moment.`,
+        );
+      })
+      .finally(() => {
+        setIsDisconnecting(false);
+        setIsConfirming(false);
+      });
+  }, [accountEmail, connectionId, queryClient]);
+
+  if (!isConfirming) {
+    return (
+      <button
+        aria-label={`Disconnect ${accountEmail}`}
+        className="c-focus-ring rounded-xs px-1.5 py-0.5 text-text-muted text-xs hover:text-text"
+        onClick={() => setIsConfirming(true)}
+        type="button"
+      >
+        Disconnect
+      </button>
+    );
+  }
+
+  return (
+    <>
+      <button
+        aria-busy={isDisconnecting || undefined}
+        aria-label={`Confirm disconnecting ${accountEmail}`}
+        className="c-focus-ring rounded-xs px-1.5 py-0.5 text-error text-xs hover:brightness-110 disabled:pointer-events-none disabled:opacity-60"
+        disabled={isDisconnecting}
+        onClick={disconnect}
+        type="button"
+      >
+        {isDisconnecting ? "Disconnecting…" : "Confirm disconnect"}
+      </button>
+      <button
+        className="c-focus-ring rounded-xs px-1.5 py-0.5 text-text-muted text-xs hover:text-text disabled:pointer-events-none disabled:opacity-60"
+        disabled={isDisconnecting}
+        onClick={() => setIsConfirming(false)}
+        type="button"
+      >
+        Cancel
+      </button>
+    </>
   );
 };


### PR DESCRIPTION
## What

Completes the manage-accounts pair started by the add-account PR.

- **Sidebar action.** Each account section gains a Disconnect action. Disconnecting cannot be undone without redoing the whole OAuth flow, so the first press swaps in an explicit "Confirm disconnect" (with Cancel) rather than acting immediately. A failure returns to the un-confirmed state and toasts, so nothing reads as a disconnect that half-happened.
- **Backend delegation.** `DELETE /api/auth/google/connect/:connectionId` delegates to the sync service's existing per-connection disconnect, which revokes the credential at the provider. Sync scopes the operation to the signed-in principal, so a connection id the caller does not own is rejected there and never revokes anything; the backend surfaces every failure as the same opaque 503 as the other connection delegations, so the endpoint cannot be used to probe for other users' connection ids.
- **Client.** `SyncServiceClient` gained `disconnectConnection`. Sync answers 204 with an empty body, which the client previously would have read as JSON and reported as an unexpected status, so `#send` now understands a no-content route.

After a successful disconnect the calendar and event queries are invalidated and the connection list is refetched, so the section and its events disappear without a reload. The user's other accounts, and their Compass sign-in, are untouched.

## Still open: the login-identity guard

The plan also called for rejecting an account that is another Compass user's login identity. That guard has no correct home in the current architecture and is deliberately **not** in this PR:

- It cannot run at begin time, because the whole point of the account chooser is that the account is unknown until the user picks it.
- It cannot run in sync, which owns the OAuth callback: sync has no HTTP client to the backend, and is deliberately firewalled from the backend's database (`forbiddenDatabaseName`). Adding either would create a new service dependency in a direction that does not exist today.
- Detecting it post-hoc on the metadata path would put a per-connection user lookup on a hot request, and would still leave the connection briefly live.

Worth weighing against the actual risk: completing OAuth requires controlling the target Google account, so the realistic case is one person with two Compass accounts. The exposure is identity confusion, not access to someone else's data. Happy to build whichever option you prefer.

## Tests

- Client: signed DELETE to the per-connection path, 204 treated as success, verifier accepts the signature and sees the caller's own principal; a 404 reports failure.
- Sidebar: first press only asks; confirming disconnects that connection id; Cancel backs out without calling; a failed disconnect returns to the un-confirmed state; an account with no connection summary yet offers no disconnect.
- Full backend (325) and web (1623) suites green; `bun run type-check` and biome clean.

## Verification

Disconnecting a real second account end to end, and confirming the other account's calendars and events survive it, is part of the staging soak before this reaches production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)