### PR TITLE
fix(web): relabel the local calendar row via its existing account heading

### DIFF
--- a/packages/web/src/components/Sidebar/CalendarList/CalendarList.test.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarList.test.tsx
@@ -207,10 +207,12 @@ describe("CalendarList", () => {
     expect(screen.queryByText("ahab@pequod.com")).not.toBeInTheDocument();
   });
 
-  it("keeps the local sentinel's own name for anonymous sessions (still toggleable)", () => {
-    // The anonymous synthesized local calendar is isPrimary, but must not be
-    // relabeled "primary" - the header shows "Temporary account", not its name.
-    // Visibility is client-owned, so the toggle stays available offline.
+  it("relabels the local sentinel row as 'primary' for anonymous sessions (still toggleable)", () => {
+    // CalendarListHeader's own heading ("This browser") already names the
+    // account for this row, same as any other primary calendar's account
+    // section header - so the row abbreviates like every other primary
+    // calendar. Visibility is client-owned, so the toggle stays available
+    // offline.
     const local = makeCalendar({
       name: "Compass",
       provider: "local",
@@ -219,10 +221,10 @@ describe("CalendarList", () => {
 
     renderCalendarList([local], { authenticated: false });
 
-    expect(screen.getByText("Compass")).toBeInTheDocument();
-    expect(screen.queryByText("primary")).not.toBeInTheDocument();
+    expect(screen.getByText("primary")).toBeInTheDocument();
+    expect(screen.queryByText("Compass")).not.toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "Hide Compass calendar" }),
+      screen.getByRole("button", { name: "Hide primary calendar" }),
     ).toBeInTheDocument();
   });
 

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarList.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarList.tsx
@@ -133,14 +133,13 @@ const CalendarRow: FC<{
   calendar: Calendar;
   onToggle: (calendarId: Calendar["id"], isVisible: boolean) => void;
 }> = ({ calendar, onToggle }) => {
-  // The account heading above the row already names the account, so a primary
-  // calendar's row reads "primary" instead of repeating it. The local sentinel
-  // is also isPrimary, but a lone "primary" row under a "Temporary account"
-  // header reads wrong - keep its own name.
-  const displayName =
-    calendar.isPrimary && calendar.provider !== "local"
-      ? "primary"
-      : calendar.name;
+  // The heading above the row already names the account - the signed-in
+  // user's email, or CalendarListHeader's "This browser" for anonymous - so a
+  // primary calendar's row reads "primary" instead of repeating it. The local
+  // sentinel is also isPrimary and gets no exception: it only ever renders
+  // once connected accounts have none (LCV3), so CalendarListHeader is always
+  // the row's heading, never a per-account section.
+  const displayName = calendar.isPrimary ? "primary" : calendar.name;
 
   return (
     <li className="flex min-w-0 items-center gap-1">

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarListHeader.test.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarListHeader.test.tsx
@@ -116,10 +116,10 @@ describe("CalendarListHeader", () => {
     renderHeader();
 
     expect(
-      screen.getByRole("heading", { name: "Saved on this device" }),
+      screen.getByRole("heading", { name: "This browser" }),
     ).toBeInTheDocument();
     const trigger = screen.getByRole("button", {
-      name: "Saved on this device",
+      name: "This browser",
     });
     expect(trigger).toHaveClass("text-text");
     expect(trigger).not.toHaveClass("c-sync-text-wave");
@@ -140,7 +140,7 @@ describe("CalendarListHeader", () => {
     renderHeader();
 
     const trigger = screen.getByRole("button", {
-      name: "Saved on this device",
+      name: "This browser",
     });
     expect(trigger).toHaveClass("c-sync-text-wave");
     expect(trigger).not.toHaveClass("text-text");
@@ -151,9 +151,7 @@ describe("CalendarListHeader", () => {
 
     renderHeader();
 
-    await user.click(
-      screen.getByRole("button", { name: "Saved on this device" }),
-    );
+    await user.click(screen.getByRole("button", { name: "This browser" }));
     expect(mockOpenModal).toHaveBeenCalledWith("signUp");
   });
 

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarListHeader.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarListHeader.tsx
@@ -57,7 +57,7 @@ const AnonymousAccountHeader: FC = () => {
     shouldShowAnonymousCalendarChangeSignUpPrompt,
     shouldShowAnonymousCalendarChangeSignUpPrompt,
   );
-  const accountLabel = "Saved on this device";
+  const accountLabel = "This browser";
   const handleOpenSignUp = useCallback(() => {
     openModal("signUp");
   }, [openModal]);


### PR DESCRIPTION
## Summary
- The local calendar's sidebar row kept its own name ("Compass") instead of relabeling to "primary" the way every other primary calendar's row does once its account heading names the account. The exception existed because the heading above it used to say a generic "Temporary account" - a bare "primary" underneath that would have read wrong.
- That heading (`CalendarListHeader`) no longer says anything generic: whenever no account is connected (the only population LCV3 leaves this row visible for), it already shows the signed-in user's own email, or an anonymous label, right above the local row.
- Renamed the anonymous label from "Saved on this device" to **"This browser"**, matching the local-calendar-visibility decision log.
- Removed the local-provider exception in `CalendarRow` so its row now reads "primary" like every other primary calendar - the heading above it already names the account, so repeating "Compass" was the last vestige of the local calendar looking like a second, unexplained calendar rather than the account's own.
- Design note: the original plan described the *row itself* carrying the email/"This browser" text. Implementing it, `CalendarListHeader` turned out to already show exactly that identity for this population - so putting it on the row too would have doubled the same text back-to-back. Went with the existing "primary" convention instead, which achieves the same outcome (no more "Compass" read as an orphan) without the duplication. Doc updated to match.

## Test plan
- [x] `bun test CalendarList.test.tsx CalendarListHeader.test.tsx` — 38/38 pass; updated the two tests whose fixtures asserted the old "Compass" text and the old anonymous-label string
- [x] `bun run type-check` — clean
- [x] `biome check` on changed files — clean
- [ ] Not verified against a live preview, per the same worktree constraint as #2610

Part of the local-calendar-visibility project (LCV4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)