### PR TITLE
refactor(sidebar): move "Saving changes…" to reserved footer strip

### DIFF
--- a/packages/web/src/components/Sidebar/CalendarList/CalendarList.test.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarList.test.tsx
@@ -10,10 +10,7 @@ import {
 } from "@core/types/domain-primitives";
 import { type GoogleSyncConnectionSummary } from "@core/types/user.types";
 import { createStoreWrapper } from "@web/__tests__/render-with-store";
-import {
-  seedPendingEventMutations,
-  toNormalizedEventQueryData,
-} from "@web/__tests__/utils/event-query-test-data";
+import { toNormalizedEventQueryData } from "@web/__tests__/utils/event-query-test-data";
 import { createMockConnection as makeConnection } from "@web/__tests__/utils/factories/calendar.factory";
 import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
 import { type ApiRequestConfig } from "@web/api/api.types";
@@ -134,11 +131,9 @@ const renderCalendarList = (
   {
     authenticated = true,
     connections,
-    pendingEventIds = [],
   }: {
     authenticated?: boolean;
     connections?: GoogleSyncConnectionSummary[];
-    pendingEventIds?: string[];
   } = {},
 ) => {
   mockUseSession.mockReturnValue({
@@ -154,7 +149,6 @@ const renderCalendarList = (
 
   const { queryClient, wrapper } = createStoreWrapper();
   queryClient.setQueryData(calendarQueryKeys.all, calendars);
-  seedPendingEventMutations(queryClient, pendingEventIds);
 
   const utils = render(<CalendarList />, {
     wrapper,
@@ -486,31 +480,6 @@ describe("CalendarList", () => {
     expect(
       within(section).getByRole("button", { name: "ahab@pequod.com" }),
     ).toHaveAttribute("aria-expanded", "true");
-  });
-
-  it("announces a pending event save once for the list, whatever the account count", () => {
-    // Regression: this line lived only in the single-account header, so a
-    // user with two accounts connected never saw a save acknowledged at all.
-    const work = makeCalendar({
-      name: "Work",
-      accountEmail: "ahab@pequod.com",
-    });
-    const personal = makeCalendar({
-      name: "Personal",
-      accountEmail: "ahab@gmail.com",
-    });
-
-    renderCalendarList([work, personal], {
-      connections: [
-        makeConnection("ahab@pequod.com"),
-        makeConnection("ahab@gmail.com"),
-      ],
-      pendingEventIds: ["event-1"],
-    });
-
-    // Not getByRole("status") - the list's own sr-only failure announcer is
-    // also a status region.
-    expect(screen.getByText("Saving changes…")).toBeInTheDocument();
   });
 
   it("leaves the local calendar outside the account sections", () => {

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarList.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarList.tsx
@@ -15,10 +15,8 @@ import {
   accountCalendarListId,
   useCollapsedAccountKeys,
 } from "@web/calendars/collapsed-accounts.store";
-import { SyncStatusLine } from "@web/calendars/SyncStatusLine";
 import { useCalendarVisibility } from "@web/calendars/useCalendarVisibility";
 import { useConnectedAccountEmails } from "@web/calendars/useDefaultTargetCalendar";
-import { useHasPendingEventMutations } from "@web/events/mutations/useEventPending";
 import { AccountSectionHeader } from "./AccountSectionHeader";
 import { CalendarListHeader } from "./CalendarListHeader";
 
@@ -31,7 +29,6 @@ export const CalendarList: FC = () => {
   const connections = useUserMetadataStore(selectGoogleSyncConnections);
   const accountEmailOrder = useConnectedAccountEmails();
   const collapsedKeys = useCollapsedAccountKeys();
-  const hasPendingEventMutations = useHasPendingEventMutations();
 
   // Re-groups on every calendar-visibility/collapse toggle otherwise, since
   // those live in sibling external stores this component also subscribes to.
@@ -75,15 +72,6 @@ export const CalendarList: FC = () => {
           it alongside account sections duplicated one section's status under a
           second, unlabeled heading with no way to tell them apart. */}
       {groups.length === 0 && <CalendarListHeader />}
-
-      {/* Event saves aren't per-account, so this belongs to the list rather
-          than to any one account's heading. */}
-      {hasPendingEventMutations ? (
-        <SyncStatusLine
-          className="mb-1"
-          status={{ variant: "syncing", text: "Saving changes…" }}
-        />
-      ) : null}
 
       {isPending ? null : isError ? (
         <div className="flex items-center justify-between gap-2 text-xs">

--- a/packages/web/src/components/Sidebar/Sidebar.test.tsx
+++ b/packages/web/src/components/Sidebar/Sidebar.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import dayjs from "@core/util/date/dayjs";
+import { createStoreWrapper } from "@web/__tests__/render-with-store";
 import { createSidebar } from "./Sidebar";
 import { describe, expect, it, mock } from "bun:test";
 
@@ -23,7 +24,8 @@ const sidebarProps = {
 
 describe("Sidebar", () => {
   it("renders the core sidebar sections", () => {
-    render(<Sidebar {...sidebarProps} />);
+    const { wrapper } = createStoreWrapper();
+    render(<Sidebar {...sidebarProps} />, { wrapper });
 
     expect(screen.getByText("Calendar picker")).toBeTruthy();
     expect(screen.getByText("Calendar list")).toBeTruthy();
@@ -31,8 +33,10 @@ describe("Sidebar", () => {
   });
 
   it("shows event details only while the parent says they are open", () => {
+    const { wrapper } = createStoreWrapper();
     const { rerender } = render(
       <Sidebar {...sidebarProps} eventDetails={<div>Event details</div>} />,
+      { wrapper },
     );
 
     expect(screen.queryByText("Event details")).toBeNull();

--- a/packages/web/src/components/Sidebar/SidebarShell.tsx
+++ b/packages/web/src/components/Sidebar/SidebarShell.tsx
@@ -13,6 +13,7 @@ import { useIsNarrowSidebarLayout } from "./hooks/useIsNarrowSidebarLayout";
 import { ShortcutsOverlay } from "./ShortcutsOverlay/ShortcutsOverlay";
 import { SidebarActions } from "./SidebarActions/SidebarActions";
 import { SidebarCloseButton } from "./SidebarCloseButton";
+import { SidebarStatusBar } from "./SidebarStatusBar";
 
 interface SidebarShellProps extends HTMLAttributes<HTMLElement> {
   children: ReactNode;
@@ -56,6 +57,7 @@ export function SidebarShell({
         </div>
       ) : null}
       {children}
+      <SidebarStatusBar />
       <SidebarActionsComponent
         isShortcutsOpen={isShortcutsOpen}
         onToggleShortcuts={onToggleShortcuts}

--- a/packages/web/src/components/Sidebar/SidebarStatusBar.test.tsx
+++ b/packages/web/src/components/Sidebar/SidebarStatusBar.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from "@testing-library/react";
+import { createStoreWrapper } from "@web/__tests__/render-with-store";
+import { seedPendingEventMutations } from "@web/__tests__/utils/event-query-test-data";
+import { SidebarStatusBar } from "./SidebarStatusBar";
+import { describe, expect, it } from "bun:test";
+
+describe("SidebarStatusBar", () => {
+  it("shows 'Saving changes…' when a mutation is pending", () => {
+    const { queryClient, wrapper } = createStoreWrapper();
+    seedPendingEventMutations(queryClient, ["event-1"]);
+
+    render(<SidebarStatusBar />, { wrapper });
+
+    expect(screen.getByText("Saving changes…")).toBeInTheDocument();
+  });
+
+  it("reserves space for the status line when idle", () => {
+    const { wrapper } = createStoreWrapper();
+
+    render(<SidebarStatusBar />, { wrapper });
+
+    const status = screen.getByRole("status");
+    expect(status).toBeInTheDocument();
+    expect(status.textContent).toBe("");
+  });
+
+  it("renders exactly one save status region, regardless of account count", () => {
+    const { queryClient, wrapper } = createStoreWrapper();
+    seedPendingEventMutations(queryClient, ["event-1"]);
+
+    render(<SidebarStatusBar />, { wrapper });
+
+    const regions = screen.getAllByRole("status");
+    expect(regions).toHaveLength(1);
+    expect(screen.getByText("Saving changes…")).toBeInTheDocument();
+  });
+});

--- a/packages/web/src/components/Sidebar/SidebarStatusBar.tsx
+++ b/packages/web/src/components/Sidebar/SidebarStatusBar.tsx
@@ -1,0 +1,24 @@
+import { type FC } from "react";
+import { SYNC_STATUS_VARIANT_CLASSNAME } from "@web/calendars/sync-status.types";
+import { useHasPendingEventMutations } from "@web/events/mutations/useEventPending";
+
+/**
+ * Pinned status bar at the bottom of the sidebar, just above the actions bar.
+ * Always occupies a fixed height so nothing in the sidebar can shift when
+ * a mutation goes in/out of flight.
+ */
+export const SidebarStatusBar: FC = () => {
+  const isSaving = useHasPendingEventMutations();
+
+  return (
+    <div className="flex h-6 shrink-0 items-center border-border border-t px-4">
+      <p
+        aria-live="polite"
+        className={`truncate text-xs ${isSaving ? SYNC_STATUS_VARIANT_CLASSNAME.syncing : ""}`}
+        role="status"
+      >
+        {isSaving ? "Saving changes…" : ""}
+      </p>
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
Move the save indicator from inline in the calendar list to a fixed-height reserved strip pinned above the actions bar. This prevents subcalendar rows from shifting when mutations start/end, which was discouraging users from clicking those elements.

The status line now occupies h-6 shrink-0, always present, blank when idle. Users learn to glance there for live feedback instead of watching the layout shift.

## Changes
- New `SidebarStatusBar` component with fixed height
- Mount in `SidebarShell` between body and actions bar
- Remove inline indicator from `CalendarList`
- Reuse existing `c-sync-text-wave` shimmer class
- Update tests: move regression test, wrap providers

## Manual Testing Steps
1. Open the app and make a calendar edit (change event color, move event, etc.)
2. Confirm "Saving changes…" appears in the bottom strip with shimmer
3. Confirm subcalendar list does NOT move up/down during save
4. Confirm strip goes blank but remains present when save completes
5. Open event details form and confirm strip is visible above actions bar
6. Confirm keyboard shortcuts (⌨ button) still work