### PR TITLE
test(web): verify disconnect restores the local calendar as a target and row

### DIFF
--- a/packages/web/src/components/Settings/SettingsModal.test.tsx
+++ b/packages/web/src/components/Settings/SettingsModal.test.tsx
@@ -382,6 +382,47 @@ describe("SettingsModal", () => {
     expect(options).toEqual(["Work"]);
   });
 
+  it("restores the local calendar as a writable target once the only connected account is disconnected", async () => {
+    // ensureLocalCalendar exists precisely so a disconnected user never loses
+    // every writable calendar - LCV2's exclusion must lift the moment the
+    // account it depends on is gone, not stay stuck excluding a calendar
+    // nothing else can write to (local-calendar-visibility LCV5).
+    const disconnect = spyOn(
+      AuthApi,
+      "disconnectGoogleConnection",
+    ).mockResolvedValue(undefined);
+
+    const work = createMockCalendar({
+      name: "Work",
+      accountEmail: "ahab@pequod.com",
+    });
+    const local = createMockCalendar({ name: "Compass", provider: "local" });
+
+    const user = userEvent.setup({ delay: null });
+    renderSettings({ calendars: [work, local] });
+
+    expect(
+      screen.getAllByRole("option").map((option) => option.textContent),
+    ).toEqual(["Work"]);
+
+    await user.click(
+      screen.getByRole("button", { name: "Disconnect ahab@pequod.com" }),
+    );
+    await user.click(
+      screen.getByRole("button", {
+        name: "Confirm disconnecting ahab@pequod.com",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getAllByRole("option").map((option) => option.textContent),
+      ).toEqual(["Compass"]);
+    });
+
+    disconnect.mockRestore();
+  });
+
   it("badges the account that owns the default calendar", () => {
     const work = createMockCalendar({
       name: "Work",

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarList.test.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarList.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, within } from "@testing-library/react";
+import { act, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import {
   type Calendar,
@@ -525,6 +525,33 @@ describe("CalendarList", () => {
         ).queryByText("Compass"),
       ).not.toBeInTheDocument();
     }
+  });
+
+  it("un-hides the local calendar once the only connected account disconnects", () => {
+    // ensureLocalCalendar exists precisely so a disconnected user never loses
+    // every writable calendar - the row LCV3 hides must come back the moment
+    // its precondition (a connected account) stops holding, not stay stuck
+    // hidden with no calendar left to show instead. useDisconnectGoogleAccount
+    // calls userMetadataActions.removeConnection synchronously on success,
+    // before its network refetch even resolves - simulate exactly that,
+    // rather than the eventual refetch, since the row must not wait on it
+    // (local-calendar-visibility LCV5).
+    const work = makeCalendar({
+      name: "Work",
+      accountEmail: "ahab@pequod.com",
+    });
+    const local = makeCalendar({ name: "Compass", provider: "local" });
+    const onlyConnection = makeConnection("ahab@pequod.com");
+
+    renderCalendarList([work, local], { connections: [onlyConnection] });
+
+    expect(screen.queryByText("Compass")).not.toBeInTheDocument();
+
+    act(() => {
+      userMetadataActions.removeConnection(onlyConnection.id);
+    });
+
+    expect(screen.getByText("Compass")).toBeInTheDocument();
   });
 
   it("collapses and re-expands an account's calendar rows on heading click", async () => {


### PR DESCRIPTION
## Summary
- LCV2 and LCV3 ([#2609](https://github.com/SwitchbackTech/compass-calendar/pull/2609), [#2610](https://github.com/SwitchbackTech/compass-calendar/pull/2610)) both gate on `useConnectedAccountEmails().length > 0`, which reads the same user-metadata store `useDisconnectGoogleAccount` already updates optimistically (`userMetadataActions.removeConnection`) before its network refetch resolves - so both should already un-gate automatically the moment the only connected account disconnects.
- This was the failure mode the project doc flagged hardest: `ensureLocalCalendar` exists specifically to prevent `CALENDAR_NOT_FOUND` once nothing else is writable, so it gets an explicit regression test rather than an inferred guarantee (LCV5).
- **No production code changed** - both tests pass against the code as it landed in #2609/#2610.

## What's covered
- `SettingsModal.test.tsx`: after confirming a real disconnect (via the existing disconnect-confirmation flow, `AuthApi` mocked), the local calendar reappears as the only option in the default-calendar/create-target picker.
- `CalendarList.test.tsx`: after `userMetadataActions.removeConnection` fires - the exact call the disconnect hook makes - the sidebar row reappears without waiting on any refetch.

## Test plan
- [x] `bun test CalendarList.test.tsx SettingsModal.test.tsx` — 39/39 pass
- [x] `bun run type-check` — clean
- [x] `biome check` on changed files — clean

This closes out the local-calendar-visibility project (LCV1-LCV5 all shipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)