### PR TITLE
fix(events): stop delete-undo from failing and lying about it

### DIFF
--- a/packages/backend/src/common/services/sync-service/event-command.translation.test.ts
+++ b/packages/backend/src/common/services/sync-service/event-command.translation.test.ts
@@ -181,6 +181,31 @@ describe("toCreateSubmitRequest", () => {
       clientEventId: null,
     });
   });
+
+  it("forwards restore:true from an undo-of-delete input", () => {
+    const { request } = toCreateSubmitRequest({
+      id: objectId(),
+      calendarId: objectId(),
+      content: { kind: "details", title: "X", description: "", location: "" },
+      schedule: timedSchedule,
+      recurrence: { kind: "single" },
+      restore: true,
+    });
+
+    expect(request.restore).toBe(true);
+    expect(() => CommandSubmitRequestSchema.parse(request)).not.toThrow();
+  });
+
+  it("omits restore when the input does not set it", () => {
+    const { request } = toCreateSubmitRequest({
+      calendarId: objectId(),
+      content: { kind: "details", title: "X", description: "", location: "" },
+      schedule: timedSchedule,
+      recurrence: { kind: "single" },
+    });
+
+    expect(request.restore).toBeUndefined();
+  });
 });
 
 describe("toReplaceSubmitRequests", () => {
@@ -229,6 +254,32 @@ describe("toReplaceSubmitRequests", () => {
     if (update?.input.kind !== "update") return;
     expect(update.input.scope).toBe("this");
     expect(update.input.recurrenceId).toBe(recurrenceId);
+  });
+
+  it("forwards restore:true without changing the update idempotency key", () => {
+    const eventId = objectId();
+    const input = {
+      content: {
+        kind: "details" as const,
+        title: "Renamed",
+        description: "",
+        location: "",
+      },
+      schedule: timedSchedule,
+      recurrence: { kind: "preserve" as const },
+      scope: "this" as const,
+    };
+    const { requests: plain } = toReplaceSubmitRequests(eventId, input);
+    const { requests: restored } = toReplaceSubmitRequests(eventId, {
+      ...input,
+      restore: true,
+    });
+
+    expect(plain[0]?.restore).toBeUndefined();
+    expect(restored[0]?.restore).toBe(true);
+    // The whole point: a replayed edit collides with the original update's
+    // command record, so the reopen guard in command-replay.ts can act on it.
+    expect(restored[0]?.idempotencyKey).toBe(plain[0]?.idempotencyKey);
   });
 
   it("appends a move command when calendarId is present", () => {

--- a/packages/backend/src/common/services/sync-service/event-command.translation.ts
+++ b/packages/backend/src/common/services/sync-service/event-command.translation.ts
@@ -147,6 +147,7 @@ export const toCreateSubmitRequest = (
       schedule: input.schedule,
       recurrence: input.recurrence,
     },
+    ...(input.restore ? { restore: true as const } : {}),
   });
 
   const now = new Date().toISOString();
@@ -193,6 +194,10 @@ export const toReplaceSubmitRequests = (
       scope: target.scope,
       recurrenceId: target.recurrenceId,
     },
+    // Deliberately excluded from the hashed key above - colliding with the
+    // original update's key is the point (that's how a replayed edit reaches
+    // the same command for the reopen guard to act on).
+    ...(input.restore ? { restore: true as const } : {}),
   });
 
   const requests: CommandSubmitRequest[] = [updateRequest];
