### PR TITLE
fix(web): eliminate flash when creating and saving a new event

### DIFF
--- a/packages/web/src/events/mutations/useEventMutations.ts
+++ b/packages/web/src/events/mutations/useEventMutations.ts
@@ -199,7 +199,11 @@ function seriesWriteKey(
   return original.id;
 }
 
-type CreateVariables = { input: CreateEventInput; writeKey: EventId };
+type CreateVariables = {
+  input: CreateEventInput;
+  writeKey: EventId;
+  callbacks?: EventMutationCallbacks;
+};
 type ReplaceVariables = {
   id: EventId;
   input: ReplaceEventInput;
@@ -219,6 +223,7 @@ type DeleteVariables = {
 export type EventMutationCallbacks = {
   onSuccess?: () => void;
   onError?: () => void;
+  onOptimisticApplied?: () => void;
 };
 
 export type EventMutations = {
@@ -338,6 +343,15 @@ export function useEventMutations(
         queryKey: eventQueryKeys.all,
       });
       optimistic(variables);
+      // Callers that tear down their own pre-save UI (the event form's grid
+      // draft) run it here so the teardown lands in the same task — and so
+      // the same React commit — as the cache write. useBaseQuery recomputes
+      // getOptimisticResult on every render, so the re-render the teardown
+      // itself triggers already shows the inserted event: the grid never
+      // paints a frame with neither the draft nor the saved card.
+      const callbacks = (variables as { callbacks?: EventMutationCallbacks })
+        .callbacks;
+      callbacks?.onOptimisticApplied?.();
       return { previousQueries };
     },
     onError: (
@@ -617,7 +631,11 @@ export function useEventMutations(
         recordEventCreateHistory({
           event: optimisticEventFromCreate(finalInput),
         });
-        createMutation.mutate({ input: finalInput, writeKey: id }, callbacks);
+        createMutation.mutate({
+          input: finalInput,
+          writeKey: id,
+          callbacks,
+        });
       },
       replace: (
         payload: { id: EventId; input: ReplaceEventInput },

--- a/packages/web/src/views/Forms/hooks/useSaveEventForm.ts
+++ b/packages/web/src/views/Forms/hooks/useSaveEventForm.ts
@@ -51,8 +51,10 @@ export function useSaveEventForm() {
 
         if (parsed.mode === "create") {
           clearFieldErrors();
-          create(parsed.input);
-          closeEventForm();
+          // Closing via the callback (not after `create` returns) keeps the draft
+          // card mounted until the optimistic insert exists, so the saved card
+          // replaces it in one commit instead of flashing empty.
+          create(parsed.input, { onOptimisticApplied: closeEventForm });
         }
         return;
       }


### PR DESCRIPTION
## Summary

When a user creates an event on the grid and saves it, the optimistic write and draft teardown were happening in separate React commits, causing a one-frame gap where the grid rendered neither the draft nor the saved card.

**Solution:** Add an `onOptimisticApplied` callback to the existing `EventMutationCallbacks` pattern and invoke it synchronously inside `onMutate`, before the mutation executes. This ensures the cache write and draft discard happen in the same task, so React batches them into a single commit.

## Changes

- `EventMutationCallbacks`: add optional `onOptimisticApplied` callback
- `useEventMutations.ts`: thread callbacks through `CreateVariables` and invoke `onOptimisticApplied` in `onMutate` immediately after the optimistic cache write
- `useSaveEventForm.ts`: pass `closeEventForm` as `onOptimisticApplied` when creating, instead of calling it after `mutate()` returns

This fix applies to Week/Day timed events and all-day events automatically—no separate handling needed.

## Test plan

- [x] \`bun run test:web packages/web/src/views/Forms/hooks/useSaveEventForm.test.tsx\` — 1 pass
- [x] \`bun run type-check\` — all pass
- [x] \`bun lint\` — no errors

🤖 Generated with Claude Code