### PR TITLE
fix(web): eliminate the flaky keyboard-selection e2e failure

### DIFF
--- a/e2e/calendars/calendar-experience.spec.ts
+++ b/e2e/calendars/calendar-experience.spec.ts
@@ -430,8 +430,14 @@ test("a new event form offers only writable calendars and supports keyboard sele
   ).toHaveCount(0);
 
   // Keyboard flow: Down moves off the default (primary, index 0) selection,
-  // Enter commits it.
+  // Enter commits it. floating-ui applies the arrow-key move a frame later
+  // (roving tabindex), so wait for the active option to visibly change hands
+  // before committing - a human cannot type both keys inside one frame, but
+  // Playwright can, and an instant Enter would re-commit the old selection.
   await page.keyboard.press("ArrowDown");
+  await expect(
+    listbox.getByRole("option", { name: LOCAL_CALENDAR_NAME, exact: true }),
+  ).toHaveAttribute("tabindex", "0");
   await page.keyboard.press("Enter");
 
   await expect(

--- a/e2e/calendars/calendar-experience.spec.ts
+++ b/e2e/calendars/calendar-experience.spec.ts
@@ -403,9 +403,7 @@ test("day view separates visible calendars into distinct columns", async ({
   expect(readerEventBox!.width).toBeLessThanOrEqual(readerHeaderBox!.width);
 });
 
-test("a new event form offers only writable calendars and supports keyboard selection", async ({
-  page,
-}) => {
+test("a new event form offers only writable calendars", async ({ page }) => {
   await setupCalendarExperiencePage(page, []);
 
   await openTimedEventFormWithMouse(page);
@@ -429,20 +427,13 @@ test("a new event form offers only writable calendars and supports keyboard sele
     listbox.getByRole("option", { name: CALENDAR_B_NAME }),
   ).toHaveCount(0);
 
-  // Keyboard flow: Down moves off the default (primary, index 0) selection,
-  // Enter commits it. floating-ui applies the arrow-key move a frame later
-  // (roving tabindex), so wait for the active option to visibly change hands
-  // before committing - a human cannot type both keys inside one frame, but
-  // Playwright can, and an instant Enter would re-commit the old selection.
-  await page.keyboard.press("ArrowDown");
-  await expect(
-    listbox.getByRole("option", { name: LOCAL_CALENDAR_NAME, exact: true }),
-  ).toHaveAttribute("tabindex", "0");
-  await page.keyboard.press("Enter");
-
-  await expect(
-    form.getByRole("combobox", { name: "Calendar: Local" }),
-  ).toBeVisible();
+  // Deliberately NOT exercised here: committing a selection with
+  // ArrowDown+Enter. That flow was intermittently flaky under Playwright's
+  // faster-than-human key cadence (~40% across repeated isolated runs, even
+  // after hardening the component against a real trigger-Enter race and
+  // waiting for the roving tabindex to move) and was deleted rather than
+  // left flaky. Keyboard navigation + Enter/Space selection are covered
+  // deterministically in CalendarSelect.test.tsx.
 });
 
 test("a read-only event blocks a drag attempt", async ({ page }) => {

--- a/packages/web/src/components/SelectView/SelectView.tsx
+++ b/packages/web/src/components/SelectView/SelectView.tsx
@@ -122,7 +122,27 @@ export const SelectView = ({ label, onToday }: SelectViewProps) => {
       <h1 className="text-text" aria-live="polite">
         <button
           ref={refs.setReference}
-          {...getReferenceProps()}
+          {...getReferenceProps({
+            onKeyDown: (e) => {
+              // While the list is open, focus can sit on this trigger for a
+              // frame - useListNavigation moves it to the active option
+              // asynchronously - so a fast ArrowDown+Enter lands Enter here.
+              // The button's native Enter-click would then toggle the
+              // dropdown closed and LOSE the selection. Commit the active
+              // option instead, mirroring the floating element's handler.
+              if (
+                isOpen &&
+                activeIndex !== null &&
+                (e.key === "Enter" || e.key === " ")
+              ) {
+                e.preventDefault();
+                const option = options[activeIndex];
+                if (option) {
+                  selectOption(option.onSelect);
+                }
+              }
+            },
+          })}
           type="button"
           className="c-focus-ring flex cursor-pointer items-center gap-1.5 rounded px-1 text-xl transition-colors hover:bg-text/10"
           aria-expanded={isOpen}

--- a/packages/web/src/views/Forms/EventForm/CalendarSelect/CalendarSelect.tsx
+++ b/packages/web/src/views/Forms/EventForm/CalendarSelect/CalendarSelect.tsx
@@ -175,7 +175,27 @@ export const CalendarSelect = ({
       <button
         id={id}
         ref={refs.setReference}
-        {...getReferenceProps()}
+        {...getReferenceProps({
+          onKeyDown: (e) => {
+            // While the list is open, focus can sit on this trigger for a
+            // frame - useListNavigation moves it to the active option
+            // asynchronously - so a fast ArrowDown+Enter lands Enter here.
+            // The button's native Enter-click would then toggle the dropdown
+            // closed and LOSE the selection. Commit the active option
+            // instead, mirroring the floating element's own handler.
+            if (
+              isOpen &&
+              activeIndex !== null &&
+              (e.key === "Enter" || e.key === " ")
+            ) {
+              e.preventDefault();
+              const calendar = writableCalendars[activeIndex];
+              if (calendar) {
+                selectCalendar(calendar);
+              }
+            }
+          },
+        })}
         aria-expanded={isOpen}
         aria-haspopup="listbox"
         aria-controls={isOpen ? dropdownId : undefined}


### PR DESCRIPTION
## What

Investigates and resolves the intermittent (~20-40%) e2e failure flagged for follow-up after the multi-account project. Two changes, in order of confidence:

**1. A real component bug, fixed.** `useListNavigation` moves DOM focus from the trigger button into the option list *asynchronously* after the dropdown opens. A fast ArrowDown -> Enter can land Enter while focus is still on the trigger `<button>`, whose native Enter behavior synthesizes a click - which `useClick` reads as a toggle, closing the dropdown with **no selection committed**. Both `CalendarSelect` and `SelectView` (the view switcher this component's floating-ui pattern was copied from, carrying the identical latent race) now commit the active option from the trigger too, mirroring the floating element's own handler - the same dual-placement floating-ui's own Select example uses.

**2. The e2e assertion itself, deleted rather than chased further.** After the component fix, I ran the test 15x isolated + 5x full-file in a disposable worktree, repeatedly: still ~40-50% failures with no app-side error to show for it (confirmed via console/pageerror listeners - nothing). The residual race lives somewhere in floating-ui's async active-item handling under Playwright's faster-than-human key cadence, and isn't worth more investigation time. Per direct instruction ("if it's too difficult it's acceptable to simply delete the tests... what is not OK is having flaky tests slowing down development"), the ArrowDown+Enter commit assertion is removed from the e2e test. The stable, otherwise-uncovered part - the form offers only writable calendars - stays. Keyboard navigation and Enter/Space selection remain covered deterministically in `CalendarSelect.test.tsx` (jsdom, no real async focus timing).

## Verification

Final check: 12/12 clean runs of the full spec file in an isolated worktree pinned to this exact commit, after both changes landed together.

## Tests

Existing `CalendarSelect.test.tsx`/`SelectView.test.tsx` suites pass unchanged (39 tests). Full web/backend/sync/scripts suites green; `bun run type-check` and biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)