### PR TITLE
fix(web): hide the local calendar sidebar row once an account is connected

### DIFF
--- a/packages/web/src/components/Sidebar/CalendarList/CalendarList.test.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarList.test.tsx
@@ -482,7 +482,22 @@ describe("CalendarList", () => {
     ).toHaveAttribute("aria-expanded", "true");
   });
 
-  it("leaves the local calendar outside the account sections", () => {
+  it("leaves the local calendar outside the account sections when no account is connected", () => {
+    const local = makeCalendar({ name: "Compass", provider: "local" });
+
+    renderCalendarList([local], { connections: [] });
+
+    expect(screen.getByText("Compass")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("region", { name: /^Calendars for/ }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides the local calendar entirely once any account is connected", () => {
+    // Once connected, the local calendar can no longer gain new events
+    // (LCV1/LCV2) and stops explaining itself the way an account-owned
+    // calendar does - drop the orphan row rather than render it alongside
+    // real accounts (local-calendar-visibility LCV3).
     const work = makeCalendar({
       name: "Work",
       accountEmail: "ahab@pequod.com",
@@ -500,7 +515,7 @@ describe("CalendarList", () => {
       ],
     });
 
-    expect(screen.getByText("Compass")).toBeInTheDocument();
+    expect(screen.queryByText("Compass")).not.toBeInTheDocument();
     for (const email of ["ahab@pequod.com", "ahab@gmail.com"]) {
       expect(
         within(
@@ -543,7 +558,7 @@ describe("CalendarList", () => {
     expect(screen.getByText("Work")).toBeInTheDocument();
   });
 
-  it("keeps the ungrouped local calendar visible regardless of account collapse state", async () => {
+  it("keeps the local calendar hidden regardless of account collapse state", async () => {
     const work = makeCalendar({
       name: "Work",
       accountEmail: "ahab@pequod.com",
@@ -565,7 +580,7 @@ describe("CalendarList", () => {
     await user.click(screen.getByRole("button", { name: "ahab@pequod.com" }));
     await user.click(screen.getByRole("button", { name: "ahab@gmail.com" }));
 
-    expect(screen.getByText("Compass")).toBeInTheDocument();
+    expect(screen.queryByText("Compass")).not.toBeInTheDocument();
   });
 
   it("renders no placeholder text while calendars are pending, to avoid a layout shift once they load", () => {

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarList.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarList.tsx
@@ -30,14 +30,28 @@ export const CalendarList: FC = () => {
   const accountEmailOrder = useConnectedAccountEmails();
   const collapsedKeys = useCollapsedAccountKeys();
 
+  const hasConnectedAccount = accountEmailOrder.length > 0;
+
   // Re-groups on every calendar-visibility/collapse toggle otherwise, since
   // those live in sibling external stores this component also subscribes to.
   const calendars = useMemo(
     () =>
       (data ?? [])
-        .filter((calendar) => calendar.isActive)
+        .filter(
+          (calendar) =>
+            calendar.isActive &&
+            // Once any account is connected, the local calendar can no
+            // longer gain new events (LCV1/LCV2 close off both the ways it
+            // could) and no longer explains itself to the user the way an
+            // account-owned calendar does - drop its orphan row rather than
+            // show it. Gated on connection state, not on the calendar being
+            // empty: nothing can write to it anymore, and prod carries zero
+            // connected users with events already on it (see
+            // local-calendar-visibility LCV3).
+            (!hasConnectedAccount || calendar.provider !== "local"),
+        )
         .sort(compareCalendars(accountEmailOrder)),
-    [data, accountEmailOrder],
+    [data, accountEmailOrder, hasConnectedAccount],
   );
   const { groups, ungrouped } = useMemo(
     () => groupCalendarsByAccount(calendars, connections),


### PR DESCRIPTION
## Summary
- The sidebar rendered the local "Compass" calendar unconditionally: it has no `accountEmail`, so `groupCalendarsByAccount` always dropped it into the "ungrouped" bucket and `CalendarList` rendered it regardless of connection state. For a connected user this read as an unexplained duplicate calendar mapping to nothing they ever configured.
- Filters it out of `CalendarList`'s calendar list once any account is connected (`useConnectedAccountEmails().length > 0`) - the same signal [#2609](https://github.com/SwitchbackTech/compass-calendar/pull/2609) (LCV2) uses.
- Gated on connection state, not on the local calendar being empty: [#2605](https://github.com/SwitchbackTech/compass-calendar/pull/2605) (LCV1) stopped new events landing there and #2609 (LCV2) closed it off as a write target, so nothing can put an event on it once connected - and a read-only prod query found zero connected users with existing events on it. A user who somehow keeps one there simply keeps the row; nothing is deleted or migrated.

## Test plan
- [x] `bun test CalendarList.test.tsx` — 20/20 pass. Two pre-existing tests asserted the row stays visible alongside connected accounts (exactly the orphan-row behavior this project removes) — updated both to assert it's hidden, and added coverage for the still-visible unconnected case.
- [x] `bun run type-check` — clean
- [x] `biome check` on changed files — clean
- [ ] Not verified against a live preview — the offset dev ports in this worktree need a Mongo user flip per prior session notes, and the RTL suite exercises the exact render logic (grouping, collapse state, empty state) end to end.

Part of the local-calendar-visibility project (LCV3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)