### PR TITLE
fix(web): flush local events onto Google, not the local calendar, at connect time

### DIFF
--- a/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.ts
+++ b/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.ts
@@ -7,7 +7,6 @@ import {
   refreshGoogleSync,
   useIsGoogleSyncRefreshInFlight,
 } from "@web/auth/google/state/google.sync.refresh";
-import { syncPendingLocalEvents } from "@web/auth/google/util/google.auth.util";
 import {
   selectPrimaryGoogleSyncConnection,
   useUserMetadataStore,
@@ -73,19 +72,16 @@ export const useConnectGoogle = (
       return;
     }
 
-    // Show loading on the sidebar/command action immediately — local-event
-    // flush and beginGoogleConnection both run before the OAuth redirect.
+    // Show loading on the sidebar/command action immediately —
+    // beginGoogleConnection runs before the OAuth redirect. Any local events
+    // still in IndexedDB stay there across the redirect and flush once the
+    // callback lands and a Google calendar exists to target (see
+    // useCompleteAuthentication) — flushing here would have no Google
+    // calendar yet and land events on the local calendar instead.
     isConnectingRef.current = true;
     setIsConnecting(true);
 
     const start = async () => {
-      const didSyncLocalEvents = await syncPendingLocalEvents();
-
-      if (!didSyncLocalEvents) {
-        stopConnecting();
-        return;
-      }
-
       settingsActions.closeCmdPalette();
 
       // The sync service owns the OAuth round-trip, so the browser just

--- a/packages/web/src/common/utils/sync/local-event-sync.util.test.ts
+++ b/packages/web/src/common/utils/sync/local-event-sync.util.test.ts
@@ -21,6 +21,36 @@ const syncLocalEventsToCloud = createSyncLocalEventsToCloud({
 });
 
 const SERVER_LOCAL_CALENDAR_ID = "aaaaaaaaaaaaaaaaaaaaaaaa";
+const GOOGLE_PRIMARY_CALENDAR_ID = "bbbbbbbbbbbbbbbbbbbbbbbb";
+
+const localCalendar = {
+  id: SERVER_LOCAL_CALENDAR_ID,
+  name: "Local",
+  description: "",
+  timeZone: null,
+  foregroundColor: "#000000",
+  backgroundColor: "#ffffff",
+  provider: "local",
+  access: "owner",
+  capabilities: {
+    canReadAvailability: true,
+    canReadDetails: true,
+    canWrite: true,
+    canManage: false,
+    canWatchEvents: false,
+  },
+  isPrimary: true,
+  isVisible: true,
+  isActive: true,
+} as const;
+
+const googlePrimaryCalendar = {
+  ...localCalendar,
+  id: GOOGLE_PRIMARY_CALENDAR_ID,
+  name: "person@example.com",
+  provider: "google",
+  accountEmail: "person@example.com",
+} as const;
 
 describe("syncLocalEventsToCloud", () => {
   beforeEach(() => {
@@ -30,28 +60,7 @@ describe("syncLocalEventsToCloud", () => {
     deleteEvent.mockClear();
     createEvent.mockClear();
     listCalendars.mockClear();
-    listCalendars.mockResolvedValue([
-      {
-        id: SERVER_LOCAL_CALENDAR_ID,
-        name: "Local",
-        description: "",
-        timeZone: null,
-        foregroundColor: "#000000",
-        backgroundColor: "#ffffff",
-        provider: "local",
-        access: "owner",
-        capabilities: {
-          canReadAvailability: true,
-          canReadDetails: true,
-          canWrite: true,
-          canManage: false,
-          canWatchEvents: false,
-        },
-        isPrimary: true,
-        isVisible: true,
-        isActive: true,
-      },
-    ]);
+    listCalendars.mockResolvedValue([localCalendar]);
   });
 
   it("syncs user-created events and skips demo events, mapping onto the server local calendar", async () => {
@@ -70,6 +79,20 @@ describe("syncLocalEventsToCloud", () => {
     );
     expect(deleteEvent).toHaveBeenCalledWith(userRecord.id);
     expect(clearAllEvents).toHaveBeenCalledTimes(1);
+  });
+
+  it("maps onto the connected Google calendar instead of the local one, when one exists", async () => {
+    listCalendars.mockResolvedValue([localCalendar, googlePrimaryCalendar]);
+    const userRecord = createMockLocalEventRecord({}, false);
+    getAllEvents.mockResolvedValue([userRecord]);
+
+    await expect(syncLocalEventsToCloud()).resolves.toBe(1);
+
+    expect(createEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        calendarId: GOOGLE_PRIMARY_CALENDAR_ID,
+      }),
+    );
   });
 
   it("defaults location to an empty string for a record that predates the field", async () => {

--- a/packages/web/src/common/utils/sync/local-event-sync.util.ts
+++ b/packages/web/src/common/utils/sync/local-event-sync.util.ts
@@ -2,7 +2,7 @@ import { type CreateEventInput } from "@core/types/event-command.contracts";
 import dayjs from "@core/util/date/dayjs";
 import { looksLikeOccurrenceId } from "@core/util/occurrence-id";
 import { CalendarApi } from "@web/api/calendar.api";
-import { getLocalCalendar } from "@web/calendars/calendar.util";
+import { getDefaultTargetCalendar } from "@web/calendars/calendar.util";
 import { type OfflineDataStore } from "@web/common/storage/offline-data/offline-data.store";
 import {
   ensureOfflineDataStoreReady,
@@ -48,11 +48,11 @@ function exdateLines(
 }
 
 // Maps a locally-stored record (calendarId = the client-generated sentinel)
-// onto the server's own local calendar id, preserving the client-generated
-// event id.
+// onto the resolved target calendar id, preserving the client-generated event
+// id.
 function toCreateInput(
   record: LocalEventRecord,
-  serverLocalCalendarId: string,
+  targetCalendarId: string,
 ): CreateEventInput {
   const recurrence = record.event.recurrence;
   const allDay = record.event.schedule.kind === "allDay";
@@ -72,7 +72,7 @@ function toCreateInput(
     // series expansion) aren't valid server ids - let the backend generate
     // one instead of rejecting the POST.
     id: looksLikeOccurrenceId(record.event.id) ? undefined : record.event.id,
-    calendarId: serverLocalCalendarId as CreateEventInput["calendarId"],
+    calendarId: targetCalendarId as CreateEventInput["calendarId"],
     schedule: record.event.schedule,
     recurrence:
       recurrence.kind === "series"
@@ -110,20 +110,25 @@ export function createSyncLocalEventsToCloud({
 
     if (recordsToSync.length > 0) {
       const calendars = await listCalendars();
-      const serverLocalCalendar = getLocalCalendar(calendars);
+      // A connected Google account's primary calendar wins over the local
+      // calendar so promoted events land on the provider the user actually
+      // connected, not on the calendar the sidebar is trying to stop showing.
+      // Falls back to local for anonymous/password-only sign-in, where it's
+      // still the only writable calendar there is.
+      const targetCalendar = getDefaultTargetCalendar(calendars);
 
       // Never fall back to the client-generated sentinel calendar id: the
       // backend can't resolve it and rejects the POST with CALENDAR_NOT_FOUND
-      // (a 404 that used to sign the just-signed-up user out). When the
-      // server-side local calendar isn't available yet, keep the records
-      // on-device - untouched, so a later sync can push them onto the real
-      // calendar - rather than losing them to a rejected request.
-      if (!serverLocalCalendar) {
+      // (a 404 that used to sign the just-signed-up user out). When no
+      // writable calendar is available yet, keep the records on-device -
+      // untouched, so a later sync can push them onto the real calendar -
+      // rather than losing them to a rejected request.
+      if (!targetCalendar) {
         return 0;
       }
 
       for (const record of recordsToSync) {
-        await createEvent(toCreateInput(record, serverLocalCalendar.id));
+        await createEvent(toCreateInput(record, targetCalendar.id));
         // Drop each promoted row immediately so a mid-batch interrupt does not
         // re-POST already-cloud events on the next resume.
         await store.deleteEvent(record.id);


### PR DESCRIPTION
## Summary
- `useConnectGoogle` flushed IndexedDB events *before* the OAuth redirect, when no Google calendar exists yet — so `syncLocalEventsToCloud` had no choice but to hardcode the local calendar as the flush target.
- That ordering is what deposits new events on the local calendar for exactly the users the local-calendar-visibility project is trying to stop showing an orphan sidebar row to (see internal project doc, LCV1).
- Removed the pre-redirect flush. Local events already survive the redirect in IndexedDB and now flush via the existing post-callback path (`useCompleteAuthentication`, called from `GoogleAuthCallbackView`), by which point the Google calendar exists.
- `syncLocalEventsToCloud` now resolves its target with `getDefaultTargetCalendar` instead of `getLocalCalendar`, so it lands on the connected Google primary when one exists, and falls back to local otherwise (anonymous / password-only sign-in — unchanged behavior there).

## Test plan
- [x] `bun test local-event-sync.util.test.ts` — 8/8 pass, including a new case asserting events map onto the connected Google calendar when one exists
- [x] `bun test useConnectGoogle.scope.test.tsx useCompleteAuthentication.test.ts` — 5/5 pass, unaffected by the call-site removal
- [x] `bun run type-check` — clean
- [x] `biome check` on changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)