### PR TITLE
feat(scripts): add backfill-icaluid CLI to correlate pre-MA1 events

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -92,7 +92,9 @@
       "version": "1.0.0",
       "dependencies": {
         "@compass/core": "1.0.0",
+        "@googleapis/calendar": "^14.1.0",
         "commander": "^10.0.0",
+        "google-auth-library": "^10.6.2",
         "yaml": "^2.9.0",
       },
       "devDependencies": {

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -7,7 +7,9 @@
   "private": true,
   "dependencies": {
     "@compass/core": "1.0.0",
+    "@googleapis/calendar": "^14.1.0",
     "commander": "^10.0.0",
+    "google-auth-library": "^10.6.2",
     "yaml": "^2.9.0"
   },
   "devDependencies": {

--- a/packages/scripts/src/cli.ts
+++ b/packages/scripts/src/cli.ts
@@ -1,4 +1,5 @@
 import { CliValidator } from "@scripts/cli.validator";
+import { runBackfillIcalUid } from "@scripts/commands/backfill-icaluid";
 import { runManageFailedJobs } from "@scripts/commands/manage-failed-jobs";
 import { runPurgeCorruptSyncEvents } from "@scripts/commands/purge-corrupt-sync-events";
 import { runPurgeUser } from "@scripts/commands/purge-user";
@@ -34,6 +35,9 @@ export default class CompassCLI {
         break;
       case cmd === "repair-recurring-series":
         await runRepairRecurringSeries();
+        break;
+      case cmd === "backfill-icaluid":
+        await runBackfillIcalUid();
         break;
       default:
         this.validator.exitHelpfully(`${cmd as string} is not a supported cmd`);
@@ -75,6 +79,14 @@ export default class CompassCLI {
       .allowUnknownOption(true)
       .description(
         "Re-derive every provider connection's stored state from live evidence (--apply to write)",
+      );
+
+    program
+      .command("backfill-icaluid")
+      .helpOption(false)
+      .allowUnknownOption(true)
+      .description(
+        "Copy Google's cross-copy correlation key onto events that predate it (--apply to write)",
       );
 
     program

--- a/packages/scripts/src/commands/backfill-icaluid.ts
+++ b/packages/scripts/src/commands/backfill-icaluid.ts
@@ -1,0 +1,140 @@
+import { calendar } from "@googleapis/calendar";
+import {
+  type BackfillDeps,
+  backfillIcalUid,
+} from "@scripts/commands/backfill-icaluid/backfill";
+import { OAuth2Client } from "google-auth-library";
+import { loadCompassConfig } from "@core/config/compass.config";
+import { Logger } from "@core/logger/winston.logger";
+import { CredentialCustody } from "@sync/credentials/credential-custody.service";
+import { GoogleAuthAdapter } from "@sync/providers/google/google-auth.adapter";
+import { GOOGLE_REQUEST_TIMEOUT_MS } from "@sync/providers/google/google-http.constants";
+import { CredentialRepository } from "@sync/storage/repositories/credential.repository";
+import { SyncMongoService } from "@sync/storage/sync-mongo.service";
+
+const logger = Logger("scripts.commands.backfill-icaluid");
+
+function syncMongoUri(): string {
+  const fromEnv = process.env["SYNC_MONGO_URI"]?.trim();
+  if (fromEnv) return fromEnv;
+  const uri = loadCompassConfig().sync?.mongoUri?.trim();
+  if (!uri) {
+    throw new Error(
+      "Set SYNC_MONGO_URI or add sync.mongoUri to compass.yaml before backfill-icaluid",
+    );
+  }
+  return uri;
+}
+
+function googleClientCredentials(): { clientId: string; clientSecret: string } {
+  let clientId = process.env["GOOGLE_CLIENT_ID"]?.trim();
+  let clientSecret = process.env["GOOGLE_CLIENT_SECRET"]?.trim();
+  if (!clientId || !clientSecret) {
+    const google = loadCompassConfig().google;
+    clientId ||= google?.clientId?.trim();
+    clientSecret ||= google?.clientSecret?.trim();
+  }
+  if (!clientId || !clientSecret) {
+    throw new Error(
+      "Set GOOGLE_CLIENT_ID/GOOGLE_CLIENT_SECRET or add google.clientId/clientSecret to compass.yaml before backfill-icaluid",
+    );
+  }
+  return { clientId, clientSecret };
+}
+
+function parseArgs(argv: string[]): {
+  dryRun: boolean;
+  connectionId?: string;
+} {
+  const connectionFlag = argv.indexOf("--connection");
+  const connectionId =
+    connectionFlag >= 0 ? argv[connectionFlag + 1]?.trim() : undefined;
+  if (connectionFlag >= 0 && !connectionId) {
+    throw new Error("--connection requires a connection id");
+  }
+  return {
+    dryRun: !argv.includes("--apply"),
+    ...(connectionId ? { connectionId } : {}),
+  };
+}
+
+// A fields-limited events.list: id + iCalUID only, not full payloads - two
+// orders of magnitude less bandwidth than the sync reader, and no strict
+// normalization that would drop rows this pass doesn't care about.
+const listIcalUidPage: BackfillDeps["listIcalUidPage"] = async ({
+  accessToken,
+  providerCalendarId,
+  pageToken,
+}) => {
+  const auth = new OAuth2Client();
+  auth.setCredentials({ access_token: accessToken });
+  const gcal = calendar({
+    version: "v3",
+    auth,
+    timeout: GOOGLE_REQUEST_TIMEOUT_MS,
+  });
+  const { data } = await gcal.events.list({
+    calendarId: providerCalendarId,
+    pageToken,
+    // Masters and exceptions as distinct items, matching how sync stores
+    // providerEventIds.
+    singleEvents: false,
+    showDeleted: false,
+    maxResults: 2500,
+    fields: "items(id,iCalUID),nextPageToken",
+  });
+  return {
+    items: data.items ?? [],
+    nextPageToken: data.nextPageToken ?? null,
+  };
+};
+
+/**
+ * Copy Google's cross-copy correlation key (iCalUID) onto stored sync events
+ * that predate MA1's ingest change. Default dry-run; `--apply` persists;
+ * `--connection <id>` scopes to one connection. Safe to rerun.
+ *
+ *   bun run cli backfill-icaluid [--apply] [--connection <id>]
+ */
+export async function runBackfillIcalUid(): Promise<void> {
+  const syncMongo = new SyncMongoService();
+  try {
+    const { dryRun, connectionId } = parseArgs(process.argv.slice(3));
+    const { clientId, clientSecret } = googleClientCredentials();
+
+    await syncMongo.connect({
+      uri: syncMongoUri(),
+      enforceLeastPrivilege: false,
+      forbiddenDatabaseName: "prod_calendar",
+    });
+
+    const custody = new CredentialCustody(
+      new CredentialRepository(syncMongo.db),
+      new GoogleAuthAdapter(clientId, clientSecret),
+    );
+
+    const report = await backfillIcalUid(
+      syncMongo.db,
+      {
+        getAccessToken: (id) => custody.getValidAccessToken(id),
+        listIcalUidPage,
+      },
+      { dryRun, ...(connectionId ? { connectionId } : {}) },
+    );
+
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    logger.info(
+      `backfill-icaluid dryRun=${report.dryRun} reportedByGoogle=${report.reportedByGoogle} matchedMissingIcalUid=${report.matchedMissingIcalUid} updated=${report.updated}`,
+    );
+    await syncMongo.disconnect();
+    process.exit(0);
+  } catch (error) {
+    logger.error(error);
+    try {
+      await syncMongo.disconnect();
+    } catch {
+      // ignore
+    }
+    process.exit(1);
+  }
+}

--- a/packages/scripts/src/commands/backfill-icaluid/backfill.db.test.ts
+++ b/packages/scripts/src/commands/backfill-icaluid/backfill.db.test.ts
@@ -1,0 +1,307 @@
+import {
+  type BackfillDeps,
+  backfillIcalUid,
+  type GoogleIcalUidItem,
+} from "@scripts/commands/backfill-icaluid/backfill";
+import { ObjectId } from "mongodb";
+import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
+import { ProviderAuthError } from "@sync/providers/provider-auth.port";
+import { SYNC_COLLECTIONS } from "@sync/storage/collections";
+import { type EventRecord } from "@sync/storage/contracts/event.contracts";
+import { type ProviderCalendarRecord } from "@sync/storage/contracts/provider-calendar.contracts";
+import { type ProviderConnectionRecord } from "@sync/storage/contracts/provider-connection.contracts";
+import { ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
+import { ProviderConnectionRepository } from "@sync/storage/repositories/provider-connection.repository";
+import { beforeEach, describe, expect, it } from "bun:test";
+
+const objectId = () => new ObjectId().toHexString();
+
+describe("backfillIcalUid", () => {
+  const storage = setupSyncStorage(import.meta.url);
+  let connections: ProviderConnectionRepository;
+  let calendars: ProviderCalendarRepository;
+
+  beforeEach(() => {
+    connections = new ProviderConnectionRepository(storage.db());
+    calendars = new ProviderCalendarRepository(storage.db());
+  });
+
+  async function seedConnection(): Promise<ProviderConnectionRecord> {
+    return connections.upsertByProviderAccount({
+      tenantId: objectId(),
+      principalId: objectId(),
+      provider: "google",
+      account: {
+        providerAccountId: objectId(),
+        email: "user@example.com",
+        displayName: "User",
+      },
+      capabilities: ["readEvents", "readBusy", "writeEvents"],
+      state: "healthy",
+      stateReason: null,
+      lastSyncedAt: null,
+      lastHealthyAt: null,
+    });
+  }
+
+  async function seedCalendar(
+    connection: ProviderConnectionRecord,
+  ): Promise<ProviderCalendarRecord> {
+    return calendars.upsertByProviderCalendar({
+      tenantId: connection.tenantId,
+      principalId: connection.principalId,
+      connectionId: connection._id,
+      providerCalendarId: "user@example.com",
+      displayName: "Primary",
+      color: null,
+      eventLabels: [],
+      active: true,
+      primary: true,
+      accessRole: "owner",
+      capabilities: {
+        canReadEvents: true,
+        canWriteEvents: true,
+        canReadBusy: true,
+        canInviteAttendees: true,
+      },
+    });
+  }
+
+  // Raw insert mirroring a stored event: provider-owned, its
+  // providerMetadata set as given (null is the common pre-MA1 case).
+  async function seedEvent(
+    connection: ProviderConnectionRecord,
+    calendar: ProviderCalendarRecord,
+    providerEventId: string,
+    providerMetadata: Record<string, string> | null = null,
+  ): Promise<string> {
+    const _id = objectId();
+    await storage
+      .db()
+      .collection(SYNC_COLLECTIONS.events)
+      .insertOne({
+        _id,
+        tenantId: connection.tenantId,
+        principalId: connection.principalId,
+        origin: "provider",
+        calendarId: calendar._id,
+        clientEventId: null,
+        connectionId: connection._id,
+        providerEventId,
+        providerVersion: "etag-1",
+        providerUpdatedAt: new Date("2024-01-01T00:00:00Z"),
+        deliveryState: null,
+        providerMetadata,
+        content: {
+          title: "Standup",
+          description: "",
+          location: null,
+          organizer: null,
+          attendees: [],
+          conference: null,
+        },
+        schedule: {
+          kind: "timed",
+          start: "2026-08-20T15:00:00+00:00",
+          end: "2026-08-20T15:30:00+00:00",
+          timeZone: "UTC",
+        },
+        recurrence: { kind: "single" },
+        lifecycleState: "active",
+        generation: 0,
+        createdAt: new Date("2026-07-25T00:00:00Z"),
+        updatedAt: new Date("2026-07-25T00:00:00Z"),
+        confirmedAt: null,
+      });
+    return _id;
+  }
+
+  function depsWithPages(
+    pages: GoogleIcalUidItem[][],
+    options: { failConnectionIds?: string[] } = {},
+  ): BackfillDeps {
+    let call = 0;
+    return {
+      getAccessToken: (connectionId) => {
+        if (options.failConnectionIds?.includes(connectionId)) {
+          return Promise.reject(
+            new ProviderAuthError("missingRefreshToken", "no credential"),
+          );
+        }
+        return Promise.resolve("token");
+      },
+      listIcalUidPage: () => {
+        const items = pages[call] ?? [];
+        call += 1;
+        return Promise.resolve({
+          items,
+          nextPageToken: call < pages.length ? `page-${call}` : null,
+        });
+      },
+    };
+  }
+
+  const findEvent = async (id: string) =>
+    (await storage
+      .db()
+      .collection(SYNC_COLLECTIONS.events)
+      .findOne({ _id: id })) as unknown as EventRecord;
+
+  it("sets iCalUID on a row whose providerMetadata is null, across pages", async () => {
+    // null is the field's common value (the default when there is nothing
+    // else to record) - the dotted-path trap this backfill exists to avoid.
+    const connection = await seedConnection();
+    const calendar = await seedCalendar(connection);
+    const eventId = await seedEvent(connection, calendar, "ev-1", null);
+
+    const report = await backfillIcalUid(
+      storage.db(),
+      depsWithPages([[{ id: "ev-1", iCalUID: "shared@google.com" }]]),
+      { dryRun: false },
+    );
+
+    expect(report.reportedByGoogle).toBe(1);
+    expect(report.updated).toBe(1);
+    expect((await findEvent(eventId)).providerMetadata).toEqual({
+      iCalUID: "shared@google.com",
+    });
+  });
+
+  it("merges into existing providerMetadata rather than overwriting it", async () => {
+    const connection = await seedConnection();
+    const calendar = await seedCalendar(connection);
+    const eventId = await seedEvent(connection, calendar, "ev-1", {
+      transparency: "transparent",
+    });
+
+    await backfillIcalUid(
+      storage.db(),
+      depsWithPages([[{ id: "ev-1", iCalUID: "shared@google.com" }]]),
+      { dryRun: false },
+    );
+
+    expect((await findEvent(eventId)).providerMetadata).toEqual({
+      transparency: "transparent",
+      iCalUID: "shared@google.com",
+    });
+  });
+
+  it("never touches an event that already carries the key", async () => {
+    const connection = await seedConnection();
+    const calendar = await seedCalendar(connection);
+    const eventId = await seedEvent(connection, calendar, "ev-1", {
+      iCalUID: "already-set@google.com",
+    });
+
+    const report = await backfillIcalUid(
+      storage.db(),
+      depsWithPages([[{ id: "ev-1", iCalUID: "different@google.com" }]]),
+      { dryRun: false },
+    );
+
+    expect(report.matchedMissingIcalUid).toBe(0);
+    expect(report.updated).toBe(0);
+    expect((await findEvent(eventId)).providerMetadata).toEqual({
+      iCalUID: "already-set@google.com",
+    });
+  });
+
+  it("writes nothing for events Google reports no iCalUID for", async () => {
+    const connection = await seedConnection();
+    const calendar = await seedCalendar(connection);
+    const eventId = await seedEvent(connection, calendar, "ev-1", null);
+
+    const report = await backfillIcalUid(
+      storage.db(),
+      depsWithPages([[{ id: "ev-1" }]]),
+      { dryRun: false },
+    );
+
+    expect(report.googleEventsSeen).toBe(1);
+    expect(report.reportedByGoogle).toBe(0);
+    expect(report.updated).toBe(0);
+    expect((await findEvent(eventId)).providerMetadata).toBeNull();
+  });
+
+  it("dry-run reports matches without persisting; rerun after apply is a no-op", async () => {
+    const connection = await seedConnection();
+    const calendar = await seedCalendar(connection);
+    const eventId = await seedEvent(connection, calendar, "ev-1", null);
+    const pages = () =>
+      depsWithPages([[{ id: "ev-1", iCalUID: "shared@google.com" }]]);
+
+    const dry = await backfillIcalUid(storage.db(), pages(), {
+      dryRun: true,
+    });
+    expect(dry.matchedMissingIcalUid).toBe(1);
+    expect(dry.updated).toBe(0);
+    expect(dry.samples).toEqual([
+      {
+        connectionId: connection._id,
+        calendarId: calendar._id,
+        providerEventId: "ev-1",
+        icalUid: "shared@google.com",
+      },
+    ]);
+    expect((await findEvent(eventId)).providerMetadata).toBeNull();
+
+    const applied = await backfillIcalUid(storage.db(), pages(), {
+      dryRun: false,
+    });
+    expect(applied.updated).toBe(1);
+    expect((await findEvent(eventId)).providerMetadata).toEqual({
+      iCalUID: "shared@google.com",
+    });
+
+    const rerun = await backfillIcalUid(storage.db(), pages(), {
+      dryRun: false,
+    });
+    expect(rerun.matchedMissingIcalUid).toBe(0);
+    expect(rerun.updated).toBe(0);
+  });
+
+  it("skips a credential-less connection and still processes the rest", async () => {
+    const doomed = await seedConnection();
+    await seedCalendar(doomed);
+    const healthy = await seedConnection();
+    const healthyCalendar = await seedCalendar(healthy);
+    const eventId = await seedEvent(healthy, healthyCalendar, "ev-1", null);
+
+    const report = await backfillIcalUid(
+      storage.db(),
+      depsWithPages([[{ id: "ev-1", iCalUID: "shared@google.com" }]], {
+        failConnectionIds: [doomed._id],
+      }),
+      { dryRun: false },
+    );
+
+    expect(report.connections).toBe(2);
+    expect(report.connectionsSkipped).toBe(1);
+    expect(report.updated).toBe(1);
+    expect((await findEvent(eventId)).providerMetadata).toEqual({
+      iCalUID: "shared@google.com",
+    });
+  });
+
+  it("scopes to one connection when --connection is given", async () => {
+    const target = await seedConnection();
+    const targetCalendar = await seedCalendar(target);
+    const targetEventId = await seedEvent(target, targetCalendar, "ev-1", null);
+    const other = await seedConnection();
+    const otherCalendar = await seedCalendar(other);
+    const otherEventId = await seedEvent(other, otherCalendar, "ev-1", null);
+
+    const report = await backfillIcalUid(
+      storage.db(),
+      depsWithPages([[{ id: "ev-1", iCalUID: "shared@google.com" }]]),
+      { dryRun: false, connectionId: target._id },
+    );
+
+    expect(report.connections).toBe(1);
+    expect(report.updated).toBe(1);
+    expect((await findEvent(targetEventId)).providerMetadata).toEqual({
+      iCalUID: "shared@google.com",
+    });
+    expect((await findEvent(otherEventId)).providerMetadata).toBeNull();
+  });
+});

--- a/packages/scripts/src/commands/backfill-icaluid/backfill.ts
+++ b/packages/scripts/src/commands/backfill-icaluid/backfill.ts
@@ -1,0 +1,247 @@
+import { type AnyBulkWriteOperation, type Db } from "mongodb";
+import { Logger } from "@core/logger/winston.logger";
+import {
+  type ConnectionId,
+  type ProviderEventId,
+} from "@core/types/sync/identity.contracts";
+import { ProviderAuthError } from "@sync/providers/provider-auth.port";
+import { SYNC_COLLECTIONS } from "@sync/storage/collections";
+import { type EventRecord } from "@sync/storage/contracts/event.contracts";
+import { ProviderConnectionRecordSchema } from "@sync/storage/contracts/provider-connection.contracts";
+import { ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
+
+const logger = Logger("scripts.commands.backfill-icaluid");
+
+export type BackfillIcalUidReport = {
+  generatedAt: string;
+  dryRun: boolean;
+  connections: number;
+  connectionsSkipped: number;
+  calendars: number;
+  calendarsFailed: number;
+  googleEventsSeen: number;
+  reportedByGoogle: number;
+  matchedMissingIcalUid: number;
+  updated: number;
+  samples: Array<{
+    connectionId: string;
+    calendarId: string;
+    providerEventId: string;
+    icalUid: string;
+  }>;
+};
+
+// The only two Google fields the backfill reads per event, plus the id to
+// match stored rows by.
+export interface GoogleIcalUidItem {
+  readonly id?: string | null;
+  readonly iCalUID?: string | null;
+}
+
+// Injected I/O so tests can script pages and tokens without network access.
+export interface BackfillDeps {
+  getAccessToken(connectionId: ConnectionId): Promise<string>;
+  listIcalUidPage(input: {
+    accessToken: string;
+    providerCalendarId: string;
+    pageToken?: string;
+  }): Promise<{
+    items: readonly GoogleIcalUidItem[];
+    nextPageToken: string | null;
+  }>;
+}
+
+/**
+ * Copy Google's cross-copy correlation key (iCalUID) onto stored sync events
+ * that predate MA1 (the normalizer only started mapping it once that slice
+ * landed, and the preseed migration never carried it at all). Without this,
+ * the same meeting on two connected accounts never merges into one card if
+ * either copy predates the ingest change.
+ *
+ * Walks every readable Google calendar with a fields-limited events.list and
+ * sets `providerMetadata.iCalUID` on stored events that lack it, leaving
+ * every other providerMetadata fact (e.g. `transparency`) untouched.
+ * Idempotent; safe to rerun.
+ *
+ * `providerMetadata` is a nullable field (null is the common case - the
+ * "nothing to record" default), so a dotted-path `$set` on
+ * "providerMetadata.iCalUID" would throw for every null row ("cannot create
+ * field ... in element {providerMetadata: null}"). Each write instead reads
+ * the row's current providerMetadata and replaces the WHOLE field with the
+ * merged object, which is safe whether the prior value was null, absent, or
+ * an object.
+ */
+export async function backfillIcalUid(
+  db: Db,
+  deps: BackfillDeps,
+  options: { dryRun: boolean; connectionId?: string },
+): Promise<BackfillIcalUidReport> {
+  const calendars = new ProviderCalendarRepository(db);
+  const events = db.collection<EventRecord>(SYNC_COLLECTIONS.events);
+
+  const report: BackfillIcalUidReport = {
+    generatedAt: new Date().toISOString(),
+    dryRun: options.dryRun,
+    connections: 0,
+    connectionsSkipped: 0,
+    calendars: 0,
+    calendarsFailed: 0,
+    googleEventsSeen: 0,
+    reportedByGoogle: 0,
+    matchedMissingIcalUid: 0,
+    updated: 0,
+    samples: [],
+  };
+
+  const connectionFilter: Record<string, unknown> = {
+    provider: "google",
+    disconnectedAt: null,
+  };
+  if (options.connectionId) connectionFilter["_id"] = options.connectionId;
+
+  const cursor = db
+    .collection(SYNC_COLLECTIONS.providerConnections)
+    .find(connectionFilter);
+
+  for await (const doc of cursor) {
+    const connection = ProviderConnectionRecordSchema.parse(doc);
+    report.connections += 1;
+
+    let accessToken: string;
+    try {
+      accessToken = await deps.getAccessToken(connection._id);
+    } catch (error) {
+      if (error instanceof ProviderAuthError) {
+        logger.warn(
+          `Skipping connection ${connection._id}: ${error.reason ?? error.message}`,
+        );
+        report.connectionsSkipped += 1;
+        continue;
+      }
+      throw error;
+    }
+
+    const connectionCalendars = await calendars.listByConnection(
+      connection.tenantId,
+      connection.principalId,
+      connection._id,
+    );
+
+    for (const calendar of connectionCalendars) {
+      if (!calendar.active || !calendar.capabilities.canReadEvents) continue;
+      report.calendars += 1;
+
+      try {
+        let pageToken: string | undefined;
+
+        do {
+          const page = await deps.listIcalUidPage({
+            accessToken,
+            providerCalendarId: calendar.providerCalendarId,
+            pageToken,
+          });
+          report.googleEventsSeen += page.items.length;
+
+          const icalUidById = new Map<string, string>();
+          for (const item of page.items) {
+            if (!item.id || !item.iCalUID) continue;
+            icalUidById.set(item.id, item.iCalUID);
+          }
+          report.reportedByGoogle += icalUidById.size;
+
+          if (icalUidById.size > 0) {
+            // Scope guard: only rows missing the key, so an already-backfilled
+            // or already-synced row is never re-written. This existence check
+            // matches whether providerMetadata is absent, null, or an object
+            // without the key - all three read as "not set" via a dotted path.
+            const missing = await events
+              .find(
+                {
+                  connectionId: connection._id,
+                  calendarId: calendar._id,
+                  providerEventId: {
+                    $in: [...icalUidById.keys()] as ProviderEventId[],
+                  },
+                  "providerMetadata.iCalUID": { $exists: false },
+                },
+                {
+                  projection: { providerEventId: 1, providerMetadata: 1 },
+                },
+              )
+              .toArray();
+            report.matchedMissingIcalUid += missing.length;
+
+            for (const match of missing) {
+              if (
+                report.samples.length >= 20 ||
+                !match.providerEventId ||
+                !icalUidById.has(match.providerEventId)
+              ) {
+                continue;
+              }
+              report.samples.push({
+                connectionId: connection._id,
+                calendarId: calendar._id,
+                providerEventId: match.providerEventId,
+                icalUid: icalUidById.get(match.providerEventId) as string,
+              });
+            }
+
+            if (!options.dryRun && missing.length > 0) {
+              const now = new Date();
+              const writes: AnyBulkWriteOperation<EventRecord>[] = missing
+                .filter(
+                  (
+                    match,
+                  ): match is typeof match & { providerEventId: string } =>
+                    match.providerEventId !== null &&
+                    icalUidById.has(match.providerEventId),
+                )
+                .map((match) => {
+                  const icalUid = icalUidById.get(
+                    match.providerEventId,
+                  ) as string;
+                  // Full-field replace, not a dotted $set - see the function
+                  // doc comment for why.
+                  const mergedProviderMetadata = {
+                    ...(match.providerMetadata ?? {}),
+                    iCalUID: icalUid,
+                  };
+                  return {
+                    updateOne: {
+                      filter: {
+                        _id: match._id,
+                        "providerMetadata.iCalUID": { $exists: false },
+                      },
+                      update: {
+                        $set: {
+                          providerMetadata: mergedProviderMetadata,
+                          updatedAt: now,
+                        },
+                      },
+                    },
+                  };
+                });
+              if (writes.length > 0) {
+                const result = await events.bulkWrite(writes);
+                report.updated += result.modifiedCount;
+              }
+            }
+          }
+
+          pageToken = page.nextPageToken ?? undefined;
+        } while (pageToken);
+      } catch (error) {
+        // Rerunnable by design: log the calendar and keep going rather than
+        // failing the fleet pass.
+        report.calendarsFailed += 1;
+        logger.error(
+          `Backfill failed for calendar ${calendar._id} (connection ${connection._id})`,
+          error,
+        );
+      }
+    }
+  }
+
+  return report;
+}


### PR DESCRIPTION
## What

Events synced before MA1's ingest change never stored Google's `iCalUID` (the preseed migration never carried it either), so `mergeCrossAccountDuplicates` (#2570) cannot recognize them as the same meeting on two accounts. This adds `bun run cli backfill-icaluid`, mirroring the shape of the (unmerged, closed) event-color backfill: default dry-run, `--apply` to persist, `--connection <id>` to scope one connection, idempotent.

## The null-traversal trap

`providerMetadata` is a nullable field, and `null` is its common value (the "nothing to record" default), not an edge case. A dotted-path `$set` on `providerMetadata.iCalUID` throws for every null row ("cannot create field ... in element {providerMetadata: null}"). Each write instead reads the row's current `providerMetadata` in the same query that finds it missing the key, and replaces the *whole* field with the merged object - safe whether the prior value was null, absent, or an object with other facts (e.g. `transparency`) already on it.

## Prod execution

**Not run against prod.** That needs prod credentials, and this environment's permission classifier correctly blocks a session from using them directly. Once merged, the runbook is the same shape as the color backfill: scoped dry-run against one connection, scoped apply, fleet dry-run, fleet apply, rerun to confirm `matchedMissingIcalUid: 0`.

Related, surfaced while researching this: PR #2509 (the analogous event-color backfill) was closed by Tyler on 2026-07-31 without merging, and it's unclear whether he ran it manually from the branch or abandoned it - worth confirming prod's actual color-backfill state before assuming either way.

## Tests

Null-providerMetadata row gets the key; merges alongside an existing `transparency` fact rather than overwriting it; a row that already carries the key is never touched; a Google item with no `iCalUID` writes nothing; dry-run reports without persisting and a rerun after apply is a no-op; a credential-less connection is skipped without stopping the rest; `--connection` scoping. Full scripts suite (31 tests) green; `bun run type-check` and biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)