### PR TITLE
feat(web): move add/disconnect account behind palette + hover, add per-account collapse

### DIFF
--- a/packages/web/src/__tests__/utils/state/reset-stores.ts
+++ b/packages/web/src/__tests__/utils/state/reset-stores.ts
@@ -10,6 +10,7 @@ import {
   useUserMetadataStore,
 } from "@web/auth/state/user-metadata.store";
 import { resetCalendarVisibilityStoreForTests } from "@web/calendars/calendar-visibility.store";
+import { resetCollapsedAccountsStoreForTests } from "@web/calendars/collapsed-accounts.store";
 import { resetDefaultCalendarStoreForTests } from "@web/calendars/default-calendar.store";
 import { useFeedbackStore } from "@web/components/Feedback/feedback.store";
 import { useReleaseNotesPromptStore } from "@web/components/ReleaseNotesPrompt/release-notes-prompt.store";
@@ -52,6 +53,7 @@ const storeResets: StoreReset[] = [
   // before this runs; this just resyncs the module-singleton store to match.
   resetCalendarVisibilityStoreForTests,
   resetDefaultCalendarStoreForTests,
+  resetCollapsedAccountsStoreForTests,
   // Lives on window.__weekInteractionMotionActive, which survives across
   // test files (the preload reuses one jsdom window). A test that starts a
   // real drag and never completes it would otherwise leave every later

--- a/packages/web/src/auth/google/hooks/useDisconnectGoogleAccount.ts
+++ b/packages/web/src/auth/google/hooks/useDisconnectGoogleAccount.ts
@@ -1,0 +1,49 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { useCallback, useState } from "react";
+import { AuthApi } from "@web/api/auth.api";
+import { refreshUserMetadata } from "@web/auth/compass/user/util/user-metadata.util";
+import { calendarQueryKeys } from "@web/calendars/calendar.query";
+import { showErrorToast } from "@web/common/utils/toast/error-toast.util";
+import { eventQueryKeys } from "@web/events/queries/event.query.keys";
+
+/**
+ * Removes one account's calendars and events from Compass. The account's
+ * Google data, and the user's other connections, are untouched. Tracks at
+ * most one in-flight disconnect at a time by connection id, since a caller
+ * (the manage-accounts dialog) may list several accounts sharing one hook
+ * instance.
+ */
+export function useDisconnectGoogleAccount(): {
+  disconnect: (connectionId: string, accountEmail: string) => Promise<void>;
+  disconnectingId: string | null;
+} {
+  const queryClient = useQueryClient();
+  const [disconnectingId, setDisconnectingId] = useState<string | null>(null);
+
+  const disconnect = useCallback(
+    (connectionId: string, accountEmail: string) => {
+      setDisconnectingId(connectionId);
+      return AuthApi.disconnectGoogleConnection(connectionId)
+        .then(async () => {
+          // The account's calendars and its events both disappear, and the
+          // remaining connections are what drive the sidebar's sections.
+          await Promise.all([
+            queryClient.invalidateQueries({ queryKey: calendarQueryKeys.all }),
+            queryClient.invalidateQueries({ queryKey: eventQueryKeys.all }),
+            refreshUserMetadata({ force: true }),
+          ]);
+        })
+        .catch(() => {
+          showErrorToast(
+            `We couldn't disconnect ${accountEmail}. Please try again in a moment.`,
+          );
+        })
+        .finally(() => {
+          setDisconnectingId(null);
+        });
+    },
+    [queryClient],
+  );
+
+  return { disconnect, disconnectingId };
+}

--- a/packages/web/src/calendars/collapsed-accounts.storage.ts
+++ b/packages/web/src/calendars/collapsed-accounts.storage.ts
@@ -1,0 +1,30 @@
+import { z } from "zod";
+import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
+import { persistentBrowserStore } from "@web/common/storage/browser-key-value.store";
+
+// Collapsed account keys only - absence means expanded (default). A Set of
+// account emails (or the single-account sentinel); unknown or malformed
+// storage falls back to empty (everything expanded) rather than hiding every
+// account's calendars.
+const CollapsedAccountsSchema = z.array(z.string().trim().min(1)).readonly();
+
+export function readCollapsedAccountKeys(): ReadonlySet<string> {
+  const raw = persistentBrowserStore.get(STORAGE_KEYS.COLLAPSED_ACCOUNTS);
+  if (!raw) return new Set();
+
+  try {
+    return new Set(CollapsedAccountsSchema.parse(JSON.parse(raw)));
+  } catch {
+    return new Set();
+  }
+}
+
+export function writeCollapsedAccountKeys(keys: ReadonlySet<string>): boolean {
+  if (keys.size === 0) {
+    return persistentBrowserStore.remove(STORAGE_KEYS.COLLAPSED_ACCOUNTS);
+  }
+  return persistentBrowserStore.set(
+    STORAGE_KEYS.COLLAPSED_ACCOUNTS,
+    JSON.stringify([...keys]),
+  );
+}

--- a/packages/web/src/calendars/collapsed-accounts.store.test.ts
+++ b/packages/web/src/calendars/collapsed-accounts.store.test.ts
@@ -1,0 +1,81 @@
+import { act, renderHook } from "@testing-library/react";
+import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
+import { persistentBrowserStore } from "@web/common/storage/browser-key-value.store";
+import { readCollapsedAccountKeys } from "./collapsed-accounts.storage";
+import {
+  toggleAccountCollapsed,
+  useCollapsedAccountKeys,
+} from "./collapsed-accounts.store";
+import { describe, expect, it, spyOn } from "bun:test";
+
+const email = "ahab@pequod.com";
+
+// Storage clearing + the collapsed-accounts store resync between tests are
+// both handled by the global test-lifecycle afterEach (resetBrowserState +
+// resetAllStores) - see packages/web/src/__tests__/setup/test-lifecycle.ts.
+
+describe("collapsed-accounts.store", () => {
+  it("persists a toggle and notifies subscribers", () => {
+    const { result } = renderHook(() => useCollapsedAccountKeys());
+
+    expect(result.current.has(email)).toBe(false);
+
+    act(() => {
+      expect(toggleAccountCollapsed(email)).toBe(true);
+    });
+
+    expect(result.current.has(email)).toBe(true);
+    expect(readCollapsedAccountKeys().has(email)).toBe(true);
+
+    act(() => {
+      expect(toggleAccountCollapsed(email)).toBe(true);
+    });
+
+    expect(result.current.has(email)).toBe(false);
+  });
+
+  it("leaves the store untouched when the storage write fails", () => {
+    const setSpy = spyOn(persistentBrowserStore, "set").mockReturnValue(false);
+    const { result } = renderHook(() => useCollapsedAccountKeys());
+
+    act(() => {
+      expect(toggleAccountCollapsed(email)).toBe(false);
+    });
+
+    expect(result.current.has(email)).toBe(false);
+    setSpy.mockRestore();
+  });
+
+  it("picks up a collapse written by another tab via the storage event", () => {
+    const { result } = renderHook(() => useCollapsedAccountKeys());
+    expect(result.current.has(email)).toBe(false);
+
+    persistentBrowserStore.set(
+      STORAGE_KEYS.COLLAPSED_ACCOUNTS,
+      JSON.stringify([email]),
+    );
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent("storage", { key: STORAGE_KEYS.COLLAPSED_ACCOUNTS }),
+      );
+    });
+
+    expect(result.current.has(email)).toBe(true);
+  });
+
+  it("ignores storage events for unrelated keys", () => {
+    const { result } = renderHook(() => useCollapsedAccountKeys());
+
+    persistentBrowserStore.set(
+      STORAGE_KEYS.COLLAPSED_ACCOUNTS,
+      JSON.stringify([email]),
+    );
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent("storage", { key: STORAGE_KEYS.SIDEBAR_OPEN }),
+      );
+    });
+
+    expect(result.current.has(email)).toBe(false);
+  });
+});

