### PR TITLE
fix(sync): preserve iCalUID across sparse provider upserts

### DIFF
--- a/packages/backend/src/common/middleware/http.logger.middleware.ts
+++ b/packages/backend/src/common/middleware/http.logger.middleware.ts
@@ -1,6 +1,6 @@
 import { type RequestHandler } from "express";
-import { styleText } from "node:util";
 import { Logger } from "@core/logger/winston.logger";
+import { styleText } from "node:util";
 
 const logger = Logger("app:http");
 

--- a/packages/core/src/logger/otel-logs.ts
+++ b/packages/core/src/logger/otel-logs.ts
@@ -20,7 +20,8 @@ let posthogClient: PostHog | undefined;
 
 export function startOtelLogs(options: OtelLogsOptions): PostHog | null {
   const isRemoteLoggingEnvironment =
-    options.nodeEnv === NodeEnv.Staging || options.nodeEnv === NodeEnv.Production;
+    options.nodeEnv === NodeEnv.Staging ||
+    options.nodeEnv === NodeEnv.Production;
 
   if (isRemoteLoggingEnvironment && options.posthogKey) {
     const host = options.posthogHost || "https://us.i.posthog.com";

--- a/packages/core/src/logger/otel.transport.ts
+++ b/packages/core/src/logger/otel.transport.ts
@@ -1,6 +1,6 @@
 import { logs, SeverityNumber } from "@opentelemetry/api-logs";
-import TransportStream from "winston-transport";
 import { type TransformableInfo } from "logform";
+import TransportStream from "winston-transport";
 
 const otelLogger = logs.getLogger("compass");
 
@@ -19,15 +19,28 @@ const severityNumbers: Record<string, SeverityNumber> = {
 export class OpenTelemetryTransport extends TransportStream {
   log(info: TransformableInfo, next: () => void): void {
     const attributes = Object.entries(info)
-      .filter(([key]) => key !== "level" && key !== "message" && !key.startsWith("[") && typeof key !== "symbol")
-      .reduce<Record<string, string | number | boolean | undefined>>((acc, [key, value]) => {
-        if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
-          acc[key] = value;
-        } else if (value != null) {
-          acc[key] = JSON.stringify(value);
-        }
-        return acc;
-      }, {});
+      .filter(
+        ([key]) =>
+          key !== "level" &&
+          key !== "message" &&
+          !key.startsWith("[") &&
+          typeof key !== "symbol",
+      )
+      .reduce<Record<string, string | number | boolean | undefined>>(
+        (acc, [key, value]) => {
+          if (
+            typeof value === "string" ||
+            typeof value === "number" ||
+            typeof value === "boolean"
+          ) {
+            acc[key] = value;
+          } else if (value != null) {
+            acc[key] = JSON.stringify(value);
+          }
+          return acc;
+        },
+        {},
+      );
 
     otelLogger.emit({
       severityText: info.level,

--- a/packages/core/src/logger/posthog-exception.transport.ts
+++ b/packages/core/src/logger/posthog-exception.transport.ts
@@ -1,5 +1,5 @@
-import TransportStream from "winston-transport";
 import { type TransformableInfo } from "logform";
+import TransportStream from "winston-transport";
 import { getPostHogClient } from "./otel-logs";
 
 export class PostHogExceptionTransport extends TransportStream {

--- a/packages/sync/src/app.ts
+++ b/packages/sync/src/app.ts
@@ -1,5 +1,5 @@
-import { Logger } from "@core/logger/winston.logger";
 import { startOtelLogs, stopOtelLogs } from "@core/logger/otel-logs";
+import { Logger } from "@core/logger/winston.logger";
 import {
   SYNC_RECONCILE_SWEEP_EVENT,
   SyncReconcileSweepEventSchema,

--- a/packages/sync/src/domain/provider-command.service.db.test.ts
+++ b/packages/sync/src/domain/provider-command.service.db.test.ts
@@ -255,6 +255,7 @@ describe("executeProviderCreate", () => {
     expect(stored?.providerEventId).toBe("g-evt-1");
     expect(stored?.providerVersion).toBe("etag-1");
     expect(stored?.deliveryState).toBe("confirmed");
+    expect(stored?.providerMetadata).toBeNull();
 
     // The provider-linked event is projected into the read model.
     const occ = await mongo.db
@@ -264,6 +265,37 @@ describe("executeProviderCreate", () => {
     expect(occ.map((o) => (o["startAt"] as Date).toISOString())).toEqual([
       "2026-07-14T15:00:00.000Z",
     ]);
+  });
+
+  it("stores iCalUID from the write result on create", async () => {
+    const { tenantId, principalId, calendar, command } = await seed();
+    const writer = new FakeWriter();
+    writer.result = {
+      providerEventId: "g-evt-1",
+      providerVersion: "etag-1",
+      icalUid: "g-evt-1@google.com",
+    };
+
+    await executeProviderCreate(
+      {
+        commands,
+        events,
+        occurrences,
+        resources,
+        writer,
+        custody: tokenSource(),
+      },
+      command,
+      calendar,
+      now,
+    );
+
+    const stored = await events.findById(
+      tenantId,
+      principalId,
+      command.eventId,
+    );
+    expect(stored?.providerMetadata).toEqual({ iCalUID: "g-evt-1@google.com" });
   });
 
   it("passes the caller's invitation intent through to the writer", async () => {

--- a/packages/sync/src/domain/provider-command.service.ts
+++ b/packages/sync/src/domain/provider-command.service.ts
@@ -218,7 +218,7 @@ function buildLinkedEventRecord(
     // The write result carries no provider update time; a later read sets it.
     providerUpdatedAt: null,
     deliveryState: "confirmed",
-    providerMetadata: null,
+    providerMetadata: result.icalUid ? { iCalUID: result.icalUid } : null,
     content: omitNullColor(input.content),
     schedule: input.schedule,
     recurrence:

--- a/packages/sync/src/domain/provider-metadata.test.ts
+++ b/packages/sync/src/domain/provider-metadata.test.ts
@@ -1,0 +1,58 @@
+import { mergeProviderMetadataPreservingIcalUid } from "@sync/domain/provider-metadata";
+
+describe("mergeProviderMetadataPreservingIcalUid", () => {
+  it("keeps existing iCalUID when incoming is null (busy default)", () => {
+    expect(
+      mergeProviderMetadataPreservingIcalUid(null, {
+        iCalUID: "kept@google.com",
+      }),
+    ).toEqual({ iCalUID: "kept@google.com" });
+  });
+
+  it("stays null when incoming is null and nothing was stored", () => {
+    expect(mergeProviderMetadataPreservingIcalUid(null, null)).toBeNull();
+    expect(mergeProviderMetadataPreservingIcalUid(null, undefined)).toBeNull();
+  });
+
+  it("clears transparency while preserving iCalUID when becoming busy", () => {
+    expect(
+      mergeProviderMetadataPreservingIcalUid(null, {
+        transparency: "transparent",
+        iCalUID: "kept@google.com",
+      }),
+    ).toEqual({ iCalUID: "kept@google.com" });
+  });
+
+  it("merges existing iCalUID into an incoming transparency-only bag", () => {
+    expect(
+      mergeProviderMetadataPreservingIcalUid(
+        { transparency: "transparent" },
+        { iCalUID: "kept@google.com" },
+      ),
+    ).toEqual({
+      transparency: "transparent",
+      iCalUID: "kept@google.com",
+    });
+  });
+
+  it("lets an incoming iCalUID replace the stored one", () => {
+    expect(
+      mergeProviderMetadataPreservingIcalUid(
+        { iCalUID: "new@google.com" },
+        { iCalUID: "old@google.com", transparency: "transparent" },
+      ),
+    ).toEqual({ iCalUID: "new@google.com" });
+  });
+
+  it("uses an incoming bag that already carries both facts", () => {
+    expect(
+      mergeProviderMetadataPreservingIcalUid(
+        { transparency: "transparent", iCalUID: "free@google.com" },
+        { iCalUID: "old@google.com" },
+      ),
+    ).toEqual({
+      transparency: "transparent",
+      iCalUID: "free@google.com",
+    });
+  });
+});

--- a/packages/sync/src/domain/provider-metadata.ts
+++ b/packages/sync/src/domain/provider-metadata.ts
@@ -1,0 +1,29 @@
+// Merge rules for the stored provider-fact bag on sync upsert:
+// - Incoming wins for transparency (busy↔free must clear/set it).
+// - Incoming iCalUID wins when present.
+// - If incoming omits iCalUID but the existing row has one, keep it so a
+//   sparse re-read cannot wipe a backfill or a prior full read.
+// - Incoming null with no existing iCalUID stays null (busy default).
+export function mergeProviderMetadataPreservingIcalUid(
+  incoming: Record<string, string> | null,
+  existing: Record<string, string> | null | undefined,
+): Record<string, string> | null {
+  const existingUid =
+    existing && typeof existing["iCalUID"] === "string"
+      ? existing["iCalUID"]
+      : undefined;
+
+  if (incoming === null) {
+    return existingUid ? { iCalUID: existingUid } : null;
+  }
+
+  if (incoming["iCalUID"]) {
+    return { ...incoming };
+  }
+
+  if (existingUid) {
+    return { ...incoming, iCalUID: existingUid };
+  }
+
+  return Object.keys(incoming).length > 0 ? { ...incoming } : null;
+}

--- a/packages/sync/src/domain/provider-page-applier.db.test.ts
+++ b/packages/sync/src/domain/provider-page-applier.db.test.ts
@@ -128,6 +128,95 @@ describe("ProviderPageApplier", () => {
     });
   });
 
+  it("preserves an existing iCalUID when a later sparse read omits it", async () => {
+    const calendar = await seedCalendar();
+    const byId = (providerEventId: string) =>
+      events.findByProviderIdentity(calendar.tenantId, calendar.principalId, {
+        connectionId: calendar.connectionId,
+        calendarId: calendar._id,
+        providerEventId,
+      });
+
+    await applier(calendar).applyPage([
+      { ...single("kept"), icalUid: "kept@google.com" },
+    ]);
+    expect((await byId("kept"))?.providerMetadata).toEqual({
+      iCalUID: "kept@google.com",
+    });
+
+    // Same provider identity, no icalUid on the read — must not wipe the key.
+    await applier(calendar).applyPage([single("kept")]);
+    expect((await byId("kept"))?.providerMetadata).toEqual({
+      iCalUID: "kept@google.com",
+    });
+  });
+
+  it("updates transparency from a sparse read without dropping iCalUID", async () => {
+    const calendar = await seedCalendar();
+    const byId = (providerEventId: string) =>
+      events.findByProviderIdentity(calendar.tenantId, calendar.principalId, {
+        connectionId: calendar.connectionId,
+        calendarId: calendar._id,
+        providerEventId,
+      });
+
+    await applier(calendar).applyPage([
+      { ...single("flex"), icalUid: "flex@google.com" },
+    ]);
+    await applier(calendar).applyPage([{ ...single("flex"), busy: false }]);
+
+    expect((await byId("flex"))?.providerMetadata).toEqual({
+      transparency: "transparent",
+      iCalUID: "flex@google.com",
+    });
+  });
+
+  it("lets an incoming iCalUID replace a previously stored one", async () => {
+    const calendar = await seedCalendar();
+    const byId = (providerEventId: string) =>
+      events.findByProviderIdentity(calendar.tenantId, calendar.principalId, {
+        connectionId: calendar.connectionId,
+        calendarId: calendar._id,
+        providerEventId,
+      });
+
+    await applier(calendar).applyPage([
+      { ...single("swap"), icalUid: "old@google.com" },
+    ]);
+    await applier(calendar).applyPage([
+      { ...single("swap"), icalUid: "new@google.com" },
+    ]);
+
+    expect((await byId("swap"))?.providerMetadata).toEqual({
+      iCalUID: "new@google.com",
+    });
+  });
+
+  it("still clears providerMetadata on a cancelled series exception", async () => {
+    const calendar = await seedCalendar();
+    const run = applier(calendar);
+
+    await run.applyPage([
+      { ...master("m"), icalUid: "series@google.com" },
+      seriesCancellation("m_c", "m", "2026-07-21T09:00:00-06:00"),
+    ]);
+
+    const cancelled = await events.findByProviderIdentity(
+      calendar.tenantId,
+      calendar.principalId,
+      {
+        connectionId: calendar.connectionId,
+        calendarId: calendar._id,
+        providerEventId: "m_c",
+      },
+    );
+    expect(cancelled?.providerMetadata).toBeNull();
+    expect(cancelled?.recurrence).toMatchObject({
+      kind: "exception",
+      cancelled: true,
+    });
+  });
+
   it("returns standalone cancellations unconsumed and writes nothing for them", async () => {
     const calendar = await seedCalendar();
     const run = applier(calendar);

--- a/packages/sync/src/domain/provider-page-applier.ts
+++ b/packages/sync/src/domain/provider-page-applier.ts
@@ -300,32 +300,38 @@ export class ProviderPageApplier {
     read: ProviderEvent,
     recurrence: SyncEventRecurrence,
   ): Promise<EventRecord> {
-    const record = await this.events.upsertByProviderIdentity({
-      tenantId: this.calendar.tenantId,
-      principalId: this.calendar.principalId,
-      origin: "provider",
-      calendarId: this.calendar._id,
-      clientEventId: null,
-      connectionId: this.calendar.connectionId,
-      providerEventId: read.providerEventId as NonNullable<
-        EventRecord["providerEventId"]
-      >,
-      providerVersion: read.providerVersion as NonNullable<
-        EventRecord["providerVersion"]
-      >,
-      providerUpdatedAt: read.providerUpdatedAt
-        ? new Date(read.providerUpdatedAt)
-        : null,
-      // Imported provider events carry no Compass delivery intent.
-      deliveryState: null,
-      providerMetadata: providerMetadataFor(read),
-      content: read.content,
-      schedule: read.schedule,
-      recurrence,
-      lifecycleState: "active",
-      generation: this.generation,
-      confirmedAt: this.now(),
-    });
+    const record = await this.events.upsertByProviderIdentity(
+      {
+        tenantId: this.calendar.tenantId,
+        principalId: this.calendar.principalId,
+        origin: "provider",
+        calendarId: this.calendar._id,
+        clientEventId: null,
+        connectionId: this.calendar.connectionId,
+        providerEventId: read.providerEventId as NonNullable<
+          EventRecord["providerEventId"]
+        >,
+        providerVersion: read.providerVersion as NonNullable<
+          EventRecord["providerVersion"]
+        >,
+        providerUpdatedAt: read.providerUpdatedAt
+          ? new Date(read.providerUpdatedAt)
+          : null,
+        // Imported provider events carry no Compass delivery intent.
+        deliveryState: null,
+        providerMetadata: providerMetadataFor(read),
+        content: read.content,
+        schedule: read.schedule,
+        recurrence,
+        lifecycleState: "active",
+        generation: this.generation,
+        confirmedAt: this.now(),
+      },
+      // Sparse Google reads (or deploy skew) must not wipe a backfilled /
+      // previously-synced iCalUID. Cancelled exceptions still clear the bag
+      // via the default (non-preserve) upsert path.
+      { preserveIcalUidWhenAbsent: true },
+    );
     this.#importedIds.add(record.providerEventId as string);
     return record;
   }

--- a/packages/sync/src/providers/google/google-event-writer.adapter.test.ts
+++ b/packages/sync/src/providers/google/google-event-writer.adapter.test.ts
@@ -196,6 +196,24 @@ describe("GoogleEventWriter", () => {
     });
   });
 
+  it("returns iCalUID from the Google write response when present", async () => {
+    const api = new FakeEventsApi({
+      insert: {
+        ...scriptedEvent("abc12deadbeef00000000000"),
+        iCalUID: "abc12deadbeef00000000000@google.com",
+      },
+    });
+    const { writer } = writerWith(api);
+
+    const result = await writer.createEvent(baseCreate);
+
+    expect(result).toEqual({
+      providerEventId: "abc12deadbeef00000000000",
+      providerVersion: '"v1"',
+      icalUid: "abc12deadbeef00000000000@google.com",
+    });
+  });
+
   it("treats a duplicate-id create as success by reading the event back", async () => {
     // 409 => a prior attempt already created it; the retry must not fail.
     const api = new FakeEventsApi({ insert: gError(409, "duplicate") });

--- a/packages/sync/src/providers/google/google-event-writer.adapter.ts
+++ b/packages/sync/src/providers/google/google-event-writer.adapter.ts
@@ -243,7 +243,11 @@ function toResult(event: gSchema$Event): ProviderWriteResult {
       "Google returned an event without an id or etag",
     );
   }
-  return { providerEventId: event.id, providerVersion: event.etag };
+  return {
+    providerEventId: event.id,
+    providerVersion: event.etag,
+    ...(event.iCalUID ? { icalUid: event.iCalUID } : {}),
+  };
 }
 
 // Map neutral content/schedule/recurrence to a Google event body. Because

--- a/packages/sync/src/providers/provider-event-writer.port.ts
+++ b/packages/sync/src/providers/provider-event-writer.port.ts
@@ -69,6 +69,9 @@ export interface ProviderInstanceFetchInput {
 export interface ProviderWriteResult {
   readonly providerEventId: string;
   readonly providerVersion: string;
+  // Google's cross-copy correlation key when the write response includes it.
+  // Optional so non-Google writers and older fixtures stay valid.
+  readonly icalUid?: string;
 }
 
 // A provider-neutral event mutation port. Neutral inputs in, provider identity

--- a/packages/sync/src/storage/repositories/event.repository.db.test.ts
+++ b/packages/sync/src/storage/repositories/event.repository.db.test.ts
@@ -101,6 +101,52 @@ describe("EventRepository", () => {
     expect(await db.collection("events").countDocuments()).toBe(1);
   });
 
+  it("preserves iCalUID atomically when a sparse upsert omits it", async () => {
+    const identity = {
+      connectionId: objectId(),
+      calendarId: objectId(),
+      providerEventId: "evt-uid",
+    };
+    const first = await repo.upsertByProviderIdentity(
+      linkedUpsert({
+        ...identity,
+        providerMetadata: { iCalUID: "kept@google.com" },
+      }),
+      { preserveIcalUidWhenAbsent: true },
+    );
+    expect(first.providerMetadata).toEqual({ iCalUID: "kept@google.com" });
+
+    const second = await repo.upsertByProviderIdentity(
+      linkedUpsert({
+        ...identity,
+        providerVersion: "etag-2",
+        providerMetadata: null,
+      }),
+      { preserveIcalUidWhenAbsent: true },
+    );
+    expect(second._id).toBe(first._id);
+    expect(second.providerVersion).toBe("etag-2");
+    expect(second.providerMetadata).toEqual({ iCalUID: "kept@google.com" });
+  });
+
+  it("clears providerMetadata when preserve is off", async () => {
+    const identity = {
+      connectionId: objectId(),
+      calendarId: objectId(),
+      providerEventId: "evt-clear",
+    };
+    await repo.upsertByProviderIdentity(
+      linkedUpsert({
+        ...identity,
+        providerMetadata: { iCalUID: "gone@google.com" },
+      }),
+    );
+    const cleared = await repo.upsertByProviderIdentity(
+      linkedUpsert({ ...identity, providerMetadata: null }),
+    );
+    expect(cleared.providerMetadata).toBeNull();
+  });
+
   // The $type in the upsert filter looks redundant (the input is always a
   // string) but is what lets the planner use the provider_event_identity
   // PARTIAL index — without it every upsert COLLSCANs, which took prod down.

--- a/packages/sync/src/storage/repositories/event.repository.ts
+++ b/packages/sync/src/storage/repositories/event.repository.ts
@@ -22,6 +22,13 @@ export type ProviderEventUpsert = Omit<
   providerEventId: NonNullable<EventRecord["providerEventId"]>;
 };
 
+export type UpsertByProviderIdentityOptions = {
+  // When true, an incoming providerMetadata that omits iCalUID keeps any
+  // existing iCalUID on the row (aggregation-pipeline merge). Cancelled
+  // exceptions pass false so they can still clear the bag to null.
+  preserveIcalUidWhenAbsent?: boolean;
+};
+
 export interface EventListQuery {
   tenantId: TenantId;
   principalId: PrincipalId;
@@ -55,26 +62,120 @@ export class EventRepository {
   // that signal. The filter therefore excludes generation on purpose.
   async upsertByProviderIdentity(
     input: ProviderEventUpsert,
+    options?: UpsertByProviderIdentityOptions,
   ): Promise<EventRecord> {
     const now = new Date();
+    const filter = {
+      connectionId: input.connectionId,
+      calendarId: input.calendarId,
+      // $type is a semantic no-op but makes the provider_event_identity
+      // partial index provable to the planner — without it, COLLSCAN.
+      // See the PLANNER TRAP note in index-manifest.ts.
+      providerEventId: {
+        $eq: input.providerEventId,
+        $type: "string" as const,
+      },
+    };
+
+    if (!options?.preserveIcalUidWhenAbsent) {
+      const result = await this.collection.findOneAndUpdate(
+        filter,
+        {
+          // input already omits _id/createdAt/updatedAt (see ProviderEventUpsert).
+          $set: { ...input, updatedAt: now },
+          $setOnInsert: {
+            _id: new ObjectId().toHexString() as EventId,
+            createdAt: now,
+          },
+        },
+        { upsert: true, returnDocument: "after" },
+      );
+      if (!result) throw new Error("Upsert did not return an event record");
+      return EventRecordSchema.parse(result);
+    }
+
+    // Pipeline update so iCalUID preserve is atomic with the rest of the
+    // upsert (no find-then-write TOCTOU against a concurrent sparse pull).
+    // Strings in a pipeline $set are field refs, so every literal value goes
+    // through $literal. $setOnInsert is unavailable in pipeline mode.
+    // Use the array form of $cond ([if, then, else]) — the object form's
+    // `then` key trips Biome's noThenProperty rule.
+    const insertId = new ObjectId().toHexString() as EventId;
+    const { providerMetadata: incomingMetadata, ...fieldsWithoutMetadata } =
+      input;
+    const literalFields = Object.fromEntries(
+      Object.entries({ ...fieldsWithoutMetadata, updatedAt: now }).map(
+        ([key, value]) => [key, { $literal: value }],
+      ),
+    );
 
     const result = await this.collection.findOneAndUpdate(
-      {
-        connectionId: input.connectionId,
-        calendarId: input.calendarId,
-        // $type is a semantic no-op but makes the provider_event_identity
-        // partial index provable to the planner — without it, COLLSCAN.
-        // See the PLANNER TRAP note in index-manifest.ts.
-        providerEventId: { $eq: input.providerEventId, $type: "string" },
-      },
-      {
-        // input already omits _id/createdAt/updatedAt (see ProviderEventUpsert).
-        $set: { ...input, updatedAt: now },
-        $setOnInsert: {
-          _id: new ObjectId().toHexString() as EventId,
-          createdAt: now,
+      filter,
+      [
+        {
+          $set: {
+            ...literalFields,
+            _id: { $ifNull: ["$_id", { $literal: insertId }] },
+            createdAt: { $ifNull: ["$createdAt", { $literal: now }] },
+            // Same merge rules as mergeProviderMetadataPreservingIcalUid:
+            // incoming wins for transparency / present iCalUID; otherwise keep
+            // any existing iCalUID so a sparse re-read cannot wipe a backfill.
+            providerMetadata: {
+              $let: {
+                vars: {
+                  incoming: { $literal: incomingMetadata },
+                  existingUid: {
+                    $cond: [
+                      { $eq: [{ $type: "$providerMetadata" }, "object"] },
+                      { $ifNull: ["$providerMetadata.iCalUID", null] },
+                      null,
+                    ],
+                  },
+                },
+                in: {
+                  $cond: [
+                    { $eq: ["$$incoming", null] },
+                    {
+                      $cond: [
+                        { $ne: ["$$existingUid", null] },
+                        { iCalUID: "$$existingUid" },
+                        null,
+                      ],
+                    },
+                    {
+                      $let: {
+                        vars: {
+                          incomingUid: {
+                            $ifNull: ["$$incoming.iCalUID", null],
+                          },
+                        },
+                        in: {
+                          $cond: [
+                            { $ne: ["$$incomingUid", null] },
+                            "$$incoming",
+                            {
+                              $cond: [
+                                { $ne: ["$$existingUid", null] },
+                                {
+                                  $mergeObjects: [
+                                    "$$incoming",
+                                    { iCalUID: "$$existingUid" },
+                                  ],
+                                },
+                                "$$incoming",
+                              ],
+                            },
+                          ],
+                        },
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          },
         },
-      },
+      ],
       { upsert: true, returnDocument: "after" },
     );
     if (!result) throw new Error("Upsert did not return an event record");


### PR DESCRIPTION
## Summary
- Preserve existing `providerMetadata.iCalUID` on sync upsert when a sparse Google read omits it (atomic aggregation-pipeline merge), so live pulls cannot wipe a backfill.
- Return `iCalUID` from Google write results and store it on Compass→Google create so new linked events are not born with `providerMetadata: null`.
- Cancelled series exceptions still clear metadata intentionally.

## Why
Production `backfill-icaluid` applies could not converge: confirm dry-runs kept finding thousands of missing rows because concurrent sync full-replaced `providerMetadata` without the key. This is the durable fix before one final production apply.

## Test plan
- [x] `bun test:sync --` focused files (metadata merge, applier, repository, writer, provider-command create)
- [x] `bun type-check`
- [ ] CI green
- [ ] After deploy: one production `backfill-icaluid --apply` + confirm with `matchedMissingIcalUid: 0`