### PR TITLE
refactor(sync): one signal for a stalled bootstrap

### DIFF
--- a/packages/sync/src/app.ts
+++ b/packages/sync/src/app.ts
@@ -13,6 +13,7 @@ import {
   CONNECTION_CACHE_RETENTION_MS,
   purgeExpiredDisconnectedConnections,
 } from "@sync/domain/connection-retention.service";
+import { BOOTSTRAP_STALLED_AFTER_MS } from "@sync/domain/connection-state";
 import {
   FAILED_JOB_MAX_REQUEUES,
   requeueFailedJobs,
@@ -274,11 +275,9 @@ async function start(): Promise<void> {
 const FAILED_JOB_REQUEUE_COOLDOWN_MS = 30 * 60_000;
 // A resource not synced within this window is swept for a reconcile pull.
 const RECONCILE_STALE_AFTER_MS = 15 * 60_000;
-// A resource whose bootstrap chain (importing -> watching -> catchingUp ->
-// ready) has not advanced within this window is swept for recovery. Matches
-// reconcile's window: both are "the fallback fires this long after normal
-// forward progress should have happened".
-const BOOTSTRAP_STALLED_AFTER_MS = 15 * 60_000;
+// The bootstrap-recovery sweep below and connection-state's own bootstrapOverdue
+// evidence share BOOTSTRAP_STALLED_AFTER_MS (imported from connection-state.ts)
+// so the UI and the self-heal sweep agree on which resources are stuck.
 // A cloud command left nonterminal past this long since its last update is
 // eligible for a retry - long enough that a transient provider blip has
 // almost certainly cleared, short enough that "deleting" doesn't sit visibly

--- a/packages/sync/src/domain/connection-state-refresh.service.db.test.ts
+++ b/packages/sync/src/domain/connection-state-refresh.service.db.test.ts
@@ -4,7 +4,7 @@ import {
   type ProviderCalendarSourceId,
 } from "@core/types/sync/identity.contracts";
 import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
-import { BOOTSTRAP_OVERDUE_MS } from "@sync/domain/connection-state";
+import { BOOTSTRAP_STALLED_AFTER_MS } from "@sync/domain/connection-state";
 import { refreshConnectionState } from "@sync/domain/connection-state-refresh.service";
 import { type JobEnqueue } from "@sync/storage/contracts/job.contracts";
 import { CredentialRepository } from "@sync/storage/repositories/credential.repository";
@@ -410,8 +410,11 @@ describe("refreshConnectionState", () => {
     const stillFresh = await refreshConnectionState(deps(), connection);
     expect(stillFresh.state).toBe("importing");
 
+    // Staleness is measured from the resource's updatedAt (the last
+    // advanceCursor call above), not its createdAt - a resource whose chain
+    // keeps advancing must never trip this just for having existed a while.
     const wellPastOverdue = () =>
-      new Date(eventsResource.createdAt.getTime() + BOOTSTRAP_OVERDUE_MS);
+      new Date(Date.now() + BOOTSTRAP_STALLED_AFTER_MS);
     const after = await refreshConnectionState(
       deps(),
       connection,

--- a/packages/sync/src/domain/connection-state-refresh.service.ts
+++ b/packages/sync/src/domain/connection-state-refresh.service.ts
@@ -1,5 +1,5 @@
 import {
-  BOOTSTRAP_OVERDUE_MS,
+  BOOTSTRAP_STALLED_AFTER_MS,
   type ConnectionStateEvidence,
   type CredentialState,
   deriveConnectionState,
@@ -125,10 +125,16 @@ export async function gatherConnectionStateEvidence(
         resource?.syncCursor != null && resource.bootstrapState === "ready"
       );
     });
+  // Same basis as the bootstrap-recovery sweep's own staleness check
+  // (listStalledBootstraps): time since the resource last advanced, not since
+  // it was created, so a resource whose chain is genuinely alive never trips
+  // this just for taking a while.
   const bootstrapOverdue = activeCalendars.some((c) => {
     const resource = eventsByCalendar.get(c._id);
     if (!resource || resource.bootstrapState === "ready") return false;
-    return now.getTime() - resource.createdAt.getTime() >= BOOTSTRAP_OVERDUE_MS;
+    return (
+      now.getTime() - resource.updatedAt.getTime() >= BOOTSTRAP_STALLED_AFTER_MS
+    );
   });
 
   // "Last synced" must be as old as the least-recent active calendar. Taking

--- a/packages/sync/src/domain/connection-state.ts
+++ b/packages/sync/src/domain/connection-state.ts
@@ -10,14 +10,19 @@ import {
 
 // Work overdue by at least this long stops a connection from looking healthy.
 export const DELAYED_THRESHOLD_MS = 2 * 60 * 1000;
-// An active calendar still bootstrapping after this long is delayed rather
-// than perpetually "importing", even with no retrying/overdue job to point to
-// (a chain that keeps settling every job "done" - e.g. the unsupported-watch
-// loop this guards against - never trips the oldestDueWorkAt check above,
-// since nothing is ever actually overdue). Generous relative to
-// DELAYED_THRESHOLD_MS: a large first import legitimately takes minutes, so
-// this should only fire once that explanation has been exhausted.
-export const BOOTSTRAP_OVERDUE_MS = 20 * 60 * 1000;
+// An active calendar still bootstrapping after this long since it last
+// advanced is delayed rather than perpetually "importing", even with no
+// retrying/overdue job to point to (a chain that keeps settling every job
+// "done" - e.g. the unsupported-watch loop this guards against - never trips
+// the oldestDueWorkAt check above, since nothing is ever actually overdue).
+// Same threshold and the same `updatedAt`-staleness basis as the
+// bootstrap-recovery sweep (app.ts) that re-enters a resource stuck here - a
+// resource whose chain is genuinely alive keeps advancing updatedAt, so this
+// and the sweep now agree on exactly which resources are stuck, instead of
+// each answering "is this stalled?" on a different clock (createdAt at 20m
+// here vs. updatedAt at 15m there could disagree on a resource the sweep had
+// already re-entered while this still called it merely importing).
+export const BOOTSTRAP_STALLED_AFTER_MS = 15 * 60 * 1000;
 
 export type CredentialState =
   | "valid"
@@ -41,8 +46,9 @@ export interface ConnectionStateEvidence {
   readonly accountIdentified: boolean;
   // The first import, watch setup, and post-watch catch-up have finished.
   readonly initialImportComplete: boolean;
-  // An active calendar has been mid-bootstrap longer than BOOTSTRAP_OVERDUE_MS.
-  // Only consulted when initialImportComplete is false.
+  // An active calendar has been mid-bootstrap and untouched (no advancing
+  // updatedAt) for longer than BOOTSTRAP_STALLED_AFTER_MS. Only consulted when
+  // initialImportComplete is false.
   readonly bootstrapOverdue: boolean;
   // A non-destructive repair or post-gap reconciliation is running while
   // existing data stays queryable.


### PR DESCRIPTION
## Summary

Two mechanisms both answered "is this resource's bootstrap wedged?" on different clocks: `bootstrapOverdue` evidence (feeding the UI-facing derived connection state, `delayed`/`workOverdue`) used 20 minutes since `resource.createdAt`; the bootstrap-recovery sweep's `listStalledBootstraps` (the self-heal that re-enters a resource) used 15 minutes since `resource.updatedAt`. A resource could get swept for recovery while the UI still calmly reported "importing", or the UI could flip to delayed while the sweep still considered the chain alive.

`bootstrapOverdue` now checks `resource.updatedAt` against `BOOTSTRAP_STALLED_AFTER_MS` (15 min, unchanged value) - the same basis and threshold the sweep already used. The constant moves to `connection-state.ts` as the one place both the UI-facing derivation and `app.ts`'s sweep import it from (`app.ts` previously declared its own local copy of the same name and value).

`updatedAt` is the more honest signal: a chain that's genuinely alive keeps advancing it on every step, while `createdAt` never moves regardless of progress - so the old basis could flag a resource as "delayed" purely for having existed 20 minutes, even mid useful work.

## Simplicity

One constant instead of two (`BOOTSTRAP_OVERDUE_MS` deleted, `BOOTSTRAP_STALLED_AFTER_MS` now declared once and imported by both consumers), one field basis instead of two.

## Automated validation

Server-side scheduling/derivation logic with no UI surface to browser-verify - validated through the sync package's test suite, including a fresh review pass tracing every consumer of the old and new constants across the repo.

## Independent review

Fresh reviewer over the diff confirmed: the new constant is exactly 15 minutes (900000ms), matching what the sweep already used, with no drift between the two importers; every reference to the deleted `BOOTSTRAP_OVERDUE_MS` is gone repo-wide, including test files; the updated db-test's `Date.now() + BOOTSTRAP_STALLED_AFTER_MS` deterministically clears the threshold against the resource's `updatedAt` (set moments earlier by `advanceCursor`) without flaking or losing the boundary the test means to exercise; `updatedAt` is a required, always-set field on every sync resource mutation, so there's no state where it could be stale/absent in a way `createdAt` wasn't; and no leftover doc/comment anywhere still describes the old 20-minute or `createdAt`-based threshold.

## Test plan

- [x] `bun run test:sync` - 778/778 pass
- [x] `bun run type-check` - clean
- [x] `bun run knip` - clean
- [x] `biome check` on touched files - clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)