### PR TITLE
refactor(web): memoize the event pipeline once, in its only consumer

### DIFF
--- a/packages/web/src/calendars/calendar.query.ts
+++ b/packages/web/src/calendars/calendar.query.ts
@@ -43,9 +43,9 @@ export function calendarsQueryOptions(authenticated: boolean) {
 // reference pair - both are stable across renders until the underlying
 // store/query data actually changes (see useHiddenCalendarIds and this
 // query's staleTime) - so every consumer on the same versions gets back the
-// exact same output array. That's also what lets
-// filter-events-by-visible-calendars.ts's WeakMap dedupe downstream instead
-// of re-filtering per consumer.
+// exact same output array. That stable reference is also what
+// useCalendarEventViewModel's memo keys on, so the event pipeline runs once
+// per (data, calendars) rather than once per consumer.
 const visibilityResultCache = new WeakMap<
   ReadonlySet<string>,
   WeakMap<Calendar[], Calendar[]>

--- a/packages/web/src/calendars/calendarCardIdentity.test.tsx
+++ b/packages/web/src/calendars/calendarCardIdentity.test.tsx
@@ -62,10 +62,7 @@ const makeGridEvent = (overrides: Partial<GridEvent> = {}): GridEvent =>
 // passes it down as a prop - not new production code.
 function TimedCardWithResolvedIdentity({ event }: { event: GridEvent }) {
   const lookup = useCalendarLookup();
-  const calendarIdentity = resolveCalendarCardIdentity(
-    lookup,
-    event.calendarId,
-  );
+  const calendarIdentity = resolveCalendarCardIdentity(lookup, event);
 
   return (
     <TimedEventCard
@@ -80,10 +77,7 @@ function TimedCardWithResolvedIdentity({ event }: { event: GridEvent }) {
 
 function AllDayCardWithResolvedIdentity({ event }: { event: GridEvent }) {
   const lookup = useCalendarLookup();
-  const calendarIdentity = resolveCalendarCardIdentity(
-    lookup,
-    event.calendarId,
-  );
+  const calendarIdentity = resolveCalendarCardIdentity(lookup, event);
 
   return (
     <AllDayEventCard

--- a/packages/web/src/calendars/useCalendarLookup.test.ts
+++ b/packages/web/src/calendars/useCalendarLookup.test.ts
@@ -12,7 +12,9 @@ describe("resolveCalendarCardIdentity", () => {
     const solo = calendar();
     const lookup = buildCalendarLookup([solo]);
 
-    expect(resolveCalendarCardIdentity(lookup, solo.id)).toBeNull();
+    expect(
+      resolveCalendarCardIdentity(lookup, { calendarId: solo.id }),
+    ).toBeNull();
   });
 
   it("returns the calendar's name and color with two or more calendars", () => {
@@ -20,7 +22,9 @@ describe("resolveCalendarCardIdentity", () => {
     const personal = calendar({ name: "Personal" });
     const lookup = buildCalendarLookup([work, personal]);
 
-    expect(resolveCalendarCardIdentity(lookup, work.id)).toEqual({
+    expect(
+      resolveCalendarCardIdentity(lookup, { calendarId: work.id }),
+    ).toEqual({
       name: "Work",
       backgroundColor: "#3b82f6",
     });
@@ -35,7 +39,12 @@ describe("resolveCalendarCardIdentity", () => {
       backgroundColor: "#ef4444",
     };
 
-    expect(resolveCalendarCardIdentity(lookup, work.id, duplicate)).toEqual({
+    expect(
+      resolveCalendarCardIdentity(lookup, {
+        calendarId: work.id,
+        otherAccount: duplicate,
+      }),
+    ).toEqual({
       name: "Work",
       backgroundColor: work.backgroundColor,
       otherAccount: duplicate,
@@ -48,6 +57,8 @@ describe("resolveCalendarCardIdentity", () => {
     const lookup = buildCalendarLookup([work, personal]);
     const missing = CalendarIdSchema.parse(createObjectIdString());
 
-    expect(resolveCalendarCardIdentity(lookup, missing)).toBeNull();
+    expect(
+      resolveCalendarCardIdentity(lookup, { calendarId: missing }),
+    ).toBeNull();
   });
 });

--- a/packages/web/src/calendars/useCalendarLookup.ts
+++ b/packages/web/src/calendars/useCalendarLookup.ts
@@ -77,15 +77,18 @@ export type CalendarCardIdentity = {
  * either the accent or a redundant name suffix, since every card would say
  * the same thing.
  *
- * `duplicate` is the event's own `otherAccount` (joined by the view model),
- * passed in by the caller since a card's merge status is a property of the
- * specific event instance, not of its calendar.
+ * Takes the event rather than a calendar id plus its `otherAccount`, which
+ * every call site was reading off the same object anyway - and matches
+ * {@link isGridEventInteractionReadOnly}, its neighbor at those call sites.
  */
 export function resolveCalendarCardIdentity(
   lookup: ReadonlyMap<CalendarId, Calendar>,
-  calendarId: CalendarId | null | undefined,
-  duplicate?: CrossAccountDuplicate,
+  event: {
+    calendarId?: CalendarId | null;
+    otherAccount?: CrossAccountDuplicate;
+  },
 ): CalendarCardIdentity | null {
+  const { calendarId, otherAccount } = event;
   if (!calendarId || lookup.size <= 1) return null;
 
   const calendar = lookup.get(calendarId);
@@ -94,7 +97,7 @@ export function resolveCalendarCardIdentity(
   return {
     name: calendar.name,
     backgroundColor: calendar.backgroundColor,
-    ...(duplicate ? { otherAccount: duplicate } : {}),
+    ...(otherAccount ? { otherAccount } : {}),
   };
 }
 

--- a/packages/web/src/events/queries/event.view-model.ts
+++ b/packages/web/src/events/queries/event.view-model.ts
@@ -180,7 +180,7 @@ const rowCountFrom = (events: GridEvent[]) => {
   return rows.length === 0 ? 1 : Math.max(...rows);
 };
 
-type CalendarEventViewModel = {
+export type CalendarEventViewModel = {
   entities: NormalizedEventQueryData["entities"];
   events: Event[];
   timedEvents: GridEvent[];
@@ -188,6 +188,17 @@ type CalendarEventViewModel = {
   rowCount: number;
   demoEventIds?: readonly EventId[];
 };
+
+/**
+ * Assemble the grid arrays. Pure: useCalendarEventViewModel memoizes the whole
+ * pipeline this ends, so there is nothing to cache here - only the empty case
+ * keeps a shared constant, so a view with no data doesn't hand its consumers a
+ * fresh object every render.
+ */
+export const deriveCalendarEventViewModel = (
+  data?: NormalizedEventQueryData,
+): CalendarEventViewModel =>
+  data ? computeCalendarEventViewModel(data) : EMPTY_CALENDAR_VIEW_MODEL;
 
 const computeCalendarEventViewModel = (
   data?: NormalizedEventQueryData,
@@ -210,25 +221,4 @@ const computeCalendarEventViewModel = (
   };
 };
 
-// Module-level memo keyed on the `query.data` object reference. The Week view
-// model is consumed by many components; a per-hook `useMemo` recomputes the
-// filter + grid assembly independently in each. Caching on the data reference
-// (stable while the cache entry is unchanged) collapses that to a single
-// derivation shared by every consumer, and keeps the result referentially
-// stable across renders.
-const viewModelCache = new WeakMap<
-  NormalizedEventQueryData,
-  CalendarEventViewModel
->();
 const EMPTY_CALENDAR_VIEW_MODEL = computeCalendarEventViewModel(undefined);
-
-export const deriveCalendarEventViewModel = (
-  data?: NormalizedEventQueryData,
-): CalendarEventViewModel => {
-  if (!data) return EMPTY_CALENDAR_VIEW_MODEL;
-  const cached = viewModelCache.get(data);
-  if (cached) return cached;
-  const result = computeCalendarEventViewModel(data);
-  viewModelCache.set(data, result);
-  return result;
-};

--- a/packages/web/src/events/queries/filter-events-by-visible-calendars.ts
+++ b/packages/web/src/events/queries/filter-events-by-visible-calendars.ts
@@ -1,41 +1,19 @@
 import { type Calendar } from "@core/types/calendar.contracts";
 import { type NormalizedEventQueryData } from "./event.query.types";
 
-// Module-level memo keyed on the (data, calendars) cache references — both
-// are stable between cache writes. Without it, each consumer's useMemo builds
-// a distinct filtered object whenever a calendar is hidden, which defeats
-// deriveCalendarEventViewModel's WeakMap and re-runs the grid assembly once
-// per consumer instead of once total.
-const filteredCache = new WeakMap<
-  NormalizedEventQueryData,
-  WeakMap<Calendar[], NormalizedEventQueryData>
->();
-
-// Drop events whose calendar is hidden. When calendars have not loaded yet,
-// pass the data through unchanged so the grid does not flash empty.
+/**
+ * Drop events whose calendar is hidden. When calendars have not loaded yet,
+ * pass the data through unchanged so the grid does not flash empty.
+ *
+ * Pure: useCalendarEventViewModel memoizes the whole pipeline this belongs to,
+ * so there is nothing to cache here.
+ */
 export function filterEventsByVisibleCalendars(
   data: NormalizedEventQueryData | undefined,
   calendars: Calendar[] | undefined,
 ): NormalizedEventQueryData | undefined {
   if (!data || !calendars) return data;
 
-  let byCalendars = filteredCache.get(data);
-  if (!byCalendars) {
-    byCalendars = new WeakMap();
-    filteredCache.set(data, byCalendars);
-  }
-  const cached = byCalendars.get(calendars);
-  if (cached) return cached;
-
-  const result = computeFilteredData(data, calendars);
-  byCalendars.set(calendars, result);
-  return result;
-}
-
-function computeFilteredData(
-  data: NormalizedEventQueryData,
-  calendars: Calendar[],
-): NormalizedEventQueryData {
   const visibleIds = new Set(
     calendars.filter((calendar) => calendar.isVisible).map((c) => c.id),
   );

--- a/packages/web/src/events/queries/merge-cross-account-duplicates.test.ts
+++ b/packages/web/src/events/queries/merge-cross-account-duplicates.test.ts
@@ -164,18 +164,4 @@ describe("mergeCrossAccountDuplicates", () => {
 
     expect(mergeCrossAccountDuplicates(data, [work, personal])).toBe(data);
   });
-
-  it("reuses the cached result for the same data and calendars", () => {
-    const data = dataOf(copy(work), copy(personal));
-
-    const first = mergeCrossAccountDuplicates(data, [work, personal]);
-    const calendarsRef = [work, personal];
-    const second = mergeCrossAccountDuplicates(data, calendarsRef);
-    const third = mergeCrossAccountDuplicates(data, calendarsRef);
-
-    // Same (data, calendars) references must not re-derive; a fresh object
-    // each call would defeat the view model's own WeakMap downstream.
-    expect(third).toBe(second);
-    expect(first).not.toBe(second);
-  });
 });

--- a/packages/web/src/events/queries/merge-cross-account-duplicates.ts
+++ b/packages/web/src/events/queries/merge-cross-account-duplicates.ts
@@ -4,18 +4,11 @@ import { type Event } from "@core/types/event.contracts";
 import { type CrossAccountDuplicate } from "@web/common/types/web.event.types";
 import { type NormalizedEventQueryData } from "./event.query.types";
 
-// Memo keyed on the (data, calendars) cache references, the same shape
-// filter-events-by-visible-calendars.ts uses, plus a last-value slot for the
-// default account email: every consumer in a render derives the same email
-// from the same store, so one remembered (key, result) pair hits as often as
-// a map would.
-const mergeCache = new WeakMap<
-  NormalizedEventQueryData,
-  WeakMap<
-    Calendar[],
-    { defaultAccountEmail: string; result: NormalizedEventQueryData }
-  >
->();
+interface Copy {
+  id: EventId;
+  event: Event;
+  accountEmail: string;
+}
 
 /**
  * Collapse copies of one meeting that live on two connected accounts into a
@@ -33,6 +26,9 @@ const mergeCache = new WeakMap<
  * unmerges on its own (the hidden copy is already gone by the time this sees
  * the data), and before the grid view model, so everything downstream - the
  * grid and the Up Next banner alike - sees one event per meeting.
+ *
+ * Pure: useCalendarEventViewModel memoizes the whole pipeline this belongs to,
+ * so there is nothing to cache here.
  */
 export function mergeCrossAccountDuplicates(
   data: NormalizedEventQueryData | undefined,
@@ -42,38 +38,12 @@ export function mergeCrossAccountDuplicates(
   if (!data || !calendars) return data;
 
   // Duplicates need two accounts; almost every user has one. Skip the
-  // per-event pass (and the cache write) entirely for them.
+  // per-event pass entirely for them.
   const accountEmails = new Set(
     calendars.map((c) => c.accountEmail).filter(Boolean),
   );
   if (accountEmails.size < 2) return data;
 
-  let byCalendars = mergeCache.get(data);
-  if (!byCalendars) {
-    byCalendars = new WeakMap();
-    mergeCache.set(data, byCalendars);
-  }
-  const cached = byCalendars.get(calendars);
-  if (cached && cached.defaultAccountEmail === defaultAccountEmail) {
-    return cached.result;
-  }
-
-  const result = computeMerge(data, calendars, defaultAccountEmail);
-  byCalendars.set(calendars, { defaultAccountEmail, result });
-  return result;
-}
-
-interface Copy {
-  id: EventId;
-  event: Event;
-  accountEmail: string;
-}
-
-function computeMerge(
-  data: NormalizedEventQueryData,
-  calendars: Calendar[],
-  defaultAccountEmail: string,
-): NormalizedEventQueryData {
   const calendarsById = new Map(calendars.map((c) => [c.id, c]));
 
   // Group only events that can possibly merge: they need a correlation key,

--- a/packages/web/src/events/queries/useCalendarEventViewModel.test.ts
+++ b/packages/web/src/events/queries/useCalendarEventViewModel.test.ts
@@ -1,0 +1,84 @@
+import { renderHook } from "@testing-library/react";
+import { type Calendar } from "@core/types/calendar.contracts";
+import { type Event } from "@core/types/event.contracts";
+import { createStoreWrapper } from "@web/__tests__/render-with-store";
+import { createMockCalendar } from "@web/__tests__/utils/factories/calendar.factory";
+import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
+import { calendarQueryKeys } from "@web/calendars/calendar.query";
+import { type NormalizedEventQueryData } from "./event.query.types";
+import { useCalendarEventViewModel } from "./useCalendarEventViewModel";
+import { describe, expect, it } from "bun:test";
+
+const dataOf = (...events: Event[]): NormalizedEventQueryData => ({
+  ids: events.map((event) => event.id),
+  entities: Object.fromEntries(events.map((event) => [event.id, event])),
+});
+
+const setup = (calendars: Calendar[]) => {
+  const { queryClient, wrapper } = createStoreWrapper();
+  queryClient.setQueryData(calendarQueryKeys.all, calendars);
+  return wrapper;
+};
+
+describe("useCalendarEventViewModel", () => {
+  it("hands every consumer of the same query data the same view model", () => {
+    // The Week view model has many consumers. Each one rebuilding its own
+    // filtered/merged copies would re-run the grid assembly per consumer and
+    // hand each a distinct object, defeating the cards' memo comparators.
+    const calendar = createMockCalendar();
+    const wrapper = setup([calendar]);
+    const data = dataOf(createMockEvent({ calendarId: calendar.id }));
+
+    const { result, rerender } = renderHook(
+      () => useCalendarEventViewModel(data),
+      { wrapper },
+    );
+    const first = result.current;
+    rerender();
+
+    const { result: otherConsumer } = renderHook(
+      () => useCalendarEventViewModel(data),
+      { wrapper },
+    );
+
+    expect(result.current).toBe(first);
+    expect(otherConsumer.current).toBe(first);
+  });
+
+  it("re-derives once the query data changes", () => {
+    const calendar = createMockCalendar();
+    const wrapper = setup([calendar]);
+    const first = dataOf(createMockEvent({ calendarId: calendar.id }));
+    const second = dataOf(createMockEvent({ calendarId: calendar.id }));
+
+    const { result, rerender } = renderHook(
+      ({ data }: { data: NormalizedEventQueryData }) =>
+        useCalendarEventViewModel(data),
+      { initialProps: { data: first }, wrapper },
+    );
+    const firstViewModel = result.current;
+
+    rerender({ data: second });
+
+    expect(result.current).not.toBe(firstViewModel);
+    expect(result.current.events).toHaveLength(1);
+  });
+
+  it("keeps events while the calendars are still loading", () => {
+    // No calendars yet is not "nothing is visible" - the grid must not flash
+    // empty while they load, and that case gets its own memo slot.
+    const data = dataOf(createMockEvent());
+    const { queryClient, wrapper } = createStoreWrapper();
+    queryClient.setQueryData(calendarQueryKeys.all, undefined);
+
+    const { result, rerender } = renderHook(
+      () => useCalendarEventViewModel(data),
+      { wrapper },
+    );
+    const first = result.current;
+    rerender();
+
+    expect(result.current.events).toHaveLength(1);
+    expect(result.current).toBe(first);
+  });
+});

--- a/packages/web/src/events/queries/useCalendarEventViewModel.ts
+++ b/packages/web/src/events/queries/useCalendarEventViewModel.ts
@@ -1,9 +1,33 @@
+import { type Calendar } from "@core/types/calendar.contracts";
 import { useCalendarsQuery } from "@web/calendars/calendar.query";
 import { useDefaultTargetCalendar } from "@web/calendars/useDefaultTargetCalendar";
 import { type NormalizedEventQueryData } from "./event.query.types";
-import { deriveCalendarEventViewModel } from "./event.view-model";
+import {
+  type CalendarEventViewModel,
+  deriveCalendarEventViewModel,
+} from "./event.view-model";
 import { filterEventsByVisibleCalendars } from "./filter-events-by-visible-calendars";
 import { mergeCrossAccountDuplicates } from "./merge-cross-account-duplicates";
+
+// Stable stand-in for calendars that haven't loaded, so the empty default
+// doesn't churn the memo below (or useDefaultTargetCalendar) once per render.
+const NO_CALENDARS: Calendar[] = [];
+
+// One memo for the whole pipeline, keyed on the references the three stages
+// read: the query data, the calendars, and the default account's email. The
+// Week view model is consumed by many components, and every one of them
+// derives that same triple from the same stores, so a single remembered entry
+// serves them all - without it each consumer would build its own filtered and
+// merged copies and re-run the grid assembly. The email is a plain value
+// rather than a third map level, since one remembered pair hits as often as a
+// map would.
+const pipelineCache = new WeakMap<
+  NormalizedEventQueryData,
+  WeakMap<
+    Calendar[],
+    { defaultAccountEmail: string; viewModel: CalendarEventViewModel }
+  >
+>();
 
 /**
  * The shared query-data -> grid pipeline behind the Day and Week view models:
@@ -11,24 +35,37 @@ import { mergeCrossAccountDuplicates } from "./merge-cross-account-duplicates";
  * the grid arrays. Order matters - the merge runs AFTER the visibility filter
  * so hiding one account's calendar unmerges on its own, and BEFORE the view
  * model so the grid and the Up Next banner both see one event per meeting.
- *
- * No useMemo here: all three stages are module-level caches keyed on their
- * input references, so every consumer of the same query data already gets
- * the same output references back.
  */
 export function useCalendarEventViewModel(
   data: NormalizedEventQueryData | undefined,
-) {
+): CalendarEventViewModel {
   const { data: calendars } = useCalendarsQuery();
-  const defaultAccountEmail = useDefaultTargetCalendar(
-    calendars ?? [],
-  )?.accountEmail;
+  const defaultAccountEmail =
+    useDefaultTargetCalendar(calendars ?? NO_CALENDARS)?.accountEmail ?? "";
 
-  return deriveCalendarEventViewModel(
+  if (!data) return deriveCalendarEventViewModel(undefined);
+
+  let byCalendars = pipelineCache.get(data);
+  if (!byCalendars) {
+    byCalendars = new WeakMap();
+    pipelineCache.set(data, byCalendars);
+  }
+  // Calendars still loading is its own cache slot: the stages pass the data
+  // through untouched then, which must not be confused with "no calendars are
+  // visible".
+  const cacheKey = calendars ?? NO_CALENDARS;
+  const cached = byCalendars.get(cacheKey);
+  if (cached?.defaultAccountEmail === defaultAccountEmail) {
+    return cached.viewModel;
+  }
+
+  const viewModel = deriveCalendarEventViewModel(
     mergeCrossAccountDuplicates(
       filterEventsByVisibleCalendars(data, calendars),
       calendars,
       defaultAccountEmail,
     ),
   );
+  byCalendars.set(cacheKey, { defaultAccountEmail, viewModel });
+  return viewModel;
 }

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarEventLayers.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarEventLayers.tsx
@@ -73,11 +73,7 @@ export const DayCalendarAllDayEventsLayer = ({
     >
       {renderedEvents.map((event) => (
         <DayAllDayCalendarEvent
-          calendarIdentity={resolveCalendarCardIdentity(
-            calendarLookup,
-            event.calendarId,
-            event.otherAccount,
-          )}
+          calendarIdentity={resolveCalendarCardIdentity(calendarLookup, event)}
           columnIndex={getCalendarColumnIndex(event)}
           event={event}
           isActiveDraft={isActiveDraftEvent(event, draft, savedEventIds)}
@@ -132,11 +128,7 @@ export const DayCalendarTimedEventsLayer = ({
     <div id={ID_GRID_EVENTS_TIMED}>
       {timedEventItems.map(({ deckLayout, event }) => (
         <DayTimedCalendarEvent
-          calendarIdentity={resolveCalendarCardIdentity(
-            calendarLookup,
-            event.calendarId,
-            event.otherAccount,
-          )}
+          calendarIdentity={resolveCalendarCardIdentity(calendarLookup, event)}
           columnIndex={getCalendarColumnIndex(event)}
           deckLayout={deckLayout}
           event={event}

--- a/packages/web/src/views/Week/components/Grid/AllDayRow/AllDayEvents.tsx
+++ b/packages/web/src/views/Week/components/Grid/AllDayRow/AllDayEvents.tsx
@@ -70,11 +70,7 @@ export const AllDayEvents = ({
     () =>
       visibleAllDayEvents.map((event) => ({
         event,
-        calendarIdentity: resolveCalendarCardIdentity(
-          calendarLookup,
-          event.calendarId,
-          event.otherAccount,
-        ),
+        calendarIdentity: resolveCalendarCardIdentity(calendarLookup, event),
         // Read-only (unwritable calendar or busy content) events never
         // attach interaction attributes/registration below, so the drag/
         // resize engine can't find them as a target - blocked before any
@@ -105,11 +101,7 @@ export const AllDayEvents = ({
             // from the draft store; everything else reuses the stable,
             // list-level resolved identity above.
             const identityForDisplay = isPlaceholder
-              ? resolveCalendarCardIdentity(
-                  calendarLookup,
-                  eventForDisplay.calendarId,
-                  eventForDisplay.otherAccount,
-                )
+              ? resolveCalendarCardIdentity(calendarLookup, eventForDisplay)
               : calendarIdentity;
 
             return (

--- a/packages/web/src/views/Week/components/Grid/MainGrid/MainGridEvents.tsx
+++ b/packages/web/src/views/Week/components/Grid/MainGrid/MainGridEvents.tsx
@@ -93,8 +93,7 @@ export const MainGridEvents = ({ measurements, weekProps }: Props) => {
         ...item,
         calendarIdentity: resolveCalendarCardIdentity(
           calendarLookup,
-          item.event.calendarId,
-          item.event.otherAccount,
+          item.event,
         ),
         // Read-only (unwritable calendar or busy content) events never
         // attach interaction attributes/registration below, so the drag/
@@ -122,11 +121,7 @@ export const MainGridEvents = ({ measurements, weekProps }: Props) => {
             // from the draft store; everything else reuses the stable,
             // list-level resolved identity above.
             const identityForDisplay = isPlaceholder
-              ? resolveCalendarCardIdentity(
-                  calendarLookup,
-                  eventForDisplay.calendarId,
-                  eventForDisplay.otherAccount,
-                )
+              ? resolveCalendarCardIdentity(calendarLookup, eventForDisplay)
               : calendarIdentity;
 
             return (


### PR DESCRIPTION
## Summary

The query-data to grid pipeline is three stages - `filterEventsByVisibleCalendars`, `mergeCrossAccountDuplicates`, `deriveCalendarEventViewModel` - and each one carried its own module-level `WeakMap`, the merge stage additionally carrying a hand-rolled last-value slot for `defaultAccountEmail` and a six-line comment explaining why one slot was enough. Each also repeated the same "order matters" note about where it sits in the chain.

All three have exactly one production consumer: `useCalendarEventViewModel`. So the memo moves there, keyed on the same `(data, calendars, defaultAccountEmail)` triple the merge cache already used, and the three stages become plain pure functions. Same hit rate, one cache to reason about instead of three, and two fewer levels of `WeakMap`-of-`WeakMap` bookkeeping.

Also in this PR: `resolveCalendarCardIdentity(lookup, calendarId, duplicate)` becomes `resolveCalendarCardIdentity(lookup, event)`. All six call sites were reading `calendarId` and `otherAccount` off the same object and passing them as separate arguments, right next to `isGridEventInteractionReadOnly(lookup, event)` - which already takes the event.

## Simplicity

Net removal: two nested-`WeakMap` blocks, the last-value slot, one repeated doc paragraph, and six three-argument calls. `CalendarEventViewModel` is now exported (the hook's cache entry needs to name it) - the only thing this adds.

Not done: collapsing the three stage functions into one. They stay separate and independently tested; only their caching moved.

## Automated validation

Ran the web app locally (`bun run dev:web`, anonymous session, 1440x900) after the change: the week grid renders its timed and all-day sample events normally and `read_console_messages` reports no errors. The cross-account merge path itself needs two connected Google accounts, so it is covered by unit tests here and verified on staging after merge.

## Independent review

Fresh reviewer over the final diff, focused on cache correctness. One confirmed finding, fixed in a follow-up commit: a comment in `calendar.query.ts` still described the (now removed) `WeakMap` in the filter stage as what deduped downstream. It specifically cleared the keying (calendars-undefined vs a real empty array cannot collide - `NO_CALENDARS` is a distinct reference), the empty-view-model referential stability, every remaining direct caller of `deriveCalendarEventViewModel`, and the draft-overlay placeholder path (`mergeGridEventWithDraftOverlay` spreads a `CompassEvent` with no `otherAccount` key, so the original event's value survives).

## Test plan

- [x] `bun run test:web` - 1661/1661 pass
- [x] `bun run type-check` - clean
- [x] `bun run knip` - clean
- [x] `biome check` on touched files - clean

Coverage moved with the cache: the merge stage's "reuses the cached result" test is replaced by `useCalendarEventViewModel.test.ts`, which asserts the guarantee that actually matters - two independent consumers of the same query data get the identical view-model object, a rerender does not re-derive, new data does, and the calendars-still-loading case keeps its events and its own memo slot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)