### PR TITLE
feat(scripts): add backfill-bootstrap-state CLI for the OPS-1 migration

### DIFF
--- a/packages/scripts/src/cli.ts
+++ b/packages/scripts/src/cli.ts
@@ -1,5 +1,6 @@
 import { CliValidator } from "@scripts/cli.validator";
 import { runAuditConnectionIdentity } from "@scripts/commands/audit-connection-identity";
+import { runBackfillBootstrapState } from "@scripts/commands/backfill-bootstrap-state";
 import { runBackfillIcalUid } from "@scripts/commands/backfill-icaluid";
 import { runManageFailedJobs } from "@scripts/commands/manage-failed-jobs";
 import { runPurgeCorruptSyncEvents } from "@scripts/commands/purge-corrupt-sync-events";
@@ -39,6 +40,9 @@ export default class CompassCLI {
         break;
       case cmd === "backfill-icaluid":
         await runBackfillIcalUid();
+        break;
+      case cmd === "backfill-bootstrap-state":
+        await runBackfillBootstrapState();
         break;
       case cmd === "audit-connection-identity":
         await runAuditConnectionIdentity();
@@ -91,6 +95,14 @@ export default class CompassCLI {
       .allowUnknownOption(true)
       .description(
         "Copy Google's cross-copy correlation key onto events that predate it (--apply to write)",
+      );
+
+    program
+      .command("backfill-bootstrap-state")
+      .helpOption(false)
+      .allowUnknownOption(true)
+      .description(
+        "Stamp bootstrapState: ready onto sync_resources rows that predate the field (--apply to write)",
       );
 
     program

--- a/packages/scripts/src/cli.ts
+++ b/packages/scripts/src/cli.ts
@@ -102,7 +102,7 @@ export default class CompassCLI {
       .helpOption(false)
       .allowUnknownOption(true)
       .description(
-        "Stamp bootstrapState: ready onto sync_resources rows that predate the field (--apply to write)",
+        "Stamp bootstrapState: ready onto sync_resources rows that predate the field (--apply to write, --limit <n> to cap a run)",
       );
 
     program

--- a/packages/scripts/src/commands/backfill-bootstrap-state.ts
+++ b/packages/scripts/src/commands/backfill-bootstrap-state.ts
@@ -17,14 +17,29 @@ function syncMongoUri(): string {
   return uri;
 }
 
+function parseLimit(argv: string[]): number | undefined {
+  const flagIndex = argv.indexOf("--limit");
+  if (flagIndex === -1) return undefined;
+  const raw = argv[flagIndex + 1];
+  const limit = raw ? Number.parseInt(raw, 10) : Number.NaN;
+  if (!Number.isFinite(limit) || limit <= 0) {
+    throw new Error("--limit requires a positive integer");
+  }
+  return limit;
+}
+
 /**
  * Stamp bootstrapState: "ready" onto sync_resources rows written before the
- * field existed. Default dry-run; `--apply` writes. Safe to rerun.
+ * field existed. Default dry-run; `--apply` writes; `--limit <n>` caps how
+ * many rows one run touches, for a cautious first batch against a real
+ * database before trusting the full collection. Safe to rerun.
  *
- *   bun run cli backfill-bootstrap-state [--apply]
+ *   bun run cli backfill-bootstrap-state [--apply] [--limit <n>]
  */
 export async function runBackfillBootstrapState(): Promise<void> {
-  const apply = process.argv.slice(3).includes("--apply");
+  const argv = process.argv.slice(3);
+  const apply = argv.includes("--apply");
+  const limit = parseLimit(argv);
   const syncMongo = new SyncMongoService();
   try {
     await syncMongo.connect({
@@ -34,6 +49,7 @@ export async function runBackfillBootstrapState(): Promise<void> {
     });
     const report = await backfillBootstrapState(syncMongo.db, {
       dryRun: !apply,
+      ...(limit !== undefined ? { limit } : {}),
     });
     process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
     logger.info(

--- a/packages/scripts/src/commands/backfill-bootstrap-state.ts
+++ b/packages/scripts/src/commands/backfill-bootstrap-state.ts
@@ -1,0 +1,53 @@
+import { backfillBootstrapState } from "@scripts/commands/backfill-bootstrap-state/backfill";
+import { loadCompassConfig } from "@core/config/compass.config";
+import { Logger } from "@core/logger/winston.logger";
+import { SyncMongoService } from "@sync/storage/sync-mongo.service";
+
+const logger = Logger("scripts.commands.backfill-bootstrap-state");
+
+function syncMongoUri(): string {
+  const fromEnv = process.env["SYNC_MONGO_URI"]?.trim();
+  if (fromEnv) return fromEnv;
+  const uri = loadCompassConfig().sync?.mongoUri?.trim();
+  if (!uri) {
+    throw new Error(
+      "Set SYNC_MONGO_URI or add sync.mongoUri to compass.yaml before backfill-bootstrap-state",
+    );
+  }
+  return uri;
+}
+
+/**
+ * Stamp bootstrapState: "ready" onto sync_resources rows written before the
+ * field existed. Default dry-run; `--apply` writes. Safe to rerun.
+ *
+ *   bun run cli backfill-bootstrap-state [--apply]
+ */
+export async function runBackfillBootstrapState(): Promise<void> {
+  const apply = process.argv.slice(3).includes("--apply");
+  const syncMongo = new SyncMongoService();
+  try {
+    await syncMongo.connect({
+      uri: syncMongoUri(),
+      enforceLeastPrivilege: false,
+      forbiddenDatabaseName: "prod_calendar",
+    });
+    const report = await backfillBootstrapState(syncMongo.db, {
+      dryRun: !apply,
+    });
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    logger.info(
+      `backfill-bootstrap-state dryRun=${report.dryRun} matched=${report.matched} updated=${report.updated}`,
+    );
+    await syncMongo.disconnect();
+    process.exit(0);
+  } catch (error) {
+    logger.error(error);
+    try {
+      await syncMongo.disconnect();
+    } catch {
+      // ignore
+    }
+    process.exit(1);
+  }
+}

--- a/packages/scripts/src/commands/backfill-bootstrap-state/backfill.db.test.ts
+++ b/packages/scripts/src/commands/backfill-bootstrap-state/backfill.db.test.ts
@@ -1,0 +1,100 @@
+import { backfillBootstrapState } from "@scripts/commands/backfill-bootstrap-state/backfill";
+import { ObjectId } from "mongodb";
+import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
+import { SYNC_COLLECTIONS } from "@sync/storage/collections";
+import { type SyncResourceRecord } from "@sync/storage/contracts/sync-resource.contracts";
+import { SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
+import { beforeEach, describe, expect, it } from "bun:test";
+
+const objectId = () => new ObjectId().toHexString();
+
+describe("backfillBootstrapState", () => {
+  const storage = setupSyncStorage(import.meta.url);
+  let resources: SyncResourceRepository;
+
+  beforeEach(() => {
+    resources = new SyncResourceRepository(storage.db());
+  });
+
+  const collection = () =>
+    storage.db().collection(SYNC_COLLECTIONS.syncResources);
+
+  // ensure() always writes an explicit bootstrapState, so a legacy row (one
+  // written before the field existed) is simulated by unsetting it after
+  // insert - the only way such a row exists today.
+  async function seedLegacyResource(): Promise<SyncResourceRecord> {
+    const resource = await resources.ensure({
+      tenantId: objectId() as SyncResourceRecord["tenantId"],
+      principalId: objectId() as SyncResourceRecord["principalId"],
+      connectionId: objectId() as SyncResourceRecord["connectionId"],
+      resourceKind: "events",
+      calendarId: objectId() as SyncResourceRecord["calendarId"],
+    });
+    await collection().updateOne(
+      { _id: resource._id },
+      { $unset: { bootstrapState: "" } },
+    );
+    return resource;
+  }
+
+  it("dry-runs by default: finds legacy rows but writes nothing", async () => {
+    const legacy = await seedLegacyResource();
+
+    const report = await backfillBootstrapState(storage.db(), {
+      dryRun: true,
+    });
+
+    expect(report.matched).toBe(1);
+    expect(report.updated).toBe(0);
+    expect(report.ids).toEqual([legacy._id]);
+    const raw = await collection().findOne({ _id: legacy._id });
+    expect(raw?.["bootstrapState"]).toBeUndefined();
+  });
+
+  it("stamps bootstrapState: ready onto legacy rows when applied", async () => {
+    const legacy = await seedLegacyResource();
+
+    const report = await backfillBootstrapState(storage.db(), {
+      dryRun: false,
+    });
+
+    expect(report.matched).toBe(1);
+    expect(report.updated).toBe(1);
+    const raw = await collection().findOne({ _id: legacy._id });
+    expect(raw?.["bootstrapState"]).toBe("ready");
+  });
+
+  it("leaves a resource that already has an explicit bootstrapState untouched", async () => {
+    // A fresh events resource inserts as "importing" - if the backfill's
+    // filter were wrong (e.g. matched on state rather than field presence)
+    // this would get wrongly bumped to "ready" mid-import.
+    const fresh = await resources.ensure({
+      tenantId: objectId() as SyncResourceRecord["tenantId"],
+      principalId: objectId() as SyncResourceRecord["principalId"],
+      connectionId: objectId() as SyncResourceRecord["connectionId"],
+      resourceKind: "events",
+      calendarId: objectId() as SyncResourceRecord["calendarId"],
+    });
+    expect(fresh.bootstrapState).toBe("importing");
+
+    const report = await backfillBootstrapState(storage.db(), {
+      dryRun: false,
+    });
+
+    expect(report.matched).toBe(0);
+    const raw = await collection().findOne({ _id: fresh._id });
+    expect(raw?.["bootstrapState"]).toBe("importing");
+  });
+
+  it("is idempotent: a second run finds nothing left to do", async () => {
+    await seedLegacyResource();
+    await backfillBootstrapState(storage.db(), { dryRun: false });
+
+    const second = await backfillBootstrapState(storage.db(), {
+      dryRun: false,
+    });
+
+    expect(second.matched).toBe(0);
+    expect(second.updated).toBe(0);
+  });
+});

--- a/packages/scripts/src/commands/backfill-bootstrap-state/backfill.db.test.ts
+++ b/packages/scripts/src/commands/backfill-bootstrap-state/backfill.db.test.ts
@@ -97,4 +97,35 @@ describe("backfillBootstrapState", () => {
     expect(second.matched).toBe(0);
     expect(second.updated).toBe(0);
   });
+
+  it("caps a run to --limit rows, for a cautious first batch against a real database", async () => {
+    await seedLegacyResource();
+    await seedLegacyResource();
+    await seedLegacyResource();
+
+    const report = await backfillBootstrapState(storage.db(), {
+      dryRun: false,
+      limit: 2,
+    });
+
+    expect(report.matched).toBe(2);
+    expect(report.updated).toBe(2);
+    expect(
+      await collection().countDocuments({ bootstrapState: { $exists: false } }),
+    ).toBe(1);
+  });
+
+  it("does not write past --limit even when more rows would otherwise match", async () => {
+    // The limit must bound the query itself, not just the reported count -
+    // a limit that only trims the report while still writing every match
+    // would defeat the point of a cautious first batch.
+    await seedLegacyResource();
+    await seedLegacyResource();
+
+    await backfillBootstrapState(storage.db(), { dryRun: false, limit: 1 });
+
+    expect(await collection().countDocuments({ bootstrapState: "ready" })).toBe(
+      1,
+    );
+  });
 });

--- a/packages/scripts/src/commands/backfill-bootstrap-state/backfill.ts
+++ b/packages/scripts/src/commands/backfill-bootstrap-state/backfill.ts
@@ -1,0 +1,54 @@
+import { type Db } from "mongodb";
+import { SYNC_COLLECTIONS } from "@sync/storage/collections";
+
+export type BackfillBootstrapStateReport = {
+  generatedAt: string;
+  dryRun: boolean;
+  matched: number;
+  updated: number;
+  ids: string[];
+};
+
+/**
+ * Stamp `bootstrapState: "ready"` onto sync_resources rows written before the
+ * field existed (currently synthesized at read time by
+ * ResourceBootstrapStateSchema's `.default("ready")`). Once every row has an
+ * explicit value, that schema default - and the read-time ambiguity it papers
+ * over - can be retired.
+ *
+ * Only touches rows genuinely missing the field; already-migrated or
+ * newly-created rows (which always write an explicit bootstrapState) are
+ * untouched. Idempotent; safe to rerun.
+ */
+export async function backfillBootstrapState(
+  db: Db,
+  options: { dryRun: boolean; limit?: number } = { dryRun: true },
+): Promise<BackfillBootstrapStateReport> {
+  const limit = options.limit ?? Infinity;
+  const collection = db.collection(SYNC_COLLECTIONS.syncResources);
+  const filter = { bootstrapState: { $exists: false } };
+
+  const rawIds: unknown[] = [];
+  const cursor = collection.find(filter, { projection: { _id: 1 } });
+  for await (const doc of cursor) {
+    rawIds.push(doc["_id"]);
+    if (rawIds.length >= limit) break;
+  }
+
+  let updated = 0;
+  if (!options.dryRun && rawIds.length > 0) {
+    const result = await collection.updateMany(
+      { _id: { $in: rawIds as never[] }, ...filter },
+      { $set: { bootstrapState: "ready" } },
+    );
+    updated = result.modifiedCount;
+  }
+
+  return {
+    generatedAt: new Date().toISOString(),
+    dryRun: options.dryRun,
+    matched: rawIds.length,
+    updated,
+    ids: rawIds.map(String),
+  };
+}


### PR DESCRIPTION
## Summary

Adds an operator CLI command, `backfill-bootstrap-state`, modeled directly on the existing `backfill-icaluid`/`purge-corrupt-sync-events` commands (same dry-run-by-default / `--apply` pattern, same `SyncMongoService` connection setup).

It stamps `bootstrapState: "ready"` onto `sync_resources` rows written before that field existed - currently synthesized at read time by `ResourceBootstrapStateSchema`'s `.default("ready")`. Once every row has an explicit value, that schema default (and the read-time ambiguity between "genuinely legacy-and-done" and "field just missing") can be retired in a follow-up.

```
bun run cli backfill-bootstrap-state [--apply] [--limit <n>]
```

- Default dry-run; `--apply` writes.
- `--limit <n>` caps how many rows one run touches - added after review flagged that a tool meant to run directly against production had no way to scope a first cautious batch, unlike `backfill-icaluid`'s `--connection` scoping.
- Idempotent; only touches rows genuinely missing the field, so a rerun (or a run after `--limit`-bounded batches) safely converges to `matched: 0`.

**This PR does not touch the schema default.** That's a separate, deliberately unopened change - merging it before this tool has actually run against prod would mean any legacy row still missing the field fails to parse instead of defaulting.

## Simplicity

Follows the established three-part shape for this package's operator tools (thin CLI entry with arg parsing + Mongo connection, a pure `db`-taking function, a `.db.test.ts`) rather than introducing a new pattern.

## Automated validation

Not browser-observable (backend CLI). Verified via the scripts package's db-test suite, which now covers dry-run-is-read-only, applying stamps only rows missing the field (a resource mid-import with `bootstrapState: "importing"` is untouched), idempotency, and the new `--limit` bound (both the reported count and the underlying write are capped, not just the report).

## Independent review

Given this tool will run with write access against a real production database, review was held to production-safety rigor rather than the usual bar. It confirmed: the `updateMany` re-applies the same `{ bootstrapState: { $exists: false } }` filter as the read, so a doc a concurrent process stamps between the cursor read and the write is correctly skipped (no lost-update race); `forbiddenDatabaseName: "prod_calendar"` is the existing cross-database isolation check other commands use, not an anti-prod guard; `_id` values are stored as strings (matching `ObjectIdStringSchema`), so the `$in` query has no type-mismatch risk; and dry-run has no code path that reaches the write. It found one real gap - no way to bound a first production run - fixed in a follow-up commit with `--limit`.

## Test plan

- [x] `bun run test:scripts` - 42/42 pass
- [x] `bun run type-check` - clean
- [x] `bun run knip` - clean
- [x] `biome check` on touched files - clean

## Next step (yours to run)

Once merged: run against staging first (`--apply` with no `--limit`, verify `matched: 0` on rerun), then against prod starting with `--limit 5` to inspect a small batch before a full `--apply` run. Exact commands in the follow-up message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)