### PR TITLE
fix(sync): stop a deleted-then-recreated event from becoming undeletable

### DIFF
--- a/packages/backend/src/common/services/sync-service/event-command.translation.test.ts
+++ b/packages/backend/src/common/services/sync-service/event-command.translation.test.ts
@@ -262,4 +262,20 @@ describe("toDeleteSubmitRequest", () => {
     expect(request.input.scope).toBe("this");
     expect(request.input.recurrenceId).toBe(recurrenceId);
   });
+
+  // Pins the retry contract: submitCommandOrThrow retries a timed-out delete
+  // under the SAME key so it maps back to the original command instead of
+  // double-submitting. This is deliberate, not an oversight — two identical
+  // deletes (including a delete, an undo that recreates the event under the
+  // same id, and a second delete) collide on one command record on purpose.
+  // Telling a genuine retry apart from a stale replay is Sync's job
+  // (submitCloudCommand's terminalReplayIsStale), not the key's. Don't add a
+  // nonce here.
+  it("produces the same idempotency key for two identical deletes", () => {
+    const eventId = objectId();
+    const first = toDeleteSubmitRequest(eventId, { scope: "all" });
+    const second = toDeleteSubmitRequest(eventId, { scope: "all" });
+
+    expect(second.idempotencyKey).toBe(first.idempotencyKey);
+  });
 });

--- a/packages/backend/src/common/services/sync-service/event-command.translation.ts
+++ b/packages/backend/src/common/services/sync-service/event-command.translation.ts
@@ -218,6 +218,14 @@ export const toReplaceSubmitRequests = (
   return { requests, responseEvent };
 };
 
