### PR TITLE
refactor(web): unify the add-account gate between the palette and Settings

### DIFF
--- a/packages/web/src/components/CommandPalette/hooks/useAddAccountCmdItems.test.ts
+++ b/packages/web/src/components/CommandPalette/hooks/useAddAccountCmdItems.test.ts
@@ -37,7 +37,7 @@ describe("useAddAccountCmdItems", () => {
     expect(result.current).toEqual([]);
   });
 
-  it("returns no items before a first account is connected", () => {
+  it("offers the item before any account is connected - one way to discover Google in the palette", () => {
     mockUseConnectGoogle.mockReturnValue({
       connect: mock(),
       isAvailable: true,
@@ -47,7 +47,20 @@ describe("useAddAccountCmdItems", () => {
 
     const { result } = renderHook(() => useAddAccountCmdItems());
 
-    expect(result.current).toEqual([]);
+    expect(result.current[0].label).toBe("Add account");
+  });
+
+  it("still offers the item while an existing account needs reconnecting - matches Settings' gate, which doesn't hide Add account either", () => {
+    mockUseConnectGoogle.mockReturnValue({
+      connect: mock(),
+      isAvailable: true,
+      isConnecting: false,
+      state: "RECONNECT_REQUIRED",
+    });
+
+    const { result } = renderHook(() => useAddAccountCmdItems());
+
+    expect(result.current[0].label).toBe("Add account");
   });
 
   it("connects another account from the command palette item once one account is healthy", () => {

--- a/packages/web/src/components/CommandPalette/hooks/useAddAccountCmdItems.ts
+++ b/packages/web/src/components/CommandPalette/hooks/useAddAccountCmdItems.ts
@@ -3,16 +3,16 @@ import { useConnectGoogle } from "@web/auth/google/hooks/useConnectGoogle/useCon
 import { type CommandItem } from "@web/components/CommandPalette/command-palette.types";
 
 /**
- * Connects another Google account - the palette's counterpart to the
- * sidebar's own Connect button, which only covers the FIRST account.
- * Offered once a first account is already healthy, same gating the sidebar's
- * old hover-revealed plus icon used before it moved here (too easy to miss
- * or misread as decorative).
+ * Connects a Google account. Gated only on Google being configured at all -
+ * matching Settings' "Add account" button, so the two can't disagree about
+ * when this is offered (previously this required a first account already
+ * healthy/importing, so a broken first account hid it here while Settings
+ * still showed it).
  */
 export const useAddAccountCmdItems = (): CommandItem[] => {
-  const { connect, isAvailable, isConnecting, state } = useConnectGoogle();
+  const { connect, isAvailable, isConnecting } = useConnectGoogle();
 
-  if (!isAvailable || (state !== "HEALTHY" && state !== "IMPORTING")) {
+  if (!isAvailable) {
     return [];
   }
 


### PR DESCRIPTION
## Summary

The command palette's "Add account" item and Settings' own "Add account" button disagreed on when to show: the palette required a first account already `HEALTHY` or `IMPORTING`; Settings showed it whenever Google was simply configured (`isAvailable`). With a `RECONNECT_REQUIRED` first account, the palette hid the item entirely while Settings kept offering it right next to the broken account's row.

The palette item now uses the same `isAvailable` check Settings already had - no state restriction. No other palette item reads `useConnectGoogle`'s `commandAction`/`state` (only the per-account Connect/Reconnect/Refresh buttons in the sidebar headers do), so this can't newly duplicate or conflict with another palette entry.

## Simplicity

One condition deleted (`state !== "HEALTHY" && state !== "IMPORTING"`), one doc comment rewritten to state the actual gate instead of a since-removed hover-icon's history.

## Automated validation

Verified locally (`bun run dev:web`, anonymous session): the app boots normally; the palette's Add-account gate isn't exercisable without a backend/Google connection in this sandbox, so it's covered by the unit tests below instead.

## Independent review

Fresh reviewer over the diff confirmed `isAvailable` resolves purely from whether Google is configured backend-wide (`/api/config`), not from any account's connection state, so it never secretly re-encoded the old restriction; grepped the rest of the command palette and found no other item reading `commandAction`/`state` that this could now conflict with; and noted "Add account" appearing alongside the empty "No accounts connected yet." state in Settings is pre-existing, already-shipped behavior this change simply extends to the palette rather than a new UX combination.

## Test plan

- [x] `bun run test:web` - 1672/1672 pass
- [x] `bun run type-check` - clean
- [x] `bun run knip` - clean
- [x] `biome check` on touched files - clean

`useAddAccountCmdItems.test.ts` gained coverage for the two states this actually changes - `NOT_CONNECTED` and `RECONNECT_REQUIRED` - both now asserting the item shows, matching Settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)