### PR TITLE
fix(sync): break the unwatchable-calendar bootstrap loop

### DIFF
--- a/packages/sync/src/app.ts
+++ b/packages/sync/src/app.ts
@@ -9,6 +9,7 @@ import {
 } from "@sync/auth/internal-auth";
 import { loadSyncConfig, type SyncConfig } from "@sync/config/sync.config";
 import { CredentialCustody } from "@sync/credentials/credential-custody.service";
+import { recoverStalledBootstraps } from "@sync/domain/bootstrap-recovery.service";
 import {
   CONNECTION_CACHE_RETENTION_MS,
   purgeExpiredDisconnectedConnections,
@@ -244,6 +245,7 @@ async function start(): Promise<void> {
       const sweeps = [
         ["reconcile", schedulers.reconcile],
         ["subscription", schedulers.subscription],
+        ["bootstrapRecovery", schedulers.bootstrapRecovery],
         ["failedJobRequeue", schedulers.failedJobRequeue],
         ["staleCommandRetry", schedulers.staleCommandRetry],
       ] as const;
@@ -274,6 +276,11 @@ async function start(): Promise<void> {
 const FAILED_JOB_REQUEUE_COOLDOWN_MS = 30 * 60_000;
 // A resource not synced within this window is swept for a reconcile pull.
 const RECONCILE_STALE_AFTER_MS = 15 * 60_000;
+// A resource whose bootstrap chain (importing -> watching -> catchingUp ->
+// ready) has not advanced within this window is swept for recovery. Matches
+// reconcile's window: both are "the fallback fires this long after normal
+// forward progress should have happened".
+const BOOTSTRAP_STALLED_AFTER_MS = 15 * 60_000;
 // A cloud command left nonterminal past this long since its last update is
 // eligible for a retry - long enough that a transient provider blip has
 // almost certainly cleared, short enough that "deleting" doesn't sit visibly
@@ -366,6 +373,7 @@ function buildSchedulers(
   drains: SyncScheduler[];
   reconcile: SweepScheduler;
   subscription: SweepScheduler;
+  bootstrapRecovery: SweepScheduler;
   failedJobRequeue: SweepScheduler;
   staleCommandRetry: SweepScheduler;
 } | null {
@@ -397,6 +405,7 @@ function buildSchedulers(
         // verifies them against the stored subscription.
         callbackUrl: `${config.CALLBACK_BASE_URL}${NOTIFICATIONS_PATH}`,
         invalidations: repos.invalidations,
+        log: logger,
       },
       owner,
       {
@@ -487,6 +496,38 @@ function buildSchedulers(
         logger.error("Sync subscription maintenance sweep failed", error),
     },
   );
+  // Bootstrap-recovery looks BACK, like reconcile: enqueue a bootstrapCatchup
+  // for any events resource whose bootstrap chain has gone quiet before ready.
+  const bootstrapRecovery = new SweepScheduler(
+    {
+      sweep: async (before) => {
+        const enqueued = await recoverStalledBootstraps(
+          {
+            resources,
+            jobs,
+            onEnqueueError: (error, resourceId) =>
+              logger.error(
+                `Sync bootstrap-recovery sweep could not enqueue resource ${resourceId}; skipping it and continuing`,
+                error,
+              ),
+          },
+          before,
+          () => new Date(),
+        );
+        if (enqueued > 0) {
+          logger.warn(
+            `Sync bootstrap-recovery sweep re-entered ${enqueued} stalled bootstrap(s)`,
+          );
+        }
+        return enqueued;
+      },
+    },
+    {
+      windowMs: -BOOTSTRAP_STALLED_AFTER_MS,
+      onError: (error) =>
+        logger.error("Sync bootstrap-recovery sweep failed", error),
+    },
+  );
   // Self-heal sweep: give jobs stuck in state:"failed" a fresh retry ladder
   // once they have cooled down, and loudly log any that keep re-failing past
   // the requeue cap. Looks BACK, like reconcile — a job is eligible once it
@@ -571,6 +612,7 @@ function buildSchedulers(
     drains,
     reconcile,
     subscription,
+    bootstrapRecovery,
     failedJobRequeue,
     staleCommandRetry,
   };

--- a/packages/sync/src/domain/bootstrap-recovery.service.db.test.ts
+++ b/packages/sync/src/domain/bootstrap-recovery.service.db.test.ts
@@ -1,0 +1,149 @@
+import { faker } from "@faker-js/faker";
+import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
+import { recoverStalledBootstraps } from "@sync/domain/bootstrap-recovery.service";
+import { SYNC_COLLECTIONS } from "@sync/storage/collections";
+import {
+  type ResourceBootstrapState,
+  type SyncResourceRecord,
+} from "@sync/storage/contracts/sync-resource.contracts";
+import { CredentialRepository } from "@sync/storage/repositories/credential.repository";
+import { JobRepository } from "@sync/storage/repositories/job.repository";
+import { SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
+
+const objectId = () => faker.database.mongodbObjectId();
+const now = () => new Date("2026-08-04T21:00:00.000Z");
+// Resources untouched since this instant are stalled.
+const stalledBefore = new Date("2026-08-04T20:45:00.000Z");
+
+describe("recoverStalledBootstraps", () => {
+  const storage = setupSyncStorage(import.meta.url);
+  let resources: SyncResourceRepository;
+  let jobs: JobRepository;
+  let credentials: CredentialRepository;
+
+  beforeEach(() => {
+    resources = new SyncResourceRepository(storage.db());
+    jobs = new JobRepository(storage.db());
+    credentials = new CredentialRepository(storage.db());
+  });
+
+  const deps = () => ({ resources, jobs });
+
+  // Seed an events resource in `bootstrapState`, backdated to `updatedAt` (a
+  // fresh resource defaults to "now", too recent to be stalled - pass an
+  // instant before stalledBefore to simulate one that has gone quiet). Each
+  // gets its own calendar/connection so the unique identity never collides.
+  const seedResource = async (
+    bootstrapState: ResourceBootstrapState,
+    updatedAt: Date,
+    options: { withCredential?: boolean } = {},
+  ): Promise<SyncResourceRecord> => {
+    const tenantId = objectId() as SyncResourceRecord["tenantId"];
+    const principalId = objectId() as SyncResourceRecord["principalId"];
+    const connectionId = objectId() as SyncResourceRecord["connectionId"];
+    const resource = await resources.ensure({
+      tenantId,
+      principalId,
+      connectionId,
+      resourceKind: "events",
+      calendarId: objectId() as SyncResourceRecord["calendarId"],
+    });
+    if (options.withCredential ?? true) {
+      await credentials.store({
+        connectionId,
+        provider: "google",
+        refreshToken: "refresh-token",
+        scopes: [],
+      });
+    }
+    await storage
+      .db()
+      .collection(SYNC_COLLECTIONS.syncResources)
+      .updateOne(
+        { _id: resource._id },
+        { $set: { bootstrapState, updatedAt } },
+      );
+    return { ...resource, bootstrapState, updatedAt };
+  };
+
+  const jobByKey = (coalescingKey: string) =>
+    storage.db().collection(SYNC_COLLECTIONS.jobs).findOne({ coalescingKey });
+
+  it("enqueues a bootstrapCatchup for a resource stalled mid-bootstrap", async () => {
+    const stalled = await seedResource(
+      "catchingUp",
+      new Date("2026-08-04T20:00:00.000Z"),
+    );
+
+    const enqueued = await recoverStalledBootstraps(deps(), stalledBefore, now);
+
+    expect(enqueued).toBe(1);
+    const job = await jobByKey(`bootstrapCatchup:${stalled._id}`);
+    expect(job?.kind).toBe("bootstrapCatchup");
+    expect(job?.resourceId).toBe(stalled._id);
+  });
+
+  it("skips a resource whose bootstrap already reached ready", async () => {
+    await seedResource("ready", new Date("2026-08-04T20:00:00.000Z"));
+
+    const enqueued = await recoverStalledBootstraps(deps(), stalledBefore, now);
+
+    expect(enqueued).toBe(0);
+  });
+
+  it("skips a resource still making progress within the window", async () => {
+    // Touched after stalledBefore: its chain is alive and advancing on its
+    // own, so re-entering it here would just duplicate the followup already
+    // in flight.
+    await seedResource("watching", new Date("2026-08-04T20:50:00.000Z"));
+
+    const enqueued = await recoverStalledBootstraps(deps(), stalledBefore, now);
+
+    expect(enqueued).toBe(0);
+  });
+
+  it("excludes a resource whose connection has no stored credential, however stalled", async () => {
+    // Same #2455 lesson as reconcile's finder: a dead-credential resource
+    // resumes on reconnect, not this sweep, and would otherwise tie-break to
+    // the front of every bounded batch.
+    const deadCredential = await seedResource(
+      "catchingUp",
+      new Date("2026-08-04T20:00:00.000Z"),
+      { withCredential: false },
+    );
+    const healthy = await seedResource(
+      "catchingUp",
+      new Date("2026-08-04T20:01:00.000Z"),
+    );
+
+    const enqueued = await recoverStalledBootstraps(
+      deps(),
+      stalledBefore,
+      now,
+      1,
+    );
+
+    expect(enqueued).toBe(1);
+    expect(await jobByKey(`bootstrapCatchup:${healthy._id}`)).not.toBeNull();
+    expect(await jobByKey(`bootstrapCatchup:${deadCredential._id}`)).toBeNull();
+  });
+
+  it("coalesces repeated sweeps into one job per resource", async () => {
+    const stalled = await seedResource(
+      "catchingUp",
+      new Date("2026-08-04T20:00:00.000Z"),
+    );
+
+    await recoverStalledBootstraps(deps(), stalledBefore, now);
+    await recoverStalledBootstraps(deps(), stalledBefore, now);
+
+    expect(
+      await storage
+        .db()
+        .collection(SYNC_COLLECTIONS.jobs)
+        .countDocuments({
+          coalescingKey: `bootstrapCatchup:${stalled._id}`,
+        }),
+    ).toBe(1);
+  });
+});

--- a/packages/sync/src/domain/bootstrap-recovery.service.ts
+++ b/packages/sync/src/domain/bootstrap-recovery.service.ts
@@ -1,0 +1,46 @@
+import { enqueueForResources } from "@sync/domain/resource-sweep-enqueue";
+import { type JobRepository } from "@sync/storage/repositories/job.repository";
+import { type SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
+
+export interface BootstrapRecoveryDeps {
+  resources: SyncResourceRepository;
+  jobs: JobRepository;
+  // Reported per resource that fails to enqueue; the sweep continues.
+  onEnqueueError?: (error: unknown, resourceId: string) => void;
+}
+
+// The bootstrap-recovery sweep — the self-heal for a lost bootstrap chain link.
+// A resource born importing/watching/catchingUp normally advances to ready via
+// its own followup chain (initialImport -> subscriptionMaintain ->
+// bootstrapCatchup); nothing else drives it forward. If a link is ever lost -
+// a durable failure drops the job with no followup, or any other way the chain
+// settles without reaching ready or a retryable state - the resource is
+// otherwise stuck forever: it holds no pending/failed job for any sweep to
+// notice, and the connection reports IMPORTING with no time bound.
+//
+// Find events resources that are not "ready" and have not been touched since
+// `before`, and enqueue a bootstrapCatchup for each; the worker drains them
+// like any other job. bootstrapCatchup already self-routes from wherever the
+// resource actually is (no cursor -> initialImport, expired cursor -> repair,
+// applied -> ready), so re-entering here is safe regardless of which link was
+// lost. Coalescing on `bootstrapCatchup:<id>` means a resource whose chain is
+// still alive and has its own bootstrapCatchup in flight just collapses into
+// that job rather than double-enqueueing.
+//
+// A GLOBAL scan across owners (system liveness, not a user request); each
+// enqueued job carries the resource's own owner ids.
+export function recoverStalledBootstraps(
+  deps: BootstrapRecoveryDeps,
+  before: Date,
+  now: () => Date,
+  limit = 100,
+): Promise<number> {
+  return enqueueForResources(
+    deps,
+    (b, l) => deps.resources.listStalledBootstraps(b, l),
+    "bootstrapCatchup",
+    before,
+    now,
+    limit,
+  );
+}

--- a/packages/sync/src/domain/connection-state-refresh.service.db.test.ts
+++ b/packages/sync/src/domain/connection-state-refresh.service.db.test.ts
@@ -4,6 +4,7 @@ import {
   type ProviderCalendarSourceId,
 } from "@core/types/sync/identity.contracts";
 import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
+import { BOOTSTRAP_OVERDUE_MS } from "@sync/domain/connection-state";
 import { refreshConnectionState } from "@sync/domain/connection-state-refresh.service";
 import { type JobEnqueue } from "@sync/storage/contracts/job.contracts";
 import { CredentialRepository } from "@sync/storage/repositories/credential.repository";
@@ -349,6 +350,75 @@ describe("refreshConnectionState", () => {
 
     const after = await refreshConnectionState(deps(), connection);
     expect(after.state).toBe("importing");
+  });
+
+  it("reports delayed/workOverdue once bootstrap has been incomplete past the overdue window, with no overdue job to point to", async () => {
+    // The unwatchable-calendar loop (2026-08-04): a resource that is BOTH
+    // unwatchable and has an expired sync cursor cycles cursorExpired -> repair
+    // -> subscriptionMaintain -> unsupported -> repair forever, and EVERY job
+    // in that cycle settles "done" - never overdue, never failed - so nothing
+    // in the oldestDueWorkAt evidence ever fires. Without a time-bound
+    // fallback, the connection reports "importing" with no bound, forever.
+    const connection = await seedImportingConnection();
+    const calendar = await calendars.upsertByProviderCalendar({
+      tenantId: connection.tenantId,
+      principalId: connection.principalId,
+      connectionId: connection._id,
+      providerCalendarId: "primary@example.com" as ProviderCalendarSourceId,
+      displayName: "Primary",
+      color: null,
+      active: true,
+      primary: true,
+      accessRole: "owner",
+      capabilities: {
+        canReadEvents: true,
+        canWriteEvents: true,
+        canReadBusy: true,
+        canInviteAttendees: true,
+      },
+    });
+    const listResource = await resources.ensure({
+      tenantId: connection.tenantId,
+      principalId: connection.principalId,
+      connectionId: connection._id,
+      resourceKind: "calendarList",
+      calendarId: null,
+    });
+    await resources.advanceCursor(
+      connection.tenantId,
+      connection.principalId,
+      listResource._id,
+      "list-cursor",
+      new Date(),
+    );
+    const eventsResource = await resources.ensure({
+      tenantId: connection.tenantId,
+      principalId: connection.principalId,
+      connectionId: connection._id,
+      resourceKind: "events",
+      calendarId: calendar._id as ProviderCalendarId,
+    });
+    // Still mid-bootstrap (never reaches "ready"), same as the live loop.
+    await resources.advanceCursor(
+      connection.tenantId,
+      connection.principalId,
+      eventsResource._id,
+      "events-cursor",
+      new Date(),
+    );
+
+    const stillFresh = await refreshConnectionState(deps(), connection);
+    expect(stillFresh.state).toBe("importing");
+
+    const wellPastOverdue = () =>
+      new Date(eventsResource.createdAt.getTime() + BOOTSTRAP_OVERDUE_MS);
+    const after = await refreshConnectionState(
+      deps(),
+      connection,
+      wellPastOverdue,
+    );
+    expect(after.state).toBe("delayed");
+    expect(after.stateReason).toBe("workOverdue");
   });
 
   it("reports catchingUp while a user-requested pull is queued", async () => {

--- a/packages/sync/src/domain/connection-state-refresh.service.ts
+++ b/packages/sync/src/domain/connection-state-refresh.service.ts
@@ -1,4 +1,5 @@
 import {
+  BOOTSTRAP_OVERDUE_MS,
   type ConnectionStateEvidence,
   type CredentialState,
   deriveConnectionState,
@@ -124,6 +125,11 @@ export async function gatherConnectionStateEvidence(
         resource?.syncCursor != null && resource.bootstrapState === "ready"
       );
     });
+  const bootstrapOverdue = activeCalendars.some((c) => {
+    const resource = eventsByCalendar.get(c._id);
+    if (!resource || resource.bootstrapState === "ready") return false;
+    return now.getTime() - resource.createdAt.getTime() >= BOOTSTRAP_OVERDUE_MS;
+  });
 
   // "Last synced" must be as old as the least-recent active calendar. Taking
   // the newest success would let one busy calendar say "just now" while a
@@ -153,6 +159,7 @@ export async function gatherConnectionStateEvidence(
     // have a cursor plus a successful post-watch catch-up pull. A cursor alone
     // has a gap between the import and the provider watch registration.
     initialImportComplete: discoveryDone && allActiveBootstrapReady,
+    bootstrapOverdue,
     catchingUp,
     oldestDueWorkAt: oldestOverdue?.runAfter ?? null,
     // A job that used up its retry ladder on retryableTransient failures is

--- a/packages/sync/src/domain/connection-state.test.ts
+++ b/packages/sync/src/domain/connection-state.test.ts
@@ -17,6 +17,7 @@ const healthy = (
   durableReadFailure: false,
   accountIdentified: true,
   initialImportComplete: true,
+  bootstrapOverdue: false,
   catchingUp: false,
   oldestDueWorkAt: null,
   recentProviderErrors: false,
@@ -70,6 +71,33 @@ describe("deriveConnectionState", () => {
   it("is importing until the first sync bootstrap completes", () => {
     expect(derive({ initialImportComplete: false })).toEqual({
       state: "importing",
+      reason: null,
+    });
+  });
+
+  it("is delayed (workOverdue) when bootstrap has been incomplete past the overdue window, even with no overdue job", () => {
+    expect(
+      derive({ initialImportComplete: false, bootstrapOverdue: true }),
+    ).toEqual({
+      state: "delayed",
+      reason: "workOverdue",
+    });
+  });
+
+  it("stays importing when bootstrap is incomplete but not yet overdue", () => {
+    expect(
+      derive({ initialImportComplete: false, bootstrapOverdue: false }),
+    ).toEqual({
+      state: "importing",
+      reason: null,
+    });
+  });
+
+  it("bootstrapOverdue is irrelevant once bootstrap has completed", () => {
+    expect(
+      derive({ initialImportComplete: true, bootstrapOverdue: true }),
+    ).toEqual({
+      state: "healthy",
       reason: null,
     });
   });

--- a/packages/sync/src/domain/connection-state.ts
+++ b/packages/sync/src/domain/connection-state.ts
@@ -10,6 +10,14 @@ import {
 
 // Work overdue by at least this long stops a connection from looking healthy.
 export const DELAYED_THRESHOLD_MS = 2 * 60 * 1000;
+// An active calendar still bootstrapping after this long is delayed rather
+// than perpetually "importing", even with no retrying/overdue job to point to
+// (a chain that keeps settling every job "done" - e.g. the unsupported-watch
+// loop this guards against - never trips the oldestDueWorkAt check above,
+// since nothing is ever actually overdue). Generous relative to
+// DELAYED_THRESHOLD_MS: a large first import legitimately takes minutes, so
+// this should only fire once that explanation has been exhausted.
+export const BOOTSTRAP_OVERDUE_MS = 20 * 60 * 1000;
 
 export type CredentialState =
   | "valid"
@@ -33,6 +41,9 @@ export interface ConnectionStateEvidence {
   readonly accountIdentified: boolean;
   // The first import, watch setup, and post-watch catch-up have finished.
   readonly initialImportComplete: boolean;
+  // An active calendar has been mid-bootstrap longer than BOOTSTRAP_OVERDUE_MS.
+  // Only consulted when initialImportComplete is false.
+  readonly bootstrapOverdue: boolean;
   // A non-destructive repair or post-gap reconciliation is running while
   // existing data stays queryable.
   readonly catchingUp: boolean;
@@ -104,6 +115,13 @@ export function deriveConnectionState(
   }
 
   if (!evidence.initialImportComplete) {
+    // Same reasoning as the durableReadFailure branch above, for a bootstrap
+    // that is technically still "in progress" by job-retry bookkeeping (every
+    // job keeps settling "done") but has made no real progress in ages - don't
+    // let that hide behind a perpetual "importing" message either.
+    if (evidence.bootstrapOverdue) {
+      return { state: "delayed", reason: "workOverdue" };
+    }
     return { state: "importing", reason: null };
   }
 

--- a/packages/sync/src/domain/sync-job-dispatch.service.db.test.ts
+++ b/packages/sync/src/domain/sync-job-dispatch.service.db.test.ts
@@ -15,6 +15,7 @@ import {
   type ProviderEventReader,
   type ProviderEventReadInput,
 } from "@sync/providers/provider-event-reader.port";
+import { ProviderNotificationError } from "@sync/providers/provider-notifications.port";
 import { SYNC_COLLECTIONS } from "@sync/storage/collections";
 import { type JobRecord } from "@sync/storage/contracts/job.contracts";
 import { type ProviderCalendarRecord } from "@sync/storage/contracts/provider-calendar.contracts";
@@ -166,6 +167,7 @@ describe("dispatchSyncJob", () => {
   const deps = (
     reader: FakeReader,
     custody: SyncJobDispatchDeps["custody"] = tokenSource,
+    notificationsOverride: SyncJobDispatchDeps["notifications"] = notifications,
   ): SyncJobDispatchDeps => ({
     events,
     occurrences,
@@ -177,7 +179,7 @@ describe("dispatchSyncJob", () => {
     commands,
     reader,
     custody,
-    notifications,
+    notifications: notificationsOverride,
     callbackUrl: "https://sync.example/sync/notifications/google",
     invalidations,
   });
@@ -619,6 +621,67 @@ describe("dispatchSyncJob", () => {
         )
       )?.bootstrapState,
     ).toBe("ready");
+  });
+
+  it("completes bootstrap straight to ready when the provider cannot watch the calendar", async () => {
+    // The 2026-08-04 staging loop: a calendar the provider refuses to watch
+    // (Google's public holiday calendars) used to still go through
+    // catchingUp -> bootstrapCatchup, whose pull is the ONLY place "ready" is
+    // set. A calendar with an expired sync cursor as well as no watch support
+    // then cycled cursorExpired -> repair -> subscriptionMaintain ->
+    // unsupported -> catchingUp -> cursorExpired forever, never reaching
+    // ready. There is no watch to catch up to, so unsupported must complete
+    // bootstrap directly.
+    const calendar = await seedCalendar();
+    const resource = await seedResource(calendar, null);
+    const refusing = {
+      ...notifications,
+      watchEvents: async () => {
+        throw new ProviderNotificationError(
+          "watchUnsupported",
+          "push not supported for this calendar",
+        );
+      },
+    };
+
+    const importOutcome = await dispatchSyncJob(
+      deps(
+        new FakeReader([
+          page([single("imported")]),
+          page([single("imported")], "cursor-1"),
+        ]),
+      ),
+      jobFor(resource, "initialImport"),
+      now,
+    );
+    expect(importOutcome).toMatchObject({
+      result: "done",
+      followup: { kind: "subscriptionMaintain" },
+    });
+
+    const subscriptionOutcome = await dispatchSyncJob(
+      deps(new FakeReader([]), tokenSource, refusing),
+      jobFor(resource, "subscriptionMaintain"),
+      now,
+    );
+    expect(subscriptionOutcome).toEqual({ result: "done" });
+
+    const saved = await resources.findById(
+      resource.tenantId,
+      resource.principalId,
+      resource._id,
+    );
+    expect(saved?.bootstrapState).toBe("ready");
+    expect(saved?.subscriptionId).toBeNull();
+
+    const feed = await storage
+      .db()
+      .collection(SYNC_COLLECTIONS.invalidations)
+      .find({ principalId: calendar.principalId })
+      .toArray();
+    // One from the import's own windowed-pass/full-finish notifications, one
+    // more from unsupported completing bootstrap.
+    expect(feed.length).toBeGreaterThanOrEqual(2);
   });
 
   it("bootstraps a legacy no-cursor resource through the post-watch pull", async () => {

--- a/packages/sync/src/domain/sync-job-dispatch.service.ts
+++ b/packages/sync/src/domain/sync-job-dispatch.service.ts
@@ -49,6 +49,11 @@ export interface SyncJobDispatchDeps {
   // provider pull. Without this, incremental pulls update Sync storage but the
   // open SPA never refetches (S40 gap).
   invalidations: InvalidationRepository;
+  // Optional: a bootstrap/repair job settling "done" is otherwise invisible
+  // (drops and errors are logged; "done" is not) - an hour of a resource
+  // repairing every ~2 minutes produced zero log lines (2026-08-04 staging).
+  // Defaults to a no-op so tests stay dependency-free.
+  log?: { warn: (message: string) => void };
 }
 
 // The decision a dispatch makes about a claimed job. The worker loop (a later
@@ -274,6 +279,9 @@ async function runSyncJob(
         return { result: "done", followup: importFollowup(resource, now) };
       }
       // cursorExpired: the provider cursor is unusable; a repair rebuilds.
+      deps.log?.warn(
+        `Sync resource ${resource._id} (calendar ${calendar._id}): cursor expired on incremental pull, enqueuing repair`,
+      );
       return { result: "done", followup: repairFollowup(resource, now) };
     }
     case "bootstrapCatchup": {
@@ -295,6 +303,9 @@ async function runSyncJob(
       if (pull.status === "notImported") {
         return { result: "done", followup: importFollowup(resource, now) };
       }
+      deps.log?.warn(
+        `Sync resource ${resource._id} (calendar ${calendar._id}): cursor expired on bootstrap catch-up pull, enqueuing repair`,
+      );
       return { result: "done", followup: repairFollowup(resource, now) };
     }
     case "repair": {
@@ -327,10 +338,32 @@ async function runSyncJob(
         resource,
         now,
       );
-      if (
-        needsBootstrapCompletion(resource) &&
-        subscription.status !== "authRevoked"
-      ) {
+      if (!needsBootstrapCompletion(resource)) {
+        return { result: "done" };
+      }
+      // Unsupported means the provider will never push for this calendar (e.g.
+      // Google's public holiday calendars) - there is no watch to align with, so
+      // bootstrapCatchup's "close the gap before the channel" pull has nothing
+      // to close. Without this branch, a resource that is BOTH unwatchable and
+      // has an expired sync cursor loops forever: bootstrapCatchup's pull 410s
+      // (cursorExpired) -> repair -> subscriptionMaintain -> unsupported again,
+      // never reaching "ready" (2026-08-04, both staging soak test accounts'
+      // Holidays calendars). The import that already ran is the best available
+      // state; the reconcile sweep's periodic pulls keep it current from here.
+      if (subscription.status === "unsupported") {
+        deps.log?.warn(
+          `Sync resource ${resource._id} (calendar ${calendar._id}): provider does not support watching this calendar, completing bootstrap without a push channel`,
+        );
+        await deps.resources.setBootstrapState(
+          resource.tenantId,
+          resource.principalId,
+          resource._id,
+          "ready",
+        );
+        await appendCalendarInvalidation(deps, calendar, now());
+        return { result: "done" };
+      }
+      if (subscription.status !== "authRevoked") {
         await deps.resources.setBootstrapState(
           resource.tenantId,
           resource.principalId,

--- a/packages/sync/src/storage/index-manifest.db.test.ts
+++ b/packages/sync/src/storage/index-manifest.db.test.ts
@@ -131,6 +131,14 @@ describe("installIndexManifest", () => {
     expect(lastAttempt?.key).toEqual({ resourceKind: 1, lastAttemptAt: 1 });
     expect(indexes.some((i) => i.name === "last_success")).toBe(false);
     expect(indexes.some((i) => i.name === "last_attempt")).toBe(false);
+    const bootstrapStalled = indexes.find(
+      (i) => i.name === "resource_bootstrap_stalled",
+    );
+    expect(bootstrapStalled?.key).toEqual({
+      resourceKind: 1,
+      bootstrapState: 1,
+      updatedAt: 1,
+    });
   });
 
   it("enforces the unique command idempotency key", async () => {

--- a/packages/sync/src/storage/index-manifest.ts
+++ b/packages/sync/src/storage/index-manifest.ts
@@ -183,6 +183,13 @@ export const SYNC_INDEX_MANIFEST: IndexManifest = {
       name: "resource_last_attempt",
       key: { resourceKind: 1, lastAttemptAt: 1 },
     },
+    {
+      // The bootstrap-recovery sweep's finder: lead with resourceKind (as
+      // above), then bootstrapState so the common "ready" majority never
+      // enters the updatedAt range scan.
+      name: "resource_bootstrap_stalled",
+      key: { resourceKind: 1, bootstrapState: 1, updatedAt: 1 },
+    },
   ],
   [SYNC_COLLECTIONS.commands]: [
     {

--- a/packages/sync/src/storage/repositories/sync-resource.repository.ts
+++ b/packages/sync/src/storage/repositories/sync-resource.repository.ts
@@ -402,6 +402,47 @@ export class SyncResourceRepository {
     return records.map((r) => SyncResourceRecordSchema.parse(r));
   }
 
+  // Events resources whose bootstrap chain has stalled: not yet "ready" and
+  // untouched since `before`. This is the bootstrap-recovery sweep's input — the
+  // self-heal for a lost chain link (a job dropped on a durable failure with no
+  // followup, or any other way the importing -> watching -> catchingUp -> ready
+  // handoff loses its thread without ever settling into a retryable state).
+  // Ordinary in-progress bootstrapping resources are excluded by the `before`
+  // cutoff itself: a resource whose chain is alive keeps advancing updatedAt on
+  // every step, so only a genuinely stuck one goes quiet long enough to match.
+  // Same GLOBAL scan + credential-exclusion shape as listStaleEvents, for the
+  // same reason (2026-07-29 dead-credential tie-break bias) - uses the
+  // resource_bootstrap_stalled index.
+  async listStalledBootstraps(
+    before: Date,
+    limit: number,
+  ): Promise<SyncResourceRecord[]> {
+    const records = await this.collection
+      .aggregate<SyncResourceRecord>([
+        {
+          $match: {
+            resourceKind: "events",
+            bootstrapState: { $ne: "ready" },
+            updatedAt: { $lt: before },
+          },
+        },
+        {
+          $lookup: {
+            from: SYNC_COLLECTIONS.credentials,
+            localField: "connectionId",
+            foreignField: "_id",
+            as: "_credential",
+          },
+        },
+        { $match: { "_credential.0": { $exists: true } } },
+        { $project: { _credential: 0 } },
+        { $sort: { updatedAt: 1 } },
+        { $limit: limit },
+      ])
+      .toArray();
+    return records.map((r) => SyncResourceRecordSchema.parse(r));
+  }
+
   // Events resources whose push subscription expires before `before` (soonest
   // first, bounded). This is the subscription-maintenance sweep's input, so like
   // listStaleEvents it is a GLOBAL scan across owners (system liveness, not a


### PR DESCRIPTION
## Summary

Found live on staging during the MA4 multi-account soak: both test accounts sat on "Adding your calendar..." for over an hour with no time bound. Root-caused via read-only staging DB inspection + code trace (details below), not guessed at.

A calendar the provider refuses to watch (Google's public "Holidays in United States" calendar, on both test accounts) whose sync cursor also expires cycles forever:

`cursorExpired` (pull 410s) → `repair` (full re-import, succeeds) → `subscriptionMaintain` (watch refused, `status: "unsupported"`) → `catchingUp` → `bootstrapCatchup`'s pull 410s again → back to `repair`

`bootstrapCatchup`'s pull is the *only* place `bootstrapState` ever becomes `"ready"` — so a calendar that can never pass that pull never reaches ready, and one wedged calendar pins the whole connection's derived state to `importing` indefinitely. Every step in the loop settles `"done"`, so nothing ever logged, retried, or showed up in any existing sweep.

Confirmed live: a `repair` job every ~2 min, generations climbing (0→33 in an hour), 317 events re-imported every cycle, zero log lines the entire time.

- **`subscriptionMaintain` now completes bootstrap directly on `"unsupported"`** instead of routing through `bootstrapCatchup`: there's no watch to catch up to, so there's no gap to close. The reconcile sweep's periodic pulls keep the calendar current from here, same as before.
- **New bootstrap-recovery sweep** re-enters any events resource whose bootstrap chain has gone quiet without reaching `ready` — the general self-heal for a lost chain link (e.g. a durable failure dropping a job with no followup), not just this specific loop.
- **`connection-state` now derives `delayed` (reason: `workOverdue`)** once an active calendar's bootstrap has been incomplete past a generous window (20 min), even with no retrying/overdue job for the existing overdue check to see. Reuses the `delayed`/warning UI vocabulary that already exists end-to-end (`useConnectGoogle.util.ts`) instead of showing an unbounded "Adding your calendar..." — defense in depth for any future variant of "stuck bootstrap."
- **Warn-level logging** on both the repair trigger and the unsupported transition.

No web changes needed — the delayed/warning copy and rendering already exist.

## Test plan
- [x] New/changed unit + DB-integration tests (dispatch loop-breaker, connection-state derivation, bootstrap-recovery sweep, index manifest) — 778/778 sync tests pass
- [x] `bun run type-check` clean
- [x] `biome check` clean
- [ ] After merge: confirm on staging that both stuck test connections (`compasscaltest3@gmail.com`, `lance.essert@gmail.com`) flip to `healthy` within one sweep cycle, holiday events render, and repair-job churn stops

🤖 Generated with [Claude Code](https://claude.com/claude-code)