### PR TITLE
fix(web): exclude local calendar from writable set once an account is connected

### DIFF
--- a/packages/web/src/calendars/calendar.util.test.ts
+++ b/packages/web/src/calendars/calendar.util.test.ts
@@ -4,6 +4,7 @@ import {
   compareCalendars,
   getDefaultTargetCalendar,
   getLocalCalendar,
+  getWritableCalendars,
   groupCalendarsByAccount,
   spansMultipleAccounts,
 } from "./calendar.util";
@@ -46,6 +47,39 @@ describe("getLocalCalendar", () => {
   it("returns undefined when there is no local calendar", () => {
     const google = makeCalendar({ provider: "google" });
     expect(getLocalCalendar([google])).toBeUndefined();
+  });
+});
+
+describe("getWritableCalendars", () => {
+  it("includes the local calendar when no account is connected", () => {
+    const local = makeCalendar({ provider: "local" });
+    expect(getWritableCalendars([local])).toEqual([local]);
+  });
+
+  it("excludes a non-writable or inactive calendar regardless of connection state", () => {
+    const readOnly = makeCalendar({
+      provider: "google",
+      capabilities: {
+        canReadAvailability: true,
+        canReadDetails: true,
+        canWrite: false,
+        canManage: false,
+        canWatchEvents: false,
+      },
+    });
+    const inactive = makeCalendar({ provider: "google", isActive: false });
+    expect(getWritableCalendars([readOnly, inactive])).toEqual([]);
+  });
+
+  it("drops the local calendar once an account is connected", () => {
+    const local = makeCalendar({ provider: "local" });
+    const google = makeCalendar({
+      provider: "google",
+      id: "507f1f77bcf86cd799439012" as Calendar["id"],
+    });
+    expect(
+      getWritableCalendars([local, google], { hasConnectedAccount: true }),
+    ).toEqual([google]);
   });
 });
 

--- a/packages/web/src/calendars/calendar.util.ts
+++ b/packages/web/src/calendars/calendar.util.ts
@@ -5,15 +5,37 @@ export function getLocalCalendar(calendars: Calendar[]): Calendar | undefined {
   return calendars.find((calendar) => calendar.provider === "local");
 }
 
+export interface GetWritableCalendarsOptions {
+  /**
+   * True once any account is connected. The local calendar then drops out of
+   * the writable set - a connected user's events belong on a provider
+   * calendar, and this is the prerequisite that makes it safe to stop
+   * rendering the local calendar's sidebar row (see
+   * local-calendar-visibility LCV2/LCV3). Derive this from connection state
+   * (e.g. useConnectedAccountEmails().length > 0), never from calendar rows:
+   * a just-disconnected account's Google calendars can still be present for
+   * a retention window after the connection itself is gone.
+   */
+  hasConnectedAccount?: boolean;
+}
+
 /**
  * Calendars offered as a create target: a reader/freeBusy-only calendar
  * would silently fail to accept a new event. Shared by the event form's
  * picker and the Settings default-calendar picker, which offer the same set
  * for the same reason.
  */
-export function getWritableCalendars(calendars: Calendar[]): Calendar[] {
+export function getWritableCalendars(
+  calendars: Calendar[],
+  options: GetWritableCalendarsOptions = {},
+): Calendar[] {
+  const { hasConnectedAccount = false } = options;
+
   return calendars.filter(
-    (calendar) => calendar.isActive && calendar.capabilities.canWrite,
+    (calendar) =>
+      calendar.isActive &&
+      calendar.capabilities.canWrite &&
+      (!hasConnectedAccount || calendar.provider !== "local"),
   );
 }
 

--- a/packages/web/src/components/Settings/SettingsModal.test.tsx
+++ b/packages/web/src/components/Settings/SettingsModal.test.tsx
@@ -345,9 +345,29 @@ describe("SettingsModal", () => {
     ).toBeInTheDocument();
   });
 
