### PR TITLE
Remove donation language from welcome dialog and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,6 @@ A simple calendar that helps you manage your time.
 - **We're bootstrapped.** While VC-backed teams think in terms of months and funding rounds, we think in terms of decades and profit. We don't need to make $1B in 5 years or sell your data to an acquirer. As long as we keep users like you happy, we'll be fine.
 - **We have a plan.** Our long-term [vision](https://alpaca-ty.notion.site/about-us) will keep us busy for generations. Our practical roadmap and focus on profitability will keep our feet on the ground along the way.
 
-### It'll help others
-
-We donate 10% of revenue to support mental health programs in our home city of Bozeman, Montana. Your support helps us support others in need.
-
 ## Features
 
 Cool things you can do with in Compass

--- a/packages/web/src/components/WelcomeModal/faq.ts
+++ b/packages/web/src/components/WelcomeModal/faq.ts
@@ -12,6 +12,6 @@ export const FAQ_ITEMS = [
   {
     question: "How is Compass different?",
     answer:
-      "We're simpler, faster, open-source...er. We remind you of your mortality (/life). Oh, and we donate 10% of revenue to support mental health.",
+      "We're simpler, faster, open-source...er. We remind you of your mortality (/life).",
   },
 ];


### PR DESCRIPTION
## Summary
Removed the commitment to donate 10% of revenue to mental health programs from:
- Welcome modal FAQ ("How is Compass different?")
- README's "It'll help others" section

We're no longer committing to this donation pledge and have updated the public-facing messaging accordingly.

## Test plan
- [ ] Verify welcome modal displays updated FAQ without donation language
- [ ] Verify README no longer contains donation section