### PR TITLE
refactor(web): one calendar ordering shared by sidebar, Settings and the event form

### DIFF
--- a/packages/web/src/calendars/calendar.util.test.ts
+++ b/packages/web/src/calendars/calendar.util.test.ts
@@ -1,5 +1,12 @@
 import { type Calendar } from "@core/types/calendar.contracts";
-import { getDefaultTargetCalendar, getLocalCalendar } from "./calendar.util";
+import { type GoogleSyncConnectionSummary } from "@core/types/user.types";
+import {
+  compareCalendars,
+  getDefaultTargetCalendar,
+  getLocalCalendar,
+  groupCalendarsByAccount,
+  spansMultipleAccounts,
+} from "./calendar.util";
 import { describe, expect, it } from "bun:test";
 
 function makeCalendar(overrides: Partial<Calendar>): Calendar {
@@ -197,5 +204,140 @@ describe("getDefaultTargetCalendar", () => {
         accountEmailOrder: ["old@example.com", "new@example.com"],
       }),
     ).toBe(primary);
+  });
+});
+
+describe("compareCalendars", () => {
+  it("orders by account (connection order), then primary first, then name", () => {
+    const work = makeCalendar({ name: "Work", accountEmail: "old@x.com" });
+    const personal = makeCalendar({
+      name: "Personal",
+      isPrimary: true,
+      accountEmail: "old@x.com",
+      id: "507f1f77bcf86cd799439012" as Calendar["id"],
+    });
+    const side = makeCalendar({
+      name: "Side",
+      accountEmail: "new@x.com",
+      id: "507f1f77bcf86cd799439013" as Calendar["id"],
+    });
+    const local = makeCalendar({
+      name: "Compass",
+      provider: "local",
+      id: "507f1f77bcf86cd799439014" as Calendar["id"],
+    });
+
+    const ordered = [local, side, work, personal].sort(
+      compareCalendars(["old@x.com", "new@x.com"]),
+    );
+
+    expect(ordered.map((c) => c.name)).toEqual([
+      "Personal",
+      "Work",
+      "Side",
+      "Compass",
+    ]);
+  });
+
+  it("ranks an unlisted account the same as no account - both sort after known accounts, then alphabetically", () => {
+    const known = makeCalendar({ name: "Known", accountEmail: "old@x.com" });
+    const unknown = makeCalendar({
+      name: "Unknown",
+      accountEmail: "mystery@x.com",
+      id: "507f1f77bcf86cd799439012" as Calendar["id"],
+    });
+    const local = makeCalendar({
+      name: "Compass",
+      provider: "local",
+      id: "507f1f77bcf86cd799439013" as Calendar["id"],
+    });
+
+    const ordered = [local, unknown, known].sort(
+      compareCalendars(["old@x.com"]),
+    );
+
+    expect(ordered.map((c) => c.name)).toEqual(["Known", "Compass", "Unknown"]);
+  });
+});
+
+describe("spansMultipleAccounts", () => {
+  it("is false for zero or one distinct account", () => {
+    expect(spansMultipleAccounts([])).toBe(false);
+    expect(
+      spansMultipleAccounts([
+        makeCalendar({ accountEmail: "a@x.com" }),
+        makeCalendar({
+          accountEmail: "a@x.com",
+          id: "507f1f77bcf86cd799439012" as Calendar["id"],
+        }),
+      ]),
+    ).toBe(false);
+  });
+
+  it("is true once a second distinct account appears", () => {
+    expect(
+      spansMultipleAccounts([
+        makeCalendar({ accountEmail: "a@x.com" }),
+        makeCalendar({
+          accountEmail: "b@x.com",
+          id: "507f1f77bcf86cd799439012" as Calendar["id"],
+        }),
+      ]),
+    ).toBe(true);
+  });
+});
+
+describe("groupCalendarsByAccount", () => {
+  const connection = (accountEmail: string): GoogleSyncConnectionSummary => ({
+    id: `conn-${accountEmail}`,
+    state: "healthy",
+    stateReason: null,
+    lastSyncedAt: null,
+    lastHealthyAt: null,
+    accountEmail,
+    connectionState: "HEALTHY",
+  });
+
+  it("buckets by account in connection order and leaves the local calendar ungrouped", () => {
+    const work = makeCalendar({ name: "Work", accountEmail: "old@x.com" });
+    const personal = makeCalendar({
+      name: "Personal",
+      accountEmail: "new@x.com",
+      id: "507f1f77bcf86cd799439012" as Calendar["id"],
+    });
+    const local = makeCalendar({
+      name: "Compass",
+      provider: "local",
+      id: "507f1f77bcf86cd799439013" as Calendar["id"],
+    });
+
+    const { groups, ungrouped } = groupCalendarsByAccount(
+      [personal, work, local],
+      [connection("old@x.com"), connection("new@x.com")],
+    );
+
+    expect(groups.map((g) => g.accountEmail)).toEqual([
+      "old@x.com",
+      "new@x.com",
+    ]);
+    expect(ungrouped).toEqual([local]);
+  });
+
+  it("groups a lone connected account too - no two-account threshold", () => {
+    const work = makeCalendar({ name: "Work", accountEmail: "old@x.com" });
+
+    const { groups } = groupCalendarsByAccount(
+      [work],
+      [connection("old@x.com")],
+    );
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0]?.calendars).toEqual([work]);
+  });
+
+  it("omits a connected account with no calendars yet", () => {
+    const { groups } = groupCalendarsByAccount([], [connection("old@x.com")]);
+
+    expect(groups).toHaveLength(0);
   });
 });

