### PR TITLE
fix(web): pin google sync status to sidebar bottom bar, add Settings log out

### DIFF
--- a/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.ts
+++ b/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.ts
@@ -148,6 +148,7 @@ export const useConnectGoogle = (
       onRefreshGoogle,
     }),
     connect: onOpenGoogleAuth,
+    connection: syncConnection,
     refresh: onRefreshGoogle,
     isAvailable,
     isConnecting,

--- a/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.types.ts
+++ b/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.types.ts
@@ -1,5 +1,8 @@
 import { type Icon } from "@phosphor-icons/react";
-import { type GoogleConnectionState } from "@core/types/user.types";
+import {
+  type GoogleConnectionState,
+  type GoogleSyncConnectionSummary,
+} from "@core/types/user.types";
 
 export type GoogleUiState = "checking" | GoogleConnectionState;
 
@@ -14,6 +17,8 @@ export type GoogleUiConfig = {
 };
 
 export type UseConnectGoogleResult = GoogleUiConfig & {
+  /** The scoped connection when passed in, else the aggregate's primary. */
+  connection: GoogleSyncConnectionSummary | null;
   isAvailable: boolean;
   /** True while connect/reconnect OAuth is starting (before redirect). */
   isConnecting: boolean;

--- a/packages/web/src/calendars/SyncStatusLine.tsx
+++ b/packages/web/src/calendars/SyncStatusLine.tsx
@@ -11,10 +11,11 @@ interface SyncStatusLineProps {
 }
 
 /**
- * One account's live sync status line - shared by the sidebar's single- and
- * per-account headers and the manage-accounts dialog, so the surfaces a user
- * directly compares cannot drift. Renders nothing when there's no status to
- * show (e.g. NOT_CONNECTED).
+ * One account's live sync status line - used by the Settings modal's account
+ * rows (the sidebar surfaces this same status text in the pinned
+ * SidebarStatusBar instead, so an account's status appearing/disappearing
+ * can never shift the calendar list below it). Renders nothing when there's
+ * no status to show (e.g. NOT_CONNECTED).
  */
 export const SyncStatusLine: FC<SyncStatusLineProps> = ({
   status,

--- a/packages/web/src/components/Settings/SettingsModal.test.tsx
+++ b/packages/web/src/components/Settings/SettingsModal.test.tsx
@@ -6,6 +6,7 @@ import { createTestToastPort } from "@web/__tests__/helpers/web-test-seams";
 import { createStoreWrapper } from "@web/__tests__/render-with-store";
 import { createMockCalendar } from "@web/__tests__/utils/factories/calendar.factory";
 import { AuthApi } from "@web/api/auth.api";
+import { SessionContext } from "@web/auth/compass/session/session.context";
 import { userMetadataActions } from "@web/auth/state/user-metadata.store";
 import { calendarQueryKeys } from "@web/calendars/calendar.query";
 import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
@@ -19,8 +20,43 @@ import {
   resetToastPort,
 } from "@web/common/utils/toast/toast.port";
 import { settingsActions } from "@web/settings/settings.store";
-import { SettingsModal } from "./SettingsModal";
-import { describe, expect, it, spyOn } from "bun:test";
+import { afterAll, describe, expect, it, mock, spyOn } from "bun:test";
+
+// mock.module is process-wide and not reliably restorable, so - as elsewhere
+// in this suite of files - the real hook is captured up front and a flag
+// (flipped in afterAll) decides which one runs.
+const actualUseLogoutConfirmation = (
+  await import("@web/components/LogoutConfirmation/hooks/useLogoutConfirmation")
+).useLogoutConfirmation;
+let isLogoutConfirmationMocked = true;
+const mockOpenLogoutConfirmation = mock();
+mock.module(
+  "@web/components/LogoutConfirmation/hooks/useLogoutConfirmation",
+  () => ({
+    useLogoutConfirmation: (
+      ...args: Parameters<typeof actualUseLogoutConfirmation>
+    ) =>
+      isLogoutConfirmationMocked
+        ? {
+            isOpen: false,
+            closeLogoutConfirmation: mock(),
+            openLogoutConfirmation: mockOpenLogoutConfirmation,
+          }
+        : actualUseLogoutConfirmation(...args),
+  }),
+);
+
+afterAll(() => {
+  isLogoutConfirmationMocked = false;
+});
+
+const settingsModalUrl = new URL(
+  `./SettingsModal.tsx?test=${Math.random().toString(36).slice(2)}`,
+  import.meta.url,
+);
+const { SettingsModal } = (await import(
+  settingsModalUrl.href
+)) as typeof import("./SettingsModal");
 
 const connection = (
   overrides: Partial<GoogleSyncConnectionSummary> = {},
@@ -36,10 +72,12 @@ const connection = (
 });
 
 const renderSettings = ({
+  authenticated = false,
   connections = [connection()],
   calendars = [],
   open = true,
 }: {
+  authenticated?: boolean;
   connections?: GoogleSyncConnectionSummary[];
   calendars?: Calendar[];
   open?: boolean;
@@ -51,7 +89,17 @@ const renderSettings = ({
   queryClient.setQueryData(calendarQueryKeys.all, calendars);
   if (open) settingsActions.openSettings();
 
-  return { queryClient, ...render(<SettingsModal />, { wrapper }) };
+  return {
+    queryClient,
+    ...render(
+      <SessionContext.Provider
+        value={{ authenticated, setAuthenticated: () => {} }}
+      >
+        <SettingsModal />
+      </SessionContext.Provider>,
+      { wrapper },
+    ),
+  };
 };
 
 describe("SettingsModal", () => {
@@ -330,5 +378,19 @@ describe("SettingsModal", () => {
     expect(
       gmailRow ? within(gmailRow).queryByText("Default") : null,
     ).not.toBeInTheDocument();
+  });
+
+  it("shows a Log out action for a signed-in user", async () => {
+    const user = userEvent.setup({ delay: null });
+    renderSettings({ authenticated: true });
+
+    await user.click(screen.getByRole("button", { name: "Log out" }));
+    expect(mockOpenLogoutConfirmation).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides the Log out action for a signed-out (local-only) session", () => {
+    renderSettings({ authenticated: false });
+
+    expect(screen.queryByRole("button", { name: "Log out" })).toBeNull();
   });
 });

--- a/packages/web/src/components/Settings/SettingsModal.test.tsx
+++ b/packages/web/src/components/Settings/SettingsModal.test.tsx
@@ -6,7 +6,6 @@ import { createTestToastPort } from "@web/__tests__/helpers/web-test-seams";
 import { createStoreWrapper } from "@web/__tests__/render-with-store";
 import { createMockCalendar } from "@web/__tests__/utils/factories/calendar.factory";
 import { AuthApi } from "@web/api/auth.api";
-import { SessionContext } from "@web/auth/compass/session/session.context";
 import { userMetadataActions } from "@web/auth/state/user-metadata.store";
 import { calendarQueryKeys } from "@web/calendars/calendar.query";
 import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
@@ -46,8 +45,25 @@ mock.module(
   }),
 );
 
+// Other test files (e.g. useLogoutCmdItems.test.ts) also mock.module this
+// same path without ever restoring it, so - regardless of load order - this
+// module can already be permanently swapped to a foreign mock by the time
+// this file runs. Mock it here too rather than relying on a real
+// SessionContext.Provider, which that foreign mock would bypass entirely.
+const actualUseSession = (await import("@web/auth/compass/session/useSession"))
+  .useSession;
+let isSessionMocked = true;
+let authenticated = false;
+mock.module("@web/auth/compass/session/useSession", () => ({
+  useSession: (...args: Parameters<typeof actualUseSession>) =>
+    isSessionMocked
+      ? { authenticated, setAuthenticated: mock() }
+      : actualUseSession(...args),
+}));
+
 afterAll(() => {
   isLogoutConfirmationMocked = false;
+  isSessionMocked = false;
 });
 
 const settingsModalUrl = new URL(
@@ -72,7 +88,7 @@ const connection = (
 });
 
 const renderSettings = ({
-  authenticated = false,
+  authenticated: isAuthenticated = false,
   connections = [connection()],
   calendars = [],
   open = true,
@@ -82,6 +98,7 @@ const renderSettings = ({
   calendars?: Calendar[];
   open?: boolean;
 } = {}) => {
+  authenticated = isAuthenticated;
   userMetadataActions.set({
     google: { connectionState: "HEALTHY", connections },
   });
@@ -89,17 +106,7 @@ const renderSettings = ({
   queryClient.setQueryData(calendarQueryKeys.all, calendars);
   if (open) settingsActions.openSettings();
 
-  return {
-    queryClient,
-    ...render(
-      <SessionContext.Provider
-        value={{ authenticated, setAuthenticated: () => {} }}
-      >
-        <SettingsModal />
-      </SessionContext.Provider>,
-      { wrapper },
-    ),
-  };
+  return { queryClient, ...render(<SettingsModal />, { wrapper }) };
 };
 
 describe("SettingsModal", () => {

--- a/packages/web/src/components/Settings/SettingsModal.tsx
+++ b/packages/web/src/components/Settings/SettingsModal.tsx
@@ -2,6 +2,7 @@ import { type FC, useEffect, useRef, useState } from "react";
 import { type Calendar } from "@core/types/calendar.contracts";
 import { type CalendarId } from "@core/types/domain-primitives";
 import { type GoogleSyncConnectionSummary } from "@core/types/user.types";
+import { useSession } from "@web/auth/compass/session/useSession";
 import { useConnectGoogle } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle";
 import {
   formatLastSyncedLabel,
@@ -32,6 +33,7 @@ import { runExportMyData } from "@web/common/storage/offline-data/export-user-da
 import { showErrorToast } from "@web/common/utils/toast/error-toast.util";
 import { showStatusToast } from "@web/common/utils/toast/status-toast.util";
 import { useDeleteAccountConfirmation } from "@web/components/DeleteAccountConfirmation/hooks/useDeleteAccountConfirmation";
+import { useLogoutConfirmation } from "@web/components/LogoutConfirmation/hooks/useLogoutConfirmation";
 import {
   OverlayPanel,
   OverlayPanelActionButton,
@@ -61,6 +63,8 @@ export const SettingsModal: FC = () => {
   const [confirmingId, setConfirmingId] = useState<string | null>(null);
   useAppLockReason("settingsModal", isOpen);
   const { openDeleteAccountConfirmation } = useDeleteAccountConfirmation();
+  const { authenticated } = useSession();
+  const { openLogoutConfirmation } = useLogoutConfirmation();
 
   // The modal stays mounted (self-reads the store) so a stray close path
   // that skips handleDismiss (e.g. the Mod+, toggle) can't leave a
@@ -149,6 +153,11 @@ export const SettingsModal: FC = () => {
               >
                 Delete account
               </OverlayPanelActionButton>
+              {authenticated ? (
+                <OverlayPanelActionButton onClick={openLogoutConfirmation}>
+                  Log out
+                </OverlayPanelActionButton>
+              ) : null}
             </OverlayPanelActions>
           </div>
         </div>

--- a/packages/web/src/components/Settings/SettingsModal.tsx
+++ b/packages/web/src/components/Settings/SettingsModal.tsx
@@ -51,12 +51,14 @@ const OUTLINE_BUTTON_CLASSNAME =
 
 /**
  * The app's Settings menu (Mod+,): a nav shell (one item today - Accounts)
- * holding default-calendar choice and connected-account management, which
- * used to live scattered across the sidebar (the default-calendar star) and
- * a dedicated "manage accounts" dialog. ESC steps back a level - out of an
- * open disconnect confirmation first, then out of the modal - via
- * `handleDismiss`, since OverlayPanel already routes both ESC and a
- * backdrop click through `onDismiss`.
+ * holding default-calendar choice, connected-account management, and the
+ * signed-in user's own Log out action (which stays reachable from the
+ * Command Palette too - see useLogoutCmdItems). Default-calendar and
+ * account management used to live scattered across the sidebar (the
+ * default-calendar star) and a dedicated "manage accounts" dialog. ESC steps
+ * back a level - out of an open disconnect confirmation first, then out of
+ * the modal - via `handleDismiss`, since OverlayPanel already routes both
+ * ESC and a backdrop click through `onDismiss`.
  */
 export const SettingsModal: FC = () => {
   const isOpen = useSettingsStore(selectIsSettingsOpen);

--- a/packages/web/src/components/Sidebar/CalendarList/AccountSectionHeader.test.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/AccountSectionHeader.test.tsx
@@ -107,7 +107,7 @@ describe("AccountSectionHeader", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("shows the account's own error status and a reconnect action scoped to it", async () => {
+  it("shows a reconnect action scoped to the account with an error", async () => {
     const user = userEvent.setup({ delay: null });
     googleState = "RECONNECT_REQUIRED";
 
@@ -117,10 +117,9 @@ describe("AccountSectionHeader", () => {
       connectionState: "RECONNECT_REQUIRED",
     });
 
-    expect(screen.getByRole("status")).toHaveTextContent(
-      "Calendar needs reconnecting",
-    );
-    expect(screen.getByRole("status")).toHaveClass("text-error");
+    // The status text itself now lives in the pinned SidebarStatusBar, not
+    // inline here - see SidebarStatusBar.test.tsx.
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
 
     // Named per account, so two broken accounts give a screen reader two
     // distinguishable buttons.
@@ -132,7 +131,7 @@ describe("AccountSectionHeader", () => {
     expect(onSelect).toHaveBeenCalledTimes(1);
   });
 
-  it("shows the setup status and shimmer while the account's first import runs", () => {
+  it("shows the shimmer on the email while the account's first import runs", () => {
     googleState = "IMPORTING";
 
     renderHeader({
@@ -141,9 +140,7 @@ describe("AccountSectionHeader", () => {
       connectionState: "IMPORTING",
     });
 
-    expect(screen.getByRole("status")).toHaveTextContent(
-      "Adding your calendar…",
-    );
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
     expect(screen.getByText(EMAIL)).toHaveClass("c-sync-text-wave");
   });
 });

--- a/packages/web/src/components/Sidebar/CalendarList/AccountSectionHeader.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/AccountSectionHeader.tsx
@@ -9,8 +9,6 @@ import {
   toggleAccountCollapsed,
   useCollapsedAccountKeys,
 } from "@web/calendars/collapsed-accounts.store";
-import { SyncStatusLine } from "@web/calendars/SyncStatusLine";
-
 /**
  * Heading for one connected account's calendars: the account email (also the
  * collapse toggle for its calendar rows, see CalendarList.tsx), that
@@ -73,7 +71,6 @@ export const AccountSectionHeader: FC<{
           </span>
         </button>
       </h2>
-      <SyncStatusLine status={syncStatus} />
       {isAvailable && commandAction != null && actionLabel != null ? (
         <button
           aria-busy={isConnecting || isRefreshing || undefined}

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarList.test.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarList.test.tsx
@@ -424,7 +424,7 @@ describe("CalendarList", () => {
     expect(headings).toEqual(["ahab@pequod.com", "ahab@gmail.com"]);
   });
 
-  it("gives each account its own status line", () => {
+  it("keeps each account's own section quiet - status text lives in the pinned SidebarStatusBar instead", () => {
     const work = makeCalendar({
       name: "Work",
       accountEmail: "ahab@pequod.com",
@@ -452,12 +452,12 @@ describe("CalendarList", () => {
     const broken = within(
       screen.getByRole("region", { name: "Calendars for ahab@gmail.com" }),
     );
-    // A healthy account stays quiet in the sidebar - full status lives in
-    // Settings - but a broken one still needs to surface here.
+    // Neither account's own section renders status text - it moved to the
+    // sidebar's pinned bottom bar (see SidebarStatusBar.test.tsx) so a
+    // status appearing/disappearing per account can never shift the
+    // calendar rows below it.
     expect(healthy.queryByRole("status")).not.toBeInTheDocument();
-    expect(broken.getByRole("status").textContent).toBe(
-      "Calendar needs reconnecting",
-    );
+    expect(broken.queryByRole("status")).not.toBeInTheDocument();
   });
 
   it("gives a lone account the same labelled section as several", () => {

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarListHeader.test.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarListHeader.test.tsx
@@ -192,7 +192,7 @@ describe("CalendarListHeader", () => {
     expect(screen.queryByRole("tooltip")).toBeNull();
   });
 
-  it("shows setup status only while the first calendar import is in progress", async () => {
+  it("shows the wave shimmer on the email while the first calendar import is in progress", async () => {
     const user = userEvent.setup();
     mockEmail = "ahab@pequod.com";
     mockGoogleState = "IMPORTING";
@@ -201,9 +201,9 @@ describe("CalendarListHeader", () => {
 
     const email = screen.getByText("ahab@pequod.com");
     expect(email).toHaveClass("c-sync-text-wave");
-    expect(screen.getByRole("status")).toHaveTextContent(
-      "Adding your calendar…",
-    );
+    // The status text itself now lives in the pinned SidebarStatusBar, not
+    // inline here - see SidebarStatusBar.test.tsx.
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
 
     await user.hover(email);
     expect(screen.queryByRole("tooltip")).toBeNull();
@@ -220,10 +220,6 @@ describe("CalendarListHeader", () => {
     expect(email.tagName).toBe("SPAN");
     expect(email).toHaveClass("text-text-muted");
     expect(email).not.toHaveClass("text-warning");
-    expect(screen.getByRole("status")).toHaveTextContent(
-      "Calendar updates are taking longer than usual. We'll keep trying.",
-    );
-    expect(screen.getByRole("status")).toHaveClass("text-warning");
 
     const syncButton = screen.getByRole("button", {
       name: "Refresh calendar",
@@ -242,10 +238,6 @@ describe("CalendarListHeader", () => {
     const email = screen.getByText("ahab@pequod.com");
     expect(email).toHaveClass("text-text-muted");
     expect(email).not.toHaveClass("text-error");
-    expect(screen.getByRole("status")).toHaveTextContent(
-      "Calendar needs reconnecting",
-    );
-    expect(screen.getByRole("status")).toHaveClass("text-error");
 
     const reconnectButton = screen.getByRole("button", {
       name: "Reconnect Google Calendar",
@@ -266,9 +258,6 @@ describe("CalendarListHeader", () => {
     const reconnectButton = screen.getByRole("button", {
       name: "Reconnecting…",
     });
-    expect(screen.getByRole("status")).toHaveTextContent(
-      "Reconnecting your calendar…",
-    );
     expect(reconnectButton).toBeDisabled();
     expect(reconnectButton).toHaveAttribute("aria-busy", "true");
     expect(
@@ -286,9 +275,6 @@ describe("CalendarListHeader", () => {
     const connectButton = screen.getByRole("button", {
       name: "Connecting…",
     });
-    expect(screen.getByRole("status")).toHaveTextContent(
-      "Connecting your calendar…",
-    );
     expect(connectButton).toBeDisabled();
     expect(connectButton).toHaveAttribute("aria-busy", "true");
   });
@@ -303,9 +289,6 @@ describe("CalendarListHeader", () => {
     const refreshButton = screen.getByRole("button", {
       name: "Refreshing…",
     });
-    expect(screen.getByRole("status")).toHaveTextContent(
-      "Calendar updates are taking longer than usual. We'll keep trying.",
-    );
     expect(refreshButton).toBeDisabled();
     expect(refreshButton).toHaveAttribute("aria-busy", "true");
   });
@@ -333,7 +316,6 @@ describe("CalendarListHeader", () => {
 
     // Resolves to "healthy" (not "syncing"), so the sidebar shows nothing at
     // all rather than either status text - full detail lives in Settings.
-    expect(screen.queryByRole("status")).not.toBeInTheDocument();
     expect(screen.queryByText("Adding your calendar…")).toBeNull();
     expect(screen.queryByText(/Updated/)).toBeNull();
   });

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarListHeader.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarListHeader.tsx
@@ -11,7 +11,6 @@ import {
   selectGoogleSyncConnections,
   useUserMetadataStore,
 } from "@web/auth/state/user-metadata.store";
-import { SyncStatusLine } from "@web/calendars/SyncStatusLine";
 import { useAuthModal } from "@web/components/AuthModal/hooks/useAuthModal";
 import {
   Tooltip,
@@ -138,7 +137,6 @@ const AuthenticatedAccountHeader: FC<{ email: string }> = ({ email }) => {
           {email}
         </span>
       </h2>
-      <SyncStatusLine className="mb-1" status={syncStatus} />
       {isAvailable && commandAction != null && actionLabel != null ? (
         <button
           aria-busy={isConnecting || isRefreshing || undefined}

--- a/packages/web/src/components/Sidebar/SidebarStatusBar.test.tsx
+++ b/packages/web/src/components/Sidebar/SidebarStatusBar.test.tsx
@@ -1,10 +1,54 @@
 import { render, screen } from "@testing-library/react";
 import { createStoreWrapper } from "@web/__tests__/render-with-store";
 import { seedPendingEventMutations } from "@web/__tests__/utils/event-query-test-data";
-import { SidebarStatusBar } from "./SidebarStatusBar";
-import { describe, expect, it } from "bun:test";
+import { createMockConnection } from "@web/__tests__/utils/factories/calendar.factory";
+import { type GoogleUiState } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle.types";
+import { userMetadataActions } from "@web/auth/state/user-metadata.store";
+import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
+
+// mock.module is process-wide and not reliably restorable, so - as in
+// AccountSectionHeader.test.tsx - the real hook is captured up front and a
+// flag (flipped in afterAll) decides which one runs.
+const actualUseConnectGoogle = (
+  await import("@web/auth/google/hooks/useConnectGoogle/useConnectGoogle")
+).useConnectGoogle;
+let isConnectGoogleMocked = true;
+let googleState: GoogleUiState = "HEALTHY";
+let isConnecting = false;
+mock.module("@web/auth/google/hooks/useConnectGoogle/useConnectGoogle", () => ({
+  useConnectGoogle: (...args: Parameters<typeof actualUseConnectGoogle>) =>
+    isConnectGoogleMocked
+      ? {
+          commandAction: null,
+          connect: mock(),
+          refresh: mock(),
+          isAvailable: true,
+          isConnecting,
+          isRefreshing: false,
+          state: googleState,
+        }
+      : actualUseConnectGoogle(...args),
+}));
+
+afterAll(() => {
+  isConnectGoogleMocked = false;
+});
+
+const statusBarModuleUrl = new URL(
+  `./SidebarStatusBar.tsx?test=${Math.random().toString(36).slice(2)}`,
+  import.meta.url,
+);
+const { SidebarStatusBar } = (await import(
+  statusBarModuleUrl.href
+)) as typeof import("./SidebarStatusBar");
 
 describe("SidebarStatusBar", () => {
+  beforeEach(() => {
+    googleState = "HEALTHY";
+    isConnecting = false;
+    userMetadataActions.clear();
+  });
+
   it("shows 'Saving changes…' when a mutation is pending", () => {
     const { queryClient, wrapper } = createStoreWrapper();
     seedPendingEventMutations(queryClient, ["event-1"]);
@@ -33,5 +77,88 @@ describe("SidebarStatusBar", () => {
     const regions = screen.getAllByRole("status");
     expect(regions).toHaveLength(1);
     expect(screen.getByText("Saving changes…")).toBeInTheDocument();
+  });
+
+  it("shows the aggregate Google sync status while a brand-new account's first import runs, so the calendar list below never shifts", () => {
+    googleState = "IMPORTING";
+    userMetadataActions.set({
+      google: {
+        connectionState: "IMPORTING",
+        connections: [
+          createMockConnection("ahab@pequod.com", {
+            state: "importing",
+            lastHealthyAt: null,
+            connectionState: "IMPORTING",
+          }),
+        ],
+      },
+    });
+    const { wrapper } = createStoreWrapper();
+
+    render(<SidebarStatusBar />, { wrapper });
+
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Adding your calendar…",
+    );
+  });
+
+  it("stays quiet while an already-established account runs routine catch-up, not just on first import", () => {
+    // The 2026-08-05 bug this guards against: the aggregate connectionState
+    // collapses first-import and routine incremental catch-up to the same
+    // "IMPORTING" value, so without the connection's own lastHealthyAt the
+    // bar would misreport a healthy account's reconciliation as "Adding your
+    // calendar…" - exactly the noise getSidebarSyncStatus is meant to hide.
+    googleState = "IMPORTING";
+    userMetadataActions.set({
+      google: {
+        connectionState: "IMPORTING",
+        connections: [
+          createMockConnection("ahab@pequod.com", {
+            state: "catchingUp",
+            lastSyncedAt: new Date().toISOString(),
+            lastHealthyAt: new Date().toISOString(),
+            connectionState: "IMPORTING",
+          }),
+        ],
+      },
+    });
+    const { wrapper } = createStoreWrapper();
+
+    render(<SidebarStatusBar />, { wrapper });
+
+    expect(screen.getByRole("status").textContent).toBe("");
+    expect(screen.queryByText("Adding your calendar…")).toBeNull();
+  });
+
+  it("prefers 'Saving changes…' over the Google sync status when both are true", () => {
+    googleState = "IMPORTING";
+    userMetadataActions.set({
+      google: {
+        connectionState: "IMPORTING",
+        connections: [
+          createMockConnection("ahab@pequod.com", {
+            state: "importing",
+            lastHealthyAt: null,
+            connectionState: "IMPORTING",
+          }),
+        ],
+      },
+    });
+    const { queryClient, wrapper } = createStoreWrapper();
+    seedPendingEventMutations(queryClient, ["event-1"]);
+
+    render(<SidebarStatusBar />, { wrapper });
+
+    expect(screen.getByRole("status")).toHaveTextContent("Saving changes…");
+    expect(screen.queryByText("Adding your calendar…")).toBeNull();
+  });
+
+  it("stays empty when the aggregate Google state is healthy", () => {
+    googleState = "HEALTHY";
+    const { wrapper } = createStoreWrapper();
+
+    render(<SidebarStatusBar />, { wrapper });
+
+    expect(screen.getByRole("status").textContent).toBe("");
   });
 });

--- a/packages/web/src/components/Sidebar/SidebarStatusBar.test.tsx
+++ b/packages/web/src/components/Sidebar/SidebarStatusBar.test.tsx
@@ -1,9 +1,9 @@
 import { render, screen } from "@testing-library/react";
+import { type GoogleSyncConnectionSummary } from "@core/types/user.types";
 import { createStoreWrapper } from "@web/__tests__/render-with-store";
 import { seedPendingEventMutations } from "@web/__tests__/utils/event-query-test-data";
 import { createMockConnection } from "@web/__tests__/utils/factories/calendar.factory";
 import { type GoogleUiState } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle.types";
-import { userMetadataActions } from "@web/auth/state/user-metadata.store";
 import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
 
 // mock.module is process-wide and not reliably restorable, so - as in
@@ -15,12 +15,14 @@ const actualUseConnectGoogle = (
 let isConnectGoogleMocked = true;
 let googleState: GoogleUiState = "HEALTHY";
 let isConnecting = false;
+let connection: GoogleSyncConnectionSummary | null = null;
 mock.module("@web/auth/google/hooks/useConnectGoogle/useConnectGoogle", () => ({
   useConnectGoogle: (...args: Parameters<typeof actualUseConnectGoogle>) =>
     isConnectGoogleMocked
       ? {
           commandAction: null,
           connect: mock(),
+          connection,
           refresh: mock(),
           isAvailable: true,
           isConnecting,
@@ -46,7 +48,7 @@ describe("SidebarStatusBar", () => {
   beforeEach(() => {
     googleState = "HEALTHY";
     isConnecting = false;
-    userMetadataActions.clear();
+    connection = null;
   });
 
   it("shows 'Saving changes…' when a mutation is pending", () => {
@@ -81,17 +83,10 @@ describe("SidebarStatusBar", () => {
 
   it("shows the aggregate Google sync status while a brand-new account's first import runs, so the calendar list below never shifts", () => {
     googleState = "IMPORTING";
-    userMetadataActions.set({
-      google: {
-        connectionState: "IMPORTING",
-        connections: [
-          createMockConnection("ahab@pequod.com", {
-            state: "importing",
-            lastHealthyAt: null,
-            connectionState: "IMPORTING",
-          }),
-        ],
-      },
+    connection = createMockConnection("ahab@pequod.com", {
+      state: "importing",
+      lastHealthyAt: null,
+      connectionState: "IMPORTING",
     });
     const { wrapper } = createStoreWrapper();
 
@@ -109,18 +104,11 @@ describe("SidebarStatusBar", () => {
     // bar would misreport a healthy account's reconciliation as "Adding your
     // calendar…" - exactly the noise getSidebarSyncStatus is meant to hide.
     googleState = "IMPORTING";
-    userMetadataActions.set({
-      google: {
-        connectionState: "IMPORTING",
-        connections: [
-          createMockConnection("ahab@pequod.com", {
-            state: "catchingUp",
-            lastSyncedAt: new Date().toISOString(),
-            lastHealthyAt: new Date().toISOString(),
-            connectionState: "IMPORTING",
-          }),
-        ],
-      },
+    connection = createMockConnection("ahab@pequod.com", {
+      state: "catchingUp",
+      lastSyncedAt: new Date().toISOString(),
+      lastHealthyAt: new Date().toISOString(),
+      connectionState: "IMPORTING",
     });
     const { wrapper } = createStoreWrapper();
 
@@ -132,17 +120,10 @@ describe("SidebarStatusBar", () => {
 
   it("prefers 'Saving changes…' over the Google sync status when both are true", () => {
     googleState = "IMPORTING";
-    userMetadataActions.set({
-      google: {
-        connectionState: "IMPORTING",
-        connections: [
-          createMockConnection("ahab@pequod.com", {
-            state: "importing",
-            lastHealthyAt: null,
-            connectionState: "IMPORTING",
-          }),
-        ],
-      },
+    connection = createMockConnection("ahab@pequod.com", {
+      state: "importing",
+      lastHealthyAt: null,
+      connectionState: "IMPORTING",
     });
     const { queryClient, wrapper } = createStoreWrapper();
     seedPendingEventMutations(queryClient, ["event-1"]);

--- a/packages/web/src/components/Sidebar/SidebarStatusBar.tsx
+++ b/packages/web/src/components/Sidebar/SidebarStatusBar.tsx
@@ -1,23 +1,52 @@
 import { type FC } from "react";
+import { useConnectGoogle } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle";
+import { getSidebarSyncStatus } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle.util";
+import {
+  selectPrimaryGoogleSyncConnection,
+  useUserMetadataStore,
+} from "@web/auth/state/user-metadata.store";
 import { SYNC_STATUS_VARIANT_CLASSNAME } from "@web/calendars/sync-status.types";
 import { useHasPendingEventMutations } from "@web/events/mutations/useEventPending";
 
 /**
  * Pinned status bar at the bottom of the sidebar, just above the actions bar.
- * Always occupies a fixed height so nothing in the sidebar can shift when
- * a mutation goes in/out of flight.
+ * Always occupies a fixed height so nothing in the sidebar can shift when a
+ * mutation goes in/out of flight, or an account's Google sync status changes -
+ * that status used to render inline under each account's heading, where it
+ * pushed the calendar rows below it up and down as accounts synced.
  */
 export const SidebarStatusBar: FC = () => {
   const isSaving = useHasPendingEventMutations();
+  const { isConnecting, state } = useConnectGoogle();
+  // The primary connection (the one whose own state matches the aggregate) -
+  // without it, an account's routine incremental catch-up looks identical to
+  // a brand-new import: both collapse to the aggregate "IMPORTING" state, and
+  // only the connection's own lastHealthyAt tells getSidebarSyncStatus the
+  // account was already established and should stay quiet.
+  const primaryConnection = useUserMetadataStore(
+    selectPrimaryGoogleSyncConnection,
+  );
+  const googleStatus = getSidebarSyncStatus({
+    connection: primaryConnection,
+    isConnecting,
+    state,
+  });
+
+  const text = isSaving ? "Saving changes…" : (googleStatus?.text ?? "");
+  const variantClassName = isSaving
+    ? SYNC_STATUS_VARIANT_CLASSNAME.syncing
+    : googleStatus
+      ? SYNC_STATUS_VARIANT_CLASSNAME[googleStatus.variant]
+      : "";
 
   return (
     <div className="flex h-6 shrink-0 items-center border-border border-t px-4">
       <p
         aria-live="polite"
-        className={`truncate text-xs ${isSaving ? SYNC_STATUS_VARIANT_CLASSNAME.syncing : ""}`}
+        className={`truncate text-xs ${variantClassName}`}
         role="status"
       >
-        {isSaving ? "Saving changes…" : ""}
+        {text}
       </p>
     </div>
   );

--- a/packages/web/src/components/Sidebar/SidebarStatusBar.tsx
+++ b/packages/web/src/components/Sidebar/SidebarStatusBar.tsx
@@ -1,10 +1,6 @@
 import { type FC } from "react";
 import { useConnectGoogle } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle";
 import { getSidebarSyncStatus } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle.util";
-import {
-  selectPrimaryGoogleSyncConnection,
-  useUserMetadataStore,
-} from "@web/auth/state/user-metadata.store";
 import { SYNC_STATUS_VARIANT_CLASSNAME } from "@web/calendars/sync-status.types";
 import { useHasPendingEventMutations } from "@web/events/mutations/useEventPending";
 
@@ -17,36 +13,25 @@ import { useHasPendingEventMutations } from "@web/events/mutations/useEventPendi
  */
 export const SidebarStatusBar: FC = () => {
   const isSaving = useHasPendingEventMutations();
-  const { isConnecting, state } = useConnectGoogle();
-  // The primary connection (the one whose own state matches the aggregate) -
-  // without it, an account's routine incremental catch-up looks identical to
-  // a brand-new import: both collapse to the aggregate "IMPORTING" state, and
-  // only the connection's own lastHealthyAt tells getSidebarSyncStatus the
-  // account was already established and should stay quiet.
-  const primaryConnection = useUserMetadataStore(
-    selectPrimaryGoogleSyncConnection,
-  );
-  const googleStatus = getSidebarSyncStatus({
-    connection: primaryConnection,
-    isConnecting,
-    state,
-  });
-
-  const text = isSaving ? "Saving changes…" : (googleStatus?.text ?? "");
-  const variantClassName = isSaving
-    ? SYNC_STATUS_VARIANT_CLASSNAME.syncing
-    : googleStatus
-      ? SYNC_STATUS_VARIANT_CLASSNAME[googleStatus.variant]
-      : "";
+  // The unscoped hook's `connection` is the primary connection (the one
+  // whose own state matches the aggregate) - without it, an account's
+  // routine incremental catch-up looks identical to a brand-new import: both
+  // collapse to the aggregate "IMPORTING" state, and only the connection's
+  // own lastHealthyAt tells getSidebarSyncStatus the account was already
+  // established and should stay quiet.
+  const { connection, isConnecting, state } = useConnectGoogle();
+  const status = isSaving
+    ? { variant: "syncing" as const, text: "Saving changes…" }
+    : getSidebarSyncStatus({ connection, isConnecting, state });
 
   return (
     <div className="flex h-6 shrink-0 items-center border-border border-t px-4">
       <p
         aria-live="polite"
-        className={`truncate text-xs ${variantClassName}`}
+        className={`truncate text-xs ${status ? SYNC_STATUS_VARIANT_CLASSNAME[status.variant] : ""}`}
         role="status"
       >
-        {text}
+        {status?.text ?? ""}
       </p>
     </div>
   );

--- a/packages/web/src/sse/hooks/useSyncFocusRefresh.test.ts
+++ b/packages/web/src/sse/hooks/useSyncFocusRefresh.test.ts
@@ -10,6 +10,7 @@ const fakeConnectGoogle = (
   overrides: Partial<UseConnectGoogleResult> = {},
 ): UseConnectGoogleResult => ({
   commandAction: null,
+  connection: null,
   isAvailable: true,
   isConnecting: false,
   isRefreshing: false,


### PR DESCRIPTION
## Summary

The sidebar's per-account Google sync status text ("Adding your calendar…" etc.) rendered inline under each connected account's heading, so it pushed the calendar rows below it up and down as accounts synced (visible with two Google accounts, one still importing). Moved that status into the sidebar's existing pinned, fixed-height `SidebarStatusBar` at the bottom instead, so the calendar list never shifts.

Also added a "Log out" action to the Settings modal's Accounts tab (it was previously reachable only from the Command Palette), per explicit product direction — stays in both places.

## Simplicity

- `SidebarStatusBar`'s text/class derivation collapsed from two parallel ternaries into a single status value.
- `useConnectGoogle()` now returns its resolved `connection`, so `SidebarStatusBar` doesn't need a second, duplicate store-selector read for the same data.
- Updated a stale doc comment on `SyncStatusLine` (no longer used by the sidebar) and on `SettingsModal` (now also owns the session Log out action).
- A 4-agent `/simplify` pass (reuse, simplification, efficiency, altitude) surfaced one real bug during review — see below — plus the cleanups above; a proposed Settings nav restructure and a test-helper extraction were both intentionally skipped (out of the diff's scope / already an explicit product decision to keep Log out inside the existing Accounts tab).

## Automated validation

- Loaded the app locally (anonymous/IndexedDB mode, no backend available in this environment) and confirmed the sidebar and Settings modal render cleanly with no console errors and no per-account status text leaking into the calendar list.
- Full local backend-dependent Google-import state (the exact "Adding your calendar…" scenario from the bug report) could not be exercised live in this sandbox (missing `@opentelemetry/*` deps block the local backend from booting) — covered instead by targeted regression tests exercising the real status-derivation code path (see Test plan).

## Independent review

Two independent read-only review passes were run against the diff (neither given the implementation's own conclusions):

1. First pass caught a real bug: `SidebarStatusBar` called `getSidebarSyncStatus` without a `connection`, so a routine incremental catch-up on an already-healthy account collapsed to the same aggregate `"IMPORTING"` state as a brand-new import, and would have shown "Adding your calendar…" during normal reconciliation. Fixed by threading the resolved connection through (`useConnectGoogle()`'s `connection` field) so `lastHealthyAt` correctly distinguishes "already established" from "first import." Re-reviewed and confirmed fixed, with a regression test added.
2. A second, later fresh pass over the final 3-commit diff found no further issues — confirmed internally consistent (no leftover assertions against removed inline status text, no accessibility/focus regressions in the Settings modal's Log out button, no ESC/dismiss conflicts with the stacked logout confirmation dialog).

## Test plan

- `bunx typescript@7.0.2 -p packages/web/tsconfig.app.json --noEmit` — clean.
- `./node_modules/.bin/biome check <changed files>` — clean.
- `bun run test:web` (full suite) — 1741 pass, 0 fail.
- Targeted regression tests added/updated: `SidebarStatusBar.test.tsx` (aggregate status shown for first import, stays quiet during routine catch-up, "Saving changes…" precedence), `AccountSectionHeader.test.tsx`, `CalendarListHeader.test.tsx`, `CalendarList.test.tsx` (inline status text removed, wave-shimmer email color retained), `SettingsModal.test.tsx` (Log out shown/hidden by auth state, opens confirmation).