### PR TITLE
fix(web): stop day-view all-day events rendering as slivers

### DIFF
--- a/packages/web/src/grid/components/AllDayGridRow.tsx
+++ b/packages/web/src/grid/components/AllDayGridRow.tsx
@@ -40,10 +40,10 @@ const getAllDayRowHeight = (gridOffsetTopPx: number) => {
 };
 
 /** Fixed-pixel floor so chips at EVENT_ALLDAY_ROW_HEIGHT tops are never clipped. */
-export const getAllDayRowMinHeightPx = (rowsCount: number) => {
+const getAllDayRowMinHeightPx = (rowsCount: number) => {
   const rows = Math.max(1, rowsCount);
 
-  return EVENT_ALLDAY_GAP + rows * EVENT_ALLDAY_ROW_HEIGHT + EVENT_ALLDAY_GAP;
+  return 2 * EVENT_ALLDAY_GAP + rows * EVENT_ALLDAY_ROW_HEIGHT;
 };
 
 export const AllDayGridRow: FC<AllDayRowProps> = ({

--- a/packages/web/src/grid/components/AllDayGridRow.tsx
+++ b/packages/web/src/grid/components/AllDayGridRow.tsx
@@ -10,6 +10,8 @@ import {
 } from "@web/common/constants/web.constants";
 import { type CSSVariables } from "@web/common/styles/css.types";
 import {
+  EVENT_ALLDAY_GAP,
+  EVENT_ALLDAY_ROW_HEIGHT,
   EVENT_WIDTH_MINIMUM,
   GRID_MARGIN_LEFT,
   GRID_PADDING_BOTTOM,
@@ -37,6 +39,13 @@ const getAllDayRowHeight = (gridOffsetTopPx: number) => {
   return `${gridRowHeight} / ${interval}`;
 };
 
+/** Fixed-pixel floor so chips at EVENT_ALLDAY_ROW_HEIGHT tops are never clipped. */
+export const getAllDayRowMinHeightPx = (rowsCount: number) => {
+  const rows = Math.max(1, rowsCount);
+
+  return EVENT_ALLDAY_GAP + rows * EVENT_ALLDAY_ROW_HEIGHT + EVENT_ALLDAY_GAP;
+};
+
 export const AllDayGridRow: FC<AllDayRowProps> = ({
   allDayColumnsRef,
   allDayRowRef,
@@ -56,6 +65,7 @@ export const AllDayGridRow: FC<AllDayRowProps> = ({
     onMouseDown={onMouseDown}
     style={{
       height: `calc(${getAllDayRowHeight(gridOffsetTopPx)} * 2 + ${rowsCount * 2 || 1} * ${getAllDayRowHeight(gridOffsetTopPx)})`,
+      minHeight: `${getAllDayRowMinHeightPx(rowsCount)}px`,
     }}
   >
     <div

--- a/packages/web/src/grid/components/EventGrid.test.tsx
+++ b/packages/web/src/grid/components/EventGrid.test.tsx
@@ -118,10 +118,9 @@ describe("EventGrid", () => {
       />,
     );
 
-    expect(
-      getComputedStyle(screen.getByRole("region", { name: "All-day events" }))
-        .height,
-    ).toContain("6 *");
+    const allDayRow = screen.getByRole("region", { name: "All-day events" });
+    expect(getComputedStyle(allDayRow).height).toContain("6 *");
+    expect(getComputedStyle(allDayRow).minHeight).toBe("75px");
   });
 
   it("shows a couldn't-load state with retry when event fetch failed", async () => {

--- a/packages/web/src/grid/layout/event.position.test.ts
+++ b/packages/web/src/grid/layout/event.position.test.ts
@@ -260,4 +260,52 @@ describe("event position", () => {
 
     expect(position).toEqual({ height: 0, left: 0, top: 0, width: 0 });
   });
+
+  it("sizes day-view all-day events to the calendar column even when UTC midnight dates miss the local day span", () => {
+    const dayVisibleDates = [
+      { date: dayjs("2026-05-20T15:00:00.000"), key: "cal-a" },
+      { date: dayjs("2026-05-20T15:00:00.000"), key: "cal-b" },
+      { date: dayjs("2026-05-20T15:00:00.000"), key: "cal-c" },
+    ];
+    const dayMeasurements = {
+      ...measurements,
+      colWidths: [180, 180, 180],
+    };
+
+    // UTC midnights that fall on the previous local day in US timezones —
+    // week span clamping would zero-size this, but Day passes columnIndex.
+    const position = getAllDayEventPosition(
+      {
+        endDate: "2026-05-21T00:00:00.000Z",
+        isAllDay: true,
+        row: 1,
+        startDate: "2026-05-20T00:00:00.000Z",
+      } as never,
+      {
+        columnIndex: 2,
+        isDraft: false,
+        measurements: dayMeasurements,
+        visibleDates: dayVisibleDates,
+      },
+    );
+
+    expect(position.height).toBe(20);
+    expect(position.left).toBe(360);
+    expect(position.top).toBe(3);
+    expect(position.width).toBe(170);
+  });
+
+  it("places the first all-day row near the top with only a small gap", () => {
+    const position = getAllDayEventPosition(
+      {
+        endDate: "2026-05-21",
+        isAllDay: true,
+        row: 1,
+        startDate: "2026-05-20",
+      } as never,
+      { measurements, visibleDates, isDraft: false },
+    );
+
+    expect(position.top).toBe(3);
+  });
 });

--- a/packages/web/src/grid/layout/event.position.ts
+++ b/packages/web/src/grid/layout/event.position.ts
@@ -102,33 +102,34 @@ export const getAllDayEventPosition = (
   event: GridEvent,
   input: EventPositionInput,
 ): EventPosition => {
+  let left: number;
+  let width: number;
+
   // Day view passes columnIndex: columns are calendars on one day, so the
   // caller already decided this event belongs on-screen. Skip the week-style
   // date-span clamp (which can zero-size a card when start/end are UTC
   // midnights that fall on the previous local day) and size to that column.
   if (input.columnIndex !== undefined) {
-    return allDayPositionInColumn(
-      event,
-      input.measurements.colWidths,
-      input.columnIndex,
+    const columnWidth = input.measurements.colWidths[input.columnIndex] ?? 0;
+    left = sumWidthsBefore(input.measurements.colWidths, input.columnIndex);
+    width = widthMinusPadding(columnWidth);
+  } else {
+    const span = getVisibleAllDaySpan(event, input.visibleDates);
+    if (!span) {
+      return zeroPosition();
+    }
+
+    const startIndex = getVisibleDateIndex(span.start, input.visibleDates);
+    const endIndex = getVisibleDateIndex(span.end, input.visibleDates);
+    if (startIndex === null || endIndex === null) {
+      return zeroPosition();
+    }
+
+    left = sumWidthsBefore(input.measurements.colWidths, startIndex);
+    width = widthMinusPadding(
+      sumWidthsBetween(input.measurements.colWidths, startIndex, endIndex),
     );
   }
-
-  const span = getVisibleAllDaySpan(event, input.visibleDates);
-  if (!span) {
-    return zeroPosition();
-  }
-
-  const startIndex = getVisibleDateIndex(span.start, input.visibleDates);
-  const endIndex = getVisibleDateIndex(span.end, input.visibleDates);
-  if (startIndex === null || endIndex === null) {
-    return zeroPosition();
-  }
-
-  const left = sumWidthsBefore(input.measurements.colWidths, startIndex);
-  const width = widthMinusPadding(
-    sumWidthsBetween(input.measurements.colWidths, startIndex, endIndex),
-  );
 
   return {
     height: EVENT_ALLDAY_HEIGHT,
@@ -138,24 +139,9 @@ export const getAllDayEventPosition = (
   };
 };
 
-const allDayPositionInColumn = (
-  event: GridEvent,
-  colWidths: number[],
-  columnIndex: number,
-): EventPosition => {
-  const columnWidth = colWidths[columnIndex] ?? 0;
-
-  return {
-    height: EVENT_ALLDAY_HEIGHT,
-    left: sumWidthsBefore(colWidths, columnIndex),
-    top: allDayEventTop(event.row),
-    width: widthMinusPadding(columnWidth),
-  };
-};
-
 /** Rows are 1-based; top is 0-based with a small gap above the first chip. */
 const allDayEventTop = (row: number | undefined) =>
-  EVENT_ALLDAY_GAP + EVENT_ALLDAY_ROW_HEIGHT * (Math.max(1, row || 1) - 1);
+  EVENT_ALLDAY_GAP + EVENT_ALLDAY_ROW_HEIGHT * ((row || 1) - 1);
 
 const getVisibleAllDaySpan = (
   event: GridEvent,

--- a/packages/web/src/grid/layout/event.position.ts
+++ b/packages/web/src/grid/layout/event.position.ts
@@ -2,6 +2,7 @@ import dayjs, { type Dayjs } from "@core/util/date/dayjs";
 import { type GridEvent } from "@web/common/types/web.event.types";
 import {
   DRAFT_PADDING_BOTTOM,
+  EVENT_ALLDAY_GAP,
   EVENT_ALLDAY_HEIGHT,
   EVENT_ALLDAY_ROW_HEIGHT,
   EVENT_PADDING_RIGHT,
@@ -101,15 +102,25 @@ export const getAllDayEventPosition = (
   event: GridEvent,
   input: EventPositionInput,
 ): EventPosition => {
+  // Day view passes columnIndex: columns are calendars on one day, so the
+  // caller already decided this event belongs on-screen. Skip the week-style
+  // date-span clamp (which can zero-size a card when start/end are UTC
+  // midnights that fall on the previous local day) and size to that column.
+  if (input.columnIndex !== undefined) {
+    return allDayPositionInColumn(
+      event,
+      input.measurements.colWidths,
+      input.columnIndex,
+    );
+  }
+
   const span = getVisibleAllDaySpan(event, input.visibleDates);
   if (!span) {
     return zeroPosition();
   }
 
-  const startIndex =
-    input.columnIndex ?? getVisibleDateIndex(span.start, input.visibleDates);
-  const endIndex =
-    input.columnIndex ?? getVisibleDateIndex(span.end, input.visibleDates);
+  const startIndex = getVisibleDateIndex(span.start, input.visibleDates);
+  const endIndex = getVisibleDateIndex(span.end, input.visibleDates);
   if (startIndex === null || endIndex === null) {
     return zeroPosition();
   }
@@ -122,10 +133,29 @@ export const getAllDayEventPosition = (
   return {
     height: EVENT_ALLDAY_HEIGHT,
     left,
-    top: EVENT_ALLDAY_ROW_HEIGHT * (event.row || 1),
+    top: allDayEventTop(event.row),
     width,
   };
 };
+
+const allDayPositionInColumn = (
+  event: GridEvent,
+  colWidths: number[],
+  columnIndex: number,
+): EventPosition => {
+  const columnWidth = colWidths[columnIndex] ?? 0;
+
+  return {
+    height: EVENT_ALLDAY_HEIGHT,
+    left: sumWidthsBefore(colWidths, columnIndex),
+    top: allDayEventTop(event.row),
+    width: widthMinusPadding(columnWidth),
+  };
+};
+
+/** Rows are 1-based; top is 0-based with a small gap above the first chip. */
+const allDayEventTop = (row: number | undefined) =>
+  EVENT_ALLDAY_GAP + EVENT_ALLDAY_ROW_HEIGHT * (Math.max(1, row || 1) - 1);
 
 const getVisibleAllDaySpan = (
   event: GridEvent,

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarEventLayers.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarEventLayers.tsx
@@ -10,6 +10,7 @@ import {
 } from "@web/common/constants/web.constants";
 import { type GridEvent } from "@web/common/types/web.event.types";
 import { type GridEventDraft } from "@web/events/event-draft.types";
+import { GRID_MARGIN_LEFT } from "@web/grid/grid.constants";
 import { createTimedEventLayout } from "@web/grid/layout/timed-deck.layout";
 import {
   type GridMeasurements,
@@ -19,7 +20,6 @@ import {
   DayAllDayCalendarEvent,
   DayTimedCalendarEvent,
 } from "./DayCalendarEventCards";
-import { assignDayAllDayEventRows } from "./dayAllDayRows.util";
 import {
   addVisibleDraftEvent,
   getCalendarEventIdSet,
@@ -27,7 +27,17 @@ import {
   isDraftOnlyEvent,
 } from "./dayCalendarDraft.util";
 
-interface DayEventsProps {
+interface DayAllDayEventsProps {
+  getCalendarColumnIndex: (event: GridEvent) => number;
+  draft: GridEventDraft | null;
+  events: GridEvent[];
+  measurements: GridMeasurements;
+  onOpenEvent: (event: GridEvent) => void;
+  savedEventIds: Set<string>;
+  visibleDates: GridVisibleDate[];
+}
+
+interface DayTimedEventsProps {
   getCalendarColumnIndex: (event: GridEvent) => number;
   draft: GridEventDraft | null;
   events: GridEvent[];
@@ -42,33 +52,22 @@ export const DayCalendarAllDayEventsLayer = ({
   getCalendarColumnIndex,
   measurements,
   onOpenEvent,
+  savedEventIds,
   visibleDates,
-}: DayEventsProps) => {
+}: DayAllDayEventsProps) => {
   // One lookup build for the whole list (packet 08 step 5) - not per card.
   const calendarLookup = useCalendarLookup();
-  const savedEventIds = useMemo(
-    () => getCalendarEventIdSet(allDayEvents),
-    [allDayEvents],
-  );
-  const renderedEvents = useMemo(() => {
-    const withDraft = addVisibleDraftEvent({
-      draft,
-      events: allDayEvents,
-      isAllDay: true,
-      visibleDates,
-    });
-    // addVisibleDraftEvent re-stacks with week-style day overlap; restore
-    // per-calendar-column rows so chips in different columns can share a row.
-    return assignDayAllDayEventRows(withDraft, getCalendarColumnIndex)
-      .allDayEvents;
-  }, [allDayEvents, draft, getCalendarColumnIndex, visibleDates]);
 
   return (
     <div
-      className="relative ml-[50px] h-full w-full"
+      className="relative h-full"
       id={ID_GRID_EVENTS_ALLDAY}
+      style={{
+        marginLeft: GRID_MARGIN_LEFT,
+        width: `calc(100% - ${GRID_MARGIN_LEFT}px)`,
+      }}
     >
-      {renderedEvents.map((event) => (
+      {allDayEvents.map((event) => (
         <DayAllDayCalendarEvent
           calendarIdentity={resolveCalendarCardIdentity(calendarLookup, event)}
           columnIndex={getCalendarColumnIndex(event)}
@@ -93,7 +92,7 @@ export const DayCalendarTimedEventsLayer = ({
   measurements,
   onOpenEvent,
   visibleDates,
-}: DayEventsProps) => {
+}: DayTimedEventsProps) => {
   // One lookup build for the whole list (packet 08 step 5) - not per card.
   const calendarLookup = useCalendarLookup();
   const savedEventIds = useMemo(

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarEventLayers.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarEventLayers.tsx
@@ -10,7 +10,6 @@ import {
 } from "@web/common/constants/web.constants";
 import { type GridEvent } from "@web/common/types/web.event.types";
 import { type GridEventDraft } from "@web/events/event-draft.types";
-import { GRID_MARGIN_LEFT } from "@web/grid/grid.constants";
 import { createTimedEventLayout } from "@web/grid/layout/timed-deck.layout";
 import {
   type GridMeasurements,
@@ -20,6 +19,7 @@ import {
   DayAllDayCalendarEvent,
   DayTimedCalendarEvent,
 } from "./DayCalendarEventCards";
+import { assignDayAllDayEventRows } from "./dayAllDayRows.util";
 import {
   addVisibleDraftEvent,
   getCalendarEventIdSet,
@@ -50,26 +50,23 @@ export const DayCalendarAllDayEventsLayer = ({
     () => getCalendarEventIdSet(allDayEvents),
     [allDayEvents],
   );
-  const renderedEvents = useMemo(
-    () =>
-      addVisibleDraftEvent({
-        draft,
-        events: allDayEvents,
-        isAllDay: true,
-        visibleDates,
-      }),
-    [allDayEvents, draft, visibleDates],
-  );
+  const renderedEvents = useMemo(() => {
+    const withDraft = addVisibleDraftEvent({
+      draft,
+      events: allDayEvents,
+      isAllDay: true,
+      visibleDates,
+    });
+    // addVisibleDraftEvent re-stacks with week-style day overlap; restore
+    // per-calendar-column rows so chips in different columns can share a row.
+    return assignDayAllDayEventRows(withDraft, getCalendarColumnIndex)
+      .allDayEvents;
+  }, [allDayEvents, draft, getCalendarColumnIndex, visibleDates]);
 
   return (
     <div
+      className="relative ml-[50px] h-full w-full"
       id={ID_GRID_EVENTS_ALLDAY}
-      style={{
-        height: "100%",
-        marginLeft: GRID_MARGIN_LEFT,
-        position: "relative",
-        width: `calc(100% - ${GRID_MARGIN_LEFT}px)`,
-      }}
     >
       {renderedEvents.map((event) => (
         <DayAllDayCalendarEvent

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.test.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.test.tsx
@@ -974,6 +974,13 @@ describe("DayCalendarGrid", () => {
       expect(parseFloat(draft.style.top)).toBeGreaterThan(
         parseFloat(second.style.top),
       );
+      // Strip minHeight must count the draft row (3) or the chip overflows.
+      expect(
+        parseFloat(
+          screen.getByRole("region", { name: /all-day events/i }).style
+            .minHeight,
+        ),
+      ).toBeGreaterThanOrEqual(parseFloat(draft.style.top) + 20);
     });
   });
 

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.test.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.test.tsx
@@ -904,6 +904,36 @@ describe("DayCalendarGrid", () => {
     );
   });
 
+  it("renders a saved all-day event at full calendar-column width", async () => {
+    const primary = makeCalendar("Primary", { isPrimary: true });
+    const projects = makeCalendar("Projects");
+    seededEvents = [
+      createMockEvent({
+        calendarId: projects.id,
+        content: {
+          kind: "details",
+          title: "Column width all-day",
+          description: "",
+        },
+        schedule: EventScheduleSchema.parse({
+          kind: "allDay",
+          start: "2026-05-20",
+          end: "2026-05-21",
+        }),
+      }),
+    ];
+    renderDayCalendarGrid([primary, projects]);
+
+    const eventButton = await screen.findByRole("button", {
+      name: /all-day event: column width all-day/i,
+    });
+
+    expect(parseFloat(eventButton.style.width)).toBe(170);
+    expect(parseFloat(eventButton.style.height)).toBe(20);
+    expect(parseFloat(eventButton.style.left)).toBe(180);
+    expect(parseFloat(eventButton.style.top)).toBe(3);
+  });
+
   it("places a new all-day draft below existing all-day events", async () => {
     setDayEvents([
       createAllDayEvent({

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
@@ -42,6 +42,11 @@ import {
   DayCalendarAllDayEventsLayer,
   DayCalendarTimedEventsLayer,
 } from "./DayCalendarEventLayers";
+import { assignDayAllDayEventRows } from "./dayAllDayRows.util";
+import {
+  addVisibleDraftEvent,
+  getCalendarEventIdSet,
+} from "./dayCalendarDraft.util";
 import { useDayCalendarColumns } from "./useDayCalendarColumns";
 import { useDayCalendarScrollToNow } from "./useDayCalendarScrollToNow";
 import { useDayTimedDraftCreation } from "./useDayTimedDraftCreation";
@@ -88,7 +93,6 @@ export function DayCalendarGrid() {
     dayEvents.length === 0 &&
     googleState === "IMPORTING";
   const {
-    allDayRowsCount,
     calendarColumnIndexById,
     displayedAllDayEvents,
     displayedCalendars,
@@ -111,6 +115,27 @@ export function DayCalendarGrid() {
     timedEvents: displayedTimedEvents,
   });
   const gridDraft = useDraftStore(selectGridDraft);
+  // Strip height must include the all-day draft: layer rendering used to
+  // re-stack with the draft while EventGrid still sized from saved events only.
+  const savedAllDayEventIds = useMemo(
+    () => getCalendarEventIdSet(displayedAllDayEvents),
+    [displayedAllDayEvents],
+  );
+  const { allDayEvents: renderedAllDayEvents, rowsCount: allDayRowsCount } =
+    useMemo(() => {
+      const withDraft = addVisibleDraftEvent({
+        draft: gridDraft,
+        events: displayedAllDayEvents,
+        isAllDay: true,
+        visibleDates,
+      });
+      return assignDayAllDayEventRows(withDraft, getCalendarColumnIndex);
+    }, [
+      displayedAllDayEvents,
+      getCalendarColumnIndex,
+      gridDraft,
+      visibleDates,
+    ]);
 
   const calendarColumnKeys = useMemo(
     () => displayedCalendars.map((calendar) => calendar.id),
@@ -283,20 +308,22 @@ export function DayCalendarGrid() {
   const allDayEventsLayer = useMemo(
     () => (
       <DayCalendarAllDayEventsLayer
-        events={displayedAllDayEvents}
+        events={renderedAllDayEvents}
         getCalendarColumnIndex={getCalendarColumnIndex}
         draft={gridDraft}
         measurements={measurements}
         onOpenEvent={openEventFormForEvent}
+        savedEventIds={savedAllDayEventIds}
         visibleDates={visibleDates}
       />
     ),
     [
-      displayedAllDayEvents,
-      gridDraft,
       getCalendarColumnIndex,
+      gridDraft,
       measurements,
       openEventFormForEvent,
+      renderedAllDayEvents,
+      savedAllDayEventIds,
       visibleDates,
     ],
   );

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
@@ -74,7 +74,6 @@ export function DayCalendarGrid() {
     isFetching,
     isPending,
     refetch,
-    rowCount: allDayRowsCount,
     timedEvents,
   } = useDayEventViewModel(dayEventQueryRange(dateInView));
   const isLoadingEvents = isEventGridLoading(
@@ -89,6 +88,7 @@ export function DayCalendarGrid() {
     dayEvents.length === 0 &&
     googleState === "IMPORTING";
   const {
+    allDayRowsCount,
     calendarColumnIndexById,
     displayedAllDayEvents,
     displayedCalendars,

--- a/packages/web/src/views/Day/components/Calendar/dayAllDayRows.util.test.ts
+++ b/packages/web/src/views/Day/components/Calendar/dayAllDayRows.util.test.ts
@@ -1,0 +1,63 @@
+import { type GridEvent } from "@web/common/types/web.event.types";
+import { assignDayAllDayEventRows } from "./dayAllDayRows.util";
+import { describe, expect, it } from "bun:test";
+
+const allDay = (
+  id: string,
+  calendarId: string,
+  overrides: Partial<GridEvent> = {},
+): GridEvent =>
+  ({
+    _id: id,
+    calendarId,
+    endDate: "2026-05-21",
+    isAllDay: true,
+    startDate: "2026-05-20",
+    title: id,
+    ...overrides,
+  }) as GridEvent;
+
+describe("assignDayAllDayEventRows", () => {
+  it("lets all-day events on different calendars share row 1", () => {
+    const events = [
+      allDay("a", "cal-a"),
+      allDay("b", "cal-b"),
+      allDay("c", "cal-c"),
+    ];
+    const columnById = new Map([
+      ["cal-a", 0],
+      ["cal-b", 1],
+      ["cal-c", 2],
+    ]);
+
+    const { allDayEvents, rowsCount } = assignDayAllDayEventRows(
+      events,
+      (event) => columnById.get(event.calendarId!) ?? 0,
+    );
+
+    expect(rowsCount).toBe(1);
+    expect(allDayEvents.map((event) => event.row)).toEqual([1, 1, 1]);
+  });
+
+  it("stacks multiple all-day events in the same calendar column", () => {
+    const events = [
+      allDay("a1", "cal-a"),
+      allDay("a2", "cal-a"),
+      allDay("b1", "cal-b"),
+    ];
+    const columnById = new Map([
+      ["cal-a", 0],
+      ["cal-b", 1],
+    ]);
+
+    const { allDayEvents, rowsCount } = assignDayAllDayEventRows(
+      events,
+      (event) => columnById.get(event.calendarId!) ?? 0,
+    );
+
+    expect(rowsCount).toBe(2);
+    expect(allDayEvents.find((event) => event._id === "a1")?.row).toBe(1);
+    expect(allDayEvents.find((event) => event._id === "a2")?.row).toBe(2);
+    expect(allDayEvents.find((event) => event._id === "b1")?.row).toBe(1);
+  });
+});

--- a/packages/web/src/views/Day/components/Calendar/dayAllDayRows.util.test.ts
+++ b/packages/web/src/views/Day/components/Calendar/dayAllDayRows.util.test.ts
@@ -18,6 +18,13 @@ const allDay = (
   }) as GridEvent;
 
 describe("assignDayAllDayEventRows", () => {
+  it("returns one row when there are no all-day events", () => {
+    expect(assignDayAllDayEventRows([], () => 0)).toEqual({
+      allDayEvents: [],
+      rowsCount: 1,
+    });
+  });
+
   it("lets all-day events on different calendars share row 1", () => {
     const events = [
       allDay("a", "cal-a"),

--- a/packages/web/src/views/Day/components/Calendar/dayAllDayRows.util.ts
+++ b/packages/web/src/views/Day/components/Calendar/dayAllDayRows.util.ts
@@ -1,0 +1,56 @@
+import { type GridEvent } from "@web/common/types/web.event.types";
+import { assignEventsToRow } from "@web/common/utils/grid/assign.row";
+
+/**
+ * Day view columns are calendars on the same date. Week-style row assignment
+ * treats every same-day event as overlapping, so N calendars' all-day events
+ * stack into N vertical rows. Re-assign rows per calendar column so events in
+ * different columns can share a row and the all-day strip stays short.
+ *
+ * Rows are keyed by input index (not `_id`) so untitled drafts without an id
+ * still keep their stacked row.
+ */
+export const assignDayAllDayEventRows = (
+  events: GridEvent[],
+  getColumnIndex: (event: GridEvent) => number,
+): { allDayEvents: GridEvent[]; rowsCount: number } => {
+  if (events.length === 0) {
+    return { allDayEvents: events, rowsCount: 1 };
+  }
+
+  const columnIndexes = events.map((event) => getColumnIndex(event));
+  const eventsByColumn = new Map<
+    number,
+    { event: GridEvent; index: number }[]
+  >();
+
+  events.forEach((event, index) => {
+    const columnIndex = columnIndexes[index]!;
+    const columnEvents = eventsByColumn.get(columnIndex) ?? [];
+    columnEvents.push({ event, index });
+    eventsByColumn.set(columnIndex, columnEvents);
+  });
+
+  const rowByIndex = new Map<number, number>();
+  let rowsCount = 1;
+
+  for (const columnEvents of eventsByColumn.values()) {
+    const { allDayEvents: positioned } = assignEventsToRow(
+      columnEvents.map(({ event }) => event),
+    );
+
+    columnEvents.forEach(({ index }, columnOrder) => {
+      const row = positioned[columnOrder]?.row ?? columnOrder + 1;
+      rowByIndex.set(index, row);
+      rowsCount = Math.max(rowsCount, row);
+    });
+  }
+
+  return {
+    allDayEvents: events.map((event, index) => ({
+      ...event,
+      row: rowByIndex.get(index) ?? 1,
+    })),
+    rowsCount,
+  };
+};

--- a/packages/web/src/views/Day/components/Calendar/dayAllDayRows.util.ts
+++ b/packages/web/src/views/Day/components/Calendar/dayAllDayRows.util.ts
@@ -1,14 +1,15 @@
 import { type GridEvent } from "@web/common/types/web.event.types";
-import { assignEventsToRow } from "@web/common/utils/grid/assign.row";
 
 /**
  * Day view columns are calendars on the same date. Week-style row assignment
  * treats every same-day event as overlapping, so N calendars' all-day events
- * stack into N vertical rows. Re-assign rows per calendar column so events in
- * different columns can share a row and the all-day strip stays short.
+ * stack into N vertical rows. Assign rows per calendar column instead so
+ * events in different columns can share a row and the all-day strip stays short.
  *
- * Rows are keyed by input index (not `_id`) so untitled drafts without an id
- * still keep their stacked row.
+ * Within a column every displayed all-day event covers the same day, so they
+ * always overlap — stacking in input order is enough (no day-span packing).
+ * Rows are keyed by encounter order (not `_id`) so untitled drafts without an
+ * id still keep their stacked row.
  */
 export const assignDayAllDayEventRows = (
   events: GridEvent[],
@@ -18,39 +19,17 @@ export const assignDayAllDayEventRows = (
     return { allDayEvents: events, rowsCount: 1 };
   }
 
-  const columnIndexes = events.map((event) => getColumnIndex(event));
-  const eventsByColumn = new Map<
-    number,
-    { event: GridEvent; index: number }[]
-  >();
-
-  events.forEach((event, index) => {
-    const columnIndex = columnIndexes[index]!;
-    const columnEvents = eventsByColumn.get(columnIndex) ?? [];
-    columnEvents.push({ event, index });
-    eventsByColumn.set(columnIndex, columnEvents);
-  });
-
-  const rowByIndex = new Map<number, number>();
+  const nextRowByColumn = new Map<number, number>();
   let rowsCount = 1;
 
-  for (const columnEvents of eventsByColumn.values()) {
-    const { allDayEvents: positioned } = assignEventsToRow(
-      columnEvents.map(({ event }) => event),
-    );
+  const allDayEvents = events.map((event) => {
+    const columnIndex = getColumnIndex(event);
+    const row = nextRowByColumn.get(columnIndex) ?? 1;
+    nextRowByColumn.set(columnIndex, row + 1);
+    rowsCount = Math.max(rowsCount, row);
 
-    columnEvents.forEach(({ index }, columnOrder) => {
-      const row = positioned[columnOrder]?.row ?? columnOrder + 1;
-      rowByIndex.set(index, row);
-      rowsCount = Math.max(rowsCount, row);
-    });
-  }
+    return { ...event, row };
+  });
 
-  return {
-    allDayEvents: events.map((event, index) => ({
-      ...event,
-      row: rowByIndex.get(index) ?? 1,
-    })),
-    rowsCount,
-  };
+  return { allDayEvents, rowsCount };
 };

--- a/packages/web/src/views/Day/components/Calendar/useDayCalendarColumns.ts
+++ b/packages/web/src/views/Day/components/Calendar/useDayCalendarColumns.ts
@@ -3,7 +3,6 @@ import { YEAR_MONTH_DAY_FORMAT } from "@core/constants/date.constants";
 import { type Dayjs } from "@core/util/date/dayjs";
 import { useCalendarsQuery } from "@web/calendars/calendar.query";
 import { type GridEvent } from "@web/common/types/web.event.types";
-import { assignDayAllDayEventRows } from "./dayAllDayRows.util";
 import { getDayViewCalendars } from "./dayCalendarColumns.util";
 
 export const useDayCalendarColumns = ({
@@ -56,13 +55,12 @@ export const useDayCalendarColumns = ({
       calendarColumnIndexById.has(event.calendarId),
     [calendarColumnIndexById, calendarIds],
   );
-  // Row assignment that includes an all-day draft lives in DayCalendarGrid so
-  // strip height and chips share one draft-aware stack.
-  const displayedAllDayEvents = useMemo(() => {
-    const visibleEvents = allDayEvents.filter(isDisplayedEvent);
-    return assignDayAllDayEventRows(visibleEvents, getCalendarColumnIndex)
-      .allDayEvents;
-  }, [allDayEvents, getCalendarColumnIndex, isDisplayedEvent]);
+  // Day all-day row stacking (including drafts) is owned by DayCalendarGrid so
+  // strip height and chips stay in sync.
+  const displayedAllDayEvents = useMemo(
+    () => allDayEvents.filter(isDisplayedEvent),
+    [allDayEvents, isDisplayedEvent],
+  );
   const displayedTimedEvents = useMemo(
     () => timedEvents.filter(isDisplayedEvent),
     [isDisplayedEvent, timedEvents],

--- a/packages/web/src/views/Day/components/Calendar/useDayCalendarColumns.ts
+++ b/packages/web/src/views/Day/components/Calendar/useDayCalendarColumns.ts
@@ -3,6 +3,7 @@ import { YEAR_MONTH_DAY_FORMAT } from "@core/constants/date.constants";
 import { type Dayjs } from "@core/util/date/dayjs";
 import { useCalendarsQuery } from "@web/calendars/calendar.query";
 import { type GridEvent } from "@web/common/types/web.event.types";
+import { assignDayAllDayEventRows } from "./dayAllDayRows.util";
 import { getDayViewCalendars } from "./dayCalendarColumns.util";
 
 export const useDayCalendarColumns = ({
@@ -55,16 +56,18 @@ export const useDayCalendarColumns = ({
       calendarColumnIndexById.has(event.calendarId),
     [calendarColumnIndexById, calendarIds],
   );
-  const displayedAllDayEvents = useMemo(
-    () => allDayEvents.filter(isDisplayedEvent),
-    [allDayEvents, isDisplayedEvent],
-  );
+  const { allDayEvents: displayedAllDayEvents, rowsCount: allDayRowsCount } =
+    useMemo(() => {
+      const visibleEvents = allDayEvents.filter(isDisplayedEvent);
+      return assignDayAllDayEventRows(visibleEvents, getCalendarColumnIndex);
+    }, [allDayEvents, getCalendarColumnIndex, isDisplayedEvent]);
   const displayedTimedEvents = useMemo(
     () => timedEvents.filter(isDisplayedEvent),
     [isDisplayedEvent, timedEvents],
   );
 
   return {
+    allDayRowsCount,
     calendarColumnIndexById,
     displayedAllDayEvents,
     displayedCalendars,

--- a/packages/web/src/views/Day/components/Calendar/useDayCalendarColumns.ts
+++ b/packages/web/src/views/Day/components/Calendar/useDayCalendarColumns.ts
@@ -56,18 +56,19 @@ export const useDayCalendarColumns = ({
       calendarColumnIndexById.has(event.calendarId),
     [calendarColumnIndexById, calendarIds],
   );
-  const { allDayEvents: displayedAllDayEvents, rowsCount: allDayRowsCount } =
-    useMemo(() => {
-      const visibleEvents = allDayEvents.filter(isDisplayedEvent);
-      return assignDayAllDayEventRows(visibleEvents, getCalendarColumnIndex);
-    }, [allDayEvents, getCalendarColumnIndex, isDisplayedEvent]);
+  // Row assignment that includes an all-day draft lives in DayCalendarGrid so
+  // strip height and chips share one draft-aware stack.
+  const displayedAllDayEvents = useMemo(() => {
+    const visibleEvents = allDayEvents.filter(isDisplayedEvent);
+    return assignDayAllDayEventRows(visibleEvents, getCalendarColumnIndex)
+      .allDayEvents;
+  }, [allDayEvents, getCalendarColumnIndex, isDisplayedEvent]);
   const displayedTimedEvents = useMemo(
     () => timedEvents.filter(isDisplayedEvent),
     [isDisplayedEvent, timedEvents],
   );
 
   return {
-    allDayRowsCount,
     calendarColumnIndexById,
     displayedAllDayEvents,
     displayedCalendars,

--- a/packages/web/src/views/Week/components/Draft/grid/GridDraft.test.tsx
+++ b/packages/web/src/views/Week/components/Draft/grid/GridDraft.test.tsx
@@ -141,7 +141,7 @@ describe("GridDraft", () => {
     ).toHaveStyle({
       height: "20px",
       left: "200px",
-      top: "23px",
+      top: "3px",
       width: "90px",
     });
   });
@@ -168,7 +168,7 @@ describe("GridDraft", () => {
     expect(
       screen.getByRole("button", { name: /All-day event: Planning/ }),
     ).toHaveStyle({
-      top: "69px",
+      top: "49px",
     });
   });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

All-day events could render as a tiny sliver in Day view (while looking fine in Week) because:

1. **Zero-size positioning** — Day passes `columnIndex` (calendar columns), but `getAllDayEventPosition` still required a week-style date-span clamp first. When that clamp failed (e.g. UTC midnight date strings that fall on the previous local day), the card got `width: 0` / `height: 0` and collapsed to a character-sized chip under the first column.
2. **Same-day row stacking** — Week-style row assignment treats every event on the same calendar day as overlapping, so one all-day event per calendar became N vertical rows. Combined with a 23px top offset for row 1, chips could sit below a short all-day strip.
3. **No pixel floor on the all-day strip** — Row height was percentage-only, so it could be shorter than the fixed-pixel chip layout.
4. **Draft vs strip height mismatch** — The layer stacked drafts into extra rows while `EventGrid` sized the strip from saved events only, so a draft could overflow into the timed grid.

## Changes

- Position Day all-day events by calendar column without the week span clamp
- Start chips at `(row - 1) * rowHeight + gap` instead of `row * rowHeight`
- Assign all-day rows **per calendar column** in Day view
- Add a pixel `minHeight` on the shared all-day row so chips are never clipped
- Drive strip height and chips from one draft-aware `assignDayAllDayEventRows` result in `DayCalendarGrid`
- Restore calc-based all-day layer width (`marginLeft` + `width: calc(100% - margin)`)

## Validation

- `bun test:web` on:
  - `event.position.test.ts`
  - `dayAllDayRows.util.test.ts`
  - `DayCalendarGrid.test.tsx` (includes draft strip minHeight assertion)
  - `EventGrid.test.tsx`
  - `GridDraft.test.tsx`
- `bun lint` (no new issues)
- Independent review: no confirmed findings after draft-strip-height fix

## Manual

Create/open an all-day event in Day view with multiple calendars enabled; the chip should fill its calendar column at normal height (not a sliver). Confirm Week view still spans days correctly. Create a stacked all-day draft and confirm the strip grows with it.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5f608ac7-f04b-4a4f-a0ad-ca3e6b09702f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5f608ac7-f04b-4a4f-a0ad-ca3e6b09702f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

