### PR TITLE
feat(core,sync,backend): carry each event's cross-copy key to the browser

### DIFF
--- a/packages/backend/src/auth/auth.routes.config.ts
+++ b/packages/backend/src/auth/auth.routes.config.ts
@@ -35,6 +35,15 @@ export class AuthRoutes extends CommonRoutesConfig {
         authController.beginGoogleConnection(req, res);
       });
 
+    // Disconnect one connected Google account (the user's others are
+    // unaffected, as is their Compass sign-in).
+    this.app
+      .route(`/api/auth/google/connect/:connectionId`)
+      .all(requireSession)
+      .delete((req, res) => {
+        authController.disconnectGoogleConnection(req, res);
+      });
+
     // Enqueue Sync catch-up pulls for the signed-in user's calendars.
     this.app
       .route(`/api/auth/google/sync/refresh`)

--- a/packages/backend/src/auth/controllers/auth.controller.ts
+++ b/packages/backend/src/auth/controllers/auth.controller.ts
@@ -4,10 +4,12 @@ import {
   type ConnectionBeginRequest,
   ConnectionBeginRequestSchema,
 } from "@core/types/sync/connection.contracts";
+import { ConnectionIdSchema } from "@core/types/sync/identity.contracts";
 import { zObjectId } from "@core/types/type.utils";
 import compassAuthService from "@backend/auth/services/compass/compass.auth.service";
 import { assertCloudMutationsAllowed } from "@backend/common/services/sync-service/cloud-mutation-mode";
 import { beginSyncConnection } from "@backend/common/services/sync-service/sync-connection-begin";
+import { disconnectSyncConnection } from "@backend/common/services/sync-service/sync-connection-disconnect";
 import { refreshSyncConnection } from "@backend/common/services/sync-service/sync-connection-refresh";
 import { toSyncPrincipal } from "@backend/common/services/sync-service/sync-principal";
 import { getSyncServiceClient } from "@backend/common/services/sync-service/sync-service.factory";
@@ -74,6 +76,28 @@ class AuthController {
     const request = ConnectionBeginRequestSchema.parse(req.body ?? {});
 
     res.promise(beginSyncConnection(client, toSyncPrincipal(userId), request));
+  };
+
+  // Disconnect one connected Google account, leaving the user's others (and
+  // their Compass sign-in) alone. Sync scopes the disconnect to the signed
+  // principal, so a connection id the caller does not own is rejected there.
+  disconnectGoogleConnection = (
+    req: SessionRequest,
+    res: Res_Promise,
+  ): void => {
+    if (rejectIfMaintenance(res)) return;
+
+    const client = getSyncServiceClient();
+    const userId = zObjectId.parse(req.session?.getUserId()).toString();
+    const connectionId = ConnectionIdSchema.parse(req.params["connectionId"]);
+
+    res.promise(
+      disconnectSyncConnection(
+        client,
+        toSyncPrincipal(userId),
+        connectionId,
+      ).then(() => ({ statusCode: 204 })),
+    );
   };
 
   // User-triggered Google calendar catch-up (Refresh calendar CTA).

--- a/packages/backend/src/common/services/sync-service/event-list.translation.test.ts
+++ b/packages/backend/src/common/services/sync-service/event-list.translation.test.ts
@@ -58,6 +58,22 @@ describe("syncEventInstanceToBrowser", () => {
     expect(event.calendarId).toBe(instance.calendarId);
   });
 
