### PR TITLE
fix(web): quiet the sidebar - hide healthy status, no loading shift, muted rows

### DIFF
--- a/packages/web/src/components/Sidebar/CalendarList/AccountSectionHeader.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/AccountSectionHeader.tsx
@@ -1,10 +1,7 @@
 import { type FC } from "react";
 import { type GoogleSyncConnectionSummary } from "@core/types/user.types";
 import { useConnectGoogle } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle";
-import {
-  formatLastSyncedLabel,
-  getGoogleSyncStatus,
-} from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle.util";
+import { getGoogleSyncStatus } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle.util";
 import { useCollapsedAccountKeys } from "@web/calendars/collapsed-accounts.store";
 import { SyncStatusLine } from "@web/calendars/SyncStatusLine";
 import { AccountDisclosureHeading } from "./AccountDisclosureHeading";
@@ -29,10 +26,6 @@ export const AccountSectionHeader: FC<{
     useConnectGoogle({ connection });
   const syncStatus = getGoogleSyncStatus(state, connection);
   const isSyncing = syncStatus?.variant === "syncing";
-  const lastSyncedLabel =
-    syncStatus?.variant === "healthy"
-      ? formatLastSyncedLabel(connection?.lastSyncedAt)
-      : null;
   const actionLabel =
     commandAction == null
       ? null
@@ -58,10 +51,9 @@ export const AccountSectionHeader: FC<{
         />
         <AddAccountButton />
       </div>
-      <SyncStatusLine status={syncStatus} />
-      {lastSyncedLabel ? (
-        <p className="text-text-muted text-xs">{lastSyncedLabel}</p>
-      ) : null}
+      <SyncStatusLine
+        status={syncStatus?.variant === "healthy" ? null : syncStatus}
+      />
       {isAvailable && commandAction != null && actionLabel != null ? (
         <button
           aria-busy={isConnecting || isRefreshing || undefined}

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarList.test.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarList.test.tsx
@@ -442,7 +442,9 @@ describe("CalendarList", () => {
     const broken = within(
       screen.getByRole("region", { name: "Calendars for ahab@gmail.com" }),
     );
-    expect(healthy.getByRole("status").textContent).toBe("Calendar connected");
+    // A healthy account stays quiet in the sidebar - full status lives in
+    // Settings - but a broken one still needs to surface here.
+    expect(healthy.queryByRole("status")).not.toBeInTheDocument();
     expect(broken.getByRole("status").textContent).toBe(
       "Calendar needs reconnecting",
     );
@@ -552,13 +554,14 @@ describe("CalendarList", () => {
     expect(screen.getByText("Compass")).toBeInTheDocument();
   });
 
-  it("shows a loading state while calendars are pending", () => {
+  it("renders no placeholder text while calendars are pending, to avoid a layout shift once they load", () => {
     BaseApi.defaults.adapter = () => new Promise(() => {});
     const { wrapper } = createStoreWrapper();
 
     render(<CalendarList Header={StubHeader} />, { wrapper });
 
-    expect(screen.getByText(/loading calendars/i)).toBeInTheDocument();
+    expect(screen.queryByText(/loading/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole("listitem")).not.toBeInTheDocument();
   });
 
   it("shows an empty state when there are no calendars", () => {

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarList.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarList.tsx
@@ -143,9 +143,7 @@ export const CalendarList: FC<Props> = ({ Header = CalendarListHeader }) => {
           this never hides the sign-up-prompt header they still need. */}
       {!showAccountSections && <Header />}
 
-      {isPending ? (
-        <p className="text-text-muted text-xs">Loading calendars…</p>
-      ) : isError ? (
+      {isPending ? null : isError ? (
         <div className="flex items-center justify-between gap-2 text-xs">
           <p className="text-error">Couldn't load calendars.</p>
           <button
@@ -210,7 +208,7 @@ const CalendarRow: FC<{
       <button
         aria-label={`${calendar.isVisible ? "Hide" : "Show"} ${displayName} calendar`}
         aria-pressed={calendar.isVisible}
-        className="c-focus-ring flex min-w-0 flex-1 items-center gap-2 rounded px-1 py-0.5 text-left text-text text-xs hover:bg-surface-panel"
+        className="c-focus-ring flex min-w-0 flex-1 items-center gap-2 rounded px-1 py-0.5 text-left text-text-muted text-xs hover:bg-surface-panel hover:text-text"
         onClick={() => onToggle(calendar.id, !calendar.isVisible)}
         type="button"
       >

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarListHeader.test.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarListHeader.test.tsx
@@ -183,7 +183,7 @@ describe("CalendarListHeader", () => {
     expect(mockConnectGoogle).toHaveBeenCalledTimes(1);
   });
 
-  it("shows a healthy status without a connect button when Google is healthy", async () => {
+  it("stays quiet (no status line) when Google is healthy, to cut sidebar noise", async () => {
     const user = userEvent.setup();
     mockEmail = "ahab@pequod.com";
     mockGoogleState = "HEALTHY";
@@ -194,39 +194,11 @@ describe("CalendarListHeader", () => {
     expect(email.tagName).toBe("SPAN");
     expect(email).toHaveClass("text-text");
     expect(email).not.toHaveClass("c-sync-text-wave");
-    expect(screen.getByRole("status")).toHaveTextContent("Calendar connected");
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
     expect(screen.queryByText(/Updated/)).toBeNull();
 
     await user.hover(email);
     expect(screen.queryByRole("tooltip")).toBeNull();
-  });
-
-  it("shows last-synced timing when Sync connection metadata includes lastSyncedAt", () => {
-    mockEmail = "ahab@pequod.com";
-    mockGoogleState = "HEALTHY";
-    const connection = {
-      id: "conn-1",
-      state: "healthy",
-      stateReason: null,
-      lastSyncedAt: new Date().toISOString(),
-      lastHealthyAt: new Date().toISOString(),
-      accountEmail: "ahab@pequod.com",
-    };
-    userMetadataActions.set({
-      google: {
-        connectionState: "HEALTHY",
-        connection,
-        connections: [connection],
-      },
-    });
-
-    renderHeader();
-
-    expect(screen.getByRole("status")).toHaveTextContent("Calendar connected");
-    expect(screen.getByText("Updated just now")).toBeInTheDocument();
-    expect(
-      screen.queryByRole("button", { name: /Google Calendar/ }),
-    ).toBeNull();
   });
 
   it("shows setup status only while the first calendar import is in progress", async () => {
@@ -401,9 +373,11 @@ describe("CalendarListHeader", () => {
 
     renderHeader();
 
-    expect(screen.getByRole("status")).toHaveTextContent("Calendar connected");
+    // Resolves to "healthy" (not "syncing"), so the sidebar shows nothing at
+    // all rather than either status text - full detail lives in Settings.
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
     expect(screen.queryByText("Adding your calendar…")).toBeNull();
-    expect(screen.getByText("Updated just now")).toBeInTheDocument();
+    expect(screen.queryByText(/Updated/)).toBeNull();
   });
 
   it("scopes to the connection matching the signed-in user's own email, not sync's aggregate precedence winner across every connected account", () => {

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarListHeader.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarListHeader.tsx
@@ -7,10 +7,7 @@ import {
 import { useUser } from "@web/auth/compass/user/hooks/useUser";
 import { useConnectGoogle } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle";
 import { type GoogleUiState } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle.types";
-import {
-  formatLastSyncedLabel,
-  getGoogleSyncStatus,
-} from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle.util";
+import { getGoogleSyncStatus } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle.util";
 import {
   selectGoogleSyncConnections,
   useUserMetadataStore,
@@ -163,10 +160,6 @@ const AuthenticatedAccountHeader: FC<{ email: string }> = ({ email }) => {
   const isSyncing =
     syncStatus?.variant === "syncing" || hasPendingEventMutations;
   const showGoogleAction = isAvailable && commandAction != null;
-  const lastSyncedLabel =
-    syncStatus?.variant === "healthy"
-      ? formatLastSyncedLabel(ownConnection?.lastSyncedAt)
-      : null;
   const googleActionLabel =
     commandAction == null
       ? null
@@ -193,10 +186,10 @@ const AuthenticatedAccountHeader: FC<{ email: string }> = ({ email }) => {
         />
         <AddAccountButton />
       </div>
-      <SyncStatusLine className="mb-1" status={syncStatus} />
-      {lastSyncedLabel ? (
-        <p className="mb-2 text-text-muted text-xs">{lastSyncedLabel}</p>
-      ) : null}
+      <SyncStatusLine
+        className="mb-1"
+        status={syncStatus?.variant === "healthy" ? null : syncStatus}
+      />
       {showGoogleAction &&
       commandAction != null &&
       googleActionLabel != null ? (


### PR DESCRIPTION
## Summary
Second of two PRs addressing sidebar UX feedback (#2581 merged first; this one is rebased cleanly on top of it).

- **Hide healthy sync-status noise** in the sidebar: `AuthenticatedAccountHeader` (single-account) and `AccountSectionHeader` (multi-account) now pass `null` to `SyncStatusLine` when the status is healthy, and drop the "Updated X min ago" label entirely. Warnings/errors/syncing are unchanged. Full detail (including healthy) still shows in Settings → Accounts (#2581).
- **No loading-text layout shift**: `CalendarList`'s pending branch renders nothing instead of "Loading calendars…", so the sidebar doesn't jump the instant real data arrives.
- **Muted calendar row text**: row names are `text-text-muted` by default, full `text-text` on row hover - most users set a calendar's visibility once and don't need to keep re-reading the list.

## Test plan
- [x] `bun run test:web` - 1659/1659 pass (reworked the tests that asserted the old noisy behavior to assert the new quiet one instead)
- [x] `bun run type-check` - clean
- [x] `biome check` on touched files - clean

## Not yet verified
- Live staging check (auto-deploys once merged to main): healthy accounts show no status line, sidebar doesn't shift on hard refresh, row text is muted until hovered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)