--- a/packages/web/src/calendars/calendar.util.ts
+++ b/packages/web/src/calendars/calendar.util.ts
@@ -1,14 +1,107 @@
 import { type Calendar } from "@core/types/calendar.contracts";
+import { type GoogleSyncConnectionSummary } from "@core/types/user.types";
 
 export function getLocalCalendar(calendars: Calendar[]): Calendar | undefined {
   return calendars.find((calendar) => calendar.provider === "local");
 }
 
+/**
+ * The one order every calendar surface shows: by account in connection order,
+ * then that account's primary first, then alphabetically. A calendar with no
+ * account (the local one) or an account that isn't connected sorts last.
+ *
+ * Shared so the sidebar list, the Settings default-calendar picker and the
+ * event form's picker can't drift - they did, when each had its own
+ * comparator claiming to mirror the others.
+ */
+export function compareCalendars(
+  accountEmailOrder: readonly string[],
+): (a: Calendar, b: Calendar) => number {
+  const accountRank = (calendar: Calendar): number => {
+    const index = calendar.accountEmail
+      ? accountEmailOrder.indexOf(calendar.accountEmail)
+      : -1;
+    return index === -1 ? accountEmailOrder.length : index;
+  };
+
+  return (a, b) => {
+    const byAccount = accountRank(a) - accountRank(b);
+    if (byAccount !== 0) return byAccount;
+    if (a.isPrimary !== b.isPrimary) return a.isPrimary ? -1 : 1;
+    return a.name.localeCompare(b.name);
+  };
+}
+
+/**
+ * True when these calendars span more than one account, so naming the account
+ * on a row tells the user something. With one account every row would say the
+ * same thing.
+ */
+export function spansMultipleAccounts(calendars: Calendar[]): boolean {
+  return (
+    new Set(calendars.map((calendar) => calendar.accountEmail).filter(Boolean))
+      .size > 1
+  );
+}
+
+export interface AccountGroup {
+  accountEmail: string;
+  connection: GoogleSyncConnectionSummary | undefined;
+  calendars: Calendar[];
+}
+
+/**
+ * Bucket calendars by the account they belong to, in connection order, with
+ * anything lacking an account email (the local calendar) left ungrouped.
+ * Callers render `ungrouped` after the groups, matching {@link
+ * compareCalendars}, which sorts accountless calendars last.
+ */
+export function groupCalendarsByAccount(
+  calendars: Calendar[],
+  connections: GoogleSyncConnectionSummary[],
+): { groups: AccountGroup[]; ungrouped: Calendar[] } {
+  const groups: AccountGroup[] = [];
+  const byEmail = new Map<string, AccountGroup>();
+  const ungrouped: Calendar[] = [];
+
+  // Seed in connection order so accounts appear oldest-connected first,
+  // regardless of the order calendars came back in.
+  for (const connection of connections) {
+    const { accountEmail } = connection;
+    if (!accountEmail || byEmail.has(accountEmail)) continue;
+    const group: AccountGroup = { accountEmail, connection, calendars: [] };
+    byEmail.set(accountEmail, group);
+    groups.push(group);
+  }
+
+  for (const calendar of calendars) {
+    const { accountEmail } = calendar;
+    if (!accountEmail) {
+      ungrouped.push(calendar);
+      continue;
+    }
+    let group = byEmail.get(accountEmail);
+    if (!group) {
+      // A calendar whose account has no connection summary yet (metadata and
+      // the calendar list can load a moment apart). Still give it a section.
+      group = { accountEmail, connection: undefined, calendars: [] };
+      byEmail.set(accountEmail, group);
+      groups.push(group);
+    }
+    group.calendars.push(calendar);
+  }
+
+  // An account can be connected before its calendars have imported; an empty
+  // section would render a heading with nothing under it.
+  return { groups: groups.filter((g) => g.calendars.length > 0), ungrouped };
+}
+
 export interface DefaultTargetCalendarOptions {
   /**
-   * The calendar the user starred as their default. Ignored when it names a
-   * calendar that is gone or no longer writable, so a stale preference
-   * degrades to the derived default instead of breaking event creation.
+   * The calendar the user chose as their default in Settings. Ignored when it
+   * names a calendar that is gone or no longer writable, so a stale
+   * preference degrades to the derived default instead of breaking event
+   * creation.
    */
   preferredCalendarId?: string | null;
   /**
@@ -23,7 +116,7 @@ const isWritableGoogleCalendar = (calendar: Calendar): boolean =>
   calendar.provider === "google" && calendar.capabilities.canWrite;
 
 /**
- * Where a new event lands: the user's starred default if it is still usable,
+ * Where a new event lands: the user's chosen default if it is still usable,
  * else the primary calendar of the oldest-connected account, else the local
  * calendar (offline/anonymous mode, or a Google account with no primary the
  * user can write to).

--- a/packages/web/src/calendars/calendar.util.ts
+++ b/packages/web/src/calendars/calendar.util.ts
@@ -6,6 +6,18 @@ export function getLocalCalendar(calendars: Calendar[]): Calendar | undefined {
 }
 
 /**
+ * Calendars offered as a create target: a reader/freeBusy-only calendar
+ * would silently fail to accept a new event. Shared by the event form's
+ * picker and the Settings default-calendar picker, which offer the same set
+ * for the same reason.
+ */
+export function getWritableCalendars(calendars: Calendar[]): Calendar[] {
+  return calendars.filter(
+    (calendar) => calendar.isActive && calendar.capabilities.canWrite,
+  );
+}
+
+/**
  * The one order every calendar surface shows: by account in connection order,
  * then that account's primary first, then alphabetically. A calendar with no
  * account (the local one) or an account that isn't connected sorts last.

--- a/packages/web/src/calendars/default-calendar.store.test.ts
+++ b/packages/web/src/calendars/default-calendar.store.test.ts
@@ -1,14 +1,18 @@
+import { renderHook } from "@testing-library/react";
 import { type CalendarId } from "@core/types/domain-primitives";
 import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
 import { persistentBrowserStore } from "@web/common/storage/browser-key-value.store";
 import {
-  getStoredDefaultCalendarId,
   resetDefaultCalendarStoreForTests,
   setDefaultCalendarId,
+  useDefaultCalendarId,
 } from "./default-calendar.store";
 import { beforeEach, describe, expect, it, spyOn } from "bun:test";
 
 const calendarId = (value: string) => value as CalendarId;
+
+const readDefaultCalendarId = () =>
+  renderHook(useDefaultCalendarId).result.current;
 
 describe("default-calendar.store", () => {
   beforeEach(() => {
@@ -17,27 +21,27 @@ describe("default-calendar.store", () => {
   });
 
   it("has no default until one is chosen", () => {
-    expect(getStoredDefaultCalendarId()).toBeNull();
+    expect(readDefaultCalendarId()).toBeNull();
   });
 
   it("persists the chosen calendar and reads it back after a reload", () => {
     expect(setDefaultCalendarId(calendarId("cal-1"))).toBe(true);
 
-    expect(getStoredDefaultCalendarId()).toBe("cal-1");
+    expect(readDefaultCalendarId()).toBe("cal-1");
     expect(persistentBrowserStore.get(STORAGE_KEYS.DEFAULT_CALENDAR_ID)).toBe(
       "cal-1",
     );
 
     // A fresh page load re-reads storage rather than the in-memory value.
     resetDefaultCalendarStoreForTests();
-    expect(getStoredDefaultCalendarId()).toBe("cal-1");
+    expect(readDefaultCalendarId()).toBe("cal-1");
   });
 
   it("clears the preference when passed null", () => {
     setDefaultCalendarId(calendarId("cal-1"));
 
     expect(setDefaultCalendarId(null)).toBe(true);
-    expect(getStoredDefaultCalendarId()).toBeNull();
+    expect(readDefaultCalendarId()).toBeNull();
     expect(
       persistentBrowserStore.get(STORAGE_KEYS.DEFAULT_CALENDAR_ID),
     ).toBeNull();
@@ -49,7 +53,7 @@ describe("default-calendar.store", () => {
 
     expect(setDefaultCalendarId(calendarId("cal-2"))).toBe(false);
     // Reporting cal-2 here would show the user a preference that did not stick.
-    expect(getStoredDefaultCalendarId()).toBe("cal-1");
+    expect(readDefaultCalendarId()).toBe("cal-1");
 
     setSpy.mockRestore();
   });

--- a/packages/web/src/calendars/default-calendar.store.ts
+++ b/packages/web/src/calendars/default-calendar.store.ts
@@ -8,10 +8,10 @@ import {
 } from "@web/common/utils/external-store.util";
 
 /**
- * The calendar new events are created on, chosen by the user via the star on
- * a calendar row. Client-owned, mirroring the hidden-calendar-ids store: one
- * localStorage key is the source of truth, and this makes changes to it
- * observable.
+ * The calendar new events are created on, chosen by the user from the
+ * Default Calendar picker in Settings. Client-owned, mirroring the
+ * hidden-calendar-ids store: one localStorage key is the source of truth,
+ * and this makes changes to it observable.
  *
  * Wart, named: the preference lives on this device only, so it does not roam
  * across browsers. A server-side preference can supersede it later without a
@@ -66,16 +66,6 @@ function subscribe(onChange: () => void): () => void {
 
 export function useDefaultCalendarId(): string | null {
   return useSyncExternalStore(subscribe, defaultCalendarIdStore.get);
-}
-
-/**
- * Test-only observability today: no production code reads the preference
- * outside React (everything goes through useDefaultCalendarId /
- * useDefaultTargetCalendar). Kept exported for the store's and the calendar
- * list's tests; give it a real doc if a non-hook caller ever appears.
- */
-export function getStoredDefaultCalendarId(): string | null {
-  return defaultCalendarIdStore.get();
 }
 
 /** Test-only: resyncs the in-memory store from storage. */

--- a/packages/web/src/calendars/useDefaultTargetCalendar.ts
+++ b/packages/web/src/calendars/useDefaultTargetCalendar.ts
@@ -8,7 +8,7 @@ import { getDefaultTargetCalendar } from "@web/calendars/calendar.util";
 import { useDefaultCalendarId } from "@web/calendars/default-calendar.store";
 
 /**
- * The calendar a new event should land on: the user's starred default when
+ * The calendar a new event should land on: the user's chosen default when
  * it is still usable, else the primary calendar of the oldest-connected
  * account, else the local calendar.
  *

--- a/packages/web/src/components/Settings/SettingsModal.test.tsx
+++ b/packages/web/src/components/Settings/SettingsModal.test.tsx
@@ -7,7 +7,8 @@ import { createMockCalendar } from "@web/__tests__/utils/factories/calendar.fact
 import { AuthApi } from "@web/api/auth.api";
 import { userMetadataActions } from "@web/auth/state/user-metadata.store";
 import { calendarQueryKeys } from "@web/calendars/calendar.query";
-import { getStoredDefaultCalendarId } from "@web/calendars/default-calendar.store";
+import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
+import { persistentBrowserStore } from "@web/common/storage/browser-key-value.store";
 import { settingsActions } from "@web/settings/settings.store";
 import { SettingsModal } from "./SettingsModal";
 import { describe, expect, it, spyOn } from "bun:test";
@@ -210,7 +211,7 @@ describe("SettingsModal", () => {
     ).toHaveValue(primary.id);
   });
 
-  it("persists a new default calendar pick", async () => {
+  it("persists a new default calendar pick to storage", async () => {
     const primary = createMockCalendar({ name: "Personal", isPrimary: true });
     const side = createMockCalendar({ name: "Side project" });
 
@@ -222,7 +223,45 @@ describe("SettingsModal", () => {
       side.id,
     );
 
-    expect(getStoredDefaultCalendarId()).toBe(side.id);
+    expect(
+      screen.getByRole("combobox", { name: "Default Calendar" }),
+    ).toHaveValue(side.id);
+    expect(persistentBrowserStore.get(STORAGE_KEYS.DEFAULT_CALENDAR_ID)).toBe(
+      side.id,
+    );
+  });
+
+  it("groups the picker by account even with a single account connected", () => {
+    // Matches the sidebar, which gives a lone account the same labelled
+    // section as several (no "only group past two accounts" threshold).
+    const work = createMockCalendar({
+      name: "Work",
+      accountEmail: "ahab@pequod.com",
+    });
+
+    renderSettings({ calendars: [work] });
+
+    const combobox = screen.getByRole("combobox", { name: "Default Calendar" });
+    expect(
+      within(combobox).getByRole("group", { name: "ahab@pequod.com" }),
+    ).toBeInTheDocument();
+  });
+
+  it("lists the local calendar after the account groups, not before", () => {
+    // The sidebar renders account sections first and the local/ungrouped
+    // calendar last; this picker used to disagree.
+    const work = createMockCalendar({
+      name: "Work",
+      accountEmail: "ahab@pequod.com",
+    });
+    const local = createMockCalendar({ name: "Compass", provider: "local" });
+
+    renderSettings({ calendars: [work, local] });
+
+    const options = screen
+      .getAllByRole("option")
+      .map((option) => option.textContent);
+    expect(options).toEqual(["Work", "Compass"]);
   });
 
   it("badges the account that owns the default calendar", () => {

--- a/packages/web/src/components/Settings/SettingsModal.tsx
+++ b/packages/web/src/components/Settings/SettingsModal.tsx
@@ -1,4 +1,5 @@
 import { type FC, useEffect, useRef, useState } from "react";
+import { type Calendar } from "@core/types/calendar.contracts";
 import { type CalendarId } from "@core/types/domain-primitives";
 import { type GoogleSyncConnectionSummary } from "@core/types/user.types";
 import { useConnectGoogle } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle";
@@ -12,6 +13,7 @@ import {
   useUserMetadataStore,
 } from "@web/auth/state/user-metadata.store";
 import { useCalendarsQuery } from "@web/calendars/calendar.query";
+import { groupCalendarsByAccount } from "@web/calendars/calendar.util";
 import {
   setDefaultCalendarId,
   useDefaultCalendarId,
@@ -23,7 +25,6 @@ import {
   OverlayPanelActionButton,
   OverlayPanelActions,
 } from "@web/components/OverlayPanel/OverlayPanel";
-import { groupCalendarsByAccount } from "@web/components/Sidebar/CalendarList/CalendarList";
 import {
   selectIsSettingsOpen,
   settingsActions,
@@ -55,6 +56,13 @@ export const SettingsModal: FC = () => {
     if (!isOpen) setConfirmingId(null);
   }, [isOpen]);
 
+  const { data } = useCalendarsQuery();
+  const connections = useUserMetadataStore(selectGoogleSyncConnections);
+  const writableCalendars = (data ?? []).filter(
+    (calendar) => calendar.isActive && calendar.capabilities.canWrite,
+  );
+  const resolvedDefault = useDefaultTargetCalendar(writableCalendars);
+
   if (!isOpen) return null;
 
   const handleDismiss = () => {
@@ -84,9 +92,15 @@ export const SettingsModal: FC = () => {
           </button>
         </nav>
         <div className="flex min-w-0 flex-1 flex-col gap-4">
-          <DefaultCalendarPicker />
+          <DefaultCalendarPicker
+            calendars={writableCalendars}
+            connections={connections}
+            resolvedDefault={resolvedDefault}
+          />
           <AccountsSection
             confirmingId={confirmingId}
+            connections={connections}
+            resolvedDefault={resolvedDefault}
             setConfirmingId={setConfirmingId}
           />
         </div>
@@ -95,20 +109,23 @@ export const SettingsModal: FC = () => {
   );
 };
 
-const DefaultCalendarPicker: FC = () => {
-  const { data } = useCalendarsQuery();
-  const connections = useUserMetadataStore(selectGoogleSyncConnections);
-  const calendars = (data ?? []).filter(
-    (calendar) => calendar.isActive && calendar.capabilities.canWrite,
-  );
+interface DefaultCalendarPickerProps {
+  calendars: Calendar[];
+  connections: GoogleSyncConnectionSummary[];
+  resolvedDefault: Calendar | undefined;
+}
+
+const DefaultCalendarPicker: FC<DefaultCalendarPickerProps> = ({
+  calendars,
+  connections,
+  resolvedDefault,
+}) => {
   const storedId = useDefaultCalendarId();
-  const resolvedDefault = useDefaultTargetCalendar(calendars);
   const value = storedId ?? resolvedDefault?.id ?? "";
 
   if (calendars.length === 0) return null;
 
   const { groups, ungrouped } = groupCalendarsByAccount(calendars, connections);
-  const useAccountGroups = groups.length > 1;
 
   return (
     <div>
@@ -124,30 +141,20 @@ const DefaultCalendarPicker: FC = () => {
         onChange={(e) => setDefaultCalendarId(e.target.value as CalendarId)}
         value={value}
       >
-        {useAccountGroups ? (
-          <>
-            {ungrouped.map((calendar) => (
+        {groups.map((group) => (
+          <optgroup key={group.accountEmail} label={group.accountEmail}>
+            {group.calendars.map((calendar) => (
               <option key={calendar.id} value={calendar.id}>
                 {calendar.name}
               </option>
             ))}
-            {groups.map((group) => (
-              <optgroup key={group.accountEmail} label={group.accountEmail}>
-                {group.calendars.map((calendar) => (
-                  <option key={calendar.id} value={calendar.id}>
-                    {calendar.name}
-                  </option>
-                ))}
-              </optgroup>
-            ))}
-          </>
-        ) : (
-          calendars.map((calendar) => (
-            <option key={calendar.id} value={calendar.id}>
-              {calendar.name}
-            </option>
-          ))
-        )}
+          </optgroup>
+        ))}
+        {ungrouped.map((calendar) => (
+          <option key={calendar.id} value={calendar.id}>
+            {calendar.name}
+          </option>
+        ))}
       </select>
     </div>
   );
@@ -155,22 +162,19 @@ const DefaultCalendarPicker: FC = () => {
 
 interface AccountsSectionProps {
   confirmingId: string | null;
+  connections: GoogleSyncConnectionSummary[];
+  resolvedDefault: Calendar | undefined;
   setConfirmingId: (id: string | null) => void;
 }
 
 const AccountsSection: FC<AccountsSectionProps> = ({
   confirmingId,
+  connections,
+  resolvedDefault,
   setConfirmingId,
 }) => {
-  const connections = useUserMetadataStore(selectGoogleSyncConnections);
   const { connect, isAvailable, isConnecting } = useConnectGoogle();
   const { disconnect, disconnectingId } = useDisconnectGoogleAccount();
-  const { data } = useCalendarsQuery();
-  const resolvedDefault = useDefaultTargetCalendar(
-    (data ?? []).filter(
-      (calendar) => calendar.isActive && calendar.capabilities.canWrite,
-    ),
-  );
 
   return (
     <div className="flex flex-col gap-3">

--- a/packages/web/src/components/Settings/SettingsModal.tsx
+++ b/packages/web/src/components/Settings/SettingsModal.tsx
@@ -13,13 +13,20 @@ import {
   useUserMetadataStore,
 } from "@web/auth/state/user-metadata.store";
 import { useCalendarsQuery } from "@web/calendars/calendar.query";
-import { groupCalendarsByAccount } from "@web/calendars/calendar.util";
+import {
+  compareCalendars,
+  getWritableCalendars,
+  groupCalendarsByAccount,
+} from "@web/calendars/calendar.util";
 import {
   setDefaultCalendarId,
   useDefaultCalendarId,
 } from "@web/calendars/default-calendar.store";
 import { SyncStatusLine } from "@web/calendars/SyncStatusLine";
-import { useDefaultTargetCalendar } from "@web/calendars/useDefaultTargetCalendar";
+import {
+  useConnectedAccountEmails,
+  useDefaultTargetCalendar,
+} from "@web/calendars/useDefaultTargetCalendar";
 import {
   OverlayPanel,
   OverlayPanelActionButton,
@@ -58,8 +65,9 @@ export const SettingsModal: FC = () => {
 
   const { data } = useCalendarsQuery();
   const connections = useUserMetadataStore(selectGoogleSyncConnections);
-  const writableCalendars = (data ?? []).filter(
-    (calendar) => calendar.isActive && calendar.capabilities.canWrite,
+  const accountEmailOrder = useConnectedAccountEmails();
+  const writableCalendars = getWritableCalendars(data ?? []).sort(
+    compareCalendars(accountEmailOrder),
   );
   const resolvedDefault = useDefaultTargetCalendar(writableCalendars);
 

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarList.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarList.tsx
@@ -1,6 +1,5 @@
 import { type FC, useMemo } from "react";
 import { type Calendar } from "@core/types/calendar.contracts";
-import { type GoogleSyncConnectionSummary } from "@core/types/user.types";
 import { useSession } from "@web/auth/compass/session/useSession";
 import { useConnectGoogle } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle";
 import {
@@ -9,77 +8,19 @@ import {
 } from "@web/auth/state/user-metadata.store";
 import { useCalendarsQuery } from "@web/calendars/calendar.query";
 import {
+  compareCalendars,
+  groupCalendarsByAccount,
+} from "@web/calendars/calendar.util";
+import {
   accountCalendarListId,
   useCollapsedAccountKeys,
 } from "@web/calendars/collapsed-accounts.store";
 import { SyncStatusLine } from "@web/calendars/SyncStatusLine";
 import { useCalendarVisibility } from "@web/calendars/useCalendarVisibility";
+import { useConnectedAccountEmails } from "@web/calendars/useDefaultTargetCalendar";
 import { useHasPendingEventMutations } from "@web/events/mutations/useEventPending";
 import { AccountSectionHeader } from "./AccountSectionHeader";
 import { CalendarListHeader } from "./CalendarListHeader";
-
-// Primary calendars first, then alphabetical by name; the local calendar
-// (offline/anonymous synthesized calendar, or the server's own local
-// calendar once signed in) always sorts last since it isn't a
-// provider-backed subscription like the others (packet 08 step 2).
-function sortCalendars(calendars: Calendar[]): Calendar[] {
-  return [...calendars].sort((a, b) => {
-    if (a.provider === "local" && b.provider !== "local") return 1;
-    if (b.provider === "local" && a.provider !== "local") return -1;
-    if (a.isPrimary !== b.isPrimary) return a.isPrimary ? -1 : 1;
-    return a.name.localeCompare(b.name);
-  });
-}
-
-interface AccountGroup {
-  accountEmail: string;
-  connection: GoogleSyncConnectionSummary | undefined;
-  calendars: Calendar[];
-}
-
-/**
- * Bucket calendars by the account they belong to, in connection order, with
- * anything lacking an account email (the local calendar) left ungrouped.
- */
-export function groupCalendarsByAccount(
-  calendars: Calendar[],
-  connections: GoogleSyncConnectionSummary[],
-): { groups: AccountGroup[]; ungrouped: Calendar[] } {
-  const groups: AccountGroup[] = [];
-  const byEmail = new Map<string, AccountGroup>();
-  const ungrouped: Calendar[] = [];
-
-  // Seed in connection order so accounts appear oldest-connected first,
-  // regardless of the order calendars came back in.
-  for (const connection of connections) {
-    const { accountEmail } = connection;
-    if (!accountEmail || byEmail.has(accountEmail)) continue;
-    const group: AccountGroup = { accountEmail, connection, calendars: [] };
-    byEmail.set(accountEmail, group);
-    groups.push(group);
-  }
-
-  for (const calendar of calendars) {
-    const { accountEmail } = calendar;
-    if (!accountEmail) {
-      ungrouped.push(calendar);
-      continue;
-    }
-    let group = byEmail.get(accountEmail);
-    if (!group) {
-      // A calendar whose account has no connection summary yet (metadata and
-      // the calendar list can load a moment apart). Still give it a section.
-      group = { accountEmail, connection: undefined, calendars: [] };
-      byEmail.set(accountEmail, group);
-      groups.push(group);
-    }
-    group.calendars.push(calendar);
-  }
-
-  // An account can be connected before its calendars have imported; an empty
-  // section would render a heading with nothing under it.
-  return { groups: groups.filter((g) => g.calendars.length > 0), ungrouped };
-}
 
 export const CalendarList: FC = () => {
   const { authenticated } = useSession();
@@ -88,14 +29,18 @@ export const CalendarList: FC = () => {
   const { toggleCalendarVisibility, failureAnnouncement } =
     useCalendarVisibility();
   const connections = useUserMetadataStore(selectGoogleSyncConnections);
+  const accountEmailOrder = useConnectedAccountEmails();
   const collapsedKeys = useCollapsedAccountKeys();
   const hasPendingEventMutations = useHasPendingEventMutations();
 
   // Re-groups on every calendar-visibility/collapse toggle otherwise, since
   // those live in sibling external stores this component also subscribes to.
   const calendars = useMemo(
-    () => sortCalendars((data ?? []).filter((calendar) => calendar.isActive)),
-    [data],
+    () =>
+      (data ?? [])
+        .filter((calendar) => calendar.isActive)
+        .sort(compareCalendars(accountEmailOrder)),
+    [data, accountEmailOrder],
   );
   const { groups, ungrouped } = useMemo(
     () => groupCalendarsByAccount(calendars, connections),

--- a/packages/web/src/views/Forms/EventForm/CalendarSelect/CalendarSelect.tsx
+++ b/packages/web/src/views/Forms/EventForm/CalendarSelect/CalendarSelect.tsx
@@ -12,6 +12,10 @@ import { type Calendar } from "@core/types/calendar.contracts";
 import { type CalendarId } from "@core/types/domain-primitives";
 import { useCalendarsQuery } from "@web/calendars/calendar.query";
 import {
+  compareCalendars,
+  spansMultipleAccounts,
+} from "@web/calendars/calendar.util";
+import {
   useConnectedAccountEmails,
   useDefaultTargetCalendar,
 } from "@web/calendars/useDefaultTargetCalendar";
@@ -32,31 +36,6 @@ const getWritableCalendars = (calendars: Calendar[]): Calendar[] =>
   calendars.filter(
     (calendar) => calendar.isActive && calendar.capabilities.canWrite,
   );
-
-// Primary first (it's the default target), then alphabetical - mirrors
-// CalendarList's sort so the same calendar lands in the same relative
-// position across the sidebar list and this picker. With several accounts
-// connected, calendars are additionally kept together by account, in
-// connection order, so the list reads as one block per account.
-const sortWritableCalendars = (
-  calendars: Calendar[],
-  accountEmailOrder: readonly string[],
-): Calendar[] => {
-  const accountRank = (calendar: Calendar): number => {
-    const index = calendar.accountEmail
-      ? accountEmailOrder.indexOf(calendar.accountEmail)
-      : -1;
-    // Unknown account or no account (the local calendar) sorts last.
-    return index === -1 ? accountEmailOrder.length : index;
-  };
-
-  return [...calendars].sort((a, b) => {
-    const rankDelta = accountRank(a) - accountRank(b);
-    if (rankDelta !== 0) return rankDelta;
-    if (a.isPrimary !== b.isPrimary) return a.isPrimary ? -1 : 1;
-    return a.name.localeCompare(b.name);
-  });
-};
 
 const calendarOptionLabel = (calendar: Calendar): string =>
   calendar.isPrimary ? `${calendar.name} (primary)` : calendar.name;
@@ -93,17 +72,11 @@ export const CalendarSelect = ({
 }: CalendarSelectProps) => {
   const { data } = useCalendarsQuery();
   const accountEmailOrder = useConnectedAccountEmails();
-  const writableCalendars = sortWritableCalendars(
-    getWritableCalendars(data ?? []),
-    accountEmailOrder,
+  const writableCalendars = getWritableCalendars(data ?? []).sort(
+    compareCalendars(accountEmailOrder),
   );
   // Only disambiguate by account when there is something to disambiguate.
-  const showAccount =
-    new Set(
-      writableCalendars
-        .map((calendar) => calendar.accountEmail)
-        .filter(Boolean),
-    ).size > 1;
+  const showAccount = spansMultipleAccounts(writableCalendars);
   const [isOpen, setIsOpen] = useState(false);
   const [activeIndex, setActiveIndex] = useState<number | null>(null);
   const listRef = useRef<Array<HTMLElement | null>>([]);

--- a/packages/web/src/views/Forms/EventForm/CalendarSelect/CalendarSelect.tsx
+++ b/packages/web/src/views/Forms/EventForm/CalendarSelect/CalendarSelect.tsx
@@ -13,6 +13,7 @@ import { type CalendarId } from "@core/types/domain-primitives";
 import { useCalendarsQuery } from "@web/calendars/calendar.query";
 import {
   compareCalendars,
+  getWritableCalendars,
   spansMultipleAccounts,
 } from "@web/calendars/calendar.util";
 import {
@@ -28,14 +29,6 @@ interface CalendarSelectProps {
   errorId?: string;
   id?: string;
 }
-
-// Only calendars the user can actually write to are offered as a create
-// target - a reader/freeBusy-only calendar would silently fail to accept a
-// new event.
-const getWritableCalendars = (calendars: Calendar[]): Calendar[] =>
-  calendars.filter(
-    (calendar) => calendar.isActive && calendar.capabilities.canWrite,
-  );
 
 const calendarOptionLabel = (calendar: Calendar): string =>
   calendar.isPrimary ? `${calendar.name} (primary)` : calendar.name;


### PR DESCRIPTION
## Summary

Three surfaces each computed calendar order and grouping independently, and they had already drifted: Settings rendered the ungrouped/local calendar *before* its account optgroups while the sidebar rendered it *after*, and `CalendarSelect`'s own comparator - whose comment claimed it "mirrors CalendarList's sort" - used a different tie-break for a calendar whose account isn't in the connection-order list.

Moves both into `packages/web/src/calendars/calendar.util.ts`:
- `compareCalendars(accountEmailOrder)` - by account (connection order), then that account's primary first, then alphabetically; an unlisted or absent account sorts last.
- `groupCalendarsByAccount` - moved as-is from `CalendarList.tsx` (a sidebar component `SettingsModal` importing from was itself a layering wart).
- `getWritableCalendars` - the identical `isActive && canWrite` filter `CalendarSelect` and `SettingsModal` each defined inline.

`CalendarList` and `CalendarSelect` now call the shared functions instead of keeping their own copies. `SettingsModal` always groups by account now (dropping the old "only group past two accounts" threshold, matching the sidebar since #2585), sorts before grouping so an account's own optgroup is ordered too, and renders groups before the ungrouped/local calendar - the fixed position both surfaces now agree on.

Also lifts `SettingsModal`'s writable-calendar list and resolved default out of its two children (`DefaultCalendarPicker`, `AccountsSection`), which each recomputed the identical filter + `useDefaultTargetCalendar` call, and drops `getStoredDefaultCalendarId`, a test-only export superseded by reading the hook/store directly in tests.

**Behavior change:** Settings' calendar order now matches the sidebar; a single connected account gets a labelled optgroup there too, sorted like every other surface.

## Simplicity

Net: two comparators and a grouping function become one each; a duplicated writable-calendar filter (caught in review, see below) becomes one export; `SettingsModal` drops the double `useCalendarsQuery` + `useDefaultTargetCalendar` call between its two children.

## Automated validation

Ran the web app locally (`bun run dev:web`, anonymous session, 1440x900) after the change: the app boots, the week grid and sidebar render sample events normally, `read_console_messages` shows no errors beyond the expected `ERR_CONNECTION_REFUSED` noise from the unreachable local backend in this sandbox. The account-grouped states this PR actually changes (Settings picker ordering, sidebar-vs-Settings agreement) need a connected Google account, which this anonymous sandbox can't reach - covered instead by the unit/component tests below.

## Independent review

Fresh reviewer over the diff found two real gaps, both fixed in a follow-up commit:
1. The Settings picker grouped calendars but never sorted them, so within one account's optgroup, options stayed in raw API order instead of primary-first-then-name.
2. `getWritableCalendars` was still duplicated verbatim between `CalendarSelect.tsx` and `SettingsModal.tsx` instead of joining the other two consolidated helpers.

It confirmed the ordering logic itself matches the old per-file behavior everywhere it should, single-account grouping doesn't break `<select>`/`<optgroup>` semantics, hook-call order in the lifted `SettingsModal` state is unconditional (no rules-of-hooks violation), and no stale references to the old per-file sort functions or the two-account threshold remain.

## Test plan

- [x] `bun run test:web` - 1669/1669 pass
- [x] `bun run type-check` - clean
- [x] `bun run knip` - clean
- [x] `biome check` on touched files - clean

New coverage in `calendar.util.test.ts` for `compareCalendars`/`spansMultipleAccounts`/`groupCalendarsByAccount` (moved from scattered assertions across three component test files); `SettingsModal.test.tsx` gained tests for single-account grouping and group-before-ungrouped ordering; `default-calendar.store.test.ts` and the `SettingsModal` persistence test now assert through the real hook/storage instead of the deleted test-only accessor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)