### PR TITLE
fix(web): scope single-account sidebar header to the signed-in user's own connection

### DIFF
--- a/packages/web/src/components/Sidebar/CalendarList/CalendarListHeader.test.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarListHeader.test.tsx
@@ -204,17 +204,19 @@ describe("CalendarListHeader", () => {
   it("shows last-synced timing when Sync connection metadata includes lastSyncedAt", () => {
     mockEmail = "ahab@pequod.com";
     mockGoogleState = "HEALTHY";
+    const connection = {
+      id: "conn-1",
+      state: "healthy",
+      stateReason: null,
+      lastSyncedAt: new Date().toISOString(),
+      lastHealthyAt: new Date().toISOString(),
+      accountEmail: "ahab@pequod.com",
+    };
     userMetadataActions.set({
       google: {
         connectionState: "HEALTHY",
-        connection: {
-          id: "conn-1",
-          state: "healthy",
-          stateReason: null,
-          lastSyncedAt: new Date().toISOString(),
-          lastHealthyAt: new Date().toISOString(),
-          accountEmail: "compasscaltest3@gmail.com",
-        },
+        connection,
+        connections: [connection],
       },
     });
 
@@ -381,17 +383,19 @@ describe("CalendarListHeader", () => {
   it("keeps an established calendar calm during reconciliation", () => {
     mockEmail = "ahab@pequod.com";
     mockGoogleState = "HEALTHY";
+    const connection = {
+      id: "conn-1",
+      state: "catchingUp",
+      stateReason: null,
+      lastSyncedAt: new Date().toISOString(),
+      lastHealthyAt: new Date().toISOString(),
+      accountEmail: "ahab@pequod.com",
+    };
     userMetadataActions.set({
       google: {
         connectionState: "IMPORTING",
-        connection: {
-          id: "conn-1",
-          state: "catchingUp",
-          stateReason: null,
-          lastSyncedAt: new Date().toISOString(),
-          lastHealthyAt: new Date().toISOString(),
-          accountEmail: "compasscaltest3@gmail.com",
-        },
+        connection,
+        connections: [connection],
       },
     });
 
@@ -400,5 +404,46 @@ describe("CalendarListHeader", () => {
     expect(screen.getByRole("status")).toHaveTextContent("Calendar connected");
     expect(screen.queryByText("Adding your calendar…")).toBeNull();
     expect(screen.getByText("Updated just now")).toBeInTheDocument();
+  });
+
+  it("scopes to the connection matching the signed-in user's own email, not sync's aggregate precedence winner across every connected account", () => {
+    // The 2026-08-04 bug: with two accounts connected, disconnecting the
+    // OTHER one made this header - which is keyed to the signed-in user's
+    // OWN email - flash "needs reconnecting" anyway, because the singular
+    // `google.connection` field is sync's most-actionable-state-wins pick
+    // across ALL connections, not specifically this user's own connection.
+    mockEmail = "ahab@pequod.com";
+    mockGoogleState = "RECONNECT_REQUIRED";
+    const ownConnection = {
+      id: "conn-mine",
+      state: "healthy",
+      stateReason: null,
+      lastSyncedAt: new Date().toISOString(),
+      lastHealthyAt: new Date().toISOString(),
+      accountEmail: "ahab@pequod.com",
+      connectionState: "HEALTHY" as const,
+    };
+    const otherAccountsBrokenConnection = {
+      id: "conn-other",
+      state: "disconnected",
+      stateReason: null,
+      lastSyncedAt: null,
+      lastHealthyAt: null,
+      accountEmail: "starbuck@pequod.com",
+      connectionState: "RECONNECT_REQUIRED" as const,
+    };
+    userMetadataActions.set({
+      google: {
+        connectionState: "RECONNECT_REQUIRED",
+        connection: otherAccountsBrokenConnection,
+        connections: [otherAccountsBrokenConnection, ownConnection],
+      },
+    });
+
+    renderHeader();
+
+    expect(mockUseConnectGoogle).toHaveBeenCalledWith({
+      connection: ownConnection,
+    });
   });
 });

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarListHeader.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarListHeader.tsx
@@ -1,5 +1,5 @@
 import classNames from "classnames";
-import { type FC, useCallback, useSyncExternalStore } from "react";
+import { type FC, useCallback, useMemo, useSyncExternalStore } from "react";
 import {
   shouldShowAnonymousCalendarChangeSignUpPrompt,
   subscribeToAuthState,
@@ -12,7 +12,7 @@ import {
   getGoogleSyncStatus,
 } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle.util";
 import {
-  selectGoogleSyncConnection,
+  selectGoogleSyncConnections,
   useUserMetadataStore,
 } from "@web/auth/state/user-metadata.store";
 import {
@@ -133,12 +133,22 @@ const AnonymousAccountHeader: FC = () => {
 };
 
 const AuthenticatedAccountHeader: FC<{ email: string }> = ({ email }) => {
+  // This header shows before per-account sections take over (single account,
+  // or the moment metadata loads for a multi-account user) - it must show
+  // THIS email's own status, not sync's precedence-winning "most actionable
+  // connection across everyone", or a second account's problem flashes under
+  // the first account's name for as long as that gap lasts (2026-08-04,
+  // caught disconnecting one of two live accounts).
+  const connections = useUserMetadataStore(selectGoogleSyncConnections);
+  const ownConnection = useMemo(
+    () => connections.find((c) => c.accountEmail === email) ?? null,
+    [connections, email],
+  );
   const { commandAction, isAvailable, isConnecting, isRefreshing, state } =
-    useConnectGoogle();
-  const syncConnection = useUserMetadataStore(selectGoogleSyncConnection);
+    useConnectGoogle({ connection: ownConnection });
   const hasPendingEventMutations = useHasPendingEventMutations();
   const syncStatus = getSidebarSyncStatus({
-    googleStatus: getGoogleSyncStatus(state, syncConnection),
+    googleStatus: getGoogleSyncStatus(state, ownConnection),
     hasPendingEventMutations,
     isConnecting,
     state,
@@ -148,7 +158,7 @@ const AuthenticatedAccountHeader: FC<{ email: string }> = ({ email }) => {
   const showGoogleAction = isAvailable && commandAction != null;
   const lastSyncedLabel =
     syncStatus?.variant === "healthy"
-      ? formatLastSyncedLabel(syncConnection?.lastSyncedAt)
+      ? formatLastSyncedLabel(ownConnection?.lastSyncedAt)
       : null;
   const googleActionLabel =
     commandAction == null


### PR DESCRIPTION
## Summary

Found live on staging during the MA4 multi-account soak, while verifying disconnect behavior: with two accounts connected, disconnecting (or reconnecting) one of them briefly flashed the **wrong** account's status under the **other** account's own email in the sidebar.

Concretely: disconnecting `lance.essert@gmail.com` made the header show **"compasscaltest3@gmail.com — Calendar needs reconnecting"** — even though `compasscaltest3` was completely healthy the whole time. Reproduced a second time on reconnect (briefly showed "Adding your calendar…" under `compasscaltest3`'s name while `lance.essert` was actually the one importing).

## Root cause

The single-account fallback header (`CalendarListHeader.tsx`'s `AuthenticatedAccountHeader` — rendered for genuinely single-account users, and also briefly for multi-account users right after metadata loads, before per-account sections take over) paired `useUser().email` (the Compass login identity) with `UserMetadata.google.connection`, a **singular** field with no concept of "whose account this is." That field is sync's most-actionable-state-wins pick across **every** connected account (`RECONNECT_REQUIRED > ATTENTION > IMPORTING > HEALTHY`), by design — so a generic "Reconnect" click targets whichever account is actually broken. That's the *correct* behavior for the reconnect action, and I left it untouched (`selectPrimaryGoogleConnection` in `connection-state.translation.ts` still serves other callers correctly). It was never meant to also answer "what is *my* account's own status" — multi-account is what made those two questions diverge for the first time.

## Fix

The header now finds the connection matching its own email from the full `connections` array and scopes to it — reusing the `connection` option `useConnectGoogle` already supports for the per-account section headers (built in MA2) — falling back to the aggregate only when no match exists yet (e.g. metadata still loading). One file, `packages/web/src/components/Sidebar/CalendarList/CalendarListHeader.tsx`.

## Test plan
- [x] New regression test: two connections seeded, aggregate/singular field points at the OTHER (broken) account, asserts the header scopes to the signed-in user's own (healthy) connection instead
- [x] Fixed two existing tests whose fixtures had a mismatched `accountEmail` (worked before only because nothing checked it)
- [x] `bun run test:web` — 1644/1644 pass
- [x] `bun run type-check` clean, `biome check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)