-  it("lists the local calendar after the account groups, not before", () => {
+  it("lists the local calendar after the account groups when no account is connected", () => {
     // The sidebar renders account sections first and the local/ungrouped
-    // calendar last; this picker used to disagree.
+    // calendar last; this picker used to disagree. With no account connected
+    // the local calendar is still a legitimate writable target (see the next
+    // test for the connected case).
+    const work = createMockCalendar({
+      name: "Work",
+      accountEmail: "ahab@pequod.com",
+    });
+    const local = createMockCalendar({ name: "Compass", provider: "local" });
+
+    renderSettings({ connections: [], calendars: [work, local] });
+
+    const options = screen
+      .getAllByRole("option")
+      .map((option) => option.textContent);
+    expect(options).toEqual(["Work", "Compass"]);
+  });
+
+  it("excludes the local calendar once an account is connected", () => {
+    // Once any account is connected, new events belong on a provider
+    // calendar - the local calendar drops out of the writable set entirely
+    // rather than sorting last (local-calendar-visibility LCV2).
     const work = createMockCalendar({
       name: "Work",
       accountEmail: "ahab@pequod.com",
@@ -359,7 +379,7 @@ describe("SettingsModal", () => {
     const options = screen
       .getAllByRole("option")
       .map((option) => option.textContent);
-    expect(options).toEqual(["Work", "Compass"]);
+    expect(options).toEqual(["Work"]);
   });
 
   it("badges the account that owns the default calendar", () => {

--- a/packages/web/src/components/Settings/SettingsModal.tsx
+++ b/packages/web/src/components/Settings/SettingsModal.tsx
@@ -78,9 +78,9 @@ export const SettingsModal: FC = () => {
   const { data } = useCalendarsQuery();
   const connections = useUserMetadataStore(selectGoogleSyncConnections);
   const accountEmailOrder = useConnectedAccountEmails();
-  const writableCalendars = getWritableCalendars(data ?? []).sort(
-    compareCalendars(accountEmailOrder),
-  );
+  const writableCalendars = getWritableCalendars(data ?? [], {
+    hasConnectedAccount: accountEmailOrder.length > 0,
+  }).sort(compareCalendars(accountEmailOrder));
   const resolvedDefault = useDefaultTargetCalendar(writableCalendars);
 
   if (!isOpen) return null;

--- a/packages/web/src/views/Forms/EventForm/CalendarSelect/CalendarSelect.tsx
+++ b/packages/web/src/views/Forms/EventForm/CalendarSelect/CalendarSelect.tsx
@@ -65,9 +65,9 @@ export const CalendarSelect = ({
 }: CalendarSelectProps) => {
   const { data } = useCalendarsQuery();
   const accountEmailOrder = useConnectedAccountEmails();
-  const writableCalendars = getWritableCalendars(data ?? []).sort(
-    compareCalendars(accountEmailOrder),
-  );
+  const writableCalendars = getWritableCalendars(data ?? [], {
+    hasConnectedAccount: accountEmailOrder.length > 0,
+  }).sort(compareCalendars(accountEmailOrder));
   // Only disambiguate by account when there is something to disambiguate.
   const showAccount = spansMultipleAccounts(writableCalendars);
   const [isOpen, setIsOpen] = useState(false);


### PR DESCRIPTION
## Summary
- `getWritableCalendars` fed the event form's create-target picker and the Settings default-calendar picker off `isActive && capabilities.canWrite` alone, so the local "Compass" calendar stayed selectable forever, even after a real account was connected.
- This is doc-prerequisite 2 for the local-calendar-visibility project (LCV2): the local calendar must stop being a write target before the sidebar row can safely disappear (LCV3).
- Added an optional `hasConnectedAccount` flag to `getWritableCalendars`, threaded in from `useConnectedAccountEmails()` (the user-metadata store) at both call sites (`SettingsModal`, `CalendarSelect`).
- Deliberately **not** derived from the calendar list itself: a just-disconnected account's Google calendar rows can still be present for a retention window after the connection itself is gone (see `connection-retention.service.ts` in `packages/sync`), so scanning `calendars` for `provider === "google"` would misfire during that window and hide the local calendar's write path right when the user needs it back.
- `getDefaultTargetCalendar` already falls back gracefully when a stored default preference stops resolving to a writable calendar, so no change was needed there.

## Test plan
- [x] `bun test calendar.util.test.ts` — new `getWritableCalendars` coverage (connected/unconnected/inactive/read-only cases)
- [x] `bun test SettingsModal.test.tsx CalendarSelect.test.tsx` — updated the one pre-existing test whose fixture assumed local stays selectable while connected; all 49 tests across the three files pass
- [x] `bun run type-check` — clean
- [x] `biome check` on changed files — clean

Part of the local-calendar-visibility project (LCV2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)