@@ -225,7 +230,11 @@ export const toReplaceSubmitRequests = (
 // same target collide on one command record — including a delete, an undo
 // that recreates the event under the same id, and a second delete. Sync's
 // submitCloudCommand (terminalReplayIsStale) is what tells a genuine replay
-// apart from a stale one; don't "fix" a collision here with a nonce.
+// apart from a stale one; don't "fix" a collision here with a nonce. The
+// undo-of-delete's own recreate is a create/update command carrying the
+// `restore` flag (see toCreateSubmitRequest/toReplaceSubmitRequests) - that
+// flag is what lets ITS collision (against the original create/update, not
+// this delete) get the same reopen treatment.
 export const toDeleteSubmitRequest = (
   id: string,
   input: DeleteEventInput,

--- a/packages/backend/src/event/controllers/event.controller.test.ts
+++ b/packages/backend/src/event/controllers/event.controller.test.ts
@@ -210,6 +210,31 @@ describe("EventController", () => {
     expect(json).toHaveBeenCalled();
   });
 
+  it("rejects an unrecognized content key as 400 INVALID_INPUT, not a provider failure", async () => {
+    const { res, json } = jsonRes();
+    await eventController.create(
+      sessionReq(objectId(), {
+        body: {
+          ...sampleCreateBody(),
+          content: {
+            ...sampleCreateBody().content,
+            // Read-shaped fields a round-tripped event carries that the
+            // strict write schema never accepts - see EditableContentSchema.
+            organizer: { email: "host@example.com", displayName: null },
+            attendees: [],
+            conference: null,
+          },
+        },
+      }),
+      res,
+    );
+
+    expect(res.status).toHaveBeenCalledWith(Status.BAD_REQUEST);
+    expect(json).toHaveBeenCalledWith(
+      expect.objectContaining({ code: "INVALID_INPUT", retryable: false }),
+    );
+  });
+
   it("fails closed on a sync outage when replacing an event", async () => {
     const { res, json } = jsonRes();
     await eventController.replace(

--- a/packages/backend/src/event/event.error.ts
+++ b/packages/backend/src/event/event.error.ts
@@ -1,4 +1,4 @@
-import { type z } from "zod/v4";
+import { ZodError, type z } from "zod/v4";
 import { BaseError } from "@core/errors/errors.base";
 import { Status } from "@core/errors/status.codes";
 import {
@@ -22,6 +22,7 @@ const STATUS_BY_CODE: Record<EventMutationErrorCode, Status> = {
   GOOGLE_REVOKED: Status.UNAUTHORIZED,
   MAINTENANCE: Status.SERVICE_UNAVAILABLE,
   MOVE_UNSUPPORTED: Status.BAD_REQUEST,
+  INVALID_INPUT: Status.BAD_REQUEST,
 };
 
 const RETRYABLE_BY_CODE: Record<EventMutationErrorCode, boolean> = {
@@ -36,6 +37,7 @@ const RETRYABLE_BY_CODE: Record<EventMutationErrorCode, boolean> = {
   GOOGLE_REVOKED: false,
   MAINTENANCE: true,
   MOVE_UNSUPPORTED: false,
+  INVALID_INPUT: false,
 };
 
 export class EventMutationException extends BaseError {
@@ -89,6 +91,24 @@ export const toEventMutationError = (
         },
       };
     }
+  }
+
+  // A contract violation (e.g. CreateEventInputSchema.parse rejecting an
+  // unrecognized key) is a client-side mistake, not a provider outage — map
+  // it to its own code/status rather than falling into the provider-failure
+  // catch-all below, which used to mislabel it as a retryable 500.
+  if (e instanceof ZodError) {
+    const message = e.issues
+      .map((issue) => `${issue.path.join(".")}: ${issue.message}`)
+      .join("; ");
+    return {
+      status: STATUS_BY_CODE.INVALID_INPUT,
+      body: {
+        code: "INVALID_INPUT",
+        message,
+        retryable: RETRYABLE_BY_CODE.INVALID_INPUT,
+      },
+    };
   }
 
   const message = e instanceof Error ? e.message : "Unexpected error";

--- a/packages/core/src/types/event-command.contracts.ts
+++ b/packages/core/src/types/event-command.contracts.ts
@@ -49,6 +49,12 @@ export const CreateEventInputSchema = z.strictObject({
   content: EditableContentSchema,
   schedule: EventScheduleSchema,
   recurrence: EditableRecurrenceSchema,
+  // Undo/redo replay marker: this submission is fresh user intent that may
+  // collide with a terminal command sharing its idempotency key (undo-of-
+  // delete recreating under the same event id). Sync reopens the collided
+  // command instead of treating the resubmission as a no-op replay. Never
+  // set by a normal create or by offline-promotion retries.
+  restore: z.literal(true).optional(),
 });
 export type CreateEventInput = z.infer<typeof CreateEventInputSchema>;
 
@@ -62,6 +68,10 @@ export const ReplaceEventInputSchema = z.strictObject({
   schedule: EventScheduleSchema,
   recurrence: RecurrenceEditSchema,
   scope: RecurrenceScopeSchema,
+  // Same undo/redo replay marker as CreateEventInputSchema.restore, for
+  // replayed edits and redo-of-edit (both hit the same colliding-key replay
+  // problem on the update side).
+  restore: z.literal(true).optional(),
 });
 export type ReplaceEventInput = z.infer<typeof ReplaceEventInputSchema>;
 
@@ -143,6 +153,9 @@ export const EventMutationErrorCodeSchema = z.enum([
   // Sync has no executor for a "move" command yet (unconditionally fails it),
   // so this is rejected before any command is submitted — never retryable.
   "MOVE_UNSUPPORTED",
+  // The request body failed contract validation (e.g. an unrecognized key on
+  // a strict schema). Always a client-side mistake, never retryable.
+  "INVALID_INPUT",
 ]);
 
 export const EventMutationErrorSchema = z.strictObject({

--- a/packages/core/src/types/sync/command.contracts.ts
+++ b/packages/core/src/types/sync/command.contracts.ts
@@ -211,6 +211,12 @@ export const CommandSubmitRequestSchema = z
     eventId: EventIdSchema,
     input: SyncCommandInputSchema,
     expectedVersion: ProviderEventVersionSchema.nullable(),
+    // Per-submission undo/redo replay intent (never persisted on the command
+    // record itself) — see CreateEventInputSchema.restore in
+    // event-command.contracts.ts. Lets a resubmission that collides with a
+    // terminal command on the same idempotency key be reopened and
+    // re-executed instead of short-circuited as a no-op replay.
+    restore: z.literal(true).optional(),
   })
   .refine(
     (request) =>

--- a/packages/sync/src/domain/cloud-command.service.db.test.ts
+++ b/packages/sync/src/domain/cloud-command.service.db.test.ts
@@ -1719,6 +1719,130 @@ describe("submitCloudCommand provider dispatch", () => {
       ).toBeNull();
     });
 
+    // restore:true is the explicit client intent (undo-of-delete) that flips
+    // the above no-op into a genuine reopen — see terminalReplayIsStale's
+    // docblock in command-replay.ts. Only set by useUndoRedo's replays, never
+    // by an offline-promotion retry, so the resurrection risk above doesn't
+    // apply here.
+    it("reopens a restore-flagged create replay and re-executes it with the client's refreshed content", async () => {
+      const tenantId = objectId() as TenantId;
+      const principalId = objectId() as PrincipalId;
+      const submit = submitFor(tenantId, principalId, objectId());
+
+      const first = await submitCloudCommand(deps(), submit, now);
+      expect(first.command.outcome.state).toBe("confirmed");
+
+      await events.deleteById(tenantId, principalId, submit.eventId);
+
+      const restoreSubmit: CommandSubmit = {
+        ...submit,
+        restore: true,
+        input: {
+          kind: "create",
+          calendarId: (submit.input as { calendarId: string }).calendarId,
+          invitation: "none",
+          content: {
+            title: "Edited before delete",
+            description: "",
+            location: null,
+            organizer: null,
+            attendees: [],
+            conference: null,
+          },
+          schedule: (submit.input as { schedule: unknown }).schedule,
+          recurrence: { kind: "single" },
+        } as unknown as SyncCommandInput,
+      };
+      const second = await submitCloudCommand(deps(), restoreSubmit, now);
+
+      expect(second.changed).toBe(true);
+      expect(second.command.outcome.state).toBe("confirmed");
+      const restored = await events.findById(
+        tenantId,
+        principalId,
+        submit.eventId,
+      );
+      expect(restored?.content).toMatchObject({
+        title: "Edited before delete",
+      });
+      // Reopen updates the SAME row rather than minting a second command.
+      expect(
+        await mongo.db
+          .collection(SYNC_COLLECTIONS.commands)
+          .countDocuments({ idempotencyKey: submit.idempotencyKey }),
+      ).toBe(1);
+    });
+
+    it("treats a restore-flagged create replay as a no-op when the event is still active", async () => {
+      const tenantId = objectId() as TenantId;
+      const principalId = objectId() as PrincipalId;
+      const submit = submitFor(tenantId, principalId, objectId());
+
+      const first = await submitCloudCommand(deps(), submit, now);
+      expect(first.command.outcome.state).toBe("confirmed");
+
+      // No delete in between - a double-undo or a retry after the restore
+      // already landed.
+      const second = await submitCloudCommand(
+        deps(),
+        { ...submit, restore: true },
+        now,
+      );
+
+      expect(second.changed).toBe(false);
+    });
+
+    it("never reopens an explicitly cancelled create even when restore is set", async () => {
+      const tenantId = objectId() as TenantId;
+      const principalId = objectId() as PrincipalId;
+      const submit = submitFor(tenantId, principalId, objectId());
+      const { record: pending } = await commands.submit(submit);
+      await commands.updateOutcome(
+        tenantId,
+        principalId,
+        pending._id,
+        { state: "cancelled" },
+        pending.attemptCount,
+      );
+
+      const result = await submitCloudCommand(
+        deps(),
+        { ...submit, restore: true },
+        now,
+      );
+
+      expect(result.changed).toBe(false);
+      expect(result.command.outcome.state).toBe("cancelled");
+    });
+
+    it("reopens a restore-flagged update replay even though its content is identical to the original", async () => {
+      const tenantId = objectId() as TenantId;
+      const principalId = objectId() as PrincipalId;
+      const eventId = objectId() as EventId;
+      await seedEvent(tenantId, principalId, eventId);
+      const submit = updateAllFor(
+        tenantId,
+        principalId,
+        eventId,
+        "Replayed title",
+      );
+
+      const first = await submitCloudCommand(deps(), submit, now);
+      expect(first.command.outcome.state).toBe("confirmed");
+
+      // Without restore, this exact resubmission is the existing no-op
+      // (pinned above). With it (redo-of-edit / undo replaying the same
+      // snapshot again), it must actually re-apply.
+      const second = await submitCloudCommand(
+        deps(),
+        { ...submit, restore: true },
+        now,
+      );
+
+      expect(second.changed).toBe(true);
+      expect(second.command.outcome.state).toBe("confirmed");
+    });
+
     it("does not re-litigate an explicitly cancelled command", async () => {
       const tenantId = objectId() as TenantId;
       const principalId = objectId() as PrincipalId;

--- a/packages/sync/src/domain/cloud-command.service.ts
+++ b/packages/sync/src/domain/cloud-command.service.ts
@@ -99,16 +99,18 @@ export interface CloudCommandDeps {
 // command is likewise persisted as durable pending intent and returned
 // unchanged; applying update/move/delete locally lands in a later slice.
 //
-// A terminal DELETE replay is not automatically a no-op. Its idempotency key
-// is identity-only (eventId/scope/recurrenceId), so a delete, undo
-// (recreate under the SAME event id — see useUndoRedo.ts's "A25" doc
-// comment), and delete-again collide on the same key as the first delete.
-// terminalReplayIsStale checks whether the world still matches what that
-// terminal command once confirmed; if it doesn't, the command is reopened to
-// pending and re-executed below rather than replayed as a no-op. Without
-// this, a delete that once confirmed without truly deleting (or was undone
-// and redone) becomes permanently unreachable — `commands` has no TTL. See
-// command-replay.ts for why this guard is delete-only, not create too.
+// A terminal command replay is not automatically a no-op. A delete's
+// idempotency key is identity-only (eventId/scope/recurrenceId), and an
+// update's key hashes its full content, so a delete/undo/delete-again (or an
+// edit replayed by undo/redo) can collide with an earlier terminal command on
+// the same key. terminalReplayIsStale checks whether that collision is a
+// genuine no-op or a fresh intent (a delete is checked against world state;
+// a create/update only when the client marks the submission `restore: true`
+// — see its docblock in command-replay.ts for why they differ). When stale,
+// the command is reopened to pending and re-executed below rather than
+// replayed as a no-op. Without this, a delete that once confirmed without
+// truly deleting (or was undone and redone) becomes permanently unreachable —
+// `commands` has no TTL.
 export async function submitCloudCommand(
   deps: CloudCommandDeps,
   submit: CommandSubmit,
@@ -117,14 +119,21 @@ export async function submitCloudCommand(
   let { record: command, inserted } = await deps.commands.submit(submit);
 
   if (!inserted && command.outcome.state !== "pending") {
-    if (!(await terminalReplayIsStale(deps, command))) {
+    if (!(await terminalReplayIsStale(deps, command, submit))) {
       return { command, changed: false };
     }
+    // A restore reopen of a create refreshes the stored payload to the
+    // client's current snapshot — see CommandRepository.reopen's docblock.
+    const refreshedInput =
+      submit.restore && command.input.kind === "create"
+        ? submit.input
+        : undefined;
     const reopened = await deps.commands.reopen(
       command.tenantId,
       command.principalId,
       command._id,
       command.outcome.state,
+      refreshedInput,
     );
     // null means a concurrent submit already reopened (or re-terminated) this
     // command between our read and this write; that request owns execution.

--- a/packages/sync/src/domain/command-replay.ts
+++ b/packages/sync/src/domain/command-replay.ts
@@ -7,13 +7,15 @@ import {
   exceptionInstant,
   isCancelledException,
 } from "@sync/domain/series-exception";
-import { type CommandRecord } from "@sync/storage/contracts/command.contracts";
+import {
+  type CommandRecord,
+  type CommandSubmit,
+} from "@sync/storage/contracts/command.contracts";
 
-// Whether a terminal DELETE command's replay should be treated as a genuine
-// no-op (the world already matches what it once confirmed) or as stale (the
-// world has since diverged, so the command's target incarnation is gone and
-// this submission is really a fresh intent that happens to share an identity
-// key).
+// Whether a terminal command's replay should be treated as a genuine no-op
+// (the world already matches what it once confirmed) or as stale (this
+// submission is really a fresh intent that happens to share an identity/
+// content key with an earlier terminal command).
 //
 // The delete idempotency key is deliberately identity-only (eventId/scope/
 // recurrenceId — see toDeleteSubmitRequest in event-command.translation.ts),
@@ -22,28 +24,48 @@ import { type CommandRecord } from "@sync/storage/contracts/command.contracts";
 // Without this check, submitCloudCommand's short-circuit at the top of the
 // function returns the OLD confirmed command forever: 204 to the caller, no
 // provider call, no local change, and no TTL on `commands` to ever clear it.
+// A delete resubmit needs no explicit intent flag to get this treatment - a
+// world-state check (does the event still look deleted?) is enough on its
+// own, since a delete's only failure mode from checking too eagerly is
+// re-deleting an already-deleted event, which is harmless.
 //
-// create is deliberately NOT guarded here, unlike delete — this is not the
-// same "no observed failure, real clobber risk" tradeoff update/move make
-// (see retryCloudMutation's docblock in cloud-command.service.ts). The
-// create idempotency key (`create:${eventId}`) is stable for that event id's
-// whole lifetime, so ANY later resubmission of the same create payload
-// collides with the original — not only the A25 undo.
-// packages/web/src/common/utils/sync/local-event-sync.util.ts's offline
-// promotion retries a create under the record's own stable id whenever the
-// client never observed the first attempt's success; if the user deletes
-// that event before the retry fires, "existing === null ⇒ stale" would
-// silently resurrect an event the user deliberately removed. Nothing in the
-// command history can tell "the delete this create-replay's undo is
-// reversing" apart from "an unrelated delete that happened since" — so
-// leave create as a no-op replay (matching its pre-fix behavior) rather than
-// guess wrong in the resurrection direction.
+// create and update are different: the create idempotency key
+// (`create:${eventId}`) is stable for that event id's whole lifetime, and the
+// update key hashes its full content (see toReplaceSubmitRequests), so ANY
+// later resubmission of the same payload collides with the original - not
+// only an undo/redo replay. A world-state guess gets this wrong in a way
+// that's NOT harmless: packages/web/src/common/utils/sync/
+// local-event-sync.util.ts's offline promotion retries a create under the
+// record's own stable id whenever the client never observed the first
+// attempt's success; if the user deletes that event before the retry fires,
+// "existing === null ⇒ stale" would silently resurrect an event the user
+// deliberately removed. Nothing in the command history can tell "the delete
+// this replay's undo is reversing" apart from "an unrelated delete that
+// happened since" - so create/update are guarded only when the client
+// explicitly marks the submission `restore: true` (set by useUndoRedo's
+// replays, never by offline promotion) rather than guessing from world state.
 export async function terminalReplayIsStale(
   deps: Pick<CloudCommandDeps, "events">,
   command: CommandRecord,
+  submit: Pick<CommandSubmit, "restore">,
 ): Promise<boolean> {
   // An explicit cancellation is not re-litigated by a resubmit.
   if (command.outcome.state === "cancelled") return false;
+
+  if (command.input.kind === "update") return submit.restore === true;
+
+  if (command.input.kind === "create") {
+    if (submit.restore !== true) return false;
+    const existing = await deps.events.findById(
+      command.tenantId,
+      command.principalId,
+      command.eventId,
+    );
+    // Double-undo, or a retry after the restore already landed: the event is
+    // already back, so re-executing would risk a duplicate provider insert.
+    return !existing || existing.lifecycleState !== "active";
+  }
+
   if (command.input.kind !== "delete") return false;
 
   const existing = await deps.events.findById(

--- a/packages/sync/src/server/command.routes.ts
+++ b/packages/sync/src/server/command.routes.ts
@@ -113,6 +113,7 @@ export function registerCommandRoutes(
             eventId: request.eventId,
             input: request.input,
             expectedVersion: request.expectedVersion,
+            ...(request.restore ? { restore: true as const } : {}),
           },
           () => (deps.now ? new Date(deps.now()) : new Date()),
         );

--- a/packages/sync/src/storage/contracts/command.contracts.ts
+++ b/packages/sync/src/storage/contracts/command.contracts.ts
@@ -55,6 +55,10 @@ export const CommandSubmitSchema = z
     eventId: EventIdSchema,
     input: SyncCommandInputSchema,
     expectedVersion: ProviderEventVersionSchema.nullable(),
+    // Per-submission undo/redo replay intent, not persisted on the command
+    // record (submit() only ever $setOnInsert's this object) — see
+    // CommandSubmitRequestSchema.restore.
+    restore: z.literal(true).optional(),
   })
   .refine(createHasNoExpectedVersion, createExpectedVersionIssue);
 export type CommandSubmit = z.infer<typeof CommandSubmitSchema>;

--- a/packages/sync/src/storage/repositories/command.repository.ts
+++ b/packages/sync/src/storage/repositories/command.repository.ts
@@ -77,11 +77,19 @@ export class CommandRepository {
   // gets null back, leaving the winner as the sole executor. `_id`,
   // `idempotencyKey`, and `attemptCount` are untouched, so the one-row-per-key
   // contract and the audit trail both survive the reopen.
+  //
+  // `input`, when given, replaces the command's stored payload before it
+  // re-executes — needed for a restore reopen: `submit()` only ever sets
+  // `input` on first insert, so without this a reopened create would
+  // re-execute its ORIGINAL payload, not the (possibly since-edited) snapshot
+  // the client is restoring. The idempotency key still means "the create of
+  // event X" either way.
   async reopen(
     tenantId: TenantId,
     principalId: PrincipalId,
     id: SyncCommandId,
     expectedState: SyncCommandOutcome["state"],
+    input?: SyncCommandInput,
   ): Promise<CommandRecord | null> {
     const result = await this.collection.findOneAndUpdate(
       { _id: id, tenantId, principalId, "outcome.state": expectedState },
@@ -89,6 +97,7 @@ export class CommandRepository {
         $set: {
           outcome: { state: "pending" } as SyncCommandOutcome,
           updatedAt: new Date(),
+          ...(input ? { input } : {}),
         },
       },
       { returnDocument: "after" },

--- a/packages/web/src/common/utils/sync/local-event-sync.util.ts
+++ b/packages/web/src/common/utils/sync/local-event-sync.util.ts
@@ -9,7 +9,7 @@ import {
   getOfflineDataStore,
 } from "@web/common/storage/offline-data/offline-data.store.registry";
 import { EventApi } from "@web/events/event.api";
-import { detailsLocation } from "@web/events/grid-event-draft.adapter";
+import { editableContent } from "@web/events/grid-event-draft.adapter";
 import { type LocalEventRecord } from "@web/events/types/local-event.record";
 
 type LocalEventSyncStorage = Pick<
@@ -84,10 +84,7 @@ function toCreateInput(
             ],
           }
         : { kind: "single" },
-    content: {
-      ...content,
-      location: detailsLocation(content),
-    } as CreateEventInput["content"],
+    content: editableContent(content),
   };
 }
 

--- a/packages/web/src/common/utils/toast/deleted-toast.util.tsx
+++ b/packages/web/src/common/utils/toast/deleted-toast.util.tsx
@@ -38,3 +38,13 @@ export function showRestoredToast(): void {
     autoClose: getToastDefaultOptions().autoClose,
   });
 }
+
+/**
+ * The restore mutation failed server-side after the optimistic insert already
+ * rolled back. Unlike showRestoredToast, this uses showStatusToast's
+ * create-or-update so it still surfaces even if the "Deleted" toast already
+ * auto-dismissed by the time the failure comes back.
+ */
+export function showRestoreFailedToast(): void {
+  showStatusToast(EVENT_DELETED_TOAST_ID, "Couldn't restore the event");
+}

--- a/packages/web/src/events/grid-event-draft.adapter.ts
+++ b/packages/web/src/events/grid-event-draft.adapter.ts
@@ -493,6 +493,25 @@ export const detailsLocation = (
   content: Extract<Event["content"], { kind: "details" }>,
 ): string => content.location ?? "";
 
+// The write contracts (CreateEventInputSchema/ReplaceEventInputSchema) accept
+// only the editable subset via a strict content schema; a read-shaped
+// Event["content"] also carries provider-sourced organizer/attendees/
+// conference/colorHex (added for the read side by #2555). A spread bypasses
+// TypeScript's excess-property checks, so this runtime pick is the only thing
+// that keeps a replayed/round-tripped event from failing that strict schema.
+// Preserves color's absent-vs-null distinction: omitted leaves sync's color
+// alone, null clears it (see EditableContentSchema's comment) - a spread of
+// `color` would already do this correctly, this mirrors that.
+export const editableContent = (
+  content: Extract<Event["content"], { kind: "details" }>,
+) => ({
+  kind: "details" as const,
+  title: content.title,
+  description: content.description,
+  location: detailsLocation(content),
+  ...(content.color !== undefined ? { color: content.color } : {}),
+});
+
 const editableDetailsFromEvent = (
   event: Event,
 ): {

--- a/packages/web/src/events/mutations/useEventMutations.ts
+++ b/packages/web/src/events/mutations/useEventMutations.ts
@@ -24,6 +24,7 @@ import {
   dismissRecurrenceScopeToastFor,
   showRecurrenceScopeSuccessToast,
 } from "@web/common/utils/toast/recurrence-scope.toast";
+import { editableContent } from "@web/events/grid-event-draft.adapter";
 import {
   applyEventProjectionAcrossQueries,
   eventBelongsToEntry,
@@ -215,9 +216,17 @@ type DeleteVariables = {
   opportunityId?: number;
 };
 
+export type EventMutationCallbacks = {
+  onSuccess?: () => void;
+  onError?: () => void;
+};
+
 export type EventMutations = {
-  create: (input: CreateEventInput) => void;
-  replace: (payload: { id: EventId; input: ReplaceEventInput }) => void;
+  create: (input: CreateEventInput, callbacks?: EventMutationCallbacks) => void;
+  replace: (
+    payload: { id: EventId; input: ReplaceEventInput },
+    callbacks?: EventMutationCallbacks,
+  ) => void;
   delete: (payload: { id: EventId; scope: RecurrenceScope }) => void;
   promoteRecurring: (
     opportunity: RecurrenceScopeOpportunity,
@@ -424,7 +433,17 @@ export function useEventMutations(
           variables.writeKey,
           variables,
           precedingDeleteOk,
-          () => repository.create(variables.input),
+          // Wire boundary: strip to the editable subset here, not at the
+          // callers (useUndoRedo replays a full cached Event's content on
+          // purpose, to keep it for the optimistic insert above). This is
+          // the one place every create funnels through, so it's the only
+          // spot that needs to know the write schema is stricter than the
+          // read shape.
+          () =>
+            repository.create({
+              ...variables.input,
+              content: editableContent(variables.input.content),
+            }),
         );
       },
       ({ input }) => {
@@ -458,7 +477,12 @@ export function useEventMutations(
           variables.writeKey,
           variables,
           precedingCreateOk,
-          () => repository.replace(variables.id, variables.input),
+          // Same wire-boundary strip as create, see its comment above.
+          () =>
+            repository.replace(variables.id, {
+              ...variables.input,
+              content: editableContent(variables.input.content),
+            }),
           // A promotion replays the saved occurrence mutation at a broader
           // scope. It must reach the repository even if a later narrow edit
           // shares its occurrence write key.
@@ -587,15 +611,18 @@ export function useEventMutations(
   // they don't record themselves.
   return useMemo(
     () => ({
-      create: (input: CreateEventInput) => {
+      create: (input: CreateEventInput, callbacks?: EventMutationCallbacks) => {
         const id = input.id ?? (createObjectIdString() as EventId);
         const finalInput = { ...input, id };
         recordEventCreateHistory({
           event: optimisticEventFromCreate(finalInput),
         });
-        createMutation.mutate({ input: finalInput, writeKey: id });
+        createMutation.mutate({ input: finalInput, writeKey: id }, callbacks);
       },
-      replace: (payload: { id: EventId; input: ReplaceEventInput }) => {
+      replace: (
+        payload: { id: EventId; input: ReplaceEventInput },
+        callbacks?: EventMutationCallbacks,
+      ) => {
         const original = findEventInCache(queryClient, payload.id, source);
         if (isTargetReadOnly(original)) {
           console.warn(
@@ -631,7 +658,10 @@ export function useEventMutations(
             source,
           });
         }
-        replaceMutation.mutate({ ...payload, writeKey, opportunityId });
+        replaceMutation.mutate(
+          { ...payload, writeKey, opportunityId },
+          callbacks,
+        );
       },
       delete: (payload: { id: EventId; scope: RecurrenceScope }) => {
         if (

--- a/packages/web/src/events/mutations/useUndoRedo.test.tsx
+++ b/packages/web/src/events/mutations/useUndoRedo.test.tsx
@@ -5,6 +5,7 @@ import { type EventId } from "@core/types/domain-primitives";
 import { type Event } from "@core/types/event.contracts";
 import {
   type CreateEventInput,
+  CreateEventInputSchema,
   type ReplaceEventInput,
 } from "@core/types/event-command.contracts";
 import { createTestToastPort } from "@web/__tests__/helpers/web-test-seams";
@@ -77,7 +78,7 @@ const setup = () => {
     }),
     { wrapper },
   );
-  return { calls, hook, queryClient };
+  return { calls, hook, queryClient, repository };
 };
 
 describe("useUndoRedo", () => {
@@ -239,6 +240,113 @@ describe("useUndoRedo", () => {
     expect(
       context.calls.filter(({ method }) => method === "delete"),
     ).toHaveLength(2);
+  });
+
+  test("undo of a delete strips provider-sourced fields and recreates only after the server confirms", async () => {
+    const { port, mocks } = createTestToastPort();
+    registerToastPort(port);
+    const context = setup();
+    const original = event({
+      content: {
+        kind: "details",
+        title: "Sync'd meeting",
+        description: "",
+        organizer: { email: "host@example.com", displayName: "Host" },
+        attendees: [
+          {
+            email: "guest@example.com",
+            displayName: "Guest",
+            responseStatus: "accepted",
+          },
+        ],
+        conference: { url: "https://meet.example.com/abc", label: "Meet" },
+      },
+    });
+    context.queryClient.setQueryData(calendarKey, normalized(original));
+
+    act(() =>
+      context.hook.result.current.mutations.delete({
+        id: original.id,
+        scope: "this",
+      }),
+    );
+    await waitFor(() => {
+      expect(
+        context.queryClient.getQueryData<NormalizedEventQueryData>(calendarKey)
+          ?.ids,
+      ).toEqual([]);
+    });
+
+    act(() => context.hook.result.current.undoRedo.undo());
+
+    // The toast must not claim success before the recreate mutation settles.
+    expect(mocks.update).not.toHaveBeenCalledWith(
+      EVENT_DELETED_TOAST_ID,
+      expect.objectContaining({ render: "Restored" }),
+    );
+
+    await waitFor(() => {
+      expect(
+        context.queryClient.getQueryData<NormalizedEventQueryData>(calendarKey)
+          ?.entities[original.id],
+      ).toBeDefined();
+    });
+
+    const createCall = context.calls.find(({ method }) => method === "create");
+    const payload = createCall?.value as CreateEventInput;
+    // The repository never sees organizer/attendees/conference - only the
+    // editable subset the strict write schema accepts.
+    expect(CreateEventInputSchema.safeParse(payload).success).toBe(true);
+    expect(payload.content).not.toHaveProperty("organizer");
+    expect(payload.content).not.toHaveProperty("attendees");
+    expect(payload.content).not.toHaveProperty("conference");
+    // The replay marker that lets sync reopen a colliding terminal command
+    // instead of treating this as a no-op replay.
+    expect(payload.restore).toBe(true);
+
+    await waitFor(() => {
+      expect(mocks.update).toHaveBeenCalledWith(
+        EVENT_DELETED_TOAST_ID,
+        expect.objectContaining({ render: "Restored" }),
+      );
+    });
+  });
+
+  test("undo of a delete shows a failure toast when the recreate is rejected", async () => {
+    const { port, mocks } = createTestToastPort();
+    registerToastPort(port);
+    const context = setup();
+    const original = event();
+    context.queryClient.setQueryData(calendarKey, normalized(original));
+    act(() =>
+      context.hook.result.current.mutations.delete({
+        id: original.id,
+        scope: "this",
+      }),
+    );
+    await waitFor(() => {
+      expect(
+        context.queryClient.getQueryData<NormalizedEventQueryData>(calendarKey)
+          ?.ids,
+      ).toEqual([]);
+    });
+
+    context.repository.create = async () => {
+      throw new Error("boom");
+    };
+
+    act(() => context.hook.result.current.undoRedo.undo());
+
+    await waitFor(() => {
+      expect(mocks.update).toHaveBeenCalledWith(
+        EVENT_DELETED_TOAST_ID,
+        expect.objectContaining({ render: "Couldn't restore the event" }),
+      );
+    });
+    expect(mocks.update).not.toHaveBeenCalledWith(
+      EVENT_DELETED_TOAST_ID,
+      expect.objectContaining({ render: "Restored" }),
+    );
   });
 
   test("undo and redo are no-ops with empty history", () => {

--- a/packages/web/src/events/mutations/useUndoRedo.ts
+++ b/packages/web/src/events/mutations/useUndoRedo.ts
@@ -4,14 +4,15 @@ import { type EventId } from "@core/types/domain-primitives";
 import { type Event } from "@core/types/event.contracts";
 import { UNDO_DECLINED_TOAST_ID } from "@web/common/constants/toast.constants";
 import { DATA_EVENT_ELEMENT_ID } from "@web/common/constants/web.constants";
-import { showRestoredToast } from "@web/common/utils/toast/deleted-toast.util";
 import {
-  dismissRecurrenceScopeToast,
-  dismissRecurrenceScopeToastFor,
-} from "@web/common/utils/toast/recurrence-scope.toast";
+  showRestoredToast,
+  showRestoreFailedToast,
+} from "@web/common/utils/toast/deleted-toast.util";
+import { dismissRecurrenceScopeToastFor } from "@web/common/utils/toast/recurrence-scope.toast";
 import { showStatusToast } from "@web/common/utils/toast/status-toast.util";
 import { detailsLocation } from "@web/events/grid-event-draft.adapter";
 import {
+  type EventMutationCallbacks,
   type EventMutationDependencies,
   useEventMutations,
 } from "@web/events/mutations/useEventMutations";
@@ -132,27 +133,41 @@ export function useUndoRedo(dependencies: EventMutationDependencies = {}) {
   // busy-provider event is never user-edited through our mutations), so a
   // snapshot's content is always safe to replay as-is.
   const replaySnapshot = useCallback(
-    (id: EventId, snapshot: Event) => {
+    (id: EventId, snapshot: Event, callbacks?: EventMutationCallbacks) => {
       if (snapshot.content.kind !== "details") return;
-      mutations.replace({
-        id,
-        input: {
-          // Restores the snapshot's calendar too, so undoing a cross-calendar
-          // move puts the event back on its original calendar.
-          calendarId: snapshot.calendarId,
-          content: {
-            ...snapshot.content,
-            location: detailsLocation(snapshot.content),
+      mutations.replace(
+        {
+          id,
+          input: {
+            // Restores the snapshot's calendar too, so undoing a cross-calendar
+            // move puts the event back on its original calendar.
+            calendarId: snapshot.calendarId,
+            // The wire boundary in useEventMutations strips this back to the
+            // editable subset before it reaches the server; kept full here so
+            // the optimistic merge above doesn't drop organizer/attendees/
+            // conference until the settle refetch.
+            content: {
+              ...snapshot.content,
+              location: detailsLocation(snapshot.content),
+            },
+            schedule: snapshot.schedule,
+            // "preserve" keeps whatever recurrence linkage the target already
+            // has (single, or one occurrence of a series) — scope "this"
+            // never changes that linkage server-side regardless of what's
+            // sent, so this is both correct and recurrence-agnostic.
+            recurrence: { kind: "preserve" },
+            scope: "this",
+            // Every replaySnapshot call is a replay (undo/redo of an edit, or
+            // un-cancelling an occurrence's delete tombstone below) — never a
+            // normal user edit, which goes through useSaveEventForm instead.
+            // See CreateEventInputSchema.restore's comment for why this
+            // matters: it's what lets a collision with an earlier terminal
+            // command on the same key be reopened instead of no-op'd.
+            restore: true,
           },
-          schedule: snapshot.schedule,
-          // "preserve" keeps whatever recurrence linkage the target already
-          // has (single, or one occurrence of a series) — scope "this"
-          // never changes that linkage server-side regardless of what's
-          // sent, so this is both correct and recurrence-agnostic.
-          recurrence: { kind: "preserve" },
-          scope: "this",
         },
-      });
+        callbacks,
+      );
     },
     [mutations],
   );
@@ -167,7 +182,7 @@ export function useUndoRedo(dependencies: EventMutationDependencies = {}) {
   // (whose own optimistic merge then finds it and is a harmless no-op
   // overwrite) carries it to the server.
   const undoDelete = useCallback(
-    (event: Event) => {
+    (event: Event, callbacks?: EventMutationCallbacks) => {
       if (event.content.kind !== "details") return;
       if (event.recurrence.kind === "occurrence") {
         upsertEventAcrossQueries(
@@ -176,19 +191,26 @@ export function useUndoRedo(dependencies: EventMutationDependencies = {}) {
           (entry) => eventBelongsToEntry(event, entry, source),
           { source },
         );
-        replaySnapshot(event.id as EventId, event);
+        replaySnapshot(event.id as EventId, event, callbacks);
         return;
       }
-      mutations.create({
-        id: event.id,
-        calendarId: event.calendarId,
-        content: { ...event.content, location: detailsLocation(event.content) },
-        schedule: event.schedule,
-        recurrence:
-          event.recurrence.kind === "series"
-            ? { kind: "series", rules: event.recurrence.rules }
-            : { kind: "single" },
-      });
+      mutations.create(
+        {
+          id: event.id,
+          calendarId: event.calendarId,
+          content: {
+            ...event.content,
+            location: detailsLocation(event.content),
+          },
+          schedule: event.schedule,
+          recurrence:
+            event.recurrence.kind === "series"
+              ? { kind: "series", rules: event.recurrence.rules }
+              : { kind: "single" },
+          restore: true,
+        },
+        callbacks,
+      );
     },
     [queryClient, source, mutations, replaySnapshot],
   );
@@ -237,16 +259,21 @@ export function useUndoRedo(dependencies: EventMutationDependencies = {}) {
     undoHistoryActions.commitUndo();
     runHistoryRestore(() => {
       if (isDeleteEntry(entry)) {
-        undoDelete(entry.event);
+        // A delete surfaced a "Deleted" toast; flip it to "Restored" only
+        // once the recreate actually lands (or to a failure toast if it
+        // doesn't) — the mutation can still fail the strict write schema or
+        // no-op against a stale sync command, and the toast should never
+        // claim success before the server has said so.
+        undoDelete(entry.event, {
+          onSuccess: showRestoredToast,
+          onError: showRestoreFailedToast,
+        });
       } else if (isCreateEntry(entry)) {
         undoCreate(entry.event);
       } else {
         replaySnapshot(entry.id as EventId, entry.before);
       }
     });
-    // A delete surfaced a "Deleted" toast; if it's still up, flip it to
-    // "Restored" so it can't keep claiming the event is gone.
-    if (isDeleteEntry(entry)) showRestoredToast();
     if (!isCreateEntry(entry)) refocusAfterReplay(entryEventId(entry));
   }, [queryClient, source, undoDelete, undoCreate, replaySnapshot]);
 
@@ -282,6 +309,7 @@ export function useUndoRedo(dependencies: EventMutationDependencies = {}) {
             event.recurrence.kind === "series"
               ? { kind: "series", rules: event.recurrence.rules }
               : { kind: "single" },
+          restore: true,
         });
       } else {
         replaySnapshot(entry.id as EventId, entry.after);


### PR DESCRIPTION
## Summary

Deleting an event and undoing with cmd+z showed a "Restored" toast, but the event flashed and disappeared. Root cause: the undo path spread the full read-shaped event content — including provider-sourced `organizer`/`attendees`/`conference` (added by #2555) — into the strict write schema, which only accepts the editable subset. The server 500'd, the optimistic insert rolled back, and the toast (which fired before the response landed) kept claiming success.

A second, quieter bug surfaces once the first is fixed: undo-of-delete for a Compass-created event still silently no-ops, because the recreate collides with the original create command's idempotency key and #2615's replay guard was deliberately create/update-exempt (to avoid resurrecting events an offline-promotion retry shouldn't touch).

## Changes

- **Wire-boundary sanitization** — `useEventMutations` now strips content to the editable subset (`editableContent` in `grid-event-draft.adapter.ts`) right before the repository call, so the next read-only field added to the read contract can't break a replay again. The optimistic cache still gets the rich content.
- **Honest errors** — a `ZodError` from a strict-schema violation now maps to 400 `INVALID_INPUT` instead of a retryable 500 `PROVIDER_FAILURE`.
- **Honest toast** — "Restored" (and a new "Couldn't restore the event" failure toast) now fire off the mutation's own success/error callback instead of synchronously at dispatch.
- **Restore intent flag** — `create`/`replace` inputs carry an optional `restore: true`, set only by undo/redo replays. Sync's `terminalReplayIsStale` (from #2615) now reopens a colliding terminal **create** or **update** command when this flag is set, instead of treating it as a no-op replay — fixing undo-of-delete for Compass-created events and redo-of-edit, while leaving offline-promotion retries (which never set the flag) exactly as protected as before.

## Test plan
- [x] `bun run type-check` (all three tsconfigs)
- [x] `useUndoRedo.test.tsx` — new fixtures with organizer/attendees/conference, asserting the captured payload passes `CreateEventInputSchema.safeParse`, carries `restore: true`, and the toast only fires after the mutation settles (success and failure)
- [x] `useEventMutations.test.tsx`, `local-event-sync.util.test.ts` — unaffected, still green
- [x] `event.controller.test.ts` — unrecognized content key → 400 `INVALID_INPUT`
- [x] `event-command.translation.test.ts` — `restore` passthrough on create/update, hashed update key unchanged by the flag
- [x] `cloud-command.service.db.test.ts` — restore-flagged create replay reopens with refreshed content; still a no-op when the event is still active; never reopens a cancelled command; restore-flagged update replay reopens even with identical content; existing unflagged no-op tests (the resurrection-risk pin) still pass unmodified
- [x] Full `test:core`, `test:web`, `test:sync:fast`, `test:backend:fast` all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)