### PR TITLE
refactor(web): dedupe sidebar account-heading UI and memoize calendar grouping

### DIFF
--- a/packages/web/src/calendars/SyncStatusLine.tsx
+++ b/packages/web/src/calendars/SyncStatusLine.tsx
@@ -1,0 +1,34 @@
+import { type FC } from "react";
+import {
+  SYNC_STATUS_VARIANT_CLASSNAME,
+  type SyncStatus,
+} from "./sync-status.types";
+
+interface SyncStatusLineProps {
+  status: SyncStatus;
+  /** Extra classes (e.g. spacing) layered onto the shared status styling. */
+  className?: string;
+}
+
+/**
+ * One account's live sync status line - shared by the sidebar's single- and
+ * per-account headers and the manage-accounts dialog, so the surfaces a user
+ * directly compares cannot drift. Renders nothing when there's no status to
+ * show (e.g. NOT_CONNECTED).
+ */
+export const SyncStatusLine: FC<SyncStatusLineProps> = ({
+  status,
+  className,
+}) => {
+  if (!status) return null;
+
+  return (
+    <p
+      aria-live="polite"
+      className={`text-xs ${SYNC_STATUS_VARIANT_CLASSNAME[status.variant]} ${className ?? ""}`}
+      role="status"
+    >
+      {status.text}
+    </p>
+  );
+};

--- a/packages/web/src/components/ManageAccounts/ManageAccountsDialog.tsx
+++ b/packages/web/src/components/ManageAccounts/ManageAccountsDialog.tsx
@@ -7,7 +7,7 @@ import {
   selectGoogleSyncConnections,
   useUserMetadataStore,
 } from "@web/auth/state/user-metadata.store";