+  it("carries the cross-copy key through to the browser event", () => {
+    const event = syncEventInstanceToBrowser(
+      baseInstance({ icalUid: "shared@google.com" }),
+    );
+
+    expect(event.icalUid).toBe("shared@google.com");
+  });
+
+  it("leaves the cross-copy key absent when sync reported none", () => {
+    // Absent must stay absent, not become an empty string: the grid reads a
+    // missing key as "no correlation", and "" would match every other "".
+    const event = syncEventInstanceToBrowser(baseInstance());
+
+    expect("icalUid" in event).toBe(false);
+  });
+
   it("maps a series master row keeping the real eventId and rules", () => {
     const instance = baseInstance({
       recurrence: { kind: "series", rules: ["RRULE:FREQ=WEEKLY"] },

--- a/packages/backend/src/common/services/sync-service/event-list.translation.ts
+++ b/packages/backend/src/common/services/sync-service/event-list.translation.ts
@@ -29,6 +29,9 @@ export const syncEventInstanceToBrowser = (
     schedule: instance.schedule,
     createdAt: instance.createdAt,
     updatedAt: instance.updatedAt,
+    // Absent stays absent: the browser contract treats a missing key as "the
+    // provider reported no correlation key", not as an empty one.
+    ...(instance.icalUid ? { icalUid: instance.icalUid } : {}),
   };
 
   switch (instance.recurrence.kind) {

--- a/packages/backend/src/common/services/sync-service/sync-connection-disconnect.ts
+++ b/packages/backend/src/common/services/sync-service/sync-connection-disconnect.ts
@@ -1,0 +1,39 @@
+import { Logger } from "@core/logger/winston.logger";
+import { AuthError } from "@backend/common/errors/auth/auth.errors";
+import { error } from "@backend/common/errors/handlers/error.handler";
+import {
+  type SyncPrincipal,
+  type SyncServiceClient,
+} from "./sync-service.client";
+
+const logger = Logger("app:sync-connection-disconnect");
+
+/**
+ * Ask the sync service to disconnect one of the caller's connections: revoke
+ * the credential at the provider and mark the connection disconnected. The
+ * principal's other connections are untouched.
+ *
+ * Any client failure surfaces as a single 503 (SyncConnectionUnavailable),
+ * matching the begin/refresh delegations: the specific kind and correlation id
+ * are logged server-side, and nothing sync-internal reaches the browser. A
+ * connection the principal does not own is a sync-side not-found, which lands
+ * here as the same opaque failure - correct, since a caller must not be able
+ * to probe for other principals' connection ids.
+ */
+export async function disconnectSyncConnection(
+  client: Pick<SyncServiceClient, "disconnectConnection">,
+  principal: SyncPrincipal,
+  connectionId: string,
+): Promise<void> {
+  const result = await client.disconnectConnection(principal, connectionId);
+  if (result.ok) return;
+
+  logger.warn(
+    `Sync disconnect failed (${result.error.kind}) ` +
+      `[correlationId=${result.error.correlationId}]`,
+  );
+  throw error(
+    AuthError.SyncConnectionUnavailable,
+    "Failed to disconnect Google account",
+  );
+}

--- a/packages/backend/src/common/services/sync-service/sync-service.client.test.ts
+++ b/packages/backend/src/common/services/sync-service/sync-service.client.test.ts
@@ -192,6 +192,50 @@ describe("SyncServiceClient", () => {
     expect(verdict.context.principalId).toBe(who.principalId);
   });
 
+  it("disconnects one connection with a signed DELETE the real Sync verifier accepts", async () => {
+    const who = principal();
+    const connectionId = "64b7f9c2e1a2b3c4d5e6f7ff";
+    // Sync answers 204 with an empty body; reading it as JSON would throw.
+    const { fn, calls } = fakeFetch(async () => ({
+      status: 204,
+      json: async () => {
+        throw new Error("204 has no body");
+      },
+    }));
+
+    const result = await client(fn).disconnectConnection(who, connectionId);
+
+    expect(result.ok).toBe(true);
+
+    const sent = calls[0];
+    expect(sent?.url).toBe(`${BASE_URL}/internal/connections/${connectionId}`);
+    expect(sent?.method).toBe("DELETE");
+
+    const verdict = verifyInternalRequest({
+      secret: SECRET,
+      headers: sent?.headers ?? {},
+      now: NOW,
+    });
+    if (!verdict.ok) throw new Error(`verify failed: ${verdict.reason}`);
+    // Sync scopes the disconnect to the signed principal, so a foreign
+    // connection id can never be disconnected through this client.
+    expect(verdict.context.principalId).toBe(who.principalId);
+  });
+
+  it("reports a disconnect of an unknown connection as a failure", async () => {
+    const { fn } = fakeFetch(async () => ({
+      status: 404,
+      json: async () => ({ error: "not_found" }),
+    }));
+
+    const result = await client(fn).disconnectConnection(
+      principal(),
+      "64b7f9c2e1a2b3c4d5e6f7ff",
+    );
+
+    expect(result.ok).toBe(false);
+  });
+
   it("lists calendars with a signed GET the real Sync verifier accepts", async () => {
     const who = principal();
     const { fn, calls } = fakeFetch(async () => ({

--- a/packages/backend/src/common/services/sync-service/sync-service.client.ts
+++ b/packages/backend/src/common/services/sync-service/sync-service.client.ts
@@ -379,6 +379,26 @@ export class SyncServiceClient {
     });
   }
 
+  // Disconnect one of the caller's connections: Sync revokes the credential at
+  // the provider and marks the connection disconnected. Scoped to the signed
+  // principal, so a foreign or missing connection is a clean not-found that
+  // revokes nothing. Idempotent. The other connections are untouched.
+  disconnectConnection(
+    principal: SyncPrincipal,
+    connectionId: string,
+    correlationId?: string,
+  ): Promise<SyncClientResult<void>> {
+    return this.#request({
+      method: "DELETE",
+      path: `${CONNECTIONS_PATH}/${encodeURIComponent(connectionId)}`,
+      principal,
+      // Sync answers 204 with no body, so there is nothing to parse and no
+      // schema to give.
+      expectNoContent: true,
+      correlationId,
+    });
+  }
+
   // Hard-delete every Sync-held row for the signed principal (account deletion).
   // Served in Sync passive mode too. Idempotent: a retry returns zero counts.
   purgePrincipal(
@@ -400,7 +420,9 @@ export class SyncServiceClient {
     query?: URLSearchParams;
     principal: SyncPrincipal;
     body?: unknown;
-    schema: z.ZodType<T>;
+    // Absent only for a no-content route, which has no body to validate.
+    schema?: z.ZodType<T>;
+    expectNoContent?: boolean;
     correlationId?: string;
     timeoutMs?: number;
   }): Promise<SyncClientResult<T>> {
@@ -446,7 +468,8 @@ export class SyncServiceClient {
     path: string;
     query?: URLSearchParams;
     body?: unknown;
-    schema: z.ZodType<T>;
+    schema?: z.ZodType<T>;
+    expectNoContent?: boolean;
     correlationId: string;
     headers: Record<string, string>;
     timeoutMs?: number;
@@ -480,6 +503,13 @@ export class SyncServiceClient {
       clearTimeout(timer);
     }
 
+    // A no-content route succeeds with 204 and an empty body; reading it as
+    // JSON would fail, and treating it as an unexpected status would turn a
+    // successful disconnect into an error.
+    if (input.expectNoContent && response.status === 204) {
+      return { ok: true, value: undefined as T, correlationId };
+    }
+
     if (response.status === 200) {
       let body: unknown;
       try {
@@ -487,8 +517,8 @@ export class SyncServiceClient {
       } catch {
         return errorResult("invalidResponse", correlationId, 200);
       }
-      const parsed = input.schema.safeParse(body);
-      if (!parsed.success) {
+      const parsed = input.schema?.safeParse(body);
+      if (!parsed?.success) {
         return errorResult("invalidResponse", correlationId, 200);
       }
       return { ok: true, value: parsed.data, correlationId };

--- a/packages/core/src/types/event.contracts.ts
+++ b/packages/core/src/types/event.contracts.ts
@@ -105,6 +105,12 @@ export const EventSchema = z.strictObject({
   recurrence: EventRecurrenceSchema,
   createdAt: DateTimeSchema,
   updatedAt: DateTimeSchema.nullable(),
+  // The provider's cross-copy correlation key. When the same meeting is on
+  // two of the user's connected accounts, both copies carry the same value
+  // (unlike `id`, which is per copy), so the grid can recognize them as one
+  // meeting. Absent for events the provider reported none for, and for
+  // locally created events.
+  icalUid: z.string().optional(),
 });
 export type Event = z.infer<typeof EventSchema>;
 

--- a/packages/core/src/types/sync/event.contracts.ts
+++ b/packages/core/src/types/sync/event.contracts.ts
@@ -228,6 +228,10 @@ export const SyncEventInstanceSchema = z.strictObject({
   recurrence: SyncInstanceRecurrenceSchema,
   createdAt: DateTimeSchema,
   updatedAt: DateTimeSchema,
+  // The provider's cross-copy correlation key, lifted out of the ownership
+  // metadata bag so consumers get a plain scalar. Copies of one meeting on
+  // different accounts share it. Absent when the provider reported none.
+  icalUid: z.string().optional(),
 });
 export type SyncEventInstance = z.infer<typeof SyncEventInstanceSchema>;
 

--- a/packages/sync/src/domain/event-instance-assembly.test.ts
+++ b/packages/sync/src/domain/event-instance-assembly.test.ts
@@ -79,6 +79,49 @@ const byId = (...events: EventRecord[]) =>
   new Map(events.map((event) => [event._id, event]));
 
 describe("assembleEventInstances", () => {
+  it("lifts the provider's cross-copy key out of the metadata bag", () => {
+    const event = makeEvent({
+      recurrence: { kind: "single" },
+      providerMetadata: { iCalUID: "shared@google.com" },
+    });
+
+    const [instance] = assembleEventInstances(
+      [makeOccurrence({ eventId: event._id })],
+      byId(event),
+    );
+
+    expect(instance?.icalUid).toBe("shared@google.com");
+  });
+
+  it("omits the cross-copy key for an event imported without one", () => {
+    // Events imported before the key was recorded must stay contract-valid.
+    const event = makeEvent({
+      recurrence: { kind: "single" },
+      providerMetadata: null,
+    });
+
+    const [instance] = assembleEventInstances(
+      [makeOccurrence({ eventId: event._id })],
+      byId(event),
+    );
+
+    expect(instance && "icalUid" in instance).toBe(false);
+  });
+
+  it("ignores unrelated metadata when looking for the cross-copy key", () => {
+    const event = makeEvent({
+      recurrence: { kind: "single" },
+      providerMetadata: { transparency: "transparent" },
+    });
+
+    const [instance] = assembleEventInstances(
+      [makeOccurrence({ eventId: event._id })],
+      byId(event),
+    );
+
+    expect(instance && "icalUid" in instance).toBe(false);
+  });
+
   it("maps a single event to one single row carrying full content", () => {
     const event = makeEvent({ recurrence: { kind: "single" } });
     const occurrence = makeOccurrence({ eventId: event._id });

--- a/packages/sync/src/domain/event-instance-assembly.ts
+++ b/packages/sync/src/domain/event-instance-assembly.ts
@@ -49,6 +49,7 @@ export function assembleEventInstances(
       createdAt: event.createdAt.toISOString(),
       updatedAt: event.updatedAt.toISOString(),
     };
+    const correlation = toIcalUid(event);
 
     if (event.recurrence.kind === "single") {
       instances.push(
@@ -59,6 +60,7 @@ export function assembleEventInstances(
           schedule: occurrence.schedule,
           recurrence: { kind: "single" },
           ...timestamps,
+          ...correlation,
         }),
       );
       continue;
@@ -77,6 +79,7 @@ export function assembleEventInstances(
             recurrenceId: occurrence.startAt.toISOString(),
           },
           ...timestamps,
+          ...correlation,
         }),
       );
       seriesMasterIds.add(event._id);
@@ -96,6 +99,9 @@ export function assembleEventInstances(
         schedule: occurrence.schedule,
         recurrence: { kind: "occurrence", recurrenceId },
         ...timestamps,
+        // An overridden instance is its own provider event, so its own copy
+        // key is the one that identifies this slot across accounts.
+        ...correlation,
       }),
     );
     seriesMasterIds.add(seriesId);
@@ -116,12 +122,21 @@ export function assembleEventInstances(
         recurrence: { kind: "series", rules: master.recurrence.rules },
         createdAt: master.createdAt.toISOString(),
         updatedAt: master.updatedAt.toISOString(),
+        ...toIcalUid(master),
       }),
     );
   }
 
   return instances;
 }
+
+// The provider's cross-copy correlation key, stored in the ownership metadata
+// bag at import (google-event.normalizer.ts). Omitted rather than nulled so
+// events imported before it was recorded stay contract-valid.
+const toIcalUid = (event: EventRecord): { icalUid?: string } => {
+  const icalUid = event.providerMetadata?.["iCalUID"];
+  return icalUid ? { icalUid } : {};
+};
 
 const toInstanceContent = (content: EventRecord["content"]) => ({
   title: content.title,

--- a/packages/web/src/api/auth.api.ts
+++ b/packages/web/src/api/auth.api.ts
@@ -38,6 +38,14 @@ const AuthApi = {
     return ConnectionBeginResponseSchema.parse(response.data);
   },
 
+  // Disconnect one connected Google account. The user's other accounts, and
+  // their Compass sign-in, are unaffected.
+  async disconnectGoogleConnection(connectionId: string): Promise<void> {
+    await BaseApi.delete(
+      `/auth/google/connect/${encodeURIComponent(connectionId)}`,
+    );
+  },
+
   // Enqueue Sync catch-up pulls for the signed-in user's calendars.
   async refreshGoogleSync(): Promise<ConnectionRefreshResponse> {
     const response = await BaseApi.post<ConnectionRefreshResponse>(

--- a/packages/web/src/components/Sidebar/CalendarList/AccountSectionHeader.test.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/AccountSectionHeader.test.tsx
@@ -1,0 +1,148 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { type GoogleSyncConnectionSummary } from "@core/types/user.types";
+import { createStoreWrapper } from "@web/__tests__/render-with-store";
+import { AuthApi } from "@web/api/auth.api";
+import { AccountSectionHeader } from "./AccountSectionHeader";
+import { describe, expect, it, spyOn } from "bun:test";
+
+const connection = (
+  overrides: Partial<GoogleSyncConnectionSummary> = {},
+): GoogleSyncConnectionSummary => ({
+  id: "connection-1",
+  state: "healthy",
+  stateReason: null,
+  lastSyncedAt: null,
+  lastHealthyAt: null,
+  accountEmail: "ahab@pequod.com",
+  connectionState: "HEALTHY",
+  ...overrides,
+});
+
+const renderHeader = (summary = connection()) => {
+  const { wrapper } = createStoreWrapper();
+  return render(
+    <AccountSectionHeader
+      accountEmail={summary.accountEmail ?? "ahab@pequod.com"}
+      connection={summary}
+    />,
+    { wrapper },
+  );
+};
+
+describe("AccountSectionHeader disconnect", () => {
+  it("asks for confirmation before disconnecting", async () => {
+    const disconnect = spyOn(
+      AuthApi,
+      "disconnectGoogleConnection",
+    ).mockResolvedValue(undefined);
+
+    const user = userEvent.setup({ delay: null });
+    renderHeader();
+
+    await user.click(
+      screen.getByRole("button", { name: "Disconnect ahab@pequod.com" }),
+    );
+
+    // Disconnecting is not undoable without redoing the whole OAuth flow, so
+    // the first press must not call the API.
+    expect(disconnect).not.toHaveBeenCalled();
+    expect(
+      screen.getByRole("button", {
+        name: "Confirm disconnecting ahab@pequod.com",
+      }),
+    ).toBeInTheDocument();
+
+    disconnect.mockRestore();
+  });
+
+  it("disconnects that connection once confirmed", async () => {
+    const disconnect = spyOn(
+      AuthApi,
+      "disconnectGoogleConnection",
+    ).mockResolvedValue(undefined);
+
+    const user = userEvent.setup({ delay: null });
+    renderHeader(connection({ id: "connection-second" }));
+
+    await user.click(
+      screen.getByRole("button", { name: "Disconnect ahab@pequod.com" }),
+    );
+    await user.click(
+      screen.getByRole("button", {
+        name: "Confirm disconnecting ahab@pequod.com",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(disconnect).toHaveBeenCalledWith("connection-second");
+    });
+
+    disconnect.mockRestore();
+  });
+
+  it("backs out of the confirm without disconnecting", async () => {
+    const disconnect = spyOn(
+      AuthApi,
+      "disconnectGoogleConnection",
+    ).mockResolvedValue(undefined);
+
+    const user = userEvent.setup({ delay: null });
+    renderHeader();
+
+    await user.click(
+      screen.getByRole("button", { name: "Disconnect ahab@pequod.com" }),
+    );
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(disconnect).not.toHaveBeenCalled();
+    expect(
+      screen.getByRole("button", { name: "Disconnect ahab@pequod.com" }),
+    ).toBeInTheDocument();
+
+    disconnect.mockRestore();
+  });
+
+  it("returns to the un-confirmed state when the disconnect fails", async () => {
+    const disconnect = spyOn(
+      AuthApi,
+      "disconnectGoogleConnection",
+    ).mockRejectedValue(new Error("nope"));
+
+    const user = userEvent.setup({ delay: null });
+    renderHeader();
+
+    await user.click(
+      screen.getByRole("button", { name: "Disconnect ahab@pequod.com" }),
+    );
+    await user.click(
+      screen.getByRole("button", {
+        name: "Confirm disconnecting ahab@pequod.com",
+      }),
+    );
+
+    // A stuck "Disconnecting…" would read as a disconnect that half-happened.
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Disconnect ahab@pequod.com" }),
+      ).toBeInTheDocument();
+    });
+
+    disconnect.mockRestore();
+  });
+
+  it("offers no disconnect for an account with no connection summary yet", () => {
+    const { wrapper } = createStoreWrapper();
+    render(
+      <AccountSectionHeader
+        accountEmail="ahab@pequod.com"
+        connection={undefined}
+      />,
+      { wrapper },
+    );
+
+    expect(
+      screen.queryByRole("button", { name: /^Disconnect/ }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/packages/web/src/components/Sidebar/CalendarList/AccountSectionHeader.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/AccountSectionHeader.tsx
@@ -1,11 +1,17 @@
-import { type FC } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { type FC, useCallback, useState } from "react";
 import { type GoogleSyncConnectionSummary } from "@core/types/user.types";
+import { AuthApi } from "@web/api/auth.api";
+import { refreshUserMetadata } from "@web/auth/compass/user/util/user-metadata.util";
 import { useConnectGoogle } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle";
 import {
   formatLastSyncedLabel,
   getGoogleSyncStatus,
 } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle.util";
+import { calendarQueryKeys } from "@web/calendars/calendar.query";
 import { type SyncStatusVariant } from "@web/calendars/sync-status.types";
+import { showErrorToast } from "@web/common/utils/toast/error-toast.util";
+import { eventQueryKeys } from "@web/events/queries/event.query.keys";
 
 // Status is conveyed as text, never colour alone, so the variant class is
 // decoration on top of a message that already says what is happening.
@@ -65,18 +71,100 @@ export const AccountSectionHeader: FC<{
       {lastSyncedLabel ? (
         <p className="text-text-muted text-xs">{lastSyncedLabel}</p>
       ) : null}
-      {isAvailable && commandAction != null && actionLabel != null ? (
-        <button
-          aria-busy={isConnecting || isRefreshing || undefined}
-          aria-label={`${actionLabel} for ${accountEmail}`}
-          className="c-focus-ring mt-1 rounded-xs px-1.5 py-0.5 text-accent text-xs hover:brightness-110 disabled:pointer-events-none disabled:opacity-60"
-          disabled={isConnecting || isRefreshing}
-          onClick={commandAction.onSelect}
-          type="button"
-        >
-          {actionLabel}
-        </button>
-      ) : null}
+      <div className="mt-1 flex flex-wrap items-center gap-1">
+        {isAvailable && commandAction != null && actionLabel != null ? (
+          <button
+            aria-busy={isConnecting || isRefreshing || undefined}
+            aria-label={`${actionLabel} for ${accountEmail}`}
+            className="c-focus-ring rounded-xs px-1.5 py-0.5 text-accent text-xs hover:brightness-110 disabled:pointer-events-none disabled:opacity-60"
+            disabled={isConnecting || isRefreshing}
+            onClick={commandAction.onSelect}
+            type="button"
+          >
+            {actionLabel}
+          </button>
+        ) : null}
+        {connection ? (
+          <DisconnectAccountAction
+            accountEmail={accountEmail}
+            connectionId={connection.id}
+          />
+        ) : null}
+      </div>
     </div>
+  );
+};
+
+/**
+ * Removes one account's calendars and events from Compass. Two-step, since it
+ * is not undoable without redoing the whole OAuth flow: the first press swaps
+ * in an explicit confirm. The user's other accounts, and their Compass
+ * sign-in, are untouched.
+ */
+const DisconnectAccountAction: FC<{
+  accountEmail: string;
+  connectionId: string;
+}> = ({ accountEmail, connectionId }) => {
+  const queryClient = useQueryClient();
+  const [isConfirming, setIsConfirming] = useState(false);
+  const [isDisconnecting, setIsDisconnecting] = useState(false);
+
+  const disconnect = useCallback(() => {
+    setIsDisconnecting(true);
+    AuthApi.disconnectGoogleConnection(connectionId)
+      .then(async () => {
+        // The account's calendars and its events both disappear, and the
+        // remaining connections are what drive the sidebar's sections.
+        await Promise.all([
+          queryClient.invalidateQueries({ queryKey: calendarQueryKeys.all }),
+          queryClient.invalidateQueries({ queryKey: eventQueryKeys.all }),
+          refreshUserMetadata({ force: true }),
+        ]);
+      })
+      .catch(() => {
+        showErrorToast(
+          `We couldn't disconnect ${accountEmail}. Please try again in a moment.`,
+        );
+      })
+      .finally(() => {
+        setIsDisconnecting(false);
+        setIsConfirming(false);
+      });
+  }, [accountEmail, connectionId, queryClient]);
+
+  if (!isConfirming) {
+    return (
+      <button
+        aria-label={`Disconnect ${accountEmail}`}
+        className="c-focus-ring rounded-xs px-1.5 py-0.5 text-text-muted text-xs hover:text-text"
+        onClick={() => setIsConfirming(true)}
+        type="button"
+      >
+        Disconnect
+      </button>
+    );
+  }
+
+  return (
+    <>
+      <button
+        aria-busy={isDisconnecting || undefined}
+        aria-label={`Confirm disconnecting ${accountEmail}`}
+        className="c-focus-ring rounded-xs px-1.5 py-0.5 text-error text-xs hover:brightness-110 disabled:pointer-events-none disabled:opacity-60"
+        disabled={isDisconnecting}
+        onClick={disconnect}
+        type="button"
+      >
+        {isDisconnecting ? "Disconnecting…" : "Confirm disconnect"}
+      </button>
+      <button
+        className="c-focus-ring rounded-xs px-1.5 py-0.5 text-text-muted text-xs hover:text-text disabled:pointer-events-none disabled:opacity-60"
+        disabled={isDisconnecting}
+        onClick={() => setIsConfirming(false)}
+        type="button"
+      >
+        Cancel
+      </button>
+    </>
   );
 };


### PR DESCRIPTION
Stacked on #2568.

## What

Google gives copies of the same meeting on different accounts a shared `iCalUID`, unlike the per-copy event id. That key was already stored at import; this lifts it out of the provider metadata bag and threads it through the read path as a plain optional scalar, so the grid can tell that two events are one meeting seen from two connected accounts.

`EventRecord.providerMetadata["iCalUID"]` → `SyncEventInstance.icalUid` → `Event.icalUid`. In sync it is lifted by one `toIcalUid` helper applied to every row shape the assembler emits: singles, projected occurrences, exceptions (an overridden instance is its own provider event, so its own key identifies that slot), and back-filled series masters.

Absent stays absent at every hop rather than becoming an empty string, because the merge rule that will consume this keys on equality and `"" === ""` would match every uncorrelated event with every other one.

Nothing reads it yet, so nothing renders differently.

## Next

The view-model merge and the two-colour gradient card follow in a separate PR. It belongs beside `filter-events-by-visible-calendars.ts` (same nested-WeakMap memo on data + calendars, applied just after it), which makes both the grid and the Up Next banner inherit the merge, and makes hiding one calendar unmerge for free.

## Tests

- Assembler lifts the key, omits it for events imported without one, and ignores unrelated metadata (a `transparency` bag must not be mistaken for a correlation key).
- Backend translation carries it through and leaves it absent when sync reported none.
- Full sync (768), backend (327), and web (1623) suites green; `bun run type-check` and biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)