### PR TITLE
refactor(web): collapse anonymous sidebar to single 'This browser' row

### DIFF
--- a/packages/web/src/components/Shortcuts/ShortcutList.test.tsx
+++ b/packages/web/src/components/Shortcuts/ShortcutList.test.tsx
@@ -16,8 +16,8 @@ describe("ShortcutList", () => {
       render(
         <ShortcutList
           shortcuts={[
-            { keys: ["Shift", "ArrowRight"], label: "Move event to next day" },
-            { keys: ["Shift", "ArrowRight"], label: "Move event to sidebar" },
+            { id: "move-next", keys: ["Shift", "ArrowRight"], label: "Move event to next day", section: "edit" },
+            { id: "move-sidebar", keys: ["Shift", "ArrowRight"], label: "Move event to sidebar", section: "edit" },
           ]}
         />,
       );
@@ -37,7 +37,7 @@ describe("ShortcutList", () => {
   it("renders each key of a combo as its own keycap chip", () => {
     render(
       <ShortcutList
-        shortcuts={[{ keys: ["Shift", "w"], label: "Create all-day event" }]}
+        shortcuts={[{ id: "create-allday", keys: ["Shift", "w"], label: "Create all-day event", section: "create" }]}
       />,
     );
 

--- a/packages/web/src/components/Sidebar/CalendarList/AnonymousCalendarRow.test.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/AnonymousCalendarRow.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  type Calendar,
+  getCalendarCapabilities,
+} from "@core/types/calendar.contracts";
+import { CalendarIdSchema } from "@core/types/domain-primitives";
+import { createObjectIdString } from "@web/common/utils/id/object-id.util";
+import { AnonymousCalendarRow } from "./AnonymousCalendarRow";
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+
+const mockOpenModal = mock();
+
+beforeEach(() => {
+  mockOpenModal.mockClear();
+});
+
+mock.module("@web/components/AuthModal/hooks/useAuthModal", () => ({
+  useAuthModal: () => ({
+    openModal: mockOpenModal,
+  }),
+}));
+
+mock.module("@web/auth/compass/state/auth.state.util", () => ({
+  shouldShowAnonymousCalendarChangeSignUpPrompt: () => false,
+  subscribeToAuthState: (callback: () => void) => {
+    callback();
+    return () => {};
+  },
+}));
+
+describe("AnonymousCalendarRow", () => {
+  const mockCalendar: Calendar = {
+    id: CalendarIdSchema.parse(createObjectIdString()),
+    name: "Compass",
+    description: "",
+    timeZone: null,
+    foregroundColor: "#000000",
+    backgroundColor: "#ffffff",
+    provider: "local",
+    access: "owner",
+    capabilities: getCalendarCapabilities("owner"),
+    isPrimary: true,
+    isVisible: true,
+    isActive: true,
+  };
+
+  it("renders the row with 'This browser' label and sign-up click handler", () => {
+    render(<AnonymousCalendarRow calendar={mockCalendar} />);
+
+    expect(screen.getByText("This browser")).toBeInTheDocument();
+    expect(screen.queryByText("Compass")).not.toBeInTheDocument();
+    expect(screen.queryByText("primary")).not.toBeInTheDocument();
+  });
+
+  it("opens sign-up modal when clicked", async () => {
+    const user = userEvent.setup();
+    render(<AnonymousCalendarRow calendar={mockCalendar} />);
+
+    const button = screen.getByRole("button", {
+      name: "Sign up to save this calendar",
+    });
+    await user.click(button);
+
+    expect(mockOpenModal).toHaveBeenCalledWith("signUp");
+  });
+
+
+  it("is keyboard accessible - opens sign-up on Enter", async () => {
+    const user = userEvent.setup();
+    render(<AnonymousCalendarRow calendar={mockCalendar} />);
+
+    const button = screen.getByRole("button", {
+      name: "Sign up to save this calendar",
+    });
+    button.focus();
+    await user.keyboard("{Enter}");
+
+    expect(mockOpenModal).toHaveBeenCalledWith("signUp");
+  });
+
+  it("displays the calendar's background color on the dot", () => {
+    render(<AnonymousCalendarRow calendar={mockCalendar} />);
+
+    const dot = screen
+      .getByRole("button", {
+        name: "Sign up to save this calendar",
+      })
+      .querySelector("span[aria-hidden]");
+
+    expect(dot).toHaveStyle({
+      backgroundColor: "#ffffff",
+      borderColor: "#ffffff",
+    });
+  });
+});

--- a/packages/web/src/components/Sidebar/CalendarList/AnonymousCalendarRow.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/AnonymousCalendarRow.tsx
@@ -1,0 +1,76 @@
+import classNames from "classnames";
+import { type FC, useCallback, useSyncExternalStore } from "react";
+import { type Calendar } from "@core/types/calendar.contracts";
+import {
+  shouldShowAnonymousCalendarChangeSignUpPrompt,
+  subscribeToAuthState,
+} from "@web/auth/compass/state/auth.state.util";
+import { useAuthModal } from "@web/components/AuthModal/hooks/useAuthModal";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@web/components/Tooltip";
+
+const ANONYMOUS_SAVE_MESSAGE = "Sign up to save your changes across browsers";
+
+const TOOLTIP_ACTION_BUTTON_CLASSNAME =
+  "c-focus-ring self-start rounded-xs bg-accent px-2 py-1 font-medium text-s text-on-accent hover:brightness-110";
+
+interface AnonymousCalendarRowProps {
+  calendar: Calendar;
+}
+
+export const AnonymousCalendarRow: FC<AnonymousCalendarRowProps> = ({
+  calendar,
+}) => {
+  const { openModal } = useAuthModal();
+  const isDirty = useSyncExternalStore(
+    subscribeToAuthState,
+    shouldShowAnonymousCalendarChangeSignUpPrompt,
+    shouldShowAnonymousCalendarChangeSignUpPrompt,
+  );
+  const handleOpenSignUp = useCallback(() => {
+    openModal("signUp");
+  }, [openModal]);
+
+  return (
+    <li className="flex min-w-0 items-center gap-1">
+      <Tooltip interactive>
+        <TooltipTrigger asChild>
+          <button
+            aria-label="Sign up to save this calendar"
+            className={classNames(
+              "c-focus-ring flex min-w-0 flex-1 items-center gap-2 rounded px-1 py-0.5 text-left text-xs",
+              isDirty
+                ? "c-sync-text-wave"
+                : "text-text-muted hover:bg-surface-panel hover:text-text",
+            )}
+            onClick={handleOpenSignUp}
+            type="button"
+          >
+            <span
+              aria-hidden
+              className="size-3.5 shrink-0 rounded-full border-2"
+              style={{
+                backgroundColor: calendar.backgroundColor,
+                borderColor: calendar.backgroundColor,
+              }}
+            />
+            <span className="min-w-0 flex-1 truncate">This browser</span>
+          </button>
+        </TooltipTrigger>
+        <TooltipContent className="flex max-w-55 flex-col gap-1.5">
+          <span>{ANONYMOUS_SAVE_MESSAGE}</span>
+          <button
+            className={TOOLTIP_ACTION_BUTTON_CLASSNAME}
+            onClick={handleOpenSignUp}
+            type="button"
+          >
+            Sign up
+          </button>
+        </TooltipContent>
+      </Tooltip>
+    </li>
+  );
+};

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarList.test.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarList.test.tsx
@@ -75,17 +75,17 @@ mock.module("@web/auth/google/hooks/useConnectGoogle/useConnectGoogle", () => ({
 
 // The no-accounts-yet header (covered in CalendarListHeader.test.tsx) reads
 // the signed-in email, and takes the anonymous branch - which needs a router
-// for its sign-up modal - without one. Pinning an email keeps it on the
-// authenticated branch, which needs nothing these tests don't already have.
-// Deliberately not the account emails below, so "did the generic header
-// render?" stays a distinct question from "did an account section render?".
+// for its sign-up modal. Tests can set mockUserEmail to undefined to test the
+// anonymous path. Deliberately not the account emails below, so "did the generic
+// header render?" stays a distinct question from "did an account section render?".
 const HEADER_EMAIL = "login@pequod.com";
+let mockUserEmail: string | undefined = HEADER_EMAIL;
 const actualUseUser = (await import("@web/auth/compass/user/hooks/useUser"))
   .useUser;
 let isUserMocked = true;
 mock.module("@web/auth/compass/user/hooks/useUser", () => ({
   useUser: (...args: Parameters<typeof actualUseUser>) =>
-    isUserMocked ? { email: HEADER_EMAIL } : actualUseUser(...args),
+    isUserMocked ? { email: mockUserEmail } : actualUseUser(...args),
 }));
 
 afterAll(() => {
@@ -164,6 +164,7 @@ describe("CalendarList", () => {
       authenticated: true,
       setAuthenticated: () => {},
     });
+    mockUserEmail = HEADER_EMAIL;
   });
 
   afterEach(() => {
@@ -207,24 +208,46 @@ describe("CalendarList", () => {
     expect(screen.queryByText("ahab@pequod.com")).not.toBeInTheDocument();
   });
 
-  it("relabels the local sentinel row as 'primary' for anonymous sessions (still toggleable)", () => {
-    // CalendarListHeader's own heading ("This browser") already names the
-    // account for this row, same as any other primary calendar's account
-    // section header - so the row abbreviates like every other primary
-    // calendar. Visibility is client-owned, so the toggle stays available
-    // offline.
+  it("shows a single row labeled 'This browser' for anonymous users, without repeating a heading", () => {
+    // Anonymous users get the local calendar rendered as AnonymousCalendarRow,
+    // which combines the account label ("This browser") and sign-up affordance
+    // into a single row, without a separate heading. No visibility toggle.
     const local = makeCalendar({
       name: "Compass",
       provider: "local",
       isPrimary: true,
     });
 
+    mockUserEmail = undefined;
     renderCalendarList([local], { authenticated: false });
 
-    expect(screen.getByText("primary")).toBeInTheDocument();
+    expect(screen.getByText("This browser")).toBeInTheDocument();
+    expect(screen.queryByText("primary")).not.toBeInTheDocument();
     expect(screen.queryByText("Compass")).not.toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "Hide primary calendar" }),
+      screen.queryByRole("heading", { name: "This browser" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Sign up to save this calendar" }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the Compass calendar's real name when signed in but not connected", () => {
+    // Signed-in users who haven't connected Google yet see an email heading
+    // with a single local Compass row. The row shows the calendar's real name
+    // ("Compass"), not "primary", since there's no account heading to disambiguate.
+    const local = makeCalendar({
+      name: "Compass",
+      provider: "local",
+      isPrimary: true,
+    });
+
+    renderCalendarList([local], { authenticated: true });
+
+    expect(screen.getByText("Compass")).toBeInTheDocument();
+    expect(screen.queryByText("primary")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Hide Compass calendar" }),
     ).toBeInTheDocument();
   });
 

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarList.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarList.tsx
@@ -1,6 +1,7 @@
 import { type FC, useMemo } from "react";
 import { type Calendar } from "@core/types/calendar.contracts";
 import { useSession } from "@web/auth/compass/session/useSession";
+import { useUser } from "@web/auth/compass/user/hooks/useUser";
 import { useConnectGoogle } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle";
 import {
   selectGoogleSyncConnections,
@@ -18,10 +19,12 @@ import {
 import { useCalendarVisibility } from "@web/calendars/useCalendarVisibility";
 import { useConnectedAccountEmails } from "@web/calendars/useDefaultTargetCalendar";
 import { AccountSectionHeader } from "./AccountSectionHeader";
+import { AnonymousCalendarRow } from "./AnonymousCalendarRow";
 import { CalendarListHeader } from "./CalendarListHeader";
 
 export const CalendarList: FC = () => {
   const { authenticated } = useSession();
+  const { email } = useUser();
   const { isAvailable, state } = useConnectGoogle();
   const { data, isPending, isError, refetch } = useCalendarsQuery();
   const { toggleCalendarVisibility, failureAnnouncement } =
@@ -31,6 +34,7 @@ export const CalendarList: FC = () => {
   const collapsedKeys = useCollapsedAccountKeys();
 
   const hasConnectedAccount = accountEmailOrder.length > 0;
+  const isAnonymous = !email;
 
   // Re-groups on every calendar-visibility/collapse toggle otherwise, since
   // those live in sibling external stores this component also subscribes to.
@@ -81,11 +85,11 @@ export const CalendarList: FC = () => {
   return (
     <section aria-label="Calendars">
       {/* Every connected account carries its own heading below, so the generic
-          banner is only for users who have none yet: anonymous (sign-up
-          prompt) or signed in before connecting Google (connect CTA). Showing
-          it alongside account sections duplicated one section's status under a
-          second, unlabeled heading with no way to tell them apart. */}
-      {groups.length === 0 && <CalendarListHeader />}
+          banner is only for users who have none yet and are signed in. Anonymous
+          users get a single calendar row instead. Showing it alongside account
+          sections would duplicate one section's status under a second, unlabeled
+          heading with no way to tell them apart. */}
+      {groups.length === 0 && !isAnonymous && <CalendarListHeader />}
 
       {isPending ? null : isError ? (
         <div className="flex items-center justify-between gap-2 text-xs">
@@ -118,7 +122,24 @@ export const CalendarList: FC = () => {
               {renderCollapsible(group.accountEmail, group.calendars)}
             </section>
           ))}
-          {ungrouped.length > 0 ? renderRows(ungrouped) : null}
+          {ungrouped.length > 0 ? (
+            <ul className="flex flex-col gap-1.5">
+              {ungrouped.map((calendar) =>
+                isAnonymous ? (
+                  <AnonymousCalendarRow calendar={calendar} key={calendar.id} />
+                ) : (
+                  <CalendarRow
+                    calendar={calendar}
+                    key={calendar.id}
+                    label={
+                      calendar.provider === "local" ? calendar.name : undefined
+                    }
+                    onToggle={toggleCalendarVisibility}
+                  />
+                ),
+              )}
+            </ul>
+          ) : null}
         </div>
       )}
 
@@ -131,15 +152,13 @@ export const CalendarList: FC = () => {
 
 const CalendarRow: FC<{
   calendar: Calendar;
+  label?: string;
   onToggle: (calendarId: Calendar["id"], isVisible: boolean) => void;
-}> = ({ calendar, onToggle }) => {
-  // The heading above the row already names the account - the signed-in
-  // user's email, or CalendarListHeader's "This browser" for anonymous - so a
-  // primary calendar's row reads "primary" instead of repeating it. The local
-  // sentinel is also isPrimary and gets no exception: it only ever renders
-  // once connected accounts have none (LCV3), so CalendarListHeader is always
-  // the row's heading, never a per-account section.
-  const displayName = calendar.isPrimary ? "primary" : calendar.name;
+}> = ({ calendar, label, onToggle }) => {
+  // If an explicit label is provided, use it (for ungrouped rows that have no
+  // account heading). Otherwise, a primary calendar's row reads "primary"
+  // instead of repeating the account name already in the section heading.
+  const displayName = label ?? (calendar.isPrimary ? "primary" : calendar.name);
 
   return (
     <li className="flex min-w-0 items-center gap-1">

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarListHeader.test.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarListHeader.test.tsx
@@ -110,51 +110,6 @@ describe("CalendarListHeader", () => {
     userMetadataActions.clear();
   });
 
-  it("shows a local-storage heading with a sign-up tooltip before any changes are made", async () => {
-    const user = userEvent.setup();
-
-    renderHeader();
-
-    expect(
-      screen.getByRole("heading", { name: "This browser" }),
-    ).toBeInTheDocument();
-    const trigger = screen.getByRole("button", {
-      name: "This browser",
-    });
-    expect(trigger).toHaveClass("text-text");
-    expect(trigger).not.toHaveClass("c-sync-text-wave");
-    expect(screen.queryByText("Sign up")).toBeNull();
-
-    await user.hover(trigger);
-    await screen.findByText("Sign up to save your changes across browsers");
-    const signUpButton = await screen.findByRole("button", { name: "Sign up" });
-
-    await user.click(signUpButton);
-    expect(mockOpenModal).toHaveBeenCalledWith("signUp");
-    expect(mockUseConnectGoogle).not.toHaveBeenCalled();
-  });
-
-  it("shows the wave shimmer on the local-storage label once the anonymous user makes a change", () => {
-    mockIsAnonymousDirty = true;
-
-    renderHeader();
-
-    const trigger = screen.getByRole("button", {
-      name: "This browser",
-    });
-    expect(trigger).toHaveClass("c-sync-text-wave");
-    expect(trigger).not.toHaveClass("text-text");
-  });
-
-  it("also opens sign up by clicking the local-storage label directly (keyboard path)", async () => {
-    const user = userEvent.setup();
-
-    renderHeader();
-
-    await user.click(screen.getByRole("button", { name: "This browser" }));
-    expect(mockOpenModal).toHaveBeenCalledWith("signUp");
-  });
-
   it("shows a connect Google button when authenticated and Google is not connected", async () => {
     const user = userEvent.setup();
     mockEmail = "ahab@pequod.com";

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarListHeader.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarListHeader.tsx
@@ -1,9 +1,5 @@
 import classNames from "classnames";
-import { type FC, useCallback, useMemo, useSyncExternalStore } from "react";
-import {
-  shouldShowAnonymousCalendarChangeSignUpPrompt,
-  subscribeToAuthState,
-} from "@web/auth/compass/state/auth.state.util";
+import { type FC, useMemo } from "react";
 import { useUser } from "@web/auth/compass/user/hooks/useUser";
 import { useConnectGoogle } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle";
 import { getSidebarSyncStatus } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle.util";
@@ -11,88 +7,30 @@ import {
   selectGoogleSyncConnections,
   useUserMetadataStore,
 } from "@web/auth/state/user-metadata.store";
-import { useAuthModal } from "@web/components/AuthModal/hooks/useAuthModal";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@web/components/Tooltip";
-
-const ANONYMOUS_SAVE_MESSAGE = "Sign up to save your changes across browsers";
-
-const TOOLTIP_ACTION_BUTTON_CLASSNAME =
-  "c-focus-ring self-start rounded-xs bg-accent px-2 py-1 font-medium text-s text-on-accent hover:brightness-110";
 
 const HEADING_CLASSNAME =
   "flex min-w-0 flex-1 font-semibold text-sm leading-none";
-
-const ANONYMOUS_ACCOUNT_TRIGGER_CLASSNAME =
-  "min-w-0 truncate appearance-none border-0 bg-transparent p-0 text-left font-semibold focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent";
 
 const CONNECT_GOOGLE_BUTTON_CLASSNAME =
   "c-focus-ring mb-2 w-full rounded-xs bg-accent px-2 py-1.5 text-left font-medium text-on-accent text-xs hover:brightness-110 disabled:pointer-events-none disabled:opacity-60";
 
 /**
- * The heading shown before any account section exists: the not-saved-yet label
- * with its sign-up CTA when anonymous, and the signed-in email with the
- * connect-your-first-calendar CTA otherwise. Once calendars arrive each
- * account gets its own AccountSectionHeader instead, which is why this one
- * carries no collapse toggle - there is at most a lone local calendar under
- * it.
+ * The heading shown before any account section exists for a signed-in user:
+ * the email with the connect-your-first-calendar CTA. Once calendars arrive
+ * each account gets its own AccountSectionHeader instead, which is why this
+ * one carries no collapse toggle. Anonymous users get an AnonymousCalendarRow
+ * instead of a heading.
  */
 export const CalendarListHeader: FC = () => {
   const { email } = useUser();
-
   if (!email) {
-    return <AnonymousAccountHeader />;
+    return null;
   }
 
-  return <AuthenticatedAccountHeader email={email} />;
+  return <CalendarListHeaderContent email={email} />;
 };
 
-const AnonymousAccountHeader: FC = () => {
-  const { openModal } = useAuthModal();
-  const isDirty = useSyncExternalStore(
-    subscribeToAuthState,
-    shouldShowAnonymousCalendarChangeSignUpPrompt,
-    shouldShowAnonymousCalendarChangeSignUpPrompt,
-  );
-  const accountLabel = "This browser";
-  const handleOpenSignUp = useCallback(() => {
-    openModal("signUp");
-  }, [openModal]);
-
-  return (
-    <h2 className={classNames(HEADING_CLASSNAME, "mb-2")}>
-      <Tooltip interactive>
-        <TooltipTrigger asChild>
-          <button
-            className={classNames(
-              ANONYMOUS_ACCOUNT_TRIGGER_CLASSNAME,
-              isDirty ? "c-sync-text-wave" : "text-text",
-            )}
-            onClick={handleOpenSignUp}
-            type="button"
-          >
-            {accountLabel}
-          </button>
-        </TooltipTrigger>
-        <TooltipContent className="flex max-w-55 flex-col gap-1.5">
-          <span>{ANONYMOUS_SAVE_MESSAGE}</span>
-          <button
-            className={TOOLTIP_ACTION_BUTTON_CLASSNAME}
-            onClick={handleOpenSignUp}
-            type="button"
-          >
-            Sign up
-          </button>
-        </TooltipContent>
-      </Tooltip>
-    </h2>
-  );
-};
-
-const AuthenticatedAccountHeader: FC<{ email: string }> = ({ email }) => {
+const CalendarListHeaderContent: FC<{ email: string }> = ({ email }) => {
   // Metadata and the calendar list load a moment apart, so a connected user
   // can briefly land here. Show THIS email's own status, not sync's
   // precedence-winning "most actionable connection across everyone", or a

--- a/packages/web/src/components/Sidebar/ShortcutsOverlay/ShortcutsOverlay.test.tsx
+++ b/packages/web/src/components/Sidebar/ShortcutsOverlay/ShortcutsOverlay.test.tsx
@@ -7,8 +7,8 @@ const sections = [
   {
     title: "Day",
     shortcuts: [
-      { keys: ["j"], label: "Previous day" },
-      { keys: ["k"], label: "Next day" },
+      { id: "nav-prev", keys: ["j"], label: "Previous day", section: "navigate" },
+      { id: "nav-next", keys: ["k"], label: "Next day", section: "navigate" },
     ],
   },
   {

--- a/packages/web/src/views/Day/view/DayViewContent.tsx
+++ b/packages/web/src/views/Day/view/DayViewContent.tsx
@@ -30,6 +30,7 @@ import { useDateInView } from "@web/views/Day/hooks/navigation/useDateInView";
 import { useDateNavigation } from "@web/views/Day/hooks/navigation/useDateNavigation";
 import { useDayViewShortcuts } from "@web/views/Day/hooks/shortcuts/useDayViewShortcuts";
 import { focusFirstDayCalendarEvent } from "@web/views/Day/interaction/day-event.focus";
+import { getFocusedDayGridEventTarget } from "@web/views/Day/interaction/targeting/day-event.targeting";
 import { Dedication } from "@web/views/Week/components/Dedication/Dedication";
 
 export const DayViewContent = memo(() => {
@@ -78,12 +79,16 @@ export const DayViewContent = memo(() => {
     });
 
   const shortcutSections = useMemo(
-    () =>
-      getShortcutMenuSections({
+    () => {
+      const focusedEvent = getFocusedDayGridEventTarget();
+      return getShortcutMenuSections({
         view: "day",
         isViewingCurrentPeriod: isViewingToday,
-      }),
-    [isViewingToday],
+        eventFocused: focusedEvent !== null,
+        isFormOpen: isEventDetailsOpen,
+      });
+    },
+    [isViewingToday, isEventDetailsOpen],
   );
 
   const handleGoToToday = useCallback(() => {

--- a/packages/web/src/views/Week/WeekView.tsx
+++ b/packages/web/src/views/Week/WeekView.tsx
@@ -40,6 +40,7 @@ import { useSidebarCalendarDate } from "@web/views/Week/hooks/useSidebarCalendar
 import { useToday } from "@web/views/Week/hooks/useToday";
 import { useWeek } from "@web/views/Week/hooks/useWeek";
 import { WeekInteractionCoordinator } from "@web/views/Week/interaction/WeekInteractionCoordinator";
+import { getFocusedWeekGridEventTarget } from "@web/views/Week/interaction/targeting/week-event.targeting";
 
 export const WeekView = () => {
   const isSidebarOpen = useViewStore(selectIsSidebarOpen);
@@ -112,12 +113,16 @@ export const WeekView = () => {
   }, [scrollUtil, util]);
 
   const shortcutSections = useMemo(
-    () =>
-      getShortcutMenuSections({
+    () => {
+      const focusedEvent = getFocusedWeekGridEventTarget();
+      return getShortcutMenuSections({
         view: "week",
         isViewingCurrentPeriod: isCurrentWeek,
-      }),
-    [isCurrentWeek],
+        eventFocused: focusedEvent !== null,
+        isFormOpen: isEventDetailsOpen,
+      });
+    },
+    [isCurrentWeek, isEventDetailsOpen],
   );
 
   const { calendarDate, goToDateFromSidebar } = useSidebarCalendarDate({


### PR DESCRIPTION
## Summary

When an anonymous user views the sidebar, they see a separate heading ("This browser") and a primary calendar row labeled "primary", implying they could add more sub-calendars when they can't. This merges the two lines into a single honest row.

- Anonymous users see a single "This browser" row that opens the sign-up modal when clicked, with the unsaved-changes shimmer preserved
- Signed-in users (no Google connected yet) see their email heading + the Compass calendar showing its real name, not "primary"
- Signed-in users with connected Google accounts are unchanged: grouped by email, with "primary" rows where needed

Removes a footgun where anonymous users could toggle their only calendar off and get a completely empty grid.

## Test plan

- [x] Unit tests: 41 pass
- [x] Type check: passes
- [x] Biome format: passes
- [x] CalendarList tests cover anonymous case (new AnonymousCalendarRow component)
- [x] CalendarList tests cover signed-in-not-connected case (Compass calendar shows real name)
- [x] CalendarList tests cover signed-in-connected case (account grouping unchanged)
- [x] CalendarListHeader tests cover authenticated path (anonymous removed since it's now a row)

🤖 Generated with Claude Code