--- a/packages/web/src/calendars/collapsed-accounts.store.ts
+++ b/packages/web/src/calendars/collapsed-accounts.store.ts
@@ -1,0 +1,72 @@
+import { useSyncExternalStore } from "react";
+import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
+import {
+  createExternalStore,
+  subscribeToStorageKey,
+} from "@web/common/utils/external-store.util";
+import {
+  readCollapsedAccountKeys,
+  writeCollapsedAccountKeys,
+} from "./collapsed-accounts.storage";
+
+/**
+ * Collapse key for the flat single-account calendar list. It's a display
+ * preference ("I don't want to see subcalendars"), not tied to which
+ * specific account happens to be connected, so a fixed sentinel is simpler
+ * than threading the signed-in email down to CalendarList just for this.
+ */
+export const SINGLE_ACCOUNT_COLLAPSE_KEY = "single-account";
+
+/**
+ * Deterministic id shared between an account's heading (aria-controls) and
+ * its calendar list (id) - the two are separate sibling components, so this
+ * can't be a useId().
+ */
+export function accountCalendarListId(key: string): string {
+  return `account-calendars-${key}`;
+}
+
+const collapsedStore = createExternalStore<ReadonlySet<string>>(
+  readCollapsedAccountKeys(),
+);
+
+function refreshFromStorage(): void {
+  collapsedStore.set(readCollapsedAccountKeys());
+}
+
+/**
+ * Toggle one account's collapsed state. Returns false (leaving the store
+ * untouched) if the storage write fails.
+ */
+export function toggleAccountCollapsed(key: string): boolean {
+  const next = new Set(collapsedStore.get());
+  if (next.has(key)) next.delete(key);
+  else next.add(key);
+
+  const saved = writeCollapsedAccountKeys(next);
+  if (saved) collapsedStore.set(next);
+  return saved;
+}
+
+function subscribe(onChange: () => void): () => void {
+  const unsubscribeStore = collapsedStore.subscribe(onChange);
+  const unsubscribeStorage = subscribeToStorageKey(
+    STORAGE_KEYS.COLLAPSED_ACCOUNTS,
+    refreshFromStorage,
+  );
+
+  return () => {
+    unsubscribeStore();
+    unsubscribeStorage();
+  };
+}
+
+export function useCollapsedAccountKeys(): ReadonlySet<string> {
+  return useSyncExternalStore(subscribe, collapsedStore.get);
+}
+
+/** Test-only: resyncs the in-memory store from storage. Registered in
+ * reset-stores.ts for between-test cleanup. */
+export function resetCollapsedAccountsStoreForTests(): void {
+  refreshFromStorage();
+}

--- a/packages/web/src/common/constants/storage.constants.ts
+++ b/packages/web/src/common/constants/storage.constants.ts
@@ -14,7 +14,10 @@ type StorageKey =
   | "compass.calendars.hidden-ids"
   // Which calendar new events are created on. Device-local like the rest;
   // an unknown or stale id falls back to the derived default.
-  | "compass.calendars.default-id";
+  | "compass.calendars.default-id"
+  // Which accounts' calendar rows are collapsed in the sidebar. Device-local;
+  // an unknown or stale key falls back to expanded (default).
+  | "compass.calendars.collapsed-accounts";
 
 export const STORAGE_KEYS: Record<
   | "AUTH"
@@ -28,7 +31,8 @@ export const STORAGE_KEYS: Record<
   | "SIDEBAR_OPEN"
   | "THEME"
   | "HIDDEN_CALENDAR_IDS"
-  | "DEFAULT_CALENDAR_ID",
+  | "DEFAULT_CALENDAR_ID"
+  | "COLLAPSED_ACCOUNTS",
   StorageKey
 > = {
   AUTH: "compass.auth",
@@ -46,4 +50,5 @@ export const STORAGE_KEYS: Record<
   THEME: "compass.theme",
   HIDDEN_CALENDAR_IDS: "compass.calendars.hidden-ids",
   DEFAULT_CALENDAR_ID: "compass.calendars.default-id",
+  COLLAPSED_ACCOUNTS: "compass.calendars.collapsed-accounts",
 } as const;

--- a/packages/web/src/components/CommandPalette/CommandPalette.tsx
+++ b/packages/web/src/components/CommandPalette/CommandPalette.tsx
@@ -17,6 +17,7 @@ import { useDeleteAccountCmdItems } from "@web/components/CommandPalette/hooks/u
 import { useDemoEventsCmdItems } from "@web/components/CommandPalette/hooks/useDemoEventsCmdItems";
 import { useExportDataCmdItems } from "@web/components/CommandPalette/hooks/useExportDataCmdItems";
 import { useLogoutCmdItems } from "@web/components/CommandPalette/hooks/useLogoutCmdItems";
+import { useManageAccountsCmdItems } from "@web/components/CommandPalette/hooks/useManageAccountsCmdItems";
 import { useSubscribeCmdItems } from "@web/components/CommandPalette/hooks/useSubscribeCmdItems";
 import { useThemeCmdItems } from "@web/components/CommandPalette/hooks/useThemeCmdItems";
 import { getMoreCommandPaletteSections } from "@web/components/CommandPalette/more.cmd.constants";
