### PR TITLE
fix(web): give LifeView tests a query client provider

### DIFF
--- a/packages/web/src/views/Life/LifeView.test.tsx
+++ b/packages/web/src/views/Life/LifeView.test.tsx
@@ -1,12 +1,7 @@
-import {
-  act,
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-} from "@testing-library/react";
+import { act, fireEvent, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { type ReactNode } from "react";
+import { renderWithStore } from "@web/__tests__/render-with-store";
 import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
 import { viewActions } from "@web/events/stores/view.store";
 import { LifeView } from "./LifeView";
@@ -25,7 +20,7 @@ const originalInnerWidth = window.innerWidth;
 const originalMatchMedia = window.matchMedia;
 
 function renderLifeView() {
-  return render(<LifeView today={fixedToday} />);
+  return renderWithStore(<LifeView today={fixedToday} />);
 }
 
 async function renderLifeViewWithSidebar() {
@@ -152,9 +147,11 @@ describe("LifeView", () => {
     expect(
       screen.queryByRole("heading", { name: "Share" }),
     ).not.toBeInTheDocument();
-    expect(screen.getByRole("status")).toHaveTextContent(
-      "1,356 weeks lived - 26 years - 34%",
-    );
+    // The sidebar's saving-status live region also has role="status", so
+    // target the weeks-lived readout by its full text.
+    expect(
+      screen.getByText("1,356 weeks lived - 26 years - 34%"),
+    ).toBeInTheDocument();
     const region = screen.getByRole("region", {
       name: /life visualization/i,
     });
@@ -200,9 +197,9 @@ describe("LifeView", () => {
       target: { value: "1990-06-15" },
     });
 
-    expect(screen.getByRole("status")).toHaveTextContent(
-      "1,854 weeks lived - 35 years - 46%",
-    );
+    expect(
+      screen.getByText("1,854 weeks lived - 35 years - 46%"),
+    ).toBeInTheDocument();
     expect(
       screen
         .getByRole("region", { name: /life visualization/i })


### PR DESCRIPTION
## Summary

Main's unit (web) job has been red since #2598: mounting `SidebarStatusBar` in the shared sidebar made the sidebar depend on TanStack Query (`useMutationState`), and `LifeView.test.tsx` rendered with the bare testing-library `render`, so all 15 tests in the file crashed with `No QueryClient set, use QueryClientProvider to set one`.

## Changes

- Render through the existing `renderWithStore` helper, which wraps in a `QueryClientProvider`
- Query the weeks-lived readout by its full text — the sidebar now contributes a second `role="status"` live region (the saving indicator), so the bare `getByRole("status")` became ambiguous

## Validation

- `LifeView.test.tsx`: 15 pass / 0 fail (was 0 / 15)
- `bun run type-check`: clean
- biome: clean

Unblocks #2599, which is failing the same pre-existing check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)