### PR TITLE
Command palette: interaction quality and polish pass

### DIFF
--- a/packages/web/src/__tests__/utils/state/reset-stores.ts
+++ b/packages/web/src/__tests__/utils/state/reset-stores.ts
@@ -12,6 +12,7 @@ import {
 import { resetCalendarVisibilityStoreForTests } from "@web/calendars/calendar-visibility.store";
 import { resetCollapsedAccountsStoreForTests } from "@web/calendars/collapsed-accounts.store";
 import { resetDefaultCalendarStoreForTests } from "@web/calendars/default-calendar.store";
+import { resetRecentCommandsStoreForTests } from "@web/components/CommandPalette/recent-commands.store";
 import { useFeedbackStore } from "@web/components/Feedback/feedback.store";
 import { useReleaseNotesPromptStore } from "@web/components/ReleaseNotesPrompt/release-notes-prompt.store";
 import { useWelcomeGuideStore } from "@web/components/WelcomeModal/welcome.guide.store";
@@ -54,6 +55,7 @@ const storeResets: StoreReset[] = [
   resetCalendarVisibilityStoreForTests,
   resetDefaultCalendarStoreForTests,
   resetCollapsedAccountsStoreForTests,
+  resetRecentCommandsStoreForTests,
   // Lives on window.__weekInteractionMotionActive, which survives across
   // test files (the preload reuses one jsdom window). A test that starts a
   // real drag and never completes it would otherwise leave every later

--- a/packages/web/src/common/constants/storage.constants.ts
+++ b/packages/web/src/common/constants/storage.constants.ts
@@ -17,7 +17,10 @@ type StorageKey =
   | "compass.calendars.default-id"
   // Which accounts' calendar rows are collapsed in the sidebar. Device-local;
   // an unknown or stale key falls back to expanded (default).
-  | "compass.calendars.collapsed-accounts";
+  | "compass.calendars.collapsed-accounts"
+  // Recently-used command palette item ids, most recent first. Device-local;
+  // an id that no longer resolves to a visible item is skipped, not an error.
+  | "compass.commands.recent";
 
 export const STORAGE_KEYS: Record<
   | "AUTH"
@@ -32,7 +35,8 @@ export const STORAGE_KEYS: Record<
   | "THEME"
   | "HIDDEN_CALENDAR_IDS"
   | "DEFAULT_CALENDAR_ID"
-  | "COLLAPSED_ACCOUNTS",
+  | "COLLAPSED_ACCOUNTS"
+  | "RECENT_COMMANDS",
   StorageKey
 > = {
   AUTH: "compass.auth",
@@ -51,4 +55,5 @@ export const STORAGE_KEYS: Record<
   HIDDEN_CALENDAR_IDS: "compass.calendars.hidden-ids",
   DEFAULT_CALENDAR_ID: "compass.calendars.default-id",
   COLLAPSED_ACCOUNTS: "compass.calendars.collapsed-accounts",
+  RECENT_COMMANDS: "compass.commands.recent",
 } as const;

--- a/packages/web/src/components/CommandPalette/CommandPalette.test.tsx
+++ b/packages/web/src/components/CommandPalette/CommandPalette.test.tsx
@@ -1,5 +1,11 @@
 import "@testing-library/jest-dom";
-import { act, fireEvent, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import { renderWithStore } from "@web/__tests__/render-with-store";
 import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
 import { onViewCommand } from "@web/common/utils/dom/view-command-bus";
@@ -14,6 +20,7 @@ import {
   settingsActions,
   useSettingsStore,
 } from "@web/settings/settings.store";
+import { recordRecentCommand } from "./recent-commands.store";
 import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
 
 const mockNavigate = mock();
@@ -50,7 +57,8 @@ mock.module("@web/auth/compass/user/hooks/useUser", () => ({
   useUser: () => ({}),
 }));
 
-const { CommandPalette, LifeCommandPalette } = await import("./CommandPalette");
+const { CommandPalette, LifeCommandPalette, getRowTextColorClassName } =
+  await import("./CommandPalette");
 
 const onGoToToday = mock();
 const onShowShortcuts = mock();
@@ -80,6 +88,18 @@ const getInput = () =>
 const activeRowText = (container: HTMLElement) =>
   container.ownerDocument.querySelector(".bg-surface-overlay > span")
     ?.textContent ?? null;
+
+// Match highlighting splits a matched label into text + <strong> nodes, so
+// testing-library's default getByText(string) (which only looks at an
+// element's own direct text-node children, not nested descendants) stops
+// matching the label span once part of it is highlighted. This checks full
+// recursive textContent instead, scoped to the label span specifically
+// (the row's `<button>` has the same full text and would otherwise also match).
+const rowLabel = (label: string) =>
+  screen.getByText(
+    (_content, element) =>
+      element?.tagName === "SPAN" && element?.textContent === label,
+  );
 
 const isOpen = () => selectIsCmdPaletteOpen(useSettingsStore.getState());
 
@@ -140,9 +160,11 @@ describe("CommandPalette", () => {
     fireEvent.change(getInput(), { target: { value: "create event" } });
 
     // Both create items match ("event" is a word-prefix hit on each label);
-    // "Create event" ranks first (tie broken by authored order).
-    expect(screen.getByText("Create event")).toBeInTheDocument();
-    expect(screen.getByText("Create all-day event")).toBeInTheDocument();
+    // "Create event" ranks first (tie broken by authored order). Matched
+    // text is now bolded, so query by full recursive textContent (rowLabel)
+    // rather than the default getByText, which only reads direct children.
+    expect(rowLabel("Create event")).toBeInTheDocument();
+    expect(rowLabel("Create all-day event")).toBeInTheDocument();
     expect(activeRowText(container)).toBe("Create event");
     expect(screen.queryByText("Navigation")).not.toBeInTheDocument();
     expect(screen.queryByText("Settings")).not.toBeInTheDocument();
@@ -151,7 +173,11 @@ describe("CommandPalette", () => {
     ).not.toBeInTheDocument();
 
     fireEvent.change(getInput(), { target: { value: "zzzzz" } });
-    expect(screen.getByText(/No results for/)).toBeInTheDocument();
+    // The sr-only live region echoes the same "No results for" copy, so
+    // scope to the visible div specifically to avoid an ambiguous match.
+    expect(
+      screen.getByText(/No results for/, { selector: "div" }),
+    ).toBeInTheDocument();
   });
 
   it("matches a synonym keyword that doesn't appear in the label", () => {
@@ -159,7 +185,7 @@ describe("CommandPalette", () => {
 
     fireEvent.change(getInput(), { target: { value: "day page" } });
 
-    expect(screen.getByText("Go to Day")).toBeInTheDocument();
+    expect(rowLabel("Go to Day")).toBeInTheDocument();
     expect(activeRowText(container)).toBe("Go to Day");
   });
 
@@ -234,7 +260,7 @@ describe("CommandPalette", () => {
 
     fireEvent.change(input, { target: { value: "ligh" } });
     expect(input).toHaveValue("ligh");
-    expect(screen.getByText("Switch to light theme")).toBeInTheDocument();
+    expect(rowLabel("Switch to light theme")).toBeInTheDocument();
     expect(screen.queryByText("Go to Today")).not.toBeInTheDocument();
 
     fireEvent.keyDown(input, { key: "Escape" });
@@ -331,6 +357,83 @@ describe("CommandPalette", () => {
     expect(
       screen.queryByText(/Google Calendar|calendar sync|calendar status/i),
     ).not.toBeInTheDocument();
+  });
+
+  it("activates a row on pointer move, without requiring a keypress", () => {
+    const { container } = renderPalette();
+    expect(activeRowText(container)).toBe("Go to Today");
+
+    const dayRow = screen.getByText("Go to Day").closest("button");
+    fireEvent.pointerMove(dayRow as HTMLButtonElement);
+
+    expect(activeRowText(container)).toBe("Go to Day");
+  });
+
+  it("announces the result count in a live region, matching the visible copy", () => {
+    renderPalette();
+    const liveRegion = () =>
+      document.querySelector('[aria-live="polite"]') as HTMLElement;
+
+    // Nothing announced yet for an untouched, empty query.
+    expect(liveRegion().textContent).toBe("");
+
+    fireEvent.change(getInput(), { target: { value: "create event" } });
+    expect(liveRegion().textContent).toBe("2 results");
+
+    fireEvent.change(getInput(), { target: { value: "zzzzz" } });
+    expect(liveRegion().textContent).toBe("No results for “zzzzz”");
+  });
+
+  it("renders keyboard hint footer chips", () => {
+    renderPalette();
+
+    expect(screen.getByText("Navigate")).toBeInTheDocument();
+    expect(screen.getByText("Select")).toBeInTheDocument();
+    expect(screen.getByText("Close")).toBeInTheDocument();
+  });
+
+  it("shows a Recent section with previously used commands, hidden while typing", () => {
+    recordRecentCommand("go-to-day");
+
+    renderPalette();
+
+    const recentHeading = screen.getByText("Recent");
+    const recentSection = recentHeading.closest("div.mb-1") as HTMLElement;
+    expect(within(recentSection).getByText("Go to Day")).toBeInTheDocument();
+
+    fireEvent.change(getInput(), { target: { value: "day" } });
+    expect(screen.queryByText("Recent")).not.toBeInTheDocument();
+  });
+
+  it("records a command as recent when it's selected", () => {
+    renderPalette();
+
+    fireEvent.click(screen.getByText("Show keyboard shortcuts"));
+    expect(isOpen()).toBe(false);
+
+    // Same reopen pattern as "clears the search query when reopened after
+    // close" — the store flip re-renders CommandPaletteContent in place.
+    act(() => {
+      settingsActions.openCmdPalette();
+    });
+
+    const recentHeading = screen.getByText("Recent");
+    const recentSection = recentHeading.closest("div.mb-1") as HTMLElement;
+    expect(
+      within(recentSection).getByText("Show keyboard shortcuts"),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("getRowTextColorClassName", () => {
+  it("returns the muted-red class for a destructive item", () => {
+    expect(getRowTextColorClassName({ variant: "destructive" })).toBe(
+      "text-error",
+    );
+  });
+
+  it("returns the neutral class for a regular item", () => {
+    expect(getRowTextColorClassName({})).toBe("text-text-muted");
   });
 });
 

--- a/packages/web/src/components/CommandPalette/CommandPalette.tsx
+++ b/packages/web/src/components/CommandPalette/CommandPalette.tsx
@@ -9,9 +9,10 @@ import {
 } from "@floating-ui/react";
 import { ArrowCounterClockwiseIcon } from "@phosphor-icons/react";
 import { useNavigate } from "@tanstack/react-router";
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Z_INDEX_MODAL } from "@web/common/constants/web.constants";
 import { eventCommandPaletteItems } from "@web/components/CommandPalette/event.cmd.constants";
+import { HighlightedLabel } from "@web/components/CommandPalette/HighlightedLabel";
 import { useAddAccountCmdItems } from "@web/components/CommandPalette/hooks/useAddAccountCmdItems";
 import { useAuthCmdItems } from "@web/components/CommandPalette/hooks/useAuthCmdItems";
 import { useDeleteAccountCmdItems } from "@web/components/CommandPalette/hooks/useDeleteAccountCmdItems";
@@ -26,6 +27,10 @@ import {
   getNavigationCommandItems,
   getNavigationViewRoute,
 } from "@web/components/CommandPalette/navigation.cmd.constants";
+import {
+  recordRecentCommand,
+  useRecentCommandIds,
+} from "@web/components/CommandPalette/recent-commands.store";
 import { ShortcutKeys } from "@web/components/Shortcuts/ShortcutKeys";
 import { type EventMutationDependencies } from "@web/events/mutations/useEventMutations";
 import { useUndoRedo } from "@web/events/mutations/useUndoRedo";
@@ -36,8 +41,18 @@ import {
 } from "@web/settings/settings.store";
 import { useAppLockReason } from "@web/shortcuts/app-lock";
 import { type ViewName } from "@web/shortcuts/shortcuts.constants";
-import { filterSections } from "./command-palette.search";
-import { type CommandSection } from "./command-palette.types";
+import { filterSections, getLabelMatchRanges } from "./command-palette.search";
+import { type CommandItem, type CommandSection } from "./command-palette.types";
+
+const RECENT_SECTION_ID = "recent";
+const MAX_RECENT_ITEMS = 3;
+
+/** Muted-red text for irreversible/data-loss items (e.g. delete account); neutral otherwise. */
+export function getRowTextColorClassName(
+  item: Pick<CommandItem, "variant">,
+): string {
+  return item.variant === "destructive" ? "text-error" : "text-text-muted";
+}
 
 interface CommandPaletteProps {
   currentView: ViewName;
@@ -62,6 +77,25 @@ const CommandPaletteContent = ({
   const [activeIndex, setActiveIndex] = useState<number | null>(0);
   const listRef = useRef<Array<HTMLElement | null>>([]);
 
+  // Entrance-only fade/scale — no exit animation. Close is driven by the
+  // external `isCmdPaletteOpen` store (shortcuts + tests flip it
+  // synchronously), and this component unmounts the instant it flips false;
+  // animating that would need a delayed-unmount state machine to handle
+  // "reopened while still closing." Not worth it for a UI pattern where an
+  // instant close is normal — dismissal isn't a decision the user watches,
+  // unlike a confirmation modal.
+  const [visible, setVisible] = useState(false);
+  useEffect(() => {
+    const reduceMotion =
+      window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
+    if (reduceMotion) {
+      setVisible(true);
+      return;
+    }
+    const raf = requestAnimationFrame(() => setVisible(true));
+    return () => cancelAnimationFrame(raf);
+  }, []);
+
   // Focus the search input the moment it mounts (commit phase, like the
   // autoFocus attribute — but without tripping the a11y lint). Stable identity
   // keeps it from re-firing on every keystroke re-render.
@@ -78,12 +112,26 @@ const CommandPaletteContent = ({
     },
   });
 
-  const filteredSections = filterSections(sections, search);
+  const trimmedSearch = search.trim();
+  // The Recent section only makes sense as a landing state — once the user
+  // is typing, filterSections would keep a recent item alongside its normal
+  // section entry (same id, same label) whenever it happens to match,
+  // producing a visible duplicate row. Drop it before filtering instead.
+  const sectionsToFilter = trimmedSearch
+    ? sections.filter((section) => section.id !== RECENT_SECTION_ID)
+    : sections;
+  const filteredSections = filterSections(sectionsToFilter, search);
   const flatItems = filteredSections.flatMap((section) => section.items);
   const disabledIndices = flatItems.reduce<number[]>((acc, item, index) => {
     if (item.disabled) acc.push(index);
     return acc;
   }, []);
+  const resultCount = flatItems.length;
+  const liveRegionText = !trimmedSearch
+    ? ""
+    : resultCount === 0
+      ? `No results for “${search}”`
+      : `${resultCount} result${resultCount === 1 ? "" : "s"}`;
 
   const dismiss = useDismiss(context);
   const role = useRole(context, { role: "listbox" });
@@ -107,7 +155,9 @@ const CommandPaletteContent = ({
     <FloatingPortal>
       <FloatingOverlay
         lockScroll
-        className="flex justify-center bg-background/85 backdrop-blur-sm"
+        className={`flex justify-center bg-background/85 backdrop-blur-sm transition-opacity duration-200 ease-out motion-reduce:transition-none ${
+          visible ? "opacity-100" : "opacity-0"
+        }`}
         style={{ zIndex: Z_INDEX_MODAL }}
       >
         {/* No FloatingFocusManager: virtual list navigation keeps real focus in
@@ -115,7 +165,9 @@ const CommandPaletteContent = ({
             input on open via the focusInputOnMount callback ref above. */}
         <div
           ref={refs.setFloating}
-          className="mt-[15vh] h-fit w-[640px] max-w-[90vw] overflow-hidden rounded-xl border border-border bg-surface shadow-[0_16px_48px_var(--color-shadow-default)]"
+          className={`mt-[15vh] h-fit w-[640px] max-w-[90vw] overflow-hidden rounded-xl border border-border bg-surface shadow-[0_16px_48px_var(--color-shadow-default)] transition-[opacity,transform] duration-200 ease-out motion-reduce:transition-none ${
+            visible ? "scale-100 opacity-100" : "scale-95 opacity-0"
+          }`}
         >
           <input
             {...getReferenceProps({
@@ -138,6 +190,14 @@ const CommandPaletteContent = ({
             }}
           />
 
+          {/* Visually hidden — announces result count changes to screen
+              reader users, who otherwise get no feedback that typing
+              changed what's showing. Wording matches the visible
+              zero-results message below rather than diverging from it. */}
+          <span aria-live="polite" className="sr-only">
+            {liveRegionText}
+          </span>
+
           <div className="max-h-[50vh] overflow-y-auto p-2">
             {filteredSections.length === 0 ? (
               <div className="px-3 py-2 text-text">
@@ -153,7 +213,7 @@ const CommandPaletteContent = ({
                     itemIndex += 1;
                     const index = itemIndex;
                     const isActive = activeIndex === index;
-                    const rowClassName = `flex w-full items-center gap-3 rounded-md px-3 py-2 text-left text-text-muted ${
+                    const rowClassName = `flex w-full items-center gap-3 rounded-md px-3 py-2 text-left ${getRowTextColorClassName(item)} ${
                       isActive
                         ? "bg-surface-overlay ring-1 ring-accent ring-inset"
                         : ""
@@ -163,7 +223,14 @@ const CommandPaletteContent = ({
                       <>
                         <item.icon size={18} />
                         <span className="min-w-0 flex-1 truncate">
-                          {item.label}
+                          {trimmedSearch ? (
+                            <HighlightedLabel
+                              label={item.label}
+                              ranges={getLabelMatchRanges(item.label, search)}
+                            />
+                          ) : (
+                            item.label
+                          )}
                         </span>
                         {item.shortcut && (
                           <ShortcutKeys
@@ -181,8 +248,13 @@ const CommandPaletteContent = ({
                           ref(node: HTMLElement | null) {
                             listRef.current[index] = node;
                           },
+                          onPointerMove() {
+                            if (item.disabled || isActive) return;
+                            setActiveIndex(index);
+                          },
                           onClick() {
                             if (item.disabled) return;
+                            recordRecentCommand(item.id);
                             item.onClick?.();
                             if (!item.keepOpen) close();
                           },
@@ -200,6 +272,21 @@ const CommandPaletteContent = ({
                 </div>
               ))
             )}
+          </div>
+
+          <div className="flex items-center justify-end gap-4 border-border border-t px-4 py-1.5 text-text-muted text-xs">
+            <span className="inline-flex items-center gap-1.5">
+              <ShortcutKeys keys={["ArrowUp", "ArrowDown"]} />
+              Navigate
+            </span>
+            <span className="inline-flex items-center gap-1.5">
+              <ShortcutKeys keys="Enter" />
+              Select
+            </span>
+            <span className="inline-flex items-center gap-1.5">
+              <ShortcutKeys keys="Esc" />
+              Close
+            </span>
           </div>
         </div>
       </FloatingOverlay>
@@ -228,6 +315,7 @@ export const CommandPalette = ({
   const deleteAccountCmdItems = useDeleteAccountCmdItems();
   const themeCmdItems = useThemeCmdItems();
   const { undo, canUndo } = useUndoRedo(mutationDependencies);
+  const recentCommandIds = useRecentCommandIds();
 
   const sections: CommandSection[] = [
     {
@@ -282,10 +370,32 @@ export const CommandPalette = ({
     ...getMoreCommandPaletteSections(currentView),
   ];
 
+  // Resolved against the already-built items so a stale id (hidden by auth
+  // state, or an item that no longer exists) is skipped silently rather than
+  // rendering a broken row. Recent items still also appear in their normal
+  // section — this is a convenience shortcut, not a move.
+  const itemsById = new Map<string, CommandItem>(
+    sections.flatMap((section) => section.items.map((item) => [item.id, item])),
+  );
+  const recentItems = recentCommandIds
+    .map((id) => itemsById.get(id))
+    .filter((item): item is CommandItem => item !== undefined)
+    .slice(0, MAX_RECENT_ITEMS);
+  const sectionsWithRecent: CommandSection[] =
+    recentItems.length > 0
+      ? [
+          { id: RECENT_SECTION_ID, heading: "Recent", items: recentItems },
+          ...sections,
+        ]
+      : sections;
+
   if (!open) return null;
 
   return (
-    <CommandPaletteContent placeholder={placeholder} sections={sections} />
+    <CommandPaletteContent
+      placeholder={placeholder}
+      sections={sectionsWithRecent}
+    />
   );
 };
 

--- a/packages/web/src/components/CommandPalette/HighlightedLabel.tsx
+++ b/packages/web/src/components/CommandPalette/HighlightedLabel.tsx
@@ -1,0 +1,26 @@
+import { type ReactNode } from "react";
+
+interface HighlightedLabelProps {
+  label: string;
+  ranges: Array<[number, number]>;
+}
+
+/** Renders `label` with `ranges` (from `getLabelMatchRanges`) bolded. */
+export function HighlightedLabel({ label, ranges }: HighlightedLabelProps) {
+  if (ranges.length === 0) return <>{label}</>;
+
+  const segments: ReactNode[] = [];
+  let cursor = 0;
+  for (const [start, end] of ranges) {
+    if (start > cursor) segments.push(label.slice(cursor, start));
+    segments.push(
+      <strong key={start} className="font-semibold text-text">
+        {label.slice(start, end)}
+      </strong>,
+    );
+    cursor = end;
+  }
+  if (cursor < label.length) segments.push(label.slice(cursor));
+
+  return <>{segments}</>;
+}

--- a/packages/web/src/components/CommandPalette/command-palette.search.test.ts
+++ b/packages/web/src/components/CommandPalette/command-palette.search.test.ts
@@ -1,5 +1,9 @@
 import { PlusIcon } from "@phosphor-icons/react";
-import { filterSections, scoreCommandItem } from "./command-palette.search";
+import {
+  filterSections,
+  getLabelMatchRanges,
+  scoreCommandItem,
+} from "./command-palette.search";
 import { describe, expect, it } from "bun:test";
 
 describe("filterSections", () => {
@@ -185,5 +189,45 @@ describe("scoreCommandItem", () => {
     const exact = scoreCommandItem({ label: "day" }, "day");
     const substring = scoreCommandItem({ label: "Go to Day" }, "day");
     expect(exact).toBeGreaterThan(substring);
+  });
+});
+
+describe("getLabelMatchRanges", () => {
+  it("returns an empty array for an empty or whitespace query", () => {
+    expect(getLabelMatchRanges("Create event", "")).toEqual([]);
+    expect(getLabelMatchRanges("Create event", "   ")).toEqual([]);
+  });
+
+  it("returns an empty array when the token doesn't appear in the label", () => {
+    expect(getLabelMatchRanges("Create event", "zzzzz")).toEqual([]);
+  });
+
+  it("finds a single-token substring match, case-insensitively", () => {
+    expect(getLabelMatchRanges("Go to Day", "day")).toEqual([[6, 9]]);
+    expect(getLabelMatchRanges("Go to Day", "DAY")).toEqual([[6, 9]]);
+  });
+
+  it("does not highlight a token that only matched via a keyword, not the label", () => {
+    // getLabelMatchRanges only looks at the label itself — a token that
+    // scored via a keyword synonym simply produces no range for that token.
+    expect(getLabelMatchRanges("Go to Day", "page")).toEqual([]);
+  });
+
+  it("returns one range per matching token, sorted by position", () => {
+    expect(getLabelMatchRanges("Create all-day event", "event create")).toEqual(
+      [
+        [0, 6],
+        [15, 20],
+      ],
+    );
+  });
+
+  it("merges overlapping ranges from different tokens", () => {
+    // "lig" matches [10,13) and "ight" matches [11,15) within "light" (at
+    // index 10) — they overlap and should merge into a single [10,15) range
+    // covering the whole word.
+    expect(getLabelMatchRanges("Switch to light theme", "lig ight")).toEqual([
+      [10, 15],
+    ]);
   });
 });

--- a/packages/web/src/components/CommandPalette/command-palette.search.ts
+++ b/packages/web/src/components/CommandPalette/command-palette.search.ts
@@ -76,6 +76,43 @@ export function scoreCommandItem(
 }
 
 /**
+ * Finds where each query token appears as a literal substring in `label`
+ * (case-insensitive) so the UI can bold the matched characters. Only covers
+ * the prefix/word-prefix/substring tiers — the visually satisfying majority
+ * of real matches. Tokens that only matched via subsequence or a keyword
+ * (not the label itself) are simply not highlighted; that's a deliberate
+ * scope cut, not a bug, since subsequence highlighting would be noisy and
+ * rarely hit in practice. Overlapping/adjacent ranges are merged.
+ */
+export function getLabelMatchRanges(
+  label: string,
+  query: string,
+): Array<[number, number]> {
+  const tokens = query.trim().toLowerCase().split(/\s+/).filter(Boolean);
+  if (tokens.length === 0) return [];
+
+  const lowerLabel = label.toLowerCase();
+  const ranges: Array<[number, number]> = [];
+  for (const token of tokens) {
+    const index = lowerLabel.indexOf(token);
+    if (index !== -1) ranges.push([index, index + token.length]);
+  }
+  if (ranges.length === 0) return [];
+
+  ranges.sort((a, b) => a[0] - b[0]);
+  const merged: Array<[number, number]> = [ranges[0]];
+  for (const [start, end] of ranges.slice(1)) {
+    const last = merged[merged.length - 1];
+    if (start <= last[1]) {
+      last[1] = Math.max(last[1], end);
+    } else {
+      merged.push([start, end]);
+    }
+  }
+  return merged;
+}
+
+/**
  * Fuzzy-filters each section's items against `search`: label + keyword
  * synonyms, multi-word queries requiring every word to match, typo-tolerant
  * subsequence matching as a last resort. Items are ranked by score within

--- a/packages/web/src/components/CommandPalette/command-palette.types.ts
+++ b/packages/web/src/components/CommandPalette/command-palette.types.ts
@@ -12,6 +12,8 @@ export interface CommandItem {
   shortcut?: string | string[];
   /** Extra search terms (synonyms) matched by the palette's fuzzy filter; never rendered. */
   keywords?: string[];
+  /** Visually flags an irreversible/data-loss action (e.g. delete account). */
+  variant?: "destructive";
 }
 
 export interface CommandSection {

--- a/packages/web/src/components/CommandPalette/hooks/useDeleteAccountCmdItems.test.ts
+++ b/packages/web/src/components/CommandPalette/hooks/useDeleteAccountCmdItems.test.ts
@@ -65,4 +65,12 @@ describe("useDeleteAccountCmdItems", () => {
 
     expect(mockOpenDeleteAccountConfirmation).toHaveBeenCalledTimes(1);
   });
+
+  it("flags itself as a destructive item for the palette's styling", () => {
+    const { result } = renderHook(() => useDeleteAccountCmdItems(), {
+      wrapper,
+    });
+
+    expect(result.current[0].variant).toBe("destructive");
+  });
 });

--- a/packages/web/src/components/CommandPalette/hooks/useDeleteAccountCmdItems.ts
+++ b/packages/web/src/components/CommandPalette/hooks/useDeleteAccountCmdItems.ts
@@ -17,6 +17,7 @@ export const useDeleteAccountCmdItems = (): CommandItem[] => {
       label: "Delete account",
       icon: TrashIcon,
       keywords: ["remove account"],
+      variant: "destructive",
       onClick: openDeleteAccountConfirmation,
     },
   ];

--- a/packages/web/src/components/CommandPalette/recent-commands.storage.ts
+++ b/packages/web/src/components/CommandPalette/recent-commands.storage.ts
@@ -1,0 +1,31 @@
+import { z } from "zod";
+import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
+import { persistentBrowserStore } from "@web/common/storage/browser-key-value.store";
+
+export const MAX_RECENT_COMMANDS = 8;
+
+// Most-recent-first list of command ids. Malformed or missing storage falls
+// back to an empty list rather than surfacing an error.
+const RecentCommandsSchema = z.array(z.string().trim().min(1)).readonly();
+
+export function readRecentCommandIds(): readonly string[] {
+  const raw = persistentBrowserStore.get(STORAGE_KEYS.RECENT_COMMANDS);
+  if (!raw) return [];
+
+  try {
+    return RecentCommandsSchema.parse(JSON.parse(raw));
+  } catch {
+    return [];
+  }
+}
+
+/** Callers are responsible for capping — this writes exactly what it's given. */
+export function writeRecentCommandIds(ids: readonly string[]): boolean {
+  if (ids.length === 0) {
+    return persistentBrowserStore.remove(STORAGE_KEYS.RECENT_COMMANDS);
+  }
+  return persistentBrowserStore.set(
+    STORAGE_KEYS.RECENT_COMMANDS,
+    JSON.stringify(ids),
+  );
+}

--- a/packages/web/src/components/CommandPalette/recent-commands.store.test.ts
+++ b/packages/web/src/components/CommandPalette/recent-commands.store.test.ts
@@ -1,0 +1,80 @@
+import { act, renderHook } from "@testing-library/react";
+import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
+import { persistentBrowserStore } from "@web/common/storage/browser-key-value.store";
+import { readRecentCommandIds } from "./recent-commands.storage";
+import {
+  recordRecentCommand,
+  useRecentCommandIds,
+} from "./recent-commands.store";
+import { describe, expect, it, spyOn } from "bun:test";
+
+// Storage clearing + the recent-commands store resync between tests are both
+// handled by the global test-lifecycle afterEach (resetBrowserState +
+// resetAllStores) - see packages/web/src/__tests__/setup/test-lifecycle.ts.
+
+describe("recent-commands.store", () => {
+  it("records a command and notifies subscribers", () => {
+    const { result } = renderHook(() => useRecentCommandIds());
+    expect(result.current).toEqual([]);
+
+    act(() => recordRecentCommand("create-event"));
+
+    expect(result.current).toEqual(["create-event"]);
+    expect(readRecentCommandIds()).toEqual(["create-event"]);
+  });
+
+  it("moves a repeated command to the front instead of duplicating it", () => {
+    const { result } = renderHook(() => useRecentCommandIds());
+
+    act(() => recordRecentCommand("create-event"));
+    act(() => recordRecentCommand("toggle-theme"));
+    act(() => recordRecentCommand("create-event"));
+
+    expect(result.current).toEqual(["create-event", "toggle-theme"]);
+  });
+
+  it("caps the list at 8, dropping the oldest", () => {
+    const { result } = renderHook(() => useRecentCommandIds());
+
+    for (let i = 0; i < 9; i += 1) {
+      act(() => recordRecentCommand(`command-${i}`));
+    }
+
+    expect(result.current).toHaveLength(8);
+    expect(result.current[0]).toBe("command-8");
+    expect(result.current).not.toContain("command-0");
+  });
+
+  it("leaves the store untouched when the storage write fails", () => {
+    const setSpy = spyOn(persistentBrowserStore, "set").mockReturnValue(false);
+    const { result } = renderHook(() => useRecentCommandIds());
+
+    act(() => recordRecentCommand("create-event"));
+
+    expect(result.current).toEqual([]);
+    setSpy.mockRestore();
+  });
+
+  it("falls back to an empty list for corrupt storage", () => {
+    persistentBrowserStore.set(STORAGE_KEYS.RECENT_COMMANDS, "{not json");
+
+    expect(readRecentCommandIds()).toEqual([]);
+  });
+
+  it("picks up a write from another tab via the storage event", () => {
+    const { result } = renderHook(() => useRecentCommandIds());
+    expect(result.current).toEqual([]);
+
+    persistentBrowserStore.set(
+      STORAGE_KEYS.RECENT_COMMANDS,
+      JSON.stringify(["create-event"]),
+    );
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent("storage", { key: STORAGE_KEYS.RECENT_COMMANDS }),
+      );
+    });
+
+    expect(result.current).toEqual(["create-event"]);
+  });
+});

--- a/packages/web/src/components/CommandPalette/recent-commands.store.ts
+++ b/packages/web/src/components/CommandPalette/recent-commands.store.ts
@@ -1,0 +1,51 @@
+import { useSyncExternalStore } from "react";
+import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
+import {
+  createExternalStore,
+  subscribeToStorageKey,
+} from "@web/common/utils/external-store.util";
+import {
+  MAX_RECENT_COMMANDS,
+  readRecentCommandIds,
+  writeRecentCommandIds,
+} from "./recent-commands.storage";
+
+const recentStore = createExternalStore<readonly string[]>(
+  readRecentCommandIds(),
+);
+
+function refreshFromStorage(): void {
+  recentStore.set(readRecentCommandIds());
+}
+
+/** Moves `id` to the front of the recent list, deduping and capping. */
+export function recordRecentCommand(id: string): void {
+  const next = [
+    id,
+    ...recentStore.get().filter((existing) => existing !== id),
+  ].slice(0, MAX_RECENT_COMMANDS);
+  if (writeRecentCommandIds(next)) recentStore.set(next);
+}
+
+function subscribe(onChange: () => void): () => void {
+  const unsubscribeStore = recentStore.subscribe(onChange);
+  const unsubscribeStorage = subscribeToStorageKey(
+    STORAGE_KEYS.RECENT_COMMANDS,
+    refreshFromStorage,
+  );
+
+  return () => {
+    unsubscribeStore();
+    unsubscribeStorage();
+  };
+}
+
+export function useRecentCommandIds(): readonly string[] {
+  return useSyncExternalStore(subscribe, recentStore.get);
+}
+
+/** Test-only: resyncs the in-memory store from storage. Registered in
+ * reset-stores.ts for between-test cleanup. */
+export function resetRecentCommandsStoreForTests(): void {
+  refreshFromStorage();
+}


### PR DESCRIPTION
## Summary

Follow-up to #2601. That PR fixed the palette's search mechanics; this one is a design/UX pass — one small feature (Recent commands) plus six fixes/polish items found by reading the current implementation, not speculative additions:

- **Hover/keyboard desync (real bug)**: `CommandPaletteContent` wired `useInteractions([dismiss, role, listNav])` with no pointer handler at all, so moving the mouse over a row never touched `activeIndex` — only arrow keys did. Added `onPointerMove` per row so hover and keyboard selection stay in sync.
- **Destructive-action styling**: `Delete account` — the palette's only irreversible, data-loss action — now renders in muted red (`text-error`, the app's existing semantic color for this). `Log Out` stays neutral by design (reversible, not flagged industry-wide).
- **Live region**: an `aria-live="polite"` region announces result-count changes as you type (and the same "No results for…" wording on zero results), so screen reader users get feedback the palette currently gives none of.
- **Match highlighting**: matched characters in a fuzzy result are now bolded, so it's visible *why* a row matched — especially useful now that the matcher does synonym/subsequence matching that isn't always obvious from the query alone.
- **Entrance transition**: a subtle fade + scale-in on open (matching the transition idiom already used by `WelcomeModal`, including `prefers-reduced-motion` handling). Deliberately entrance-only — no exit animation, since open/close is driven by an external store that shortcuts and tests flip synchronously, and an exit fade would need a delayed-unmount state machine to handle "reopened while still closing." Not worth it for a UI pattern where an instant close is the norm.
- **Keyboard-hint footer**: a small `↑↓ Navigate · ↵ Select · Esc Close` strip at the bottom, using the existing `ShortcutKeys` component.
- **Recent commands**: the last few selected commands surface at the top of an empty palette (hidden the moment you type, to avoid duplicate rows), backed by a small localStorage-mirrored store following the repo's existing `collapsed-accounts` pattern.

No new dependencies. No palette rewrite.

## Simplicity

- Match highlighting is a separate pure function (`getLabelMatchRanges`) and a tiny presentational component (`HighlightedLabel`) — fully decoupled from the fuzzy scorer (`scoreToken`/`scoreAgainstTokens`), so the just-shipped matching logic and its tests are untouched.
- The destructive-color mapping was pulled into a one-line exported function (`getRowTextColorClassName`) so it's unit-testable without a full authenticated render.
- Recent commands reuse the exact storage/store/reset-test pattern already established by `collapsed-accounts.storage.ts`/`.store.ts` — no new persistence pattern introduced.
- The entrance-only (no exit) animation choice is a deliberate scope cut to avoid a real race condition, documented inline.

## Automated validation

- `bun run lint` — clean (3 pre-existing, unrelated warnings only)
- `bunx typescript@7.0.2 --noEmit`, `-p packages/web/tsconfig.app.json --noEmit`, `-p packages/web/tsconfig.test.json --noEmit` — clean
- `bun run knip` — clean
- `bun run test:web` — 1734/1734 passing

## Independent review

Self-reviewed by re-reading the full diff, and while writing tests caught two real bugs before they shipped: (1) a "No results for…" test became ambiguous once the live region echoed the same visible copy — fixed by scoping the query to the visible `div`; (2) `recordRecentCommand` capped the array written to storage but not the array kept in memory, so the in-memory recent list could grow past its 8-item cap — fixed so both use the same capped array. No separate reviewer agent pass was run.

## Test plan

- `bun run lint`
- `bunx typescript@7.0.2 --noEmit`
- `bunx typescript@7.0.2 -p packages/web/tsconfig.app.json --noEmit`
- `bunx typescript@7.0.2 -p packages/web/tsconfig.test.json --noEmit`
- `bun run knip`
- `bun run test:web`
- New tests: `getLabelMatchRanges` unit suite (co-located in `command-palette.search.test.ts`), `recent-commands.store.test.ts` (record/dedupe/cap/corrupt-storage/cross-tab), `getRowTextColorClassName` unit tests, `useDeleteAccountCmdItems.test.ts` variant assertion.
- `CommandPalette.test.tsx` additions: pointermove activates a row without a keypress, live-region text tracks result count, keyboard-hint footer renders, Recent section shows/records/hides-while-typing. Three pre-existing tests updated to query by full recursive text content (`rowLabel` helper) since match highlighting now splits matched labels into text + `<strong>` nodes, which the default `getByText` string matcher doesn't see through.


---
_Generated by [Claude Code](https://claude.ai/code/session_014UMSmLvajMQzDiR3p9HmtU)_