@@ -240,6 +241,7 @@ export const CommandPalette = ({
   const exportDataCmdItems = useExportDataCmdItems();
   const demoEventsCmdItems = useDemoEventsCmdItems();
   const authCmdItems = useAuthCmdItems();
+  const manageAccountsCmdItems = useManageAccountsCmdItems();
   const logoutCmdItems = useLogoutCmdItems();
   const deleteAccountCmdItems = useDeleteAccountCmdItems();
   const themeCmdItems = useThemeCmdItems();
@@ -288,6 +290,7 @@ export const CommandPalette = ({
         ...subscribeCmdItems,
         ...exportDataCmdItems,
         ...authCmdItems,
+        ...manageAccountsCmdItems,
         ...logoutCmdItems,
         ...deleteAccountCmdItems,
       ],

--- a/packages/web/src/components/CommandPalette/hooks/useManageAccountsCmdItems.test.ts
+++ b/packages/web/src/components/CommandPalette/hooks/useManageAccountsCmdItems.test.ts
@@ -1,0 +1,71 @@
+import { renderHook } from "@testing-library/react";
+import { act, createElement, type PropsWithChildren } from "react";
+import { ManageAccountsContext } from "@web/components/ManageAccounts/hooks/useManageAccounts";
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+
+const mockOpenManageAccounts = mock();
+const mockUseSession = mock();
+
+mock.module("@web/auth/compass/session/useSession", () => ({
+  useSession: mockUseSession,
+}));
+
+const { useManageAccountsCmdItems } = await import(
+  "./useManageAccountsCmdItems"
+);
+
+// ManageAccounts has its own dedicated tests (ManageAccountsDialog.test.tsx)
+// that import the real module - mock.module leaks process-wide across
+// files, so mocking it here would starve that later test. Supply a fake
+// value through the real context instead.
+function wrapper({ children }: PropsWithChildren) {
+  return createElement(
+    ManageAccountsContext.Provider,
+    {
+      value: {
+        isOpen: false,
+        closeManageAccounts: mock(),
+        openManageAccounts: mockOpenManageAccounts,
+      },
+    },
+    children,
+  );
+}
+
+describe("useManageAccountsCmdItems", () => {
+  beforeEach(() => {
+    mockOpenManageAccounts.mockClear();
+    mockUseSession.mockReset();
+    mockUseSession.mockReturnValue({
+      authenticated: true,
+      setAuthenticated: mock(),
+    });
+  });
+
+  it("returns no items when logged out", () => {
+    mockUseSession.mockReturnValue({
+      authenticated: false,
+      setAuthenticated: mock(),
+    });
+
+    const { result } = renderHook(() => useManageAccountsCmdItems(), {
+      wrapper,
+    });
+
+    expect(result.current).toEqual([]);
+  });
+
+  it("opens the manage-accounts dialog from the command palette item", () => {
+    const { result } = renderHook(() => useManageAccountsCmdItems(), {
+      wrapper,
+    });
+
+    expect(result.current[0].label).toBe("Add/remove accounts");
+
+    act(() => {
+      result.current[0].onClick?.();
+    });
+
+    expect(mockOpenManageAccounts).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/web/src/components/CommandPalette/hooks/useManageAccountsCmdItems.ts
+++ b/packages/web/src/components/CommandPalette/hooks/useManageAccountsCmdItems.ts
@@ -1,0 +1,22 @@
+import { UsersIcon } from "@phosphor-icons/react";
+import { useSession } from "@web/auth/compass/session/useSession";
+import { type CommandItem } from "@web/components/CommandPalette/command-palette.types";
+import { useManageAccounts } from "@web/components/ManageAccounts/hooks/useManageAccounts";
+
+export const useManageAccountsCmdItems = (): CommandItem[] => {
+  const { authenticated } = useSession();
+  const { openManageAccounts } = useManageAccounts();
+
+  if (!authenticated) {
+    return [];
+  }
+
+  return [
+    {
+      id: "manage-accounts",
+      label: "Add/remove accounts",
+      icon: UsersIcon,
+      onClick: openManageAccounts,
+    },
+  ];
+};

--- a/packages/web/src/components/CompassProvider/CompassProvider.tsx
+++ b/packages/web/src/components/CompassProvider/CompassProvider.tsx
@@ -13,6 +13,7 @@ import { DeleteAccountConfirmationProvider } from "@web/components/DeleteAccount
 import { FeedbackDialogHost } from "@web/components/Feedback/FeedbackDialogHost";
 import { IconProvider } from "@web/components/IconProvider/IconProvider";
 import { LogoutConfirmationProvider } from "@web/components/LogoutConfirmation/LogoutConfirmationProvider";
+import { ManageAccountsProvider } from "@web/components/ManageAccounts/ManageAccountsProvider";
 import { RecurrenceScopeOpportunityHost } from "@web/events/recurrence/RecurrenceScopeOpportunityHost";
 import { selectTheme, useThemeStore } from "@web/settings/theme/theme.store";
 import { useUndoRedoShortcuts } from "@web/views/Week/hooks/shortcuts/useUndoRedoShortcuts";
@@ -64,7 +65,7 @@ export const CompassRequiredProviders = ({
           <IconProvider>
             <LogoutConfirmationProvider>
               <DeleteAccountConfirmationProvider>
-                {children}
+                <ManageAccountsProvider>{children}</ManageAccountsProvider>
               </DeleteAccountConfirmationProvider>
               <ThemeAwareToastContainer />
             </LogoutConfirmationProvider>

--- a/packages/web/src/components/ManageAccounts/ManageAccountsDialog.test.tsx
+++ b/packages/web/src/components/ManageAccounts/ManageAccountsDialog.test.tsx
@@ -1,0 +1,180 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { type GoogleSyncConnectionSummary } from "@core/types/user.types";
+import { createStoreWrapper } from "@web/__tests__/render-with-store";
+import { AuthApi } from "@web/api/auth.api";
+import { userMetadataActions } from "@web/auth/state/user-metadata.store";
+import { ManageAccountsDialog } from "./ManageAccountsDialog";
+import { describe, expect, it, mock, spyOn } from "bun:test";
+
+const connection = (
+  overrides: Partial<GoogleSyncConnectionSummary> = {},
+): GoogleSyncConnectionSummary => ({
+  id: "connection-1",
+  state: "healthy",
+  stateReason: null,
+  lastSyncedAt: null,
+  lastHealthyAt: null,
+  accountEmail: "ahab@pequod.com",
+  connectionState: "HEALTHY",
+  ...overrides,
+});
+
+const renderDialog = (
+  connections: GoogleSyncConnectionSummary[] = [connection()],
+) => {
+  userMetadataActions.set({
+    google: { connectionState: "HEALTHY", connections },
+  });
+  const { wrapper } = createStoreWrapper();
+  return render(<ManageAccountsDialog isOpen onDismiss={mock()} />, {
+    wrapper,
+  });
+};
+
+describe("ManageAccountsDialog", () => {
+  it("renders nothing while closed", () => {
+    const { wrapper } = createStoreWrapper();
+    render(<ManageAccountsDialog isOpen={false} onDismiss={mock()} />, {
+      wrapper,
+    });
+
+    expect(screen.queryByText("Google accounts")).not.toBeInTheDocument();
+  });
+
+  it("lists every connected account with its own status", () => {
+    renderDialog([
+      connection(),
+      connection({
+        id: "connection-2",
+        accountEmail: "ahab@gmail.com",
+        state: "disconnected",
+        connectionState: "RECONNECT_REQUIRED",
+      }),
+    ]);
+
+    expect(screen.getByText("ahab@pequod.com")).toBeInTheDocument();
+    expect(screen.getByText("ahab@gmail.com")).toBeInTheDocument();
+    expect(screen.getByText("Calendar connected")).toBeInTheDocument();
+    expect(screen.getByText("Calendar needs reconnecting")).toBeInTheDocument();
+  });
+
+  it("asks for confirmation before disconnecting", async () => {
+    const disconnect = spyOn(
+      AuthApi,
+      "disconnectGoogleConnection",
+    ).mockResolvedValue(undefined);
+
+    const user = userEvent.setup({ delay: null });
+    renderDialog();
+
+    await user.click(
+      screen.getByRole("button", { name: "Disconnect ahab@pequod.com" }),
+    );
+
+    // Disconnecting is not undoable without redoing the whole OAuth flow, so
+    // the first press must not call the API.
+    expect(disconnect).not.toHaveBeenCalled();
+    expect(
+      screen.getByRole("button", {
+        name: "Confirm disconnecting ahab@pequod.com",
+      }),
+    ).toBeInTheDocument();
+
+    disconnect.mockRestore();
+  });
+
+  it("disconnects that connection once confirmed", async () => {
+    const disconnect = spyOn(
+      AuthApi,
+      "disconnectGoogleConnection",
+    ).mockResolvedValue(undefined);
+
+    const user = userEvent.setup({ delay: null });
+    renderDialog([connection({ id: "connection-second" })]);
+
+    await user.click(
+      screen.getByRole("button", { name: "Disconnect ahab@pequod.com" }),
+    );
+    await user.click(
+      screen.getByRole("button", {
+        name: "Confirm disconnecting ahab@pequod.com",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(disconnect).toHaveBeenCalledWith("connection-second");
+    });
+
+    disconnect.mockRestore();
+  });
+
+  it("backs out of the confirm without disconnecting", async () => {
+    const disconnect = spyOn(
+      AuthApi,
+      "disconnectGoogleConnection",
+    ).mockResolvedValue(undefined);
+
+    const user = userEvent.setup({ delay: null });
+    renderDialog();
+
+    await user.click(
+      screen.getByRole("button", { name: "Disconnect ahab@pequod.com" }),
+    );
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(disconnect).not.toHaveBeenCalled();
+    expect(
+      screen.getByRole("button", { name: "Disconnect ahab@pequod.com" }),
+    ).toBeInTheDocument();
+
+    disconnect.mockRestore();
+  });
+
+  it("returns to the un-confirmed state when the disconnect fails", async () => {
+    const disconnect = spyOn(
+      AuthApi,
+      "disconnectGoogleConnection",
+    ).mockRejectedValue(new Error("nope"));
+
+    const user = userEvent.setup({ delay: null });
+    renderDialog();
+
+    await user.click(
+      screen.getByRole("button", { name: "Disconnect ahab@pequod.com" }),
+    );
+    await user.click(
+      screen.getByRole("button", {
+        name: "Confirm disconnecting ahab@pequod.com",
+      }),
+    );
+
+    // A stuck "Disconnecting…" would read as a disconnect that half-happened.
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Disconnect ahab@pequod.com" }),
+      ).toBeInTheDocument();
+    });
+
+    disconnect.mockRestore();
+  });
+
+  it("shows an empty state with no accounts connected", () => {
+    renderDialog([]);
+
+    expect(screen.getByText("No accounts connected yet.")).toBeInTheDocument();
+  });
+
+  it("dismisses via the Done button", async () => {
+    const onDismiss = mock();
+    userMetadataActions.set({
+      google: { connectionState: "HEALTHY", connections: [connection()] },
+    });
+    const { wrapper } = createStoreWrapper();
+    const user = userEvent.setup({ delay: null });
+    render(<ManageAccountsDialog isOpen onDismiss={onDismiss} />, { wrapper });
+
+    await user.click(screen.getByRole("button", { name: "Done" }));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/web/src/components/ManageAccounts/ManageAccountsDialog.tsx
+++ b/packages/web/src/components/ManageAccounts/ManageAccountsDialog.tsx
@@ -1,0 +1,149 @@
+import { type FC, useState } from "react";
+import { type GoogleSyncConnectionSummary } from "@core/types/user.types";
+import { useConnectGoogle } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle";
+import { getGoogleSyncStatus } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle.util";
+import { useDisconnectGoogleAccount } from "@web/auth/google/hooks/useDisconnectGoogleAccount";
+import {
+  selectGoogleSyncConnections,
+  useUserMetadataStore,
+} from "@web/auth/state/user-metadata.store";
+import { SYNC_STATUS_VARIANT_CLASSNAME } from "@web/calendars/sync-status.types";
+import {
+  OverlayPanel,
+  OverlayPanelActionButton,
+  OverlayPanelActions,
+} from "@web/components/OverlayPanel/OverlayPanel";
+
+interface ManageAccountsDialogProps {
+  isOpen: boolean;
+  onDismiss: () => void;
+}
+
+export function ManageAccountsDialog({
+  isOpen,
+  onDismiss,
+}: ManageAccountsDialogProps) {
+  const connections = useUserMetadataStore(selectGoogleSyncConnections);
+  const { connect, isAvailable, isConnecting } = useConnectGoogle();
+  const { disconnect, disconnectingId } = useDisconnectGoogleAccount();
+
+  if (!isOpen) return null;
+
+  return (
+    <OverlayPanel
+      align="start"
+      onDismiss={onDismiss}
+      title="Google accounts"
+      variant="modal"
+      widthClassName="w-[420px]"
+    >
+      <div className="flex w-full flex-col gap-3">
+        {connections.length === 0 ? (
+          <p className="text-sm text-text-muted">No accounts connected yet.</p>
+        ) : (
+          connections.map((connection) => (
+            <AccountRow
+              connection={connection}
+              disconnect={disconnect}
+              isDisconnecting={disconnectingId === connection.id}
+              key={connection.id}
+            />
+          ))
+        )}
+      </div>
+
+      <OverlayPanelActions align="start">
+        {isAvailable ? (
+          <OverlayPanelActionButton
+            aria-busy={isConnecting || undefined}
+            disabled={isConnecting}
+            onClick={connect}
+            variant="primary"
+          >
+            {isConnecting ? "Opening Google…" : "Add account"}
+          </OverlayPanelActionButton>
+        ) : null}
+        <OverlayPanelActionButton onClick={onDismiss}>
+          Done
+        </OverlayPanelActionButton>
+      </OverlayPanelActions>
+    </OverlayPanel>
+  );
+}
+
+interface AccountRowProps {
+  connection: GoogleSyncConnectionSummary;
+  disconnect: (connectionId: string, accountEmail: string) => Promise<void>;
+  isDisconnecting: boolean;
+}
+
+/**
+ * One connected account: email, its own sync status, and a two-step
+ * disconnect (not undoable without redoing the whole OAuth flow, so the
+ * first press swaps in an explicit confirm - same shape the sidebar's
+ * per-account header used to own directly).
+ */
+const AccountRow: FC<AccountRowProps> = ({
+  connection,
+  disconnect,
+  isDisconnecting,
+}) => {
+  const [isConfirming, setIsConfirming] = useState(false);
+  const accountEmail = connection.accountEmail ?? "Unknown account";
+  const status = getGoogleSyncStatus(
+    connection.connectionState ?? "NOT_CONNECTED",
+    connection,
+  );
+
+  return (
+    <div className="flex items-center justify-between gap-2">
+      <div className="min-w-0">
+        <p className="truncate text-sm text-text" translate="no">
+          {accountEmail}
+        </p>
+        {status ? (
+          <p
+            className={`text-xs ${SYNC_STATUS_VARIANT_CLASSNAME[status.variant]}`}
+          >
+            {status.text}
+          </p>
+        ) : null}
+      </div>
+      {isConfirming ? (
+        <div className="flex shrink-0 items-center gap-1">
+          <button
+            aria-busy={isDisconnecting || undefined}
+            aria-label={`Confirm disconnecting ${accountEmail}`}
+            className="c-focus-ring rounded-xs px-1.5 py-0.5 text-error text-xs hover:brightness-110 disabled:pointer-events-none disabled:opacity-60"
+            disabled={isDisconnecting}
+            onClick={() =>
+              void disconnect(connection.id, accountEmail).finally(() =>
+                setIsConfirming(false),
+              )
+            }
+            type="button"
+          >
+            {isDisconnecting ? "Disconnecting…" : "Confirm"}
+          </button>
+          <button
+            className="c-focus-ring rounded-xs px-1.5 py-0.5 text-text-muted text-xs hover:text-text disabled:pointer-events-none disabled:opacity-60"
+            disabled={isDisconnecting}
+            onClick={() => setIsConfirming(false)}
+            type="button"
+          >
+            Cancel
+          </button>
+        </div>
+      ) : (
+        <button
+          aria-label={`Disconnect ${accountEmail}`}
+          className="c-focus-ring shrink-0 rounded-xs px-1.5 py-0.5 text-text-muted text-xs hover:text-text"
+          onClick={() => setIsConfirming(true)}
+          type="button"
+        >
+          Disconnect
+        </button>
+      )}
+    </div>
+  );
+};

--- a/packages/web/src/components/ManageAccounts/ManageAccountsProvider.tsx
+++ b/packages/web/src/components/ManageAccounts/ManageAccountsProvider.tsx
@@ -1,0 +1,20 @@
+import { type PropsWithChildren } from "react";
+import {
+  ManageAccountsContext,
+  useManageAccountsState,
+} from "@web/components/ManageAccounts/hooks/useManageAccounts";
+import { ManageAccountsDialog } from "@web/components/ManageAccounts/ManageAccountsDialog";
+
+export function ManageAccountsProvider({ children }: PropsWithChildren) {
+  const value = useManageAccountsState();
+
+  return (
+    <ManageAccountsContext.Provider value={value}>
+      {children}
+      <ManageAccountsDialog
+        isOpen={value.isOpen}
+        onDismiss={value.closeManageAccounts}
+      />
+    </ManageAccountsContext.Provider>
+  );
+}

--- a/packages/web/src/components/ManageAccounts/hooks/useManageAccounts.ts
+++ b/packages/web/src/components/ManageAccounts/hooks/useManageAccounts.ts
@@ -1,0 +1,43 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from "react";
+
+interface ManageAccountsContextValue {
+  isOpen: boolean;
+  closeManageAccounts: () => void;
+  openManageAccounts: () => void;
+}
+
+const defaultContextValue: ManageAccountsContextValue = {
+  isOpen: false,
+  closeManageAccounts: () => {},
+  openManageAccounts: () => {},
+};
+
+export const ManageAccountsContext =
+  createContext<ManageAccountsContextValue>(defaultContextValue);
+
+export function useManageAccounts(): ManageAccountsContextValue {
+  return useContext(ManageAccountsContext);
+}
+
+export function useManageAccountsState(): ManageAccountsContextValue {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const openManageAccounts = useCallback(() => {
+    setIsOpen(true);
+  }, []);
+
+  const closeManageAccounts = useCallback(() => {
+    setIsOpen(false);
+  }, []);
+
+  return useMemo(
+    () => ({ isOpen, closeManageAccounts, openManageAccounts }),
+    [isOpen, closeManageAccounts, openManageAccounts],
+  );
+}

--- a/packages/web/src/components/Sidebar/CalendarList/AccountSectionHeader.test.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/AccountSectionHeader.test.tsx
@@ -1,10 +1,10 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { type GoogleSyncConnectionSummary } from "@core/types/user.types";
 import { createStoreWrapper } from "@web/__tests__/render-with-store";
-import { AuthApi } from "@web/api/auth.api";
+import { toggleAccountCollapsed } from "@web/calendars/collapsed-accounts.store";
 import { AccountSectionHeader } from "./AccountSectionHeader";
-import { describe, expect, it, spyOn } from "bun:test";
+import { describe, expect, it } from "bun:test";
 
 const connection = (
   overrides: Partial<GoogleSyncConnectionSummary> = {},
@@ -30,119 +30,28 @@ const renderHeader = (summary = connection()) => {
   );
 };
 
-describe("AccountSectionHeader disconnect", () => {
-  it("asks for confirmation before disconnecting", async () => {
-    const disconnect = spyOn(
-      AuthApi,
-      "disconnectGoogleConnection",
-    ).mockResolvedValue(undefined);
-
+describe("AccountSectionHeader", () => {
+  it("expands by default, and toggles aria-expanded on click", async () => {
     const user = userEvent.setup({ delay: null });
     renderHeader();
 
-    await user.click(
-      screen.getByRole("button", { name: "Disconnect ahab@pequod.com" }),
-    );
+    const toggle = screen.getByRole("button", { name: "ahab@pequod.com" });
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
 
-    // Disconnecting is not undoable without redoing the whole OAuth flow, so
-    // the first press must not call the API.
-    expect(disconnect).not.toHaveBeenCalled();
-    expect(
-      screen.getByRole("button", {
-        name: "Confirm disconnecting ahab@pequod.com",
-      }),
-    ).toBeInTheDocument();
+    await user.click(toggle);
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
 
-    disconnect.mockRestore();
+    await user.click(toggle);
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
   });
 
-  it("disconnects that connection once confirmed", async () => {
-    const disconnect = spyOn(
-      AuthApi,
-      "disconnectGoogleConnection",
-    ).mockResolvedValue(undefined);
+  it("starts collapsed when the account's key is already in the collapsed store", () => {
+    toggleAccountCollapsed("ahab@pequod.com");
 
-    const user = userEvent.setup({ delay: null });
-    renderHeader(connection({ id: "connection-second" }));
-
-    await user.click(
-      screen.getByRole("button", { name: "Disconnect ahab@pequod.com" }),
-    );
-    await user.click(
-      screen.getByRole("button", {
-        name: "Confirm disconnecting ahab@pequod.com",
-      }),
-    );
-
-    await waitFor(() => {
-      expect(disconnect).toHaveBeenCalledWith("connection-second");
-    });
-
-    disconnect.mockRestore();
-  });
-
-  it("backs out of the confirm without disconnecting", async () => {
-    const disconnect = spyOn(
-      AuthApi,
-      "disconnectGoogleConnection",
-    ).mockResolvedValue(undefined);
-
-    const user = userEvent.setup({ delay: null });
     renderHeader();
 
-    await user.click(
-      screen.getByRole("button", { name: "Disconnect ahab@pequod.com" }),
-    );
-    await user.click(screen.getByRole("button", { name: "Cancel" }));
-
-    expect(disconnect).not.toHaveBeenCalled();
     expect(
-      screen.getByRole("button", { name: "Disconnect ahab@pequod.com" }),
-    ).toBeInTheDocument();
-
-    disconnect.mockRestore();
-  });
-
-  it("returns to the un-confirmed state when the disconnect fails", async () => {
-    const disconnect = spyOn(
-      AuthApi,
-      "disconnectGoogleConnection",
-    ).mockRejectedValue(new Error("nope"));
-
-    const user = userEvent.setup({ delay: null });
-    renderHeader();
-
-    await user.click(
-      screen.getByRole("button", { name: "Disconnect ahab@pequod.com" }),
-    );
-    await user.click(
-      screen.getByRole("button", {
-        name: "Confirm disconnecting ahab@pequod.com",
-      }),
-    );
-
-    // A stuck "Disconnecting…" would read as a disconnect that half-happened.
-    await waitFor(() => {
-      expect(
-        screen.getByRole("button", { name: "Disconnect ahab@pequod.com" }),
-      ).toBeInTheDocument();
-    });
-
-    disconnect.mockRestore();
-  });
-
-  it("offers no disconnect for an account with no connection summary yet", () => {
-    const { wrapper } = createStoreWrapper();
-    render(
-      <AccountSectionHeader
-        accountEmail="ahab@pequod.com"
-        connection={undefined}
-      />,
-      { wrapper },
-    );
-
-    expect(
-      screen.queryByRole("button", { name: /^Disconnect/ }),
-    ).not.toBeInTheDocument();
+      screen.getByRole("button", { name: "ahab@pequod.com" }),
+    ).toHaveAttribute("aria-expanded", "false");
   });
 });

--- a/packages/web/src/components/Sidebar/CalendarList/AccountSectionHeader.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/AccountSectionHeader.tsx
@@ -1,23 +1,29 @@
-import { useQueryClient } from "@tanstack/react-query";
-import { type FC, useCallback, useState } from "react";
+import { CaretDownIcon } from "@phosphor-icons/react";
+import { type FC } from "react";
 import { type GoogleSyncConnectionSummary } from "@core/types/user.types";
-import { AuthApi } from "@web/api/auth.api";
-import { refreshUserMetadata } from "@web/auth/compass/user/util/user-metadata.util";
 import { useConnectGoogle } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle";
 import {
   formatLastSyncedLabel,
   getGoogleSyncStatus,
 } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle.util";
-import { calendarQueryKeys } from "@web/calendars/calendar.query";
+import {
+  accountCalendarListId,
+  toggleAccountCollapsed,
+  useCollapsedAccountKeys,
+} from "@web/calendars/collapsed-accounts.store";
 import { SYNC_STATUS_VARIANT_CLASSNAME } from "@web/calendars/sync-status.types";
-import { showErrorToast } from "@web/common/utils/toast/error-toast.util";
-import { eventQueryKeys } from "@web/events/queries/event.query.keys";
+import { AddAccountButton } from "./AddAccountButton";
 
 /**
- * Heading for one connected account's calendars: the account email, that
+ * Heading for one connected account's calendars: the account email (also the
+ * collapse toggle for its calendar rows, see CalendarList.tsx), that
  * account's own sync status, and its own reconnect/refresh action. Rendered
  * only when more than one account is connected - with a single account the
- * calendar list heading already carries all of this.
+ * calendar list heading already carries all of this. Adding/disconnecting
+ * accounts lives in the command palette's "Add/remove accounts" (a full
+ * account-management surface) and this heading's own hover-revealed plus
+ * icon - not a permanent row here, which stayed noisy for accounts with many
+ * subcalendars.
  */
 export const AccountSectionHeader: FC<{
   accountEmail: string;
@@ -39,17 +45,34 @@ export const AccountSectionHeader: FC<{
         : isRefreshing
           ? "Refreshing…"
           : commandAction.label;
+  const collapsedKeys = useCollapsedAccountKeys();
+  const isCollapsed = collapsedKeys.has(accountEmail);
 
   return (
     <div className="mb-1.5">
-      <h3
-        className={`mb-0.5 min-w-0 truncate font-semibold text-xs leading-none ${
-          isSyncing ? "c-sync-text-wave" : "text-text"
-        }`}
-        translate="no"
-      >
-        {accountEmail}
-      </h3>
+      <div className="group/header mb-0.5 flex min-w-0 items-center justify-between gap-1">
+        <h3 className="min-w-0 flex-1 font-semibold text-xs leading-none">
+          <button
+            aria-controls={accountCalendarListId(accountEmail)}
+            aria-expanded={!isCollapsed}
+            className={`c-focus-ring flex w-full min-w-0 items-center gap-1 rounded-xs text-left ${
+              isSyncing ? "c-sync-text-wave" : "text-text"
+            }`}
+            onClick={() => toggleAccountCollapsed(accountEmail)}
+            type="button"
+          >
+            <CaretDownIcon
+              aria-hidden="true"
+              className={`shrink-0 transition-transform ${isCollapsed ? "-rotate-90" : ""}`}
+              size={10}
+            />
+            <span className="min-w-0 truncate" translate="no">
+              {accountEmail}
+            </span>
+          </button>
+        </h3>
+        <AddAccountButton />
+      </div>
       {syncStatus ? (
         <p
           aria-live="polite"
@@ -62,100 +85,18 @@ export const AccountSectionHeader: FC<{
       {lastSyncedLabel ? (
         <p className="text-text-muted text-xs">{lastSyncedLabel}</p>
       ) : null}
-      <div className="mt-1 flex flex-wrap items-center gap-1">
-        {isAvailable && commandAction != null && actionLabel != null ? (
-          <button
-            aria-busy={isConnecting || isRefreshing || undefined}
-            aria-label={`${actionLabel} for ${accountEmail}`}
-            className="c-focus-ring rounded-xs px-1.5 py-0.5 text-accent text-xs hover:brightness-110 disabled:pointer-events-none disabled:opacity-60"
-            disabled={isConnecting || isRefreshing}
-            onClick={commandAction.onSelect}
-            type="button"
-          >
-            {actionLabel}
-          </button>
-        ) : null}
-        {connection ? (
-          <DisconnectAccountAction
-            accountEmail={accountEmail}
-            connectionId={connection.id}
-          />
-        ) : null}
-      </div>
+      {isAvailable && commandAction != null && actionLabel != null ? (
+        <button
+          aria-busy={isConnecting || isRefreshing || undefined}
+          aria-label={`${actionLabel} for ${accountEmail}`}
+          className="c-focus-ring mt-1 rounded-xs px-1.5 py-0.5 text-accent text-xs hover:brightness-110 disabled:pointer-events-none disabled:opacity-60"
+          disabled={isConnecting || isRefreshing}
+          onClick={commandAction.onSelect}
+          type="button"
+        >
+          {actionLabel}
+        </button>
+      ) : null}
     </div>
-  );
-};
-
-/**
- * Removes one account's calendars and events from Compass. Two-step, since it
- * is not undoable without redoing the whole OAuth flow: the first press swaps
- * in an explicit confirm. The user's other accounts, and their Compass
- * sign-in, are untouched.
- */
-const DisconnectAccountAction: FC<{
-  accountEmail: string;
-  connectionId: string;
-}> = ({ accountEmail, connectionId }) => {
-  const queryClient = useQueryClient();
-  const [isConfirming, setIsConfirming] = useState(false);
-  const [isDisconnecting, setIsDisconnecting] = useState(false);
-
-  const disconnect = useCallback(() => {
-    setIsDisconnecting(true);
-    AuthApi.disconnectGoogleConnection(connectionId)
-      .then(async () => {
-        // The account's calendars and its events both disappear, and the
-        // remaining connections are what drive the sidebar's sections.
-        await Promise.all([
-          queryClient.invalidateQueries({ queryKey: calendarQueryKeys.all }),
-          queryClient.invalidateQueries({ queryKey: eventQueryKeys.all }),
-          refreshUserMetadata({ force: true }),
-        ]);
-      })
-      .catch(() => {
-        showErrorToast(
-          `We couldn't disconnect ${accountEmail}. Please try again in a moment.`,
-        );
-      })
-      .finally(() => {
-        setIsDisconnecting(false);
-        setIsConfirming(false);
-      });
-  }, [accountEmail, connectionId, queryClient]);
-
-  if (!isConfirming) {
-    return (
-      <button
-        aria-label={`Disconnect ${accountEmail}`}
-        className="c-focus-ring rounded-xs px-1.5 py-0.5 text-text-muted text-xs hover:text-text"
-        onClick={() => setIsConfirming(true)}
-        type="button"
-      >
-        Disconnect
-      </button>
-    );
-  }
-
-  return (
-    <>
-      <button
-        aria-busy={isDisconnecting || undefined}
-        aria-label={`Confirm disconnecting ${accountEmail}`}
-        className="c-focus-ring rounded-xs px-1.5 py-0.5 text-error text-xs hover:brightness-110 disabled:pointer-events-none disabled:opacity-60"
-        disabled={isDisconnecting}
-        onClick={disconnect}
-        type="button"
-      >
-        {isDisconnecting ? "Disconnecting…" : "Confirm disconnect"}
-      </button>
-      <button
-        className="c-focus-ring rounded-xs px-1.5 py-0.5 text-text-muted text-xs hover:text-text disabled:pointer-events-none disabled:opacity-60"
-        disabled={isDisconnecting}
-        onClick={() => setIsConfirming(false)}
-        type="button"
-      >
-        Cancel
-      </button>
-    </>
   );
 };

--- a/packages/web/src/components/Sidebar/CalendarList/AddAccountButton.test.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/AddAccountButton.test.tsx
@@ -1,0 +1,68 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { type GoogleUiState } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle.types";
+import { describe, expect, it, mock } from "bun:test";
+
+let mockState: GoogleUiState = "HEALTHY";
+let mockIsAvailable = true;
+let mockIsConnecting = false;
+const mockConnect = mock();
+
+mock.module("@web/auth/google/hooks/useConnectGoogle/useConnectGoogle", () => ({
+  useConnectGoogle: () => ({
+    connect: mockConnect,
+    isAvailable: mockIsAvailable,
+    isConnecting: mockIsConnecting,
+    state: mockState,
+  }),
+}));
+
+const { AddAccountButton } = await import("./AddAccountButton");
+
+describe("AddAccountButton", () => {
+  it("connects a new Google account on click, once a first account is healthy", async () => {
+    mockState = "HEALTHY";
+    mockIsAvailable = true;
+    mockIsConnecting = false;
+    const user = userEvent.setup({ delay: null });
+
+    render(<AddAccountButton />);
+
+    await user.click(screen.getByRole("button", { name: "Add account" }));
+    expect(mockConnect).toHaveBeenCalledTimes(1);
+  });
+
+  it("also renders while a connection is importing", () => {
+    mockState = "IMPORTING";
+    mockIsAvailable = true;
+
+    render(<AddAccountButton />);
+
+    expect(
+      screen.getByRole("button", { name: "Add account" }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders nothing before the first account is connected", () => {
+    mockState = "NOT_CONNECTED";
+    mockIsAvailable = true;
+
+    render(<AddAccountButton />);
+
+    expect(
+      screen.queryByRole("button", { name: "Add account" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders nothing when Google Calendar is not configured", () => {
+    mockState = "HEALTHY";
+    mockIsAvailable = false;
+
+    render(<AddAccountButton />);
+
+    expect(
+      screen.queryByRole("button", { name: "Add account" }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/packages/web/src/components/Sidebar/CalendarList/AddAccountButton.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/AddAccountButton.tsx
@@ -1,0 +1,38 @@
+import { PlusIcon } from "@phosphor-icons/react";
+import { type FC } from "react";
+import { useConnectGoogle } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle";
+import { TooltipWrapper } from "@web/components/Tooltip/TooltipWrapper";
+
+/**
+ * Hover-revealed affordance on an account heading for connecting another
+ * Google account - alongside the command palette's "Add/remove accounts",
+ * this is the sidebar's only entry point for adding an account, so it never
+ * needs its own permanent row. Only offered once a first account is already
+ * healthy; before that the header's own Connect button covers it. Expects a
+ * `group/header` ancestor to control its hover reveal.
+ */
+export const AddAccountButton: FC = () => {
+  const { connect, isAvailable, isConnecting, state } = useConnectGoogle();
+
+  if (!isAvailable || (state !== "HEALTHY" && state !== "IMPORTING")) {
+    return null;
+  }
+
+  return (
+    <TooltipWrapper
+      description="Add account"
+      disabled={isConnecting}
+      onClick={connect}
+    >
+      <button
+        aria-busy={isConnecting || undefined}
+        aria-label="Add account"
+        className="c-focus-ring shrink-0 rounded p-0.5 text-text-muted opacity-0 hover:bg-surface-panel focus-visible:opacity-100 group-hover/header:opacity-100"
+        disabled={isConnecting}
+        type="button"
+      >
+        <PlusIcon aria-hidden="true" size={14} />
+      </button>
+    </TooltipWrapper>
+  );
+};

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarList.test.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarList.test.tsx
@@ -572,38 +572,62 @@ describe("CalendarList", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("offers to add another account once one is connected", async () => {
-    const connect = mock();
-    mockUseConnectGoogle.mockReturnValue({
-      commandAction: null,
-      connect,
-      isAvailable: true,
-      isConnecting: false,
-      state: "HEALTHY" as const,
+  it("collapses and re-expands an account's calendar rows on heading click", async () => {
+    const work = makeCalendar({
+      name: "Work",
+      accountEmail: "ahab@pequod.com",
+    });
+    const personal = makeCalendar({
+      name: "Personal",
+      accountEmail: "ahab@gmail.com",
     });
 
     const user = userEvent.setup({ delay: null });
-    renderCalendarList([makeCalendar({ name: "Work" })]);
-
-    await user.click(screen.getByRole("button", { name: "Add account" }));
-    expect(connect).toHaveBeenCalledTimes(1);
-  });
-
-  it("does not offer to add an account before the first one is connected", () => {
-    // The header's own Connect action covers this case.
-    mockUseConnectGoogle.mockReturnValue({
-      commandAction: null,
-      connect: mock(),
-      isAvailable: true,
-      isConnecting: false,
-      state: "NOT_CONNECTED" as const,
+    renderCalendarList([work, personal], {
+      connections: [
+        makeConnection("ahab@pequod.com"),
+        makeConnection("ahab@gmail.com"),
+      ],
     });
 
-    renderCalendarList([makeCalendar({ name: "Compass", provider: "local" })]);
+    expect(screen.getByText("Work")).toBeInTheDocument();
+    const toggle = screen.getByRole("button", { name: "ahab@pequod.com" });
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
 
-    expect(
-      screen.queryByRole("button", { name: "Add account" }),
-    ).not.toBeInTheDocument();
+    await user.click(toggle);
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByText("Work")).not.toBeInTheDocument();
+    // The other section is unaffected.
+    expect(screen.getByText("Personal")).toBeInTheDocument();
+
+    await user.click(toggle);
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByText("Work")).toBeInTheDocument();
+  });
+
+  it("keeps the ungrouped local calendar visible regardless of account collapse state", async () => {
+    const work = makeCalendar({
+      name: "Work",
+      accountEmail: "ahab@pequod.com",
+    });
+    const personal = makeCalendar({
+      name: "Personal",
+      accountEmail: "ahab@gmail.com",
+    });
+    const local = makeCalendar({ name: "Compass", provider: "local" });
+
+    const user = userEvent.setup({ delay: null });
+    renderCalendarList([work, personal, local], {
+      connections: [
+        makeConnection("ahab@pequod.com"),
+        makeConnection("ahab@gmail.com"),
+      ],
+    });
+
+    await user.click(screen.getByRole("button", { name: "ahab@pequod.com" }));
+    await user.click(screen.getByRole("button", { name: "ahab@gmail.com" }));
+
+    expect(screen.getByText("Compass")).toBeInTheDocument();
   });
 
   it("shows a loading state while calendars are pending", () => {

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarList.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarList.tsx
@@ -9,6 +9,11 @@ import {
   useUserMetadataStore,
 } from "@web/auth/state/user-metadata.store";
 import { useCalendarsQuery } from "@web/calendars/calendar.query";
+import {
+  accountCalendarListId,
+  SINGLE_ACCOUNT_COLLAPSE_KEY,
+  useCollapsedAccountKeys,
+} from "@web/calendars/collapsed-accounts.store";
 import { setDefaultCalendarId } from "@web/calendars/default-calendar.store";
 import { useCalendarVisibility } from "@web/calendars/useCalendarVisibility";
 import { useDefaultTargetCalendar } from "@web/calendars/useDefaultTargetCalendar";
@@ -90,11 +95,12 @@ interface Props {
 
 export const CalendarList: FC<Props> = ({ Header = CalendarListHeader }) => {
   const { authenticated } = useSession();
-  const { connect, isAvailable, isConnecting, state } = useConnectGoogle();
+  const { isAvailable, state } = useConnectGoogle();
   const { data, isPending, isError, refetch } = useCalendarsQuery();
   const { toggleCalendarVisibility, failureAnnouncement } =
     useCalendarVisibility();
   const connections = useUserMetadataStore(selectGoogleSyncConnections);
+  const collapsedKeys = useCollapsedAccountKeys();
 
   const calendars = sortCalendars(
     (data ?? []).filter((calendar) => calendar.isActive),
@@ -103,8 +109,8 @@ export const CalendarList: FC<Props> = ({ Header = CalendarListHeader }) => {
   const { groups, ungrouped } = groupCalendarsByAccount(calendars, connections);
   const showAccountSections = groups.length > 1;
 
-  const renderRows = (rows: Calendar[]) => (
-    <ul className="flex flex-col gap-1.5">
+  const renderRows = (rows: Calendar[], id?: string) => (
+    <ul className="flex flex-col gap-1.5" id={id}>
       {rows.map((calendar) => (
         <CalendarRow
           calendar={calendar}
@@ -115,6 +121,14 @@ export const CalendarList: FC<Props> = ({ Header = CalendarListHeader }) => {
       ))}
     </ul>
   );
+
+  // Renders nothing (rather than an aria-hidden wrapper) when collapsed: the
+  // toggle in the account's own heading still announces aria-expanded, and
+  // this way a hidden section's rows are never briefly stale mid-toggle.
+  const renderCollapsible = (key: string, rows: Calendar[]) =>
+    collapsedKeys.has(key)
+      ? null
+      : renderRows(rows, accountCalendarListId(key));
 
   return (
     <section aria-label="Calendars">
@@ -158,30 +172,16 @@ export const CalendarList: FC<Props> = ({ Header = CalendarListHeader }) => {
                 accountEmail={group.accountEmail}
                 connection={group.connection}
               />
-              {renderRows(group.calendars)}
+              {renderCollapsible(group.accountEmail, group.calendars)}
             </section>
           ))}
           {ungrouped.length > 0 ? renderRows(ungrouped) : null}
         </div>
+      ) : authenticated ? (
+        renderCollapsible(SINGLE_ACCOUNT_COLLAPSE_KEY, calendars)
       ) : (
         renderRows(calendars)
       )}
-
-      {/* Adding a second account is only meaningful once the first one is
-          connected; before that the header's own Connect action covers it. */}
-      {authenticated &&
-      isAvailable &&
-      (state === "HEALTHY" || state === "IMPORTING") ? (
-        <button
-          aria-busy={isConnecting || undefined}
-          className="c-focus-ring mt-3 rounded-xs px-1 py-0.5 text-accent text-xs hover:brightness-110 disabled:pointer-events-none disabled:opacity-60"
-          disabled={isConnecting}
-          onClick={connect}
-          type="button"
-        >
-          {isConnecting ? "Opening Google…" : "Add account"}
-        </button>
-      ) : null}
 
       <span aria-live="polite" className="sr-only" role="status">
         {failureAnnouncement}

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarListHeader.test.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarListHeader.test.tsx
@@ -446,4 +446,21 @@ describe("CalendarListHeader", () => {
       connection: ownConnection,
     });
   });
+
+  it("toggles the collapse state of the calendar list on heading click", async () => {
+    mockEmail = "ahab@pequod.com";
+    mockGoogleState = "HEALTHY";
+    const user = userEvent.setup({ delay: null });
+
+    renderHeader();
+
+    const toggle = screen.getByRole("button", { name: "ahab@pequod.com" });
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+
+    await user.click(toggle);
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+
+    await user.click(toggle);
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+  });
 });

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarListHeader.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarListHeader.tsx
@@ -1,3 +1,4 @@
+import { CaretDownIcon } from "@phosphor-icons/react";
 import classNames from "classnames";
 import { type FC, useCallback, useMemo, useSyncExternalStore } from "react";
 import {
@@ -16,6 +17,12 @@ import {
   useUserMetadataStore,
 } from "@web/auth/state/user-metadata.store";
 import {
+  accountCalendarListId,
+  SINGLE_ACCOUNT_COLLAPSE_KEY,
+  toggleAccountCollapsed,
+  useCollapsedAccountKeys,
+} from "@web/calendars/collapsed-accounts.store";
+import {
   SYNC_STATUS_VARIANT_CLASSNAME,
   type SyncStatus,
 } from "@web/calendars/sync-status.types";
@@ -26,14 +33,18 @@ import {
   TooltipTrigger,
 } from "@web/components/Tooltip";
 import { useHasPendingEventMutations } from "@web/events/mutations/useEventPending";
+import { AddAccountButton } from "./AddAccountButton";
 
 const ANONYMOUS_SAVE_MESSAGE = "Sign up to save your changes across browsers";
 
 const TOOLTIP_ACTION_BUTTON_CLASSNAME =
   "c-focus-ring self-start rounded-xs bg-accent px-2 py-1 font-medium text-s text-on-accent hover:brightness-110";
 
+const HEADER_ROW_CLASSNAME =
+  "group/header mb-2 flex min-w-0 items-center justify-between gap-1";
+
 const HEADING_CLASSNAME =
-  "mb-2 flex min-w-0 font-semibold text-sm leading-none";
+  "flex min-w-0 flex-1 font-semibold text-sm leading-none";
 
 const ANONYMOUS_ACCOUNT_TRIGGER_CLASSNAME =
   "min-w-0 truncate appearance-none border-0 bg-transparent p-0 text-left font-semibold focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent";
@@ -103,7 +114,7 @@ const AnonymousAccountHeader: FC = () => {
   }, [openModal]);
 
   return (
-    <h2 className={HEADING_CLASSNAME}>
+    <h2 className={classNames(HEADING_CLASSNAME, "mb-2")}>
       <Tooltip interactive>
         <TooltipTrigger asChild>
           <button
@@ -170,20 +181,38 @@ const AuthenticatedAccountHeader: FC<{ email: string }> = ({ email }) => {
         : isRefreshing
           ? "Refreshing…"
           : commandAction.label;
+  const collapsedKeys = useCollapsedAccountKeys();
+  const isCollapsed = collapsedKeys.has(SINGLE_ACCOUNT_COLLAPSE_KEY);
 
   return (
     <>
-      <h2 className={HEADING_CLASSNAME}>
-        <span
-          className={classNames(
-            "min-w-0 truncate",
-            isSyncing ? "c-sync-text-wave" : "text-text",
-          )}
-          translate="no"
-        >
-          {email}
-        </span>
-      </h2>
+      <div className={HEADER_ROW_CLASSNAME}>
+        <h2 className={HEADING_CLASSNAME}>
+          <button
+            aria-controls={accountCalendarListId(SINGLE_ACCOUNT_COLLAPSE_KEY)}
+            aria-expanded={!isCollapsed}
+            className="c-focus-ring flex w-full min-w-0 items-center gap-1 rounded-xs text-left"
+            onClick={() => toggleAccountCollapsed(SINGLE_ACCOUNT_COLLAPSE_KEY)}
+            type="button"
+          >
+            <CaretDownIcon
+              aria-hidden="true"
+              className={`shrink-0 transition-transform ${isCollapsed ? "-rotate-90" : ""}`}
+              size={12}
+            />
+            <span
+              className={classNames(
+                "min-w-0 truncate",
+                isSyncing ? "c-sync-text-wave" : "text-text",
+              )}
+              translate="no"
+            >
+              {email}
+            </span>
+          </button>
+        </h2>
+        <AddAccountButton />
+      </div>
       {syncStatus ? (
         <p
           aria-live="polite"


### PR DESCRIPTION
## Summary

The sidebar's "Add account" button and per-account "Disconnect" link were permanent rows in the calendar list — noisy on their own, and worse for accounts with many subcalendars, where the whole list gets long fast. This gives users the same control through less-permanent surfaces, plus lets them collapse an account's calendars entirely.

- **"Add account" and "Disconnect" move into a command-palette item, "Add/remove accounts"**, which opens a modal listing every connected account with its own status and a two-step disconnect (same confirm-before-disconnect shape the sidebar used to own directly, now centralized in one place regardless of how many accounts you have).
- **A second, faster path stays in the sidebar**: hovering an account's email heading reveals a plus icon (tooltip "Add account") that starts the same OAuth flow — still gated on a first account already being healthy, same as before.
- **Each account heading is now also the collapse toggle** for its calendar rows (click the text or the caret) — for accounts with many subcalendars. Works for both multi-account section headers and the single-account flat list, persisted in localStorage per account email (a fixed sentinel key for the single-account case, since it's a display preference, not tied to which specific account happens to be connected).

`selectPrimaryGoogleConnection` (the backend precedence-winner PR #2578 fixed the header-scoping bug around) is unrelated to this and untouched — this PR doesn't change how any account's status is derived, only where the add/disconnect controls live and adds the collapse affordance.

## Test plan
- [x] New tests: collapse toggle (both multi- and single-account), `ManageAccountsDialog` (list, status per row, two-step disconnect ported from the old sidebar tests, empty state, Done), `useManageAccountsCmdItems`, `AddAccountButton` (gating + click), `collapsed-accounts.store`
- [x] Updated `CalendarList.test.tsx`/`AccountSectionHeader.test.tsx` for the removed sidebar rows
- [x] `bun run test:web` — 1660/1660 pass
- [x] `bun run type-check` clean, `biome check` clean
- [x] grepped `e2e/` for "Add account"/"Disconnect" — no references, nothing to update
- [ ] Live check on staging after merge (local dev needs Sync-service credentials not configured in this worktree): hover reveals the plus icon with "Add account" tooltip on both single- and multi-account headers; command palette → "Add/remove accounts" opens the modal; disconnect + re-add round-trip from the modal; clicking an account heading collapses/expands its calendars and survives reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)