### PR TITLE
feat(web): paint a two-color gradient accent on merged cross-account cards

### DIFF
--- a/packages/scripts/src/cli.ts
+++ b/packages/scripts/src/cli.ts
@@ -1,4 +1,5 @@
 import { CliValidator } from "@scripts/cli.validator";
+import { runAuditConnectionIdentity } from "@scripts/commands/audit-connection-identity";
 import { runBackfillIcalUid } from "@scripts/commands/backfill-icaluid";
 import { runManageFailedJobs } from "@scripts/commands/manage-failed-jobs";
 import { runPurgeCorruptSyncEvents } from "@scripts/commands/purge-corrupt-sync-events";
@@ -38,6 +39,9 @@ export default class CompassCLI {
         break;
       case cmd === "backfill-icaluid":
         await runBackfillIcalUid();
+        break;
+      case cmd === "audit-connection-identity":
+        await runAuditConnectionIdentity();
         break;
       default:
         this.validator.exitHelpfully(`${cmd as string} is not a supported cmd`);
@@ -87,6 +91,14 @@ export default class CompassCLI {
       .allowUnknownOption(true)
       .description(
         "Copy Google's cross-copy correlation key onto events that predate it (--apply to write)",
+      );
+
+    program
+      .command("audit-connection-identity")
+      .helpOption(false)
+      .allowUnknownOption(true)
+      .description(
+        "Report connected Google accounts that are another Compass user's login identity (read-only)",
       );
 
     program

--- a/packages/scripts/src/commands/audit-connection-identity.ts
+++ b/packages/scripts/src/commands/audit-connection-identity.ts
@@ -1,0 +1,65 @@
+import { auditConnectionIdentity } from "@scripts/commands/audit-connection-identity/audit";
+import { loadCompassConfig } from "@core/config/compass.config";
+import { Logger } from "@core/logger/winston.logger";
+import mongoService from "@backend/common/services/mongo.service";
+import { SyncMongoService } from "@sync/storage/sync-mongo.service";
+
+const logger = Logger("scripts.commands.audit-connection-identity");
+
+function syncMongoUri(): string {
+  const fromEnv = process.env["SYNC_MONGO_URI"]?.trim();
+  if (fromEnv) return fromEnv;
+  const uri = loadCompassConfig().sync?.mongoUri?.trim();
+  if (!uri) {
+    throw new Error(
+      "Set SYNC_MONGO_URI or add sync.mongoUri to compass.yaml before audit-connection-identity",
+    );
+  }
+  return uri;
+}
+
+/**
+ * Reports any connected Google account that is actually another Compass
+ * user's sign-in identity - added accounts are meant to be data-only (A2),
+ * so this should normally report zero. Read-only; safe to run anytime,
+ * including on a schedule.
+ *
+ *   bun run cli audit-connection-identity
+ */
+export async function runAuditConnectionIdentity(): Promise<void> {
+  const syncMongo = new SyncMongoService();
+  try {
+    await mongoService.start();
+    await syncMongo.connect({
+      uri: syncMongoUri(),
+      enforceLeastPrivilege: false,
+      forbiddenDatabaseName: "prod_calendar",
+    });
+
+    const report = await auditConnectionIdentity(mongoService.db, syncMongo.db);
+
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    if (report.collisions.length > 0) {
+      logger.warn(
+        `audit-connection-identity found ${report.collisions.length} collision(s) ` +
+          `out of ${report.connectionsChecked} connections checked`,
+      );
+    } else {
+      logger.info(
+        `audit-connection-identity clean: ${report.connectionsChecked} connections checked, 0 collisions`,
+      );
+    }
+
+    await syncMongo.disconnect();
+    await mongoService.stop();
+    process.exit(0);
+  } catch (error) {
+    logger.error(error);
+    try {
+      await syncMongo.disconnect();
+    } catch {
+      // ignore
+    }
+    process.exit(1);
+  }
+}

--- a/packages/scripts/src/commands/audit-connection-identity/audit.db.test.ts
+++ b/packages/scripts/src/commands/audit-connection-identity/audit.db.test.ts
@@ -1,0 +1,132 @@
+import { auditConnectionIdentity } from "@scripts/commands/audit-connection-identity/audit";
+import { ObjectId } from "mongodb";
+import {
+  cleanupCollections,
+  cleanupTestDb,
+  setupTestDb,
+} from "@backend/__tests__/helpers/mock.db.setup";
+import mongoService from "@backend/common/services/mongo.service";
+import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
+import { ProviderConnectionRepository } from "@sync/storage/repositories/provider-connection.repository";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
+
+describe("auditConnectionIdentity (db)", () => {
+  const syncStorage = setupSyncStorage(import.meta.url);
+  let connections: ProviderConnectionRepository;
+
+  beforeAll(() => setupTestDb(import.meta.url));
+  afterEach(async () => {
+    await cleanupCollections();
+    await mongoService.user.deleteMany({});
+  });
+  afterAll(cleanupTestDb);
+
+  const run = () => auditConnectionIdentity(mongoService.db, syncStorage.db());
+
+  const seedLoginUser = async (
+    email: string,
+    googleId: string,
+  ): Promise<string> => {
+    const userId = new ObjectId();
+    await mongoService.user.insertOne({
+      _id: userId,
+      email,
+      name: email,
+      firstName: email,
+      lastName: "",
+      locale: "not provided",
+      google: { googleId, picture: "", gRefreshToken: "refresh-token" },
+    });
+    return userId.toHexString();
+  };
+
+  const seedConnection = async (
+    principalId: string,
+    providerAccountId: string,
+    email: string,
+  ) => {
+    connections = new ProviderConnectionRepository(syncStorage.db());
+    return connections.upsertByProviderAccount({
+      tenantId: principalId,
+      principalId,
+      provider: "google",
+      account: { providerAccountId, email, displayName: null },
+      capabilities: ["readEvents", "readBusy", "writeEvents"],
+      state: "healthy",
+      stateReason: null,
+      lastSyncedAt: null,
+      lastHealthyAt: null,
+    });
+  };
+
+  it("reports zero collisions when every connection is its own owner's login", async () => {
+    const userId = await seedLoginUser("ahab@pequod.com", "google-sub-1");
+    await seedConnection(userId, "google-sub-1", "ahab@pequod.com");
+    // A second, data-only account with no matching login anywhere.
+    await seedConnection(userId, "google-sub-2", "ahab@gmail.com");
+
+    const report = await run();
+
+    expect(report.connectionsChecked).toBe(2);
+    expect(report.collisions).toEqual([]);
+  });
+
+  it("flags a connection whose account is another Compass user's login identity", async () => {
+    const victim = await seedLoginUser("victim@example.com", "google-sub-1");
+    const attacker = await seedLoginUser(
+      "attacker@example.com",
+      "google-sub-2",
+    );
+    await seedConnection(attacker, "google-sub-1", "victim@example.com");
+
+    const report = await run();
+
+    expect(report.collisions).toEqual([
+      {
+        connectingUserId: attacker,
+        connectionId: expect.any(String),
+        accountEmail: "victim@example.com",
+        loginOwnerUserId: victim,
+        loginOwnerEmail: "victim@example.com",
+      },
+    ]);
+  });
+
+  it("matches by the stable providerAccountId, not the mutable email", async () => {
+    // Two different Google accounts that happen to share a display email (a
+    // real re-registration pattern) must not false-positive against each
+    // other; only the sub id is ownership proof.
+    const owner = await seedLoginUser("shared@example.com", "google-sub-1");
+    const other = await seedLoginUser("other@example.com", "google-sub-2");
+    await seedConnection(other, "google-sub-2", "shared@example.com");
+
+    const report = await run();
+
+    expect(report.collisions).toEqual([]);
+    // Confirms the fixture actually shares an email, so this is testing the
+    // right thing and not accidentally trivial.
+    expect(owner).not.toBe(other);
+  });
+
+  it("ignores a Compass user connecting their own login account a second time", async () => {
+    const userId = await seedLoginUser("ahab@pequod.com", "google-sub-1");
+    // Reconnect / re-add flows resume the SAME connection id in practice, but
+    // even a hypothetical duplicate row for one's own account is not a
+    // collision under A2.
+    await seedConnection(userId, "google-sub-1", "ahab@pequod.com");
+
+    const report = await run();
+
+    expect(report.collisions).toEqual([]);
+  });
+
+  it("ignores connections for a Google account with no Compass login at all", async () => {
+    const userId = await seedLoginUser("ahab@pequod.com", "google-sub-1");
+    await seedConnection(userId, "google-sub-unregistered", "second@gmail.com");
+
+    const report = await run();
+
+    expect(report.usersWithGoogleLogin).toBe(1);
+    expect(report.collisions).toEqual([]);
+  });
+});

--- a/packages/scripts/src/commands/audit-connection-identity/audit.ts
+++ b/packages/scripts/src/commands/audit-connection-identity/audit.ts
@@ -1,0 +1,97 @@
+import { type Db } from "mongodb";
+import { Collections } from "@backend/common/constants/collections";
+import { SYNC_COLLECTIONS } from "@sync/storage/collections";
+
+export type ConnectionIdentityCollision = {
+  // The Compass user who added the connection (data-only, per A2).
+  connectingUserId: string;
+  connectionId: string;
+  // The connected Google account.
+  accountEmail: string | null;
+  // The Compass user whose SIGN-IN identity that Google account is.
+  loginOwnerUserId: string;
+  loginOwnerEmail: string;
+};
+
+export type ConnectionIdentityAuditReport = {
+  generatedAt: string;
+  usersWithGoogleLogin: number;
+  connectionsChecked: number;
+  collisions: ConnectionIdentityCollision[];
+};
+
+interface UserGoogleLoginDoc {
+  _id: unknown;
+  email: string;
+  google?: { googleId?: string };
+}
+
+interface ConnectionDoc {
+  _id: unknown;
+  principalId: string;
+  account: { providerAccountId: string; email: string | null };
+}
+
+/**
+ * Read-only: finds every connected Google account that is actually another
+ * Compass user's SIGN-IN identity - the collision A2 says a connect attempt
+ * should reject going forward, and this reports for anything that already
+ * slipped through (there was a window before that guard existed, and any
+ * future regression in it).
+ *
+ * Never writes. Matches by `providerAccountId` (Google's stable subject id),
+ * never email - email is mutable display data on both sides
+ * (ProviderAccountFactsSchema's own doc comment), so an email match alone
+ * would be a false positive whenever two different Google accounts have ever
+ * shared an address (a common re-registration pattern), and a false negative
+ * whenever the same account's email changed.
+ */
+export async function auditConnectionIdentity(
+  compassDb: Db,
+  syncDb: Db,
+): Promise<ConnectionIdentityAuditReport> {
+  const loginByGoogleId = new Map<string, { userId: string; email: string }>();
+  const users = compassDb
+    .collection<UserGoogleLoginDoc>(Collections.USER)
+    .find({ "google.googleId": { $exists: true } });
+  for await (const user of users) {
+    const googleId = user.google?.googleId;
+    if (!googleId) continue;
+    loginByGoogleId.set(googleId, {
+      userId: String(user._id),
+      email: user.email,
+    });
+  }
+
+  const collisions: ConnectionIdentityCollision[] = [];
+  let connectionsChecked = 0;
+
+  const connections = syncDb
+    .collection<ConnectionDoc>(SYNC_COLLECTIONS.providerConnections)
+    .find({ provider: "google", disconnectedAt: null });
+  for await (const connection of connections) {
+    connectionsChecked += 1;
+    const loginOwner = loginByGoogleId.get(
+      connection.account.providerAccountId,
+    );
+    if (!loginOwner) continue;
+    // Reconnecting/re-adding your OWN login account as a data connection is
+    // not a collision - A2 only forbids using someone ELSE's login identity.
+    if (loginOwner.userId === connection.principalId) continue;
+
+    collisions.push({
+      connectingUserId: connection.principalId,
+      connectionId: String(connection._id),
+      accountEmail: connection.account.email,
+      loginOwnerUserId: loginOwner.userId,
+      loginOwnerEmail: loginOwner.email,
+    });
+  }
+
+  return {
+    generatedAt: new Date().toISOString(),
+    usersWithGoogleLogin: loginByGoogleId.size,
+    connectionsChecked,
+    collisions,
+  };
+}

--- a/packages/web/src/calendars/useCalendarLookup.test.ts
+++ b/packages/web/src/calendars/useCalendarLookup.test.ts
@@ -1,0 +1,143 @@
+import {
+  type Calendar,
+  getCalendarCapabilities,
+} from "@core/types/calendar.contracts";
+import { CalendarIdSchema } from "@core/types/domain-primitives";
+import { createObjectIdString } from "@web/common/utils/id/object-id.util";
+import {
+  buildCalendarLookup,
+  calendarAccentAccessibleSuffix,
+  calendarAccentStyle,
+  findCrossAccountDuplicate,
+  resolveCalendarCardIdentity,
+} from "./useCalendarLookup";
+import { describe, expect, it } from "bun:test";
+
+const calendar = (overrides: Partial<Calendar> = {}): Calendar => ({
+  id: CalendarIdSchema.parse(createObjectIdString()),
+  name: "Work",
+  description: "",
+  timeZone: null,
+  foregroundColor: "#000000",
+  backgroundColor: "#3b82f6",
+  provider: "google",
+  access: "owner",
+  capabilities: getCalendarCapabilities("owner"),
+  isPrimary: false,
+  isVisible: true,
+  isActive: true,
+  ...overrides,
+});
+
+describe("resolveCalendarCardIdentity", () => {
+  it("returns null with only one calendar (nothing to distinguish)", () => {
+    const solo = calendar();
+    const lookup = buildCalendarLookup([solo]);
+
+    expect(resolveCalendarCardIdentity(lookup, solo.id)).toBeNull();
+  });
+
+  it("returns the calendar's name and color with two or more calendars", () => {
+    const work = calendar({ name: "Work", backgroundColor: "#3b82f6" });
+    const personal = calendar({ name: "Personal" });
+    const lookup = buildCalendarLookup([work, personal]);
+
+    expect(resolveCalendarCardIdentity(lookup, work.id)).toEqual({
+      name: "Work",
+      backgroundColor: "#3b82f6",
+    });
+  });
+
+  it("carries the cross-account duplicate through when given one", () => {
+    const work = calendar({ name: "Work" });
+    const personal = calendar({ name: "Personal" });
+    const lookup = buildCalendarLookup([work, personal]);
+    const duplicate = {
+      accountEmail: "ahab@gmail.com",
+      backgroundColor: "#ef4444",
+    };
+
+    expect(resolveCalendarCardIdentity(lookup, work.id, duplicate)).toEqual({
+      name: "Work",
+      backgroundColor: work.backgroundColor,
+      otherAccount: duplicate,
+    });
+  });
+
+  it("returns null for a calendarId not in the lookup", () => {
+    const work = calendar();
+    const personal = calendar();
+    const lookup = buildCalendarLookup([work, personal]);
+    const missing = CalendarIdSchema.parse(createObjectIdString());
+
+    expect(resolveCalendarCardIdentity(lookup, missing)).toBeNull();
+  });
+});
+
+describe("findCrossAccountDuplicate", () => {
+  it("returns undefined when duplicates or the event id are absent", () => {
+    expect(findCrossAccountDuplicate(undefined, "ev-1")).toBeUndefined();
+    expect(findCrossAccountDuplicate(new Map(), undefined)).toBeUndefined();
+  });
+
+  it("returns the entry for the given event id", () => {
+    const duplicate = {
+      accountEmail: "ahab@gmail.com",
+      backgroundColor: "#ef4444",
+    };
+    const duplicates = new Map([["ev-1", duplicate]]);
+
+    expect(findCrossAccountDuplicate(duplicates, "ev-1")).toBe(duplicate);
+    expect(findCrossAccountDuplicate(duplicates, "ev-2")).toBeUndefined();
+  });
+});
+
+describe("calendarAccentStyle", () => {
+  it("is a flat fill for an ordinary card", () => {
+    expect(
+      calendarAccentStyle({ name: "Work", backgroundColor: "#3b82f6" }),
+    ).toEqual({ backgroundColor: "#3b82f6" });
+  });
+
+  it("is a two-stop gradient into the other account's color for a merged card", () => {
+    const style = calendarAccentStyle({
+      name: "Work",
+      backgroundColor: "#3b82f6",
+      otherAccount: {
+        accountEmail: "ahab@gmail.com",
+        backgroundColor: "#ef4444",
+      },
+    });
+
+    expect(style).toEqual({
+      backgroundImage: "linear-gradient(to bottom, #3b82f6, #ef4444)",
+    });
+    // A flat fill and a gradient must never both apply - the gradient would
+    // render underneath an opaque solid color and never be visible.
+    expect(style).not.toHaveProperty("backgroundColor");
+  });
+});
+
+describe("calendarAccentAccessibleSuffix", () => {
+  it("names only the calendar for an ordinary card", () => {
+    expect(
+      calendarAccentAccessibleSuffix({
+        name: "Work",
+        backgroundColor: "#3b82f6",
+      }),
+    ).toBe(", Work calendar");
+  });
+
+  it("names the other account too for a merged card", () => {
+    expect(
+      calendarAccentAccessibleSuffix({
+        name: "Work",
+        backgroundColor: "#3b82f6",
+        otherAccount: {
+          accountEmail: "ahab@gmail.com",
+          backgroundColor: "#ef4444",
+        },
+      }),
+    ).toBe(", Work calendar, also on ahab@gmail.com");
+  });
+});

--- a/packages/web/src/calendars/useCalendarLookup.ts
+++ b/packages/web/src/calendars/useCalendarLookup.ts
@@ -1,6 +1,10 @@
 import { type Calendar } from "@core/types/calendar.contracts";
 import { type CalendarId } from "@core/types/domain-primitives";
 import { useCalendarsQuery } from "@web/calendars/calendar.query";
+import {
+  type CrossAccountDuplicate,
+  type CrossAccountDuplicates,
+} from "@web/events/queries/merge-cross-account-duplicates";
 
 const EMPTY_CALENDAR_LOOKUP: ReadonlyMap<CalendarId, Calendar> = new Map();
 
@@ -58,6 +62,15 @@ export function useCalendarLookup(): ReadonlyMap<CalendarId, Calendar> {
 export type CalendarCardIdentity = {
   name: string;
   backgroundColor: string;
+  /**
+   * Set when this card is standing in for a meeting that also exists on
+   * another connected account (mergeCrossAccountDuplicates). The accent
+   * becomes a two-color gradient of this calendar's color and the other
+   * account's, and the accessible label names the other account - the merge
+   * is otherwise invisible (A5), so this is the only surviving signal that a
+   * second copy exists.
+   */
+  otherAccount?: CrossAccountDuplicate;
 };
 
 /**
@@ -67,17 +80,69 @@ export type CalendarCardIdentity = {
  * active calendar - a single-calendar account's cards gain nothing from
  * either the accent or a redundant name suffix, since every card would say
  * the same thing.
+ *
+ * `duplicate` is looked up by the caller (keyed by event id) and passed in
+ * rather than looked up here, since a card's merge status is a property of
+ * the specific event instance, not of its calendar.
  */
 export function resolveCalendarCardIdentity(
   lookup: ReadonlyMap<CalendarId, Calendar>,
   calendarId: CalendarId | null | undefined,
+  duplicate?: CrossAccountDuplicate,
 ): CalendarCardIdentity | null {
   if (!calendarId || lookup.size <= 1) return null;
 
   const calendar = lookup.get(calendarId);
-  return calendar
-    ? { name: calendar.name, backgroundColor: calendar.backgroundColor }
-    : null;
+  if (!calendar) return null;
+
+  return {
+    name: calendar.name,
+    backgroundColor: calendar.backgroundColor,
+    ...(duplicate ? { otherAccount: duplicate } : {}),
+  };
+}
+
+/** Looks up a card's cross-account duplicate info by event id, or undefined. */
+export function findCrossAccountDuplicate(
+  duplicates: CrossAccountDuplicates | undefined,
+  eventId: string | undefined,
+): CrossAccountDuplicate | undefined {
+  if (!duplicates || !eventId) return undefined;
+  return duplicates.get(eventId);
+}
+
+/**
+ * The accent fill for a card's identity strip: this calendar's color, or a
+ * top-to-bottom two-stop gradient into the other account's color when the
+ * card is standing in for a cross-account duplicate (A5). Shared by
+ * TimedEventCard and AllDayEventCard so the gradient direction/shape can't
+ * drift between the two.
+ */
+export function calendarAccentStyle(identity: CalendarCardIdentity): {
+  backgroundColor?: string;
+  backgroundImage?: string;
+} {
+  if (identity.otherAccount) {
+    return {
+      backgroundImage: `linear-gradient(to bottom, ${identity.backgroundColor}, ${identity.otherAccount.backgroundColor})`,
+    };
+  }
+  return { backgroundColor: identity.backgroundColor };
+}
+
+/**
+ * The accessible-label suffix for a card's calendar identity, naming the
+ * other account when this card is a cross-account duplicate merge - the
+ * gradient accent is otherwise the only visual sign a second copy exists, and
+ * accent color alone is never how identity is conveyed (A9).
+ */
+export function calendarAccentAccessibleSuffix(
+  identity: CalendarCardIdentity,
+): string {
+  const calendarSuffix = `, ${identity.name} calendar`;
+  return identity.otherAccount
+    ? `${calendarSuffix}, also on ${identity.otherAccount.accountEmail}`
+    : calendarSuffix;
 }
 
 /**

--- a/packages/web/src/grid/components/AllDayEventCard.tsx
+++ b/packages/web/src/grid/components/AllDayEventCard.tsx
@@ -8,7 +8,11 @@ import {
 } from "react";
 import dayjs from "@core/util/date/dayjs";
 import { isRecurringEvent } from "@core/util/event/event.util";
-import { type CalendarCardIdentity } from "@web/calendars/useCalendarLookup";
+import {
+  type CalendarCardIdentity,
+  calendarAccentAccessibleSuffix,
+  calendarAccentStyle,
+} from "@web/calendars/useCalendarLookup";
 import {
   DATA_EVENT_ELEMENT_ID,
   ZIndex,
@@ -111,7 +115,7 @@ const AllDayEventCardBase = (
   // calendar signal, and the name (never color alone) is what makes it
   // accessible (A9).
   const accessibleLabel = calendarIdentity
-    ? `${baseAccessibleLabel}, ${calendarIdentity.name} calendar`
+    ? `${baseAccessibleLabel}${calendarAccentAccessibleSuffix(calendarIdentity)}`
     : baseAccessibleLabel;
 
   return (
@@ -154,7 +158,7 @@ const AllDayEventCardBase = (
         <div
           aria-hidden="true"
           className="absolute inset-y-0 left-0 w-[3px]"
-          style={{ backgroundColor: calendarIdentity.backgroundColor }}
+          style={calendarAccentStyle(calendarIdentity)}
         />
       )}
       <div

--- a/packages/web/src/grid/components/TimedEventCard.tsx
+++ b/packages/web/src/grid/components/TimedEventCard.tsx
@@ -9,7 +9,11 @@ import {
 } from "react";
 import dayjs from "@core/util/date/dayjs";
 import { isRecurringEvent } from "@core/util/event/event.util";
-import { type CalendarCardIdentity } from "@web/calendars/useCalendarLookup";
+import {
+  type CalendarCardIdentity,
+  calendarAccentAccessibleSuffix,
+  calendarAccentStyle,
+} from "@web/calendars/useCalendarLookup";
 import {
   DATA_EVENT_ELEMENT_ID,
   ZIndex,
@@ -238,7 +242,7 @@ const TimedEventCardBase = (
   // calendar signal, and the name (never color alone) is what makes it
   // accessible (A9).
   const accessibleLabel = calendarIdentity
-    ? `${samplePrefix}${baseAccessibleLabel}, ${calendarIdentity.name} calendar`
+    ? `${samplePrefix}${baseAccessibleLabel}${calendarAccentAccessibleSuffix(calendarIdentity)}`
     : `${samplePrefix}${baseAccessibleLabel}`;
 
   return (
@@ -288,7 +292,7 @@ const TimedEventCardBase = (
         <div
           aria-hidden="true"
           className="absolute inset-y-0 left-0 w-[3px]"
-          style={{ backgroundColor: calendarIdentity.backgroundColor }}
+          style={calendarAccentStyle(calendarIdentity)}
         />
       )}
       <div

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarEventLayers.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarEventLayers.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import {
+  findCrossAccountDuplicate,
   isGridEventInteractionReadOnly,
   resolveCalendarCardIdentity,
   useCalendarLookup,
@@ -10,6 +11,7 @@ import {
 } from "@web/common/constants/web.constants";
 import { type GridEvent } from "@web/common/types/web.event.types";
 import { type GridEventDraft } from "@web/events/event-draft.types";
+import { type CrossAccountDuplicates } from "@web/events/queries/merge-cross-account-duplicates";
 import { GRID_MARGIN_LEFT } from "@web/grid/grid.constants";
 import { createTimedEventLayout } from "@web/grid/layout/timed-deck.layout";
 import {
@@ -28,6 +30,7 @@ import {
 } from "./dayCalendarDraft.util";
 
 interface DayEventsProps {
+  crossAccountDuplicates: CrossAccountDuplicates;
   getCalendarColumnIndex: (event: GridEvent) => number;
   draft: GridEventDraft | null;
   events: GridEvent[];
@@ -37,6 +40,7 @@ interface DayEventsProps {
 }
 
 export const DayCalendarAllDayEventsLayer = ({
+  crossAccountDuplicates,
   draft,
   events: allDayEvents,
   getCalendarColumnIndex,
@@ -76,6 +80,7 @@ export const DayCalendarAllDayEventsLayer = ({
           calendarIdentity={resolveCalendarCardIdentity(
             calendarLookup,
             event.calendarId,
+            findCrossAccountDuplicate(crossAccountDuplicates, event._id),
           )}
           columnIndex={getCalendarColumnIndex(event)}
           event={event}
@@ -93,6 +98,7 @@ export const DayCalendarAllDayEventsLayer = ({
 };
 
 export const DayCalendarTimedEventsLayer = ({
+  crossAccountDuplicates,
   draft,
   events: timedEvents,
   getCalendarColumnIndex,
@@ -134,6 +140,7 @@ export const DayCalendarTimedEventsLayer = ({
           calendarIdentity={resolveCalendarCardIdentity(
             calendarLookup,
             event.calendarId,
+            findCrossAccountDuplicate(crossAccountDuplicates, event._id),
           )}
           columnIndex={getCalendarColumnIndex(event)}
           deckLayout={deckLayout}

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
@@ -69,6 +69,7 @@ export function DayCalendarGrid() {
     useDefaultTargetCalendar(calendars)?.id ?? null;
   const {
     allDayEvents,
+    crossAccountDuplicates,
     events: dayEvents,
     isError: isErrorEvents,
     isFetching,
@@ -283,6 +284,7 @@ export function DayCalendarGrid() {
   const allDayEventsLayer = useMemo(
     () => (
       <DayCalendarAllDayEventsLayer
+        crossAccountDuplicates={crossAccountDuplicates}
         events={displayedAllDayEvents}
         getCalendarColumnIndex={getCalendarColumnIndex}
         draft={gridDraft}
@@ -292,6 +294,7 @@ export function DayCalendarGrid() {
       />
     ),
     [
+      crossAccountDuplicates,
       displayedAllDayEvents,
       gridDraft,
       getCalendarColumnIndex,
@@ -310,6 +313,7 @@ export function DayCalendarGrid() {
           visibleDates={visibleDates}
         />
         <DayCalendarTimedEventsLayer
+          crossAccountDuplicates={crossAccountDuplicates}
           events={displayedTimedEvents}
           getCalendarColumnIndex={getCalendarColumnIndex}
           draft={gridDraft}
@@ -321,6 +325,7 @@ export function DayCalendarGrid() {
     ),
     [
       calendarColumnIndexById,
+      crossAccountDuplicates,
       dateInView,
       displayedTimedEvents,
       gridDraft,

--- a/packages/web/src/views/Week/components/Grid/AllDayRow/AllDayEvents.tsx
+++ b/packages/web/src/views/Week/components/Grid/AllDayRow/AllDayEvents.tsx
@@ -1,6 +1,7 @@
 import { type MouseEvent, useMemo } from "react";
 import {
   type CalendarCardIdentity,
+  findCrossAccountDuplicate,
   isGridEventInteractionReadOnly,
   resolveCalendarCardIdentity,
   useCalendarLookup,
@@ -38,6 +39,7 @@ export const AllDayEvents = ({
   const draftOverlay = useGridDraftSchemaOverlay();
   const {
     allDayEvents,
+    crossAccountDuplicates,
     events: weekEvents,
     isPending: isLoadingWeekView,
   } = useWeekEventViewModel({
@@ -73,6 +75,7 @@ export const AllDayEvents = ({
         calendarIdentity: resolveCalendarCardIdentity(
           calendarLookup,
           event.calendarId,
+          findCrossAccountDuplicate(crossAccountDuplicates, event._id),
         ),
         // Read-only (unwritable calendar or busy content) events never
         // attach interaction attributes/registration below, so the drag/
@@ -80,7 +83,7 @@ export const AllDayEvents = ({
         // optimistic state change (packet 08 step 8).
         isReadOnly: isGridEventInteractionReadOnly(calendarLookup, event),
       })),
-    [visibleAllDayEvents, calendarLookup],
+    [visibleAllDayEvents, calendarLookup, crossAccountDuplicates],
   );
 
   const { onEventKeyDown, onOpenReadOnlyDetails } =
@@ -107,6 +110,10 @@ export const AllDayEvents = ({
               ? resolveCalendarCardIdentity(
                   calendarLookup,
                   eventForDisplay.calendarId,
+                  findCrossAccountDuplicate(
+                    crossAccountDuplicates,
+                    eventForDisplay._id,
+                  ),
                 )
               : calendarIdentity;
 

--- a/packages/web/src/views/Week/components/Grid/MainGrid/MainGridEvents.tsx
+++ b/packages/web/src/views/Week/components/Grid/MainGrid/MainGridEvents.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import {
   type CalendarCardIdentity,
+  findCrossAccountDuplicate,
   isGridEventInteractionReadOnly,
   resolveCalendarCardIdentity,
   useCalendarLookup,
@@ -40,6 +41,7 @@ interface Props {
 export const MainGridEvents = ({ measurements, weekProps }: Props) => {
   const draftOverlay = useGridDraftSchemaOverlay();
   const {
+    crossAccountDuplicates,
     events: weekEvents,
     isPending: isLoadingWeekView,
     timedEvents,
@@ -94,6 +96,7 @@ export const MainGridEvents = ({ measurements, weekProps }: Props) => {
         calendarIdentity: resolveCalendarCardIdentity(
           calendarLookup,
           item.event.calendarId,
+          findCrossAccountDuplicate(crossAccountDuplicates, item.event._id),
         ),
         // Read-only (unwritable calendar or busy content) events never
         // attach interaction attributes/registration below, so the drag/
@@ -101,7 +104,7 @@ export const MainGridEvents = ({ measurements, weekProps }: Props) => {
         // optimistic state change (packet 08 step 8).
         isReadOnly: isGridEventInteractionReadOnly(calendarLookup, item.event),
       })),
-    [timedEventItems, calendarLookup],
+    [timedEventItems, calendarLookup, crossAccountDuplicates],
   );
 
   const { onEventKeyDown, onOpenReadOnlyDetails } =
@@ -124,6 +127,10 @@ export const MainGridEvents = ({ measurements, weekProps }: Props) => {
               ? resolveCalendarCardIdentity(
                   calendarLookup,
                   eventForDisplay.calendarId,
+                  findCrossAccountDuplicate(
+                    crossAccountDuplicates,
+                    eventForDisplay._id,
+                  ),
                 )
               : calendarIdentity;
 


### PR DESCRIPTION
## What

Completes MA5's cross-account duplicate merge (A5), the last cosmetic piece after the merge logic (#2570) landed.

A card standing in for a meeting on two connected accounts now shows a two-stop top-to-bottom gradient of both calendars' colors instead of a flat one, and its accessible label names the other account ("..., Work calendar, also on bob@gmail.com"). This is otherwise the only surviving signal that a second copy exists - the merge intentionally leaves no other trace: no synthetic entity, click/edit/drag/RSVP unchanged.

`resolveCalendarCardIdentity` (useCalendarLookup.ts) takes an optional `CrossAccountDuplicate`, looked up by event id via a new `findCrossAccountDuplicate` helper at each of the four card-rendering call sites (week timed, week all-day, day timed, day all-day) from the `crossAccountDuplicates` map both view-model hooks already return (#2570). Two small shared helpers, `calendarAccentStyle` and `calendarAccentAccessibleSuffix`, are used by both `TimedEventCard` and `AllDayEventCard` so the gradient direction and label format can't drift between the two.

## Tests

Pure-function coverage for the new helpers: ordinary card stays a flat fill, a merged card becomes the exact two-stop gradient (and never carries a competing flat `backgroundColor` alongside it), and the accessible-label suffix names the other account only when there is one. `resolveCalendarCardIdentity`'s existing single/multi-calendar behavior is re-pinned plus its new duplicate-carrying case. Full web suite (1643, +10 new) green; `bun run type-check` and biome clean.

## Note: unrelated pre-existing e2e flake found while verifying this

While confirming no e2e regression, I hit an intermittent failure in `calendar-experience.spec.ts`'s keyboard-selection test. Repeated local trials (5x) on this branch and independently on a disposable worktree at the commit immediately before any multi-account work (`47df43702`) showed the **same failure at the same ~20-40% rate on both** - confirmed pre-existing, unrelated to this or any of the multi-account PRs. Flagged separately for a dedicated fix; not addressed here to keep this PR's diff honest to its stated scope.

## Verification

Visual confirmation of the actual gradient rendering needs a real duplicate meeting across two connected accounts, so it's part of the same staging soak as the rest of multi-account (A12) - the local dev app can't produce cross-account `accountEmail`-differentiated calendars without a signed-in session holding two real connections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)