+// Deliberately identity-only (eventId/scope/recurrenceId, no nonce): a
+// timed-out delete must retry under the SAME key so it maps back to the
+// original command rather than double-submitting (see submitCommandOrThrow's
+// timeout handling in event.controller.ts). This does mean two calls with the
+// same target collide on one command record — including a delete, an undo
+// that recreates the event under the same id, and a second delete. Sync's
+// submitCloudCommand (terminalReplayIsStale) is what tells a genuine replay
+// apart from a stale one; don't "fix" a collision here with a nonce.
 export const toDeleteSubmitRequest = (
   id: string,
   input: DeleteEventInput,

--- a/packages/sync/src/domain/cloud-command.service.db.test.ts
+++ b/packages/sync/src/domain/cloud-command.service.db.test.ts
@@ -1481,4 +1481,295 @@ describe("submitCloudCommand provider dispatch", () => {
     expect(await events.findById(tenantId, principalId, masterId)).toBeNull();
     expect(await occurrenceStartsFor(masterId)).toHaveLength(0);
   });
+
+  // Regression coverage for the prod incident: deleting an event, undoing the
+  // delete (which recreates the event under its ORIGINAL id — see the "A25"
+  // doc comment in useUndoRedo.ts), then deleting again reuses the exact same
+  // idempotency key as the first delete (hashedIdempotencyKey is identity-only
+  // — eventId/scope/recurrenceId, see event-command.translation.ts). Without
+  // the liveness guard, the second delete replays the first CONFIRMED command
+  // and the event becomes permanently undeletable: 204 to the caller, no
+  // provider call, no local removal, and no TTL on `commands` to ever clear
+  // it. These pin submitCloudCommand's terminalReplayIsStale guard, which
+  // reopens a terminal command back to pending and re-executes it whenever the
+  // world no longer matches what it once confirmed.
+  describe("terminal replay liveness", () => {
+    it("re-deletes a cloud single event recreated under the same id after an earlier confirmed delete", async () => {
+      const tenantId = objectId() as TenantId;
+      const principalId = objectId() as PrincipalId;
+      const eventId = objectId() as EventId;
+      await seedEvent(tenantId, principalId, eventId);
+      const submit = deleteFor(tenantId, principalId, eventId);
+
+      const first = await submitCloudCommand(deps(), submit, now);
+      expect(first.command.outcome.state).toBe("confirmed");
+      expect(await events.findById(tenantId, principalId, eventId)).toBeNull();
+
+      // The A25 undo: recreate the SAME event id, later than the delete.
+      await seedEvent(tenantId, principalId, eventId, {
+        createdAt: new Date(now().getTime() + 1000),
+        updatedAt: new Date(now().getTime() + 1000),
+      });
+
+      // The exact same submit (same idempotencyKey) as the first delete.
+      const second = await submitCloudCommand(deps(), submit, now);
+
+      expect(second.changed).toBe(true);
+      expect(second.command.outcome.state).toBe("confirmed");
+      expect(await events.findById(tenantId, principalId, eventId)).toBeNull();
+      // Reopen updates the SAME row rather than minting a second command.
+      expect(
+        await mongo.db
+          .collection(SYNC_COLLECTIONS.commands)
+          .countDocuments({ idempotencyKey: submit.idempotencyKey }),
+      ).toBe(1);
+    });
+
+    it("calls the provider a second time when a provider-linked event is recreated under the same id and deleted again", async () => {
+      const tenantId = objectId() as TenantId;
+      const principalId = objectId() as PrincipalId;
+      const calendar = await seedProviderCalendar(tenantId, principalId);
+      const eventId = objectId() as EventId;
+      await seedEvent(tenantId, principalId, eventId, {
+        calendarId: calendar._id,
+        connectionId: calendar.connectionId as never,
+        providerEventId: "g-evt-1" as never,
+        providerVersion: "etag-1" as never,
+        deliveryState: "confirmed",
+      });
+      const writer = new FakeWriter();
+      const activeDeps = {
+        commands,
+        events,
+        calendars,
+        occurrences,
+        resources,
+        markers,
+        execution: "active" as const,
+        provider: provider(writer),
+      };
+      const submit = deleteFor(tenantId, principalId, eventId);
+
+      const first = await submitCloudCommand(activeDeps, submit, now);
+      expect(first.command.outcome.state).toBe("confirmed");
+      expect(writer.deleteCalls).toBe(1);
+
+      // Recreated under the same id (the undo path re-links it to the provider
+      // too, but a fresh provider-linked seed exercises the same collision).
+      await seedEvent(tenantId, principalId, eventId, {
+        calendarId: calendar._id,
+        connectionId: calendar.connectionId as never,
+        providerEventId: "g-evt-2" as never,
+        providerVersion: "etag-2" as never,
+        deliveryState: "confirmed",
+        createdAt: new Date(now().getTime() + 1000),
+        updatedAt: new Date(now().getTime() + 1000),
+      });
+
+      const second = await submitCloudCommand(activeDeps, submit, now);
+
+      expect(second.command.outcome.state).toBe("confirmed");
+      expect(writer.deleteCalls).toBe(2);
+      expect(await events.findById(tenantId, principalId, eventId)).toBeNull();
+    });
+
+    it("still short-circuits a genuine retry: resubmitting a confirmed delete of an event that stays gone makes no provider call", async () => {
+      const tenantId = objectId() as TenantId;
+      const principalId = objectId() as PrincipalId;
+      const calendar = await seedProviderCalendar(tenantId, principalId);
+      const eventId = objectId() as EventId;
+      await seedEvent(tenantId, principalId, eventId, {
+        calendarId: calendar._id,
+        connectionId: calendar.connectionId as never,
+        providerEventId: "g-evt-1" as never,
+        providerVersion: "etag-1" as never,
+        deliveryState: "confirmed",
+      });
+      const writer = new FakeWriter();
+      const activeDeps = {
+        commands,
+        events,
+        calendars,
+        occurrences,
+        resources,
+        markers,
+        execution: "active" as const,
+        provider: provider(writer),
+      };
+      const submit = deleteFor(tenantId, principalId, eventId);
+
+      await submitCloudCommand(activeDeps, submit, now);
+      expect(writer.deleteCalls).toBe(1);
+
+      const second = await submitCloudCommand(activeDeps, submit, now);
+
+      expect(second.changed).toBe(false);
+      expect(writer.deleteCalls).toBe(1);
+      expect(
+        await mongo.db
+          .collection(SYNC_COLLECTIONS.commands)
+          .countDocuments({ idempotencyKey: submit.idempotencyKey }),
+      ).toBe(1);
+    });
+
+    it("re-cancels a recurring occurrence whose tombstone was un-cancelled since the confirmed delete (scope this)", async () => {
+      const tenantId = objectId() as TenantId;
+      const principalId = objectId() as PrincipalId;
+      const masterId = objectId() as EventId;
+      const master = await seriesMaster(tenantId, principalId, masterId);
+      await reprojectOccurrences(occurrences, master, now);
+      const submit = deleteFor(
+        tenantId,
+        principalId,
+        masterId,
+        "this",
+        EXCEPTED,
+      );
+
+      const first = await submitCloudCommand(deps(), submit, now);
+      expect(first.command.outcome.state).toBe("confirmed");
+
+      // Undo un-cancels the tombstone in place (replaySnapshot in
+      // useUndoRedo.ts), leaving the master's own createdAt untouched.
+      await events.upsertException(
+        master,
+        EXCEPTED as never,
+        {
+          content: master.content,
+          schedule: {
+            kind: "timed",
+            start: EXCEPTED,
+            end: EXCEPTED.replace(/T\d{2}:/, "T23:"),
+            timeZone: "America/Denver",
+          } as never,
+          cancelled: false,
+        },
+        new Date(now().getTime() + 1000),
+      );
+
+      const second = await submitCloudCommand(deps(), submit, now);
+
+      expect(second.changed).toBe(true);
+      expect(second.command.outcome.state).toBe("confirmed");
+      expect(await occurrenceStartsFor(masterId)).not.toContain(
+        "2026-07-21T15:00:00.000Z",
+      );
+    });
+
+    it("re-truncates a series whose thisAndFollowing split was undone since the confirmed delete", async () => {
+      const tenantId = objectId() as TenantId;
+      const principalId = objectId() as PrincipalId;
+      const masterId = objectId() as EventId;
+      const master = await seriesMaster(tenantId, principalId, masterId);
+      await reprojectOccurrences(occurrences, master, now);
+      const submit = deleteFor(
+        tenantId,
+        principalId,
+        masterId,
+        "thisAndFollowing",
+        EXCEPTED,
+      );
+
+      const first = await submitCloudCommand(deps(), submit, now);
+      expect(first.command.outcome.state).toBe("confirmed");
+      const truncated = await events.findById(tenantId, principalId, masterId);
+      if (!truncated) throw new Error("expected the truncated master");
+
+      // Undo restores the original, untruncated rules.
+      await events.replaceExisting({
+        ...truncated,
+        recurrence: master.recurrence,
+        updatedAt: new Date(now().getTime() + 1000),
+      });
+
+      const second = await submitCloudCommand(deps(), submit, now);
+
+      expect(second.changed).toBe(true);
+      expect(second.command.outcome.state).toBe("confirmed");
+      expect(await occurrenceStartsFor(masterId)).toEqual([
+        "2026-07-14T15:00:00.000Z",
+      ]);
+    });
+
+    it("re-creates a cloud event whose confirmed create was undone (deleted) since", async () => {
+      const tenantId = objectId() as TenantId;
+      const principalId = objectId() as PrincipalId;
+      const submit = submitFor(tenantId, principalId, objectId());
+
+      const first = await submitCloudCommand(deps(), submit, now);
+      expect(first.command.outcome.state).toBe("confirmed");
+
+      await events.deleteById(tenantId, principalId, submit.eventId);
+
+      const second = await submitCloudCommand(deps(), submit, now);
+
+      expect(second.changed).toBe(true);
+      expect(second.command.outcome.state).toBe("confirmed");
+      expect(
+        await events.findById(tenantId, principalId, submit.eventId),
+      ).not.toBeNull();
+    });
+
+    it("does not re-litigate an explicitly cancelled command", async () => {
+      const tenantId = objectId() as TenantId;
+      const principalId = objectId() as PrincipalId;
+      const eventId = objectId() as EventId;
+      const submit = deleteFor(tenantId, principalId, eventId);
+      const { record: pending } = await commands.submit(submit);
+      await commands.updateOutcome(
+        tenantId,
+        principalId,
+        pending._id,
+        { state: "cancelled" },
+        pending.attemptCount,
+      );
+      await seedEvent(tenantId, principalId, eventId);
+
+      const result = await submitCloudCommand(deps(), submit, now);
+
+      expect(result.changed).toBe(false);
+      expect(result.command.outcome.state).toBe("cancelled");
+      expect(
+        await events.findById(tenantId, principalId, eventId),
+      ).not.toBeNull();
+    });
+
+    it("still short-circuits an identical update replay against a re-created event (no guard for update/move)", async () => {
+      const tenantId = objectId() as TenantId;
+      const principalId = objectId() as PrincipalId;
+      const eventId = objectId() as EventId;
+      await seedEvent(tenantId, principalId, eventId);
+      const submit = updateAllFor(
+        tenantId,
+        principalId,
+        eventId,
+        "First title",
+      );
+
+      const first = await submitCloudCommand(deps(), submit, now);
+      expect(first.command.outcome.state).toBe("confirmed");
+
+      await events.deleteById(tenantId, principalId, eventId);
+      await seedEvent(tenantId, principalId, eventId, {
+        content: {
+          title: "Re-created title",
+          description: "",
+          location: null,
+          organizer: null,
+          attendees: [],
+          conference: null,
+        } as never,
+        createdAt: new Date(now().getTime() + 1000),
+        updatedAt: new Date(now().getTime() + 1000),
+      });
+
+      const second = await submitCloudCommand(deps(), submit, now);
+
+      expect(second.changed).toBe(false);
+      const stored = await events.findById(tenantId, principalId, eventId);
+      // The re-created event's own (seeded) title survives — the stale
+      // update command was NOT reapplied on top of it.
+      expect(stored?.content).not.toMatchObject({ title: "First title" });
+    });
+  });
 });

