### PR TITLE
fix(web): read the real end time for midnight-spanning Up Next events

### DIFF
--- a/packages/web/src/components/Sidebar/UpNextCard/UpNextCard.test.tsx
+++ b/packages/web/src/components/Sidebar/UpNextCard/UpNextCard.test.tsx
@@ -23,7 +23,14 @@ import { calendarQueryKeys } from "@web/calendars/calendar.query";
 import { setCalendarVisibility } from "@web/calendars/calendar-visibility.store";
 import { draftActions, useDraftStore } from "@web/events/stores/draft.store";
 import { formatStartsIn, UpNextCard } from "./UpNextCard";
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  setSystemTime,
+} from "bun:test";
 import "@testing-library/jest-dom";
 
 const SOON_EVENT_ID = "aaaaaaaaaaaaaaaaaaaaaaaa";
@@ -228,5 +235,46 @@ describe("UpNextCard", () => {
     });
 
     expect(screen.queryByRole("link", { name: "Join" })).toBeNull();
+  });
+});
+
+// A timed event that crosses midnight is projected into the all-day row with
+// whole-calendar-day dates, so its endDate no longer says when it actually
+// ends. The card has to read the real end off the source schedule, or every
+// such event looks like it is still running until midnight. The clock is
+// pinned because that projection only kicks in while "now" and "30 minutes
+// ago" fall on different calendar days.
+describe("UpNextCard across midnight", () => {
+  const JUST_AFTER_MIDNIGHT = new Date("2026-08-06T00:13:00.000Z");
+
+  afterEach(() => {
+    setSystemTime();
+  });
+
+  it("stays all-clear for a midnight-spanning event that already ended", () => {
+    setSystemTime(JUST_AFTER_MIDNIGHT);
+
+    // 23:35 -> 00:05, so it crossed midnight and ended 8 minutes ago.
+    render(<UpNextCard />, {
+      events: [timedEvent(SOON_EVENT_ID, "Ended Event", -38)],
+    });
+
+    expect(screen.getByText("All clear")).toBeInTheDocument();
+    expect(screen.queryByText("Ended Event")).toBeNull();
+  });
+
+  it("shows a midnight-spanning event that is still underway as Now", () => {
+    setSystemTime(JUST_AFTER_MIDNIGHT);
+
+    // 23:45 -> 00:15, so it crossed midnight and has 2 minutes left.
+    render(<UpNextCard />, {
+      events: [timedEvent(SOON_EVENT_ID, "Running Event", -28)],
+    });
+
+    expect(
+      screen.getByRole("button", { name: /now: running event/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Running Event")).toBeInTheDocument();
+    expect(screen.getByText("Now")).toBeInTheDocument();
   });
 });

--- a/packages/web/src/components/Sidebar/UpNextCard/useUpNextEvent.ts
+++ b/packages/web/src/components/Sidebar/UpNextCard/useUpNextEvent.ts
@@ -23,12 +23,21 @@ export function useUpNextEvent() {
     startDate,
     endDate,
   });
+  // Restore the real timed bounds: the all-day-row projection rewrites both
+  // dates to whole calendar days, and a date-only endDate would keep a
+  // finished event looking like it is still running until midnight.
   const multiDayTimed = allDayEvents
     .filter((event) => event.isTimedMultiDayDisplay)
     .flatMap((gridEvent) => {
       const source = events.find((event) => event.id === gridEvent._id);
       if (!source || source.schedule.kind !== "timed") return [];
-      return [{ ...gridEvent, startDate: source.schedule.start }];
+      return [
+        {
+          ...gridEvent,
+          startDate: source.schedule.start,
+          endDate: source.schedule.end,
+        },
+      ];
     });
   const allTimedEvents = [...timedEvents, ...multiDayTimed];
 


### PR DESCRIPTION
## Summary

Fixes the `unit (web)` failure #2608 left on `main` ([run 31058958298](https://github.com/SwitchbackTech/compass-calendar/actions/runs/31058958298)), and the real bug behind it.

A timed event that crosses midnight is projected into the all-day row by `multiDayTimedAsAllDayFrom`, which rewrites both dates to whole calendar days — its `endDate` becomes the exclusive last day it covers, not when it ends. `useUpNextEvent` restored the real `startDate` from the source schedule but left that date-only `endDate` in place. That was harmless while the hook only looked at `startDate`, but #2608's new "Now" filter compares `endDate` against `now`, so a midnight-spanning event that ended minutes ago read as "still running until midnight": it showed as **Now** instead of ending, and the all-clear state never appeared.

The failing test (`keeps its slot with an all-clear state when today has no upcoming timed events`) builds a "Past Event" running from 30 minutes ago until now. That only crosses midnight when the suite runs between 00:00 and 00:30 — CI hit it at 00:13 UTC, which is why #2608 went green on the PR and red on `main`.

The fix restores `endDate` from the source schedule alongside `startDate`.

## Simplicity

One field added to the object already being rebuilt from the source schedule — the same restore `startDate` was already doing, for the same reason. No new filtering, no special-casing of multi-day events in the "Now" logic.

## Automated validation

Reproduced deterministically before fixing: pinning the clock to `2026-08-06T00:13:00Z` fails the existing all-clear test on unmodified `main`, matching the CI failure exactly. With the fix applied at the same pinned time, it passes.

Also verified the new regression test earns its place — reverting the hook fix while keeping the tests fails `stays all-clear for a midnight-spanning event that already ended`, and restoring it passes.

## Independent review

Traced the whole path rather than patching the test: `timedEventsFrom` drops midnight-spanning events, `multiDayTimedAsAllDayFrom` re-adds them with `timedMultiDayToAllDayDates` collapsing both dates to `YYYY-MM-DD`, and `useUpNextEvent` was restoring only one of the two. Confirmed `source.schedule.kind === "timed"` is already narrowed above the restore, so `.end` is present.

Worth noting the test was time-dependent before this change too — it only ever passed because the event ended exactly at `now`. Pinning the clock removes that fragility rather than relying on when CI happens to run.

## Test plan

```
bun run lint          # 0 errors (3 pre-existing warnings in DescriptionEditor.tsx / docker-compose.test.ts)
bun run type-check    # clean
bun run knip          # clean
bun run test:web      # 1742 pass, 0 fail
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011isJm6smu4mWedf25khmEx

---
_Generated by [Claude Code](https://claude.ai/code/session_011isJm6smu4mWedf25khmEx)_