### PR TITLE
fix(web): stop showing a redundant top-level header once account sections take over

### DIFF
--- a/packages/web/src/components/Sidebar/CalendarList/CalendarList.test.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarList.test.tsx
@@ -361,6 +361,35 @@ describe("CalendarList", () => {
     ).toBeInTheDocument();
   });
 
+  it("hides the generic single-account header once account sections take over", () => {
+    // Found live on staging: the Compass login's own Google account (A7
+    // adopts it as a connection at sign-up) is always one of the sections
+    // below, so a THIRD "Calendars" header on top just repeats one section's
+    // status under a heading with no account name attached - confusing, not
+    // merely redundant.
+    const work = makeCalendar({
+      name: "Work",
+      accountEmail: "ahab@pequod.com",
+    });
+    const personal = makeCalendar({
+      name: "Personal",
+      accountEmail: "ahab@gmail.com",
+    });
+
+    renderCalendarList([work, personal], {
+      connections: [
+        makeConnection("ahab@pequod.com"),
+        makeConnection("ahab@gmail.com"),
+      ],
+    });
+
+    expect(screen.queryByText("Calendars")).not.toBeInTheDocument();
+    // The account sections' own headings are unaffected.
+    expect(
+      screen.getByRole("region", { name: "Calendars for ahab@pequod.com" }),
+    ).toBeInTheDocument();
+  });
+
   it("orders sections by connection order, not calendar order", () => {
     const gmail = makeCalendar({
       name: "Personal",

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarList.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarList.tsx
@@ -118,7 +118,15 @@ export const CalendarList: FC<Props> = ({ Header = CalendarListHeader }) => {
 
   return (
     <section aria-label="Calendars">
-      <Header />
+      {/* The generic single-account banner (email + connection status +
+          connect/reconnect) is redundant once account sections take over -
+          it always reflects the Compass login's own Google account (A7
+          adopts it as a connection at sign-up), which is always one of the
+          sections below, so showing both duplicates one section's status
+          under a second, unlabeled heading with no way to tell them apart.
+          Anonymous/no-accounts users never reach showAccountSections, so
+          this never hides the sign-up-prompt header they still need. */}
+      {!showAccountSections && <Header />}
 
       {isPending ? (
         <p className="text-text-muted text-xs">Loading calendars…</p>


### PR DESCRIPTION
## What

Found live during the first-ever multi-account staging soak (connecting two real Google accounts to one Compass user).

The sidebar showed the generic single-account banner (email + connection status + connect/reconnect action) **above** the two per-account sections, even though the banner's email is always one of the accounts below it - A7 adopts the Compass login's own Google account as a connection at sign-up, so it can never be a third identity. The result read as three overlapping status blocks: two of them showing the same account with no way to tell they were the same thing, both potentially reading "Adding your calendar…" simultaneously - which looked like something was broken even when sync was working correctly.

### Screenshot from staging (before fix)

Sidebar showed, top to bottom: a bare "compasscaltest3@gmail.com / Adding your calendar…" with no Disconnect action, then a properly-labelled "lance.essert@gmail.com" section, then a properly-labelled "compasscaltest3@gmail.com" section - the same email appearing twice with nothing distinguishing the first occurrence.

### Fix

`CalendarList.tsx` already computes `showAccountSections` before rendering `<Header />`; gating the banner on it is sufficient. The anonymous/not-yet-connected header path never reaches `showAccountSections === true`, so it's unaffected - confirmed live against the local single-account/anonymous path.

### Why this wasn't caught by existing tests

This exact interaction - the real top header rendered simultaneously with real grouped account sections - was never exercised. `CalendarList.test.tsx` always stubs `Header` when testing grouped sections (by design, to isolate what's being tested); `CalendarListHeader.test.tsx` never renders alongside sections. Component tests in isolation didn't catch this; only connecting a second real account did, which is exactly why the plan called for a staging soak before calling multi-account done.

## Tests

New: asserts the generic "Calendars" header text is absent once two accounts are grouped into sections, while the sections' own headings remain. Full web suite (1643) green; `bun run type-check` and biome clean.

## Verification

- Component test suite green (21/21 in `CalendarList.test.tsx`, including the new regression test).
- Live-checked the local single-account/anonymous path is unregressed (sidebar still shows one "Saved on this device" header, one Compass row).
- Not yet re-verified against the live two-account staging repro that surfaced this - that happens after merge + staging redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)