--- a/packages/sync/src/domain/cloud-command.service.db.test.ts
+++ b/packages/sync/src/domain/cloud-command.service.db.test.ts
@@ -1691,7 +1691,17 @@ describe("submitCloudCommand provider dispatch", () => {
       ]);
     });
 
-    it("re-creates a cloud event whose confirmed create was undone (deleted) since", async () => {
+    // Deliberately NOT guarded, unlike delete — see the docblock above
+    // terminalReplayIsStale in command-replay.ts. Unlike a delete's key, a
+    // create's key (`create:${eventId}`) is stable for that event id's whole
+    // lifetime, so a later, UNRELATED resubmit of the same create payload
+    // (e.g. an offline promotion retry — see
+    // local-event-sync.util.ts's syncLocalEventsToCloud) collides with it
+    // too, not only an A25 undo. Nothing in the command history can tell
+    // those two apart, so guarding here would risk silently resurrecting an
+    // event the user deliberately deleted afterward. Pin the no-op replay so
+    // a future change doesn't "fix" this the same way delete was fixed.
+    it("still short-circuits a confirmed create replay for an event since deleted (no guard for create — resurrection risk)", async () => {
       const tenantId = objectId() as TenantId;
       const principalId = objectId() as PrincipalId;
       const submit = submitFor(tenantId, principalId, objectId());
@@ -1703,11 +1713,10 @@ describe("submitCloudCommand provider dispatch", () => {
 
       const second = await submitCloudCommand(deps(), submit, now);
 
-      expect(second.changed).toBe(true);
-      expect(second.command.outcome.state).toBe("confirmed");
+      expect(second.changed).toBe(false);
       expect(
         await events.findById(tenantId, principalId, submit.eventId),
-      ).not.toBeNull();
+      ).toBeNull();
     });
 
     it("does not re-litigate an explicitly cancelled command", async () => {

--- a/packages/sync/src/domain/cloud-command.service.ts
+++ b/packages/sync/src/domain/cloud-command.service.ts
@@ -4,13 +4,14 @@ import { type SyncEventRecurrence } from "@core/types/sync/event.contracts";
 import { type ProviderCalendarId } from "@core/types/sync/identity.contracts";
 import { type SyncExecutionMode } from "@sync/config/sync.config";
 import { type CredentialCustody } from "@sync/credentials/credential-custody.service";
+import { terminalReplayIsStale } from "@sync/domain/command-replay";
 import {
   mergeUpdateContent,
   omitNullColor,
 } from "@sync/domain/merge-update-content";
 import {
+  isFollowingSplitAtSeriesStart,
   occurrenceScheduleAt,
-  scheduleStartAt,
   stripRuleBounds,
   truncateRulesBefore,
 } from "@sync/domain/occurrence-projection";
@@ -97,19 +98,42 @@ export interface CloudCommandDeps {
 // write. The provider execution path applies and confirms it. A non-create
 // command is likewise persisted as durable pending intent and returned
 // unchanged; applying update/move/delete locally lands in a later slice.
+//
+// A terminal replay is not automatically a no-op. The idempotency key is
+// identity-only (eventId/scope/recurrenceId), so a create, delete, and
+// re-create-under-the-same-id (undo of a delete recreates the original event
+// id — see useUndoRedo.ts's "A25" doc comment) can all collide on the same
+// key as an earlier, unrelated command. terminalReplayIsStale checks whether
+// the world still matches what the terminal command once confirmed; if it
+// doesn't, the command is reopened to pending and re-executed below rather
+// than replayed as a no-op. Without this, a delete that once confirmed
+// without truly deleting (or was undone and redone) becomes permanently
+// unreachable — `commands` has no TTL.
 export async function submitCloudCommand(
   deps: CloudCommandDeps,
   submit: CommandSubmit,
   now: () => Date,
 ): Promise<{ command: CommandRecord; changed: boolean }> {
-  const { record: command, inserted } = await deps.commands.submit(submit);
+  let { record: command, inserted } = await deps.commands.submit(submit);
 
-  // Only a freshly-persisted create is applied here. A command already past
-  // pending (a confirmed replay, or a kind we don't apply yet) is returned as
-  // it stands, so a repeated submit never re-applies or overwrites an outcome.
-  if (command.outcome.state !== "pending") {
-    return { command, changed: false };
+  if (!inserted && command.outcome.state !== "pending") {
+    if (!(await terminalReplayIsStale(deps, command))) {
+      return { command, changed: false };
+    }
+    const reopened = await deps.commands.reopen(
+      command.tenantId,
+      command.principalId,
+      command._id,
+      command.outcome.state,
+    );
+    // null means a concurrent submit already reopened (or re-terminated) this
+    // command between our read and this write; that request owns execution.
+    if (!reopened) return { command, changed: false };
+    command = reopened;
   }
+
+  // command.outcome.state is guaranteed "pending" here: freshly inserted,
+  // already pending, or just reopened above — every other path returns early.
   const initialOutcomeState = command.outcome.state;
   const finish = (
     final: CommandRecord,
@@ -585,7 +609,7 @@ async function deleteCloudSeriesFollowing(
   }
   if (master.recurrence.kind !== "seriesMaster") return command;
   const splitAt = new Date(command.input.recurrenceId);
-  if (splitAt.getTime() <= scheduleStartAt(master.schedule).getTime()) {
+  if (isFollowingSplitAtSeriesStart(master.schedule, splitAt)) {
     return deleteCloudSeries(deps, command, master);
   }
 
@@ -629,7 +653,7 @@ async function updateCloudSeriesFollowing(
   }
   if (master.recurrence.kind !== "seriesMaster") return command;
   const splitAt = new Date(command.input.recurrenceId);
-  if (splitAt.getTime() <= scheduleStartAt(master.schedule).getTime()) {
+  if (isFollowingSplitAtSeriesStart(master.schedule, splitAt)) {
     return updateCloudSeries(deps, command, master, now);
   }
 

--- a/packages/sync/src/domain/cloud-command.service.ts
+++ b/packages/sync/src/domain/cloud-command.service.ts
@@ -99,16 +99,16 @@ export interface CloudCommandDeps {
 // command is likewise persisted as durable pending intent and returned
 // unchanged; applying update/move/delete locally lands in a later slice.
 //
-// A terminal replay is not automatically a no-op. The idempotency key is
-// identity-only (eventId/scope/recurrenceId), so a create, delete, and
-// re-create-under-the-same-id (undo of a delete recreates the original event
-// id — see useUndoRedo.ts's "A25" doc comment) can all collide on the same
-// key as an earlier, unrelated command. terminalReplayIsStale checks whether
-// the world still matches what the terminal command once confirmed; if it
-// doesn't, the command is reopened to pending and re-executed below rather
-// than replayed as a no-op. Without this, a delete that once confirmed
-// without truly deleting (or was undone and redone) becomes permanently
-// unreachable — `commands` has no TTL.
+// A terminal DELETE replay is not automatically a no-op. Its idempotency key
+// is identity-only (eventId/scope/recurrenceId), so a delete, undo
+// (recreate under the SAME event id — see useUndoRedo.ts's "A25" doc
+// comment), and delete-again collide on the same key as the first delete.
+// terminalReplayIsStale checks whether the world still matches what that
+// terminal command once confirmed; if it doesn't, the command is reopened to
+// pending and re-executed below rather than replayed as a no-op. Without
+// this, a delete that once confirmed without truly deleting (or was undone
+// and redone) becomes permanently unreachable — `commands` has no TTL. See
+// command-replay.ts for why this guard is delete-only, not create too.
 export async function submitCloudCommand(
   deps: CloudCommandDeps,
   submit: CommandSubmit,

--- a/packages/sync/src/domain/command-replay.ts
+++ b/packages/sync/src/domain/command-replay.ts
@@ -28,7 +28,7 @@ import { type CommandRecord } from "@sync/storage/contracts/command.contracts";
 // (see retryCloudMutation's docblock in cloud-command.service.ts). The
 // create idempotency key (`create:${eventId}`) is stable for that event id's
 // whole lifetime, so ANY later resubmission of the same create payload
-// collides with the original — not only the A25 undo. Content
+// collides with the original — not only the A25 undo.
 // packages/web/src/common/utils/sync/local-event-sync.util.ts's offline
 // promotion retries a create under the record's own stable id whenever the
 // client never observed the first attempt's success; if the user deletes

--- a/packages/sync/src/domain/command-replay.ts
+++ b/packages/sync/src/domain/command-replay.ts
@@ -9,35 +9,48 @@ import {
 } from "@sync/domain/series-exception";
 import { type CommandRecord } from "@sync/storage/contracts/command.contracts";
 
-// Whether a terminal command's replay should be treated as a genuine no-op
-// (the world already matches what it once confirmed) or as stale (the world
-// has since diverged, so the command's target incarnation is gone and this
-// submission is really a fresh intent that happens to share an identity key).
+// Whether a terminal DELETE command's replay should be treated as a genuine
+// no-op (the world already matches what it once confirmed) or as stale (the
+// world has since diverged, so the command's target incarnation is gone and
+// this submission is really a fresh intent that happens to share an identity
+// key).
 //
-// The idempotency key is deliberately identity-only (eventId/scope/
+// The delete idempotency key is deliberately identity-only (eventId/scope/
 // recurrenceId — see toDeleteSubmitRequest in event-command.translation.ts),
 // so a delete, undo (recreate under the SAME event id — see the "A25" doc
 // comment in useUndoRedo.ts), and delete-again collide on the exact same key.
 // Without this check, submitCloudCommand's short-circuit at the top of the
 // function returns the OLD confirmed command forever: 204 to the caller, no
 // provider call, no local change, and no TTL on `commands` to ever clear it.
+//
+// create is deliberately NOT guarded here, unlike delete — this is not the
+// same "no observed failure, real clobber risk" tradeoff update/move make
+// (see retryCloudMutation's docblock in cloud-command.service.ts). The
+// create idempotency key (`create:${eventId}`) is stable for that event id's
+// whole lifetime, so ANY later resubmission of the same create payload
+// collides with the original — not only the A25 undo. Content
+// packages/web/src/common/utils/sync/local-event-sync.util.ts's offline
+// promotion retries a create under the record's own stable id whenever the
+// client never observed the first attempt's success; if the user deletes
+// that event before the retry fires, "existing === null ⇒ stale" would
+// silently resurrect an event the user deliberately removed. Nothing in the
+// command history can tell "the delete this create-replay's undo is
+// reversing" apart from "an unrelated delete that happened since" — so
+// leave create as a no-op replay (matching its pre-fix behavior) rather than
+// guess wrong in the resurrection direction.
 export async function terminalReplayIsStale(
   deps: Pick<CloudCommandDeps, "events">,
   command: CommandRecord,
 ): Promise<boolean> {
   // An explicit cancellation is not re-litigated by a resubmit.
   if (command.outcome.state === "cancelled") return false;
-  if (command.input.kind !== "create" && command.input.kind !== "delete") {
-    return false;
-  }
+  if (command.input.kind !== "delete") return false;
 
   const existing = await deps.events.findById(
     command.tenantId,
     command.principalId,
     command.eventId,
   );
-
-  if (command.input.kind === "create") return existing === null;
 
   // Absence (or a pending-deletion row) is the delete's own desired end
   // state — a genuine timeout-retry short-circuits exactly as before.

--- a/packages/sync/src/domain/command-replay.ts
+++ b/packages/sync/src/domain/command-replay.ts
@@ -1,0 +1,86 @@
+import { type CloudCommandDeps } from "@sync/domain/cloud-command.service";
+import {
+  isFollowingSplitAtSeriesStart,
+  truncateRulesBefore,
+} from "@sync/domain/occurrence-projection";
+import {
+  exceptionInstant,
+  isCancelledException,
+} from "@sync/domain/series-exception";
+import { type CommandRecord } from "@sync/storage/contracts/command.contracts";
+
+// Whether a terminal command's replay should be treated as a genuine no-op
+// (the world already matches what it once confirmed) or as stale (the world
+// has since diverged, so the command's target incarnation is gone and this
+// submission is really a fresh intent that happens to share an identity key).
+//
+// The idempotency key is deliberately identity-only (eventId/scope/
+// recurrenceId — see toDeleteSubmitRequest in event-command.translation.ts),
+// so a delete, undo (recreate under the SAME event id — see the "A25" doc
+// comment in useUndoRedo.ts), and delete-again collide on the exact same key.
+// Without this check, submitCloudCommand's short-circuit at the top of the
+// function returns the OLD confirmed command forever: 204 to the caller, no
+// provider call, no local change, and no TTL on `commands` to ever clear it.
+export async function terminalReplayIsStale(
+  deps: Pick<CloudCommandDeps, "events">,
+  command: CommandRecord,
+): Promise<boolean> {
+  // An explicit cancellation is not re-litigated by a resubmit.
+  if (command.outcome.state === "cancelled") return false;
+  if (command.input.kind !== "create" && command.input.kind !== "delete") {
+    return false;
+  }
+
+  const existing = await deps.events.findById(
+    command.tenantId,
+    command.principalId,
+    command.eventId,
+  );
+
+  if (command.input.kind === "create") return existing === null;
+
+  // Absence (or a pending-deletion row) is the delete's own desired end
+  // state — a genuine timeout-retry short-circuits exactly as before.
+  if (!existing || existing.lifecycleState !== "active") return false;
+
+  if (command.input.scope === "all") return true;
+
+  // "this" / "thisAndFollowing" only apply to a series master; the contract
+  // guarantees recurrenceId is set for both. Anything else is unreachable
+  // from the browser today — stay conservative (not stale) rather than guess.
+  if (
+    command.input.recurrenceId === null ||
+    existing.recurrence.kind !== "seriesMaster"
+  ) {
+    return false;
+  }
+  const recurrenceId = command.input.recurrenceId;
+  const exceptions = await deps.events.findSeriesExceptions(
+    command.tenantId,
+    command.principalId,
+    existing._id,
+  );
+
+  if (command.input.scope === "this") {
+    const exception = exceptions.find(
+      (candidate) => exceptionInstant(candidate) === recurrenceId,
+    );
+    const holds = exception !== undefined && isCancelledException(exception);
+    return !holds;
+  }
+
+  // thisAndFollowing: a split at or before the series' first occurrence
+  // collapses to a full-series delete (see deleteCloudSeriesFollowing) — the
+  // master still existing means that never happened.
+  const splitAt = new Date(recurrenceId);
+  if (isFollowingSplitAtSeriesStart(existing.schedule, splitAt)) return true;
+  const alreadyTruncated =
+    JSON.stringify(existing.recurrence.rules) ===
+    JSON.stringify(truncateRulesBefore(existing.recurrence.rules, splitAt));
+  const hasFollowingException = exceptions.some(
+    (candidate) =>
+      new Date(exceptionInstant(candidate)).getTime() >= splitAt.getTime(),
+  );
+  const holds = alreadyTruncated && !hasFollowingException;
+  return !holds;
+}

--- a/packages/sync/src/domain/occurrence-projection.ts
+++ b/packages/sync/src/domain/occurrence-projection.ts
@@ -362,6 +362,20 @@ export function scheduleStartAt(schedule: EventSchedule): Date {
   return new Date(`${schedule.start}T00:00:00.000Z`);
 }
 
+// Whether a thisAndFollowing split at `splitAt` lands at or before the
+// series' own first occurrence — the threshold at which "delete/edit this
+// and following" is equivalent to "delete/edit the whole series" (there is
+// nothing left before the split to keep as a separate, un-truncated master).
+// Shared by the cloud command path's collapse-to-whole-series branches and
+// command-replay's staleness check for the same scope, so the threshold is
+// defined once.
+export function isFollowingSplitAtSeriesStart(
+  schedule: EventSchedule,
+  splitAt: Date,
+): boolean {
+  return splitAt.getTime() <= scheduleStartAt(schedule).getTime();
+}
+
 // The normalized EXCLUSIVE end instant, paired with scheduleStartAt to form a
 // half-open [startAt, endAt) interval on one coherent UTC axis — what a busy /
 // overlap query needs (a timed or all-day occurrence starting before a window

--- a/packages/sync/src/storage/repositories/command.repository.db.test.ts
+++ b/packages/sync/src/storage/repositories/command.repository.db.test.ts
@@ -118,6 +118,63 @@ describe("CommandRepository", () => {
     expect(result).toBeNull();
   });
 
+  it("reopens a terminal command to pending, preserving id/key/attemptCount", async () => {
+    const { record: command } = await repo.submit(submit());
+    const confirmed = await repo.updateOutcome(
+      command.tenantId,
+      command.principalId,
+      command._id,
+      { state: "confirmed", providerEventId: "evt-1", providerVersion: "e-1" },
+      2,
+    );
+    if (!confirmed) throw new Error("expected a confirmed command");
+
+    const reopened = await repo.reopen(
+      command.tenantId,
+      command.principalId,
+      command._id,
+      "confirmed",
+    );
+
+    expect(reopened?.outcome).toEqual({ state: "pending" });
+    expect(reopened?._id).toBe(command._id);
+    expect(reopened?.idempotencyKey).toBe(command.idempotencyKey);
+    expect(reopened?.attemptCount).toBe(2);
+    expect(await db.collection("commands").countDocuments()).toBe(1);
+  });
+
+  it("refuses to reopen when the outcome no longer matches the expected state (the concurrent-resubmit race)", async () => {
+    const { record: command } = await repo.submit(submit());
+    await repo.updateOutcome(
+      command.tenantId,
+      command.principalId,
+      command._id,
+      { state: "confirmed", providerEventId: null, providerVersion: null },
+      0,
+    );
+
+    // A concurrent resubmit already reopened (or re-terminated) it — this
+    // caller's stale expectedState no longer matches.
+    const result = await repo.reopen(
+      command.tenantId,
+      command.principalId,
+      command._id,
+      "failed",
+    );
+
+    expect(result).toBeNull();
+    const untouched = await repo.findById(
+      command.tenantId,
+      command.principalId,
+      command._id,
+    );
+    expect(untouched?.outcome).toEqual({
+      state: "confirmed",
+      providerEventId: null,
+      providerVersion: null,
+    });
+  });
+
   it("lists only nonterminal commands, oldest first", async () => {
     const tenantId = objectId();
     const principalId = objectId();

--- a/packages/sync/src/storage/repositories/command.repository.ts
+++ b/packages/sync/src/storage/repositories/command.repository.ts
@@ -70,6 +70,32 @@ export class CommandRepository {
     };
   }
 
+  // Reopen a terminal command back to pending, so submitCloudCommand's normal
+  // pending-apply path re-executes it. The `expectedState` filter is the
+  // concurrency guard: two simultaneous resubmits of the same stale terminal
+  // command cannot both reopen it — the loser's write matches nothing and
+  // gets null back, leaving the winner as the sole executor. `_id`,
+  // `idempotencyKey`, and `attemptCount` are untouched, so the one-row-per-key
+  // contract and the audit trail both survive the reopen.
+  async reopen(
+    tenantId: TenantId,
+    principalId: PrincipalId,
+    id: SyncCommandId,
+    expectedState: SyncCommandOutcome["state"],
+  ): Promise<CommandRecord | null> {
+    const result = await this.collection.findOneAndUpdate(
+      { _id: id, tenantId, principalId, "outcome.state": expectedState },
+      {
+        $set: {
+          outcome: { state: "pending" } as SyncCommandOutcome,
+          updatedAt: new Date(),
+        },
+      },
+      { returnDocument: "after" },
+    );
+    return result ? CommandRecordSchema.parse(result) : null;
+  }
+
   async findById(
     tenantId: TenantId,
     principalId: PrincipalId,


### PR DESCRIPTION
## Summary

Deleting an event, undoing that delete (Cmd+Z), then deleting again could return `204 No Content`, show a "Deleted" toast, and leave the event fully intact on both Compass and Google Calendar — permanently. Reproduced and root-caused against prod: the delete command's idempotency key is a hash of `(eventId, scope, recurrenceId)` with no nonce. Undo of a single-event delete recreates the event under its *original* id ("A25" behavior in `useUndoRedo.ts`), so the second delete collides with the first delete's already-`confirmed` command. `submitCloudCommand` replayed that stale confirmed outcome forever — no provider call, no local removal, and `commands` has no TTL to ever clear it.

Fix: `submitCloudCommand` (`packages/sync/src/domain/cloud-command.service.ts`) now checks, on a terminal replay, whether the command's effect actually still holds (`terminalReplayIsStale` in the new `packages/sync/src/domain/command-replay.ts`). If the target event is still live, the command is reopened to pending (`CommandRepository.reopen`, CAS-guarded on the expected prior state) and re-executed instead of short-circuited. Covers delete scopes `all`/`this`/`thisAndFollowing`.

The idempotency key itself is left identity-only on purpose — a timed-out delete must retry under the *same* key (see `submitCommandOrThrow`'s timeout handling). A comment now documents that at the call site so a future reader doesn't "fix" the collision with a nonce.

## Simplicity

Ran `/simplify` with 4 parallel review angles (reuse, simplification, efficiency, altitude) against the diff before opening this PR:
- Extracted a "thisAndFollowing split collapses to full-series delete" predicate (`isFollowingSplitAtSeriesStart` in `occurrence-projection.ts`) that was inlined three times (one of them new in this diff) into one shared function.
- Deduped two identical `findById` calls in `terminalReplayIsStale`.
- Removed a genuinely dead `if (state !== "pending")` check the new reopen-guard made unreachable on every path.
- Skipped (with reasoning in the diff): threading an already-fetched event through `applyCloudMutation` to save a second Mongo read — real but only on the rare stale-replay path, and the fix would touch a shared function signature for marginal benefit. Also skipped a proposed timestamp-based redesign of the liveness check — the reviewer itself called the current scope-shaped predicate "reasonable, not a bandaid," and a redesign is a bigger behavioral bet than a simplify pass should make.

## Automated validation

No browser-observable surface — this is pure backend/sync-service logic with no UI change, so browser verification wasn't applicable. Ran the equivalent: full package test suites plus a targeted, hand-constructed regression scenario reproducing the exact prod failure (delete → recreate under same id → delete again, both cloud-only and provider-linked, asserting the provider delete call actually fires the second time).

## Independent review

A fresh review agent (no access to my diagnosis or conclusions) found one real, high-confidence issue in the first cut: guarding `create` command replays for staleness too (in addition to `delete`) created a resurrection risk. `create`'s idempotency key (`create:${eventId}`) is stable for that event id's whole lifetime, so a *later, unrelated* resubmit of the same create payload — e.g. `local-event-sync.util.ts`'s offline-event-promotion retry, not just an undo — could collide with an already-confirmed create and silently recreate an event the user had since genuinely, deliberately deleted. Nothing in the command history can distinguish "the delete this undo reverses" from "an unrelated delete that happened since," so I removed the create-staleness branch entirely and scoped the guard to delete only (matching the already-accepted, explicitly-tested non-guard for update/move).

A second review pass against the updated diff confirmed the fix is fully resolved, traced the original bug scenario end-to-end through the current code to confirm it's actually fixed, checked every delete branch (`all`/`this`/`thisAndFollowing`) for any path that could itself cause resurrection (none), and found no further issues.

## Test plan

```
bun run type-check
bun run test:sync
bun run test:backend
```
Plus targeted runs during development:
```
bun packages/scripts/src/testing/test-mongo-env.ts sync -- 'packages/sync/src/domain/cloud-command.service.db.test.ts' 'packages/sync/src/storage/repositories/command.repository.db.test.ts'
cd packages/backend && TZ=UTC NODE_ENV=test PORT=0 bunx bun test src/common/services/sync-service/event-command.translation.test.ts
cd packages/web && TZ=UTC NODE_ENV=test PORT=0 bunx bun test src/events/mutations/useUndoRedo.test.tsx
```
All green (`bun run test:sync`: 804/804, `bun run test:backend`: 328/328 + 1 pre-existing skip). One pre-existing, unrelated flake noted and confirmed not caused by this change: `packages/web/src/events/queries/useWeekEventsQuery.test.ts` times out in isolation on this worktree with zero files touched in this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)