-import { SYNC_STATUS_VARIANT_CLASSNAME } from "@web/calendars/sync-status.types";
+import { SyncStatusLine } from "@web/calendars/SyncStatusLine";
 import {
   OverlayPanel,
   OverlayPanelActionButton,
@@ -101,13 +101,7 @@ const AccountRow: FC<AccountRowProps> = ({
         <p className="truncate text-sm text-text" translate="no">
           {accountEmail}
         </p>
-        {status ? (
-          <p
-            className={`text-xs ${SYNC_STATUS_VARIANT_CLASSNAME[status.variant]}`}
-          >
-            {status.text}
-          </p>
-        ) : null}
+        <SyncStatusLine status={status} />
       </div>
       {isConfirming ? (
         <div className="flex shrink-0 items-center gap-1">

--- a/packages/web/src/components/Sidebar/CalendarList/AccountDisclosureHeading.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/AccountDisclosureHeading.tsx
@@ -1,0 +1,72 @@
+import { CaretDownIcon } from "@phosphor-icons/react";
+import classNames from "classnames";
+import { type FC } from "react";
+import {
+  accountCalendarListId,
+  toggleAccountCollapsed,
+} from "@web/calendars/collapsed-accounts.store";
+
+interface AccountDisclosureHeadingProps {
+  /** Heading level - h2 for the single-account header, h3 for a multi-account
+   * section (which sits under the calendar list's own h2). */
+  as: "h2" | "h3";
+  /** Extra classes for font size etc.; layout/spacing stays with the caller. */
+  className?: string;
+  /** localStorage key this heading's collapse state is stored under - the
+   * account's own email, or the single-account sentinel. */
+  collapseKey: string;
+  email: string;
+  isCollapsed: boolean;
+  isSyncing: boolean;
+  caretSize?: number;
+}
+
+/**
+ * An account's email, rendered as both its own heading and the collapse
+ * toggle for its calendar rows - shared by the sidebar's single-account
+ * header and each multi-account section heading so the two surfaces'
+ * disclosure a11y wiring (aria-expanded/aria-controls, the caret) cannot
+ * drift apart.
+ */
+export const AccountDisclosureHeading: FC<AccountDisclosureHeadingProps> = ({
+  as: Heading,
+  className,
+  collapseKey,
+  email,
+  isCollapsed,
+  isSyncing,
+  caretSize = 12,
+}) => (
+  <Heading
+    className={classNames(
+      "min-w-0 flex-1 font-semibold leading-none",
+      className,
+    )}
+  >
+    <button
+      aria-controls={accountCalendarListId(collapseKey)}
+      aria-expanded={!isCollapsed}
+      className="c-focus-ring flex w-full min-w-0 items-center gap-1 rounded-xs text-left"
+      onClick={() => toggleAccountCollapsed(collapseKey)}
+      type="button"
+    >
+      <CaretDownIcon
+        aria-hidden="true"
+        className={classNames(
+          "shrink-0 transition-transform",
+          isCollapsed && "-rotate-90",
+        )}
+        size={caretSize}
+      />
+      <span
+        className={classNames(
+          "min-w-0 truncate",
+          isSyncing ? "c-sync-text-wave" : "text-text",
+        )}
+        translate="no"
+      >
+        {email}
+      </span>
+    </button>
+  </Heading>
+);

--- a/packages/web/src/components/Sidebar/CalendarList/AccountSectionHeader.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/AccountSectionHeader.tsx
@@ -1,4 +1,3 @@
-import { CaretDownIcon } from "@phosphor-icons/react";
 import { type FC } from "react";
 import { type GoogleSyncConnectionSummary } from "@core/types/user.types";
 import { useConnectGoogle } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle";
@@ -6,12 +5,9 @@ import {
   formatLastSyncedLabel,
   getGoogleSyncStatus,
 } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle.util";
-import {
-  accountCalendarListId,
-  toggleAccountCollapsed,
-  useCollapsedAccountKeys,
-} from "@web/calendars/collapsed-accounts.store";
-import { SYNC_STATUS_VARIANT_CLASSNAME } from "@web/calendars/sync-status.types";
+import { useCollapsedAccountKeys } from "@web/calendars/collapsed-accounts.store";
+import { SyncStatusLine } from "@web/calendars/SyncStatusLine";
+import { AccountDisclosureHeading } from "./AccountDisclosureHeading";
 import { AddAccountButton } from "./AddAccountButton";
 
 /**
@@ -51,37 +47,18 @@ export const AccountSectionHeader: FC<{
   return (
     <div className="mb-1.5">
       <div className="group/header mb-0.5 flex min-w-0 items-center justify-between gap-1">
-        <h3 className="min-w-0 flex-1 font-semibold text-xs leading-none">
-          <button
-            aria-controls={accountCalendarListId(accountEmail)}
-            aria-expanded={!isCollapsed}
-            className={`c-focus-ring flex w-full min-w-0 items-center gap-1 rounded-xs text-left ${
-              isSyncing ? "c-sync-text-wave" : "text-text"
-            }`}
-            onClick={() => toggleAccountCollapsed(accountEmail)}
-            type="button"
-          >
-            <CaretDownIcon
-              aria-hidden="true"
-              className={`shrink-0 transition-transform ${isCollapsed ? "-rotate-90" : ""}`}
-              size={10}
-            />
-            <span className="min-w-0 truncate" translate="no">
-              {accountEmail}
-            </span>
-          </button>
-        </h3>
+        <AccountDisclosureHeading
+          as="h3"
+          caretSize={10}
+          className="text-xs"
+          collapseKey={accountEmail}
+          email={accountEmail}
+          isCollapsed={isCollapsed}
+          isSyncing={isSyncing}
+        />
         <AddAccountButton />
       </div>
-      {syncStatus ? (
-        <p
-          aria-live="polite"
-          className={`text-xs ${SYNC_STATUS_VARIANT_CLASSNAME[syncStatus.variant]}`}
-          role="status"
-        >
-          {syncStatus.text}
-        </p>
-      ) : null}
+      <SyncStatusLine status={syncStatus} />
       {lastSyncedLabel ? (
         <p className="text-text-muted text-xs">{lastSyncedLabel}</p>
       ) : null}

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarList.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarList.tsx
@@ -1,5 +1,5 @@
 import { StarIcon } from "@phosphor-icons/react";
-import { type FC } from "react";
+import { type FC, useMemo } from "react";
 import { type Calendar } from "@core/types/calendar.contracts";
 import { type GoogleSyncConnectionSummary } from "@core/types/user.types";
 import { useSession } from "@web/auth/compass/session/useSession";
@@ -102,11 +102,17 @@ export const CalendarList: FC<Props> = ({ Header = CalendarListHeader }) => {
   const connections = useUserMetadataStore(selectGoogleSyncConnections);
   const collapsedKeys = useCollapsedAccountKeys();
 
-  const calendars = sortCalendars(
-    (data ?? []).filter((calendar) => calendar.isActive),
+  // Re-groups on every calendar-visibility/collapse toggle otherwise, since
+  // those live in sibling external stores this component also subscribes to.
+  const calendars = useMemo(
+    () => sortCalendars((data ?? []).filter((calendar) => calendar.isActive)),
+    [data],
   );
   const defaultTargetCalendarId = useDefaultTargetCalendar(calendars)?.id;
-  const { groups, ungrouped } = groupCalendarsByAccount(calendars, connections);
+  const { groups, ungrouped } = useMemo(
+    () => groupCalendarsByAccount(calendars, connections),
+    [calendars, connections],
+  );
   const showAccountSections = groups.length > 1;
 
   const renderRows = (rows: Calendar[], id?: string) => (

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarListHeader.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarListHeader.tsx
@@ -1,4 +1,3 @@
-import { CaretDownIcon } from "@phosphor-icons/react";
 import classNames from "classnames";
 import { type FC, useCallback, useMemo, useSyncExternalStore } from "react";
 import {
@@ -17,15 +16,11 @@ import {
   useUserMetadataStore,
 } from "@web/auth/state/user-metadata.store";
 import {
-  accountCalendarListId,
   SINGLE_ACCOUNT_COLLAPSE_KEY,
-  toggleAccountCollapsed,
   useCollapsedAccountKeys,
 } from "@web/calendars/collapsed-accounts.store";
-import {
-  SYNC_STATUS_VARIANT_CLASSNAME,
-  type SyncStatus,
-} from "@web/calendars/sync-status.types";
+import { SyncStatusLine } from "@web/calendars/SyncStatusLine";
+import { type SyncStatus } from "@web/calendars/sync-status.types";
 import { useAuthModal } from "@web/components/AuthModal/hooks/useAuthModal";
 import {
   Tooltip,
@@ -33,6 +28,7 @@ import {
   TooltipTrigger,
 } from "@web/components/Tooltip";
 import { useHasPendingEventMutations } from "@web/events/mutations/useEventPending";
+import { AccountDisclosureHeading } from "./AccountDisclosureHeading";
 import { AddAccountButton } from "./AddAccountButton";
 
 const ANONYMOUS_SAVE_MESSAGE = "Sign up to save your changes across browsers";
@@ -187,41 +183,17 @@ const AuthenticatedAccountHeader: FC<{ email: string }> = ({ email }) => {
   return (
     <>
       <div className={HEADER_ROW_CLASSNAME}>
-        <h2 className={HEADING_CLASSNAME}>
-          <button
-            aria-controls={accountCalendarListId(SINGLE_ACCOUNT_COLLAPSE_KEY)}
-            aria-expanded={!isCollapsed}
-            className="c-focus-ring flex w-full min-w-0 items-center gap-1 rounded-xs text-left"
-            onClick={() => toggleAccountCollapsed(SINGLE_ACCOUNT_COLLAPSE_KEY)}
-            type="button"
-          >
-            <CaretDownIcon
-              aria-hidden="true"
-              className={`shrink-0 transition-transform ${isCollapsed ? "-rotate-90" : ""}`}
-              size={12}
-            />
-            <span
-              className={classNames(
-                "min-w-0 truncate",
-                isSyncing ? "c-sync-text-wave" : "text-text",
-              )}
-              translate="no"
-            >
-              {email}
-            </span>
-          </button>
-        </h2>
+        <AccountDisclosureHeading
+          as="h2"
+          className="text-sm"
+          collapseKey={SINGLE_ACCOUNT_COLLAPSE_KEY}
+          email={email}
+          isCollapsed={isCollapsed}
+          isSyncing={isSyncing}
+        />
         <AddAccountButton />
       </div>
-      {syncStatus ? (
-        <p
-          aria-live="polite"
-          className={`mb-1 text-xs ${SYNC_STATUS_VARIANT_CLASSNAME[syncStatus.variant]}`}
-          role="status"
-        >
-          {syncStatus.text}
-        </p>
-      ) : null}
+      <SyncStatusLine className="mb-1" status={syncStatus} />
       {lastSyncedLabel ? (
         <p className="mb-2 text-text-muted text-xs">{lastSyncedLabel}</p>
       ) : null}


### PR DESCRIPTION
## Summary
Simplification pass on #2579 (sidebar accounts UX redesign), per the standard `/simplify` 4-angle review (reuse, simplification, efficiency, altitude):

- Extract `AccountDisclosureHeading` - the caret + collapse-toggle + email heading was duplicated between the single-account header (`CalendarListHeader.tsx`) and the multi-account section header (`AccountSectionHeader.tsx`), with 3 of 4 review agents independently flagging it as the strongest duplication in the diff.
- Extract `SyncStatusLine` - the `<p aria-live status>` sync-status paragraph was duplicated three times (both sidebar headers + the new `ManageAccountsDialog`'s account rows, which previously lacked `aria-live`/`role="status"` entirely - now consistent).
- Memoize `CalendarList`'s `sortCalendars`/`groupCalendarsByAccount` calls, which were re-running on every render even though the component re-renders on every calendar-visibility and collapse toggle from sibling external stores.

**Skipped**: the reuse agent also flagged that `collapsed-accounts.store.ts`/`.storage.ts` duplicate the Set-backed localStorage pattern from the pre-existing `calendar-visibility.store.ts`/`.storage.ts` (~50 lines). Not pursued here - those two APIs have slightly different shapes (raw toggle vs. boolean set/get) and extracting a shared factory would mean modifying working, separately-tested, pre-existing code outside this diff's scope for a modest line-count win.

No behavior changes intended; caught and fixed one regression during verification (see test plan).

## Test plan
- [x] `bun run test:web` - 1660/1660 pass (caught a regression from the `AccountDisclosureHeading` extraction: the sync-status class had moved from the email `<span>` onto the wrapping `<button>`, breaking 7 `CalendarListHeader` tests that asserted on the span directly - fixed by keeping the class on the span)
- [x] `bun run type-check` - clean
- [x] `biome check` on touched files - clean (safe fixes only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)