### PR TITLE
fix(web): 'Ends on' date now inclusive in recurring events

### DIFF
--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/components/EndsOnDate.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/components/EndsOnDate.tsx
@@ -7,7 +7,7 @@ import { TooltipWrapper } from "@web/components/Tooltip/TooltipWrapper";
 export interface EndsOnDateProps {
   minDate?: string;
   until?: Date | null;
-  setUntil: React.Dispatch<React.SetStateAction<Date | null>>;
+  setUntil: (date: Date | null) => void;
 }
 
 export const EndsOnDate = ({

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/useRecurrence/useRecurrence.test.ts
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/useRecurrence/useRecurrence.test.ts
@@ -94,11 +94,11 @@ describe("useRecurrence hook", () => {
     expect(result.current.weekDays).toEqual(["monday", "friday"]);
   });
 
-  it("can set until date", () => {
+  it("can set until date and normalizes to end-of-day", () => {
     const draft = baseDraft();
     const setDraft = mock();
     const { result } = renderHook(() => useRecurrence(draft, { setDraft }));
-    const date = new Date();
+    const date = new Date("2026-08-13T00:00:00Z");
 
     act(() => {
       result.current.toggleRecurrence();
@@ -106,7 +106,22 @@ describe("useRecurrence hook", () => {
     });
 
     expect(setDraft).toHaveBeenCalled();
-    expect(result.current.until).toEqual(date);
+    // setUntil normalizes to end-of-day (23:59:59), not the raw midnight
+    expect(result.current.until?.toISOString()).toMatch(/23:59:59/);
+  });
+
+  it("can clear until date", () => {
+    const draft = baseDraft();
+    const setDraft = mock();
+    const { result } = renderHook(() => useRecurrence(draft, { setDraft }));
+
+    act(() => {
+      result.current.toggleRecurrence();
+      result.current.setUntil(new Date());
+      result.current.setUntil(null);
+    });
+
+    expect(result.current.until).toBeNull();
   });
 
   it("initializes with recurrence", () => {

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/useRecurrence/useRecurrence.ts
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/useRecurrence/useRecurrence.ts
@@ -146,7 +146,7 @@ export const useRecurrence = (
   // never pass).
   const [freq, setFreq] = useState<Frequency>(options.freq);
   const [interval, setInterval] = useState<number>(options.interval);
-  const [until, setUntil] = useState<Date | null>(() => parsed.until);
+  const [until, setUntilState] = useState<Date | null>(() => parsed.until);
   const [count, setCount] = useState<number | null>(options.count);
   const [wkst, setWkst] = useState<Weekday | null>(defaultWkst);
   const [weekDays, setWeekDays] = useState<typeof WEEKDAYS>(defaultWeekDay);
@@ -158,11 +158,23 @@ export const useRecurrence = (
     setSyncedRuleSeedKey(ruleSeedKey);
     setFreq(options.freq);
     setInterval(options.interval);
-    setUntil(parsed.until);
+    setUntilState(parsed.until);
     setCount(options.count);
     setWkst(defaultWkst);
     setWeekDays(defaultWeekDay);
   }
+
+  // The "Ends on" picker yields local midnight of the clicked day, but RRULE
+  // UNTIL is an instant: a 7:30am occurrence on the chosen day falls *after*
+  // midnight and never expands, so the series visibly ends a day early. Pin it
+  // to the end of the chosen day so the picked date is inclusive, matching how
+  // occurrence-projection.ts already reads a date-only UNTIL (T235959) and how
+  // Google presents "ends on".
+  const setUntil = useCallback(
+    (date: Date | null) =>
+      setUntilState(date ? dayjs(date).endOf("day").toDate() : null),
+    [],
+  );
 
   const byweekday = useMemo(
     () => weekDays.map((day) => WEEKDAY_RRULE_MAP[day].weekday),


### PR DESCRIPTION
## Summary

When setting a recurring series to "end on Aug 13", the last instance appeared on Aug 12 instead — off by one day. Root cause: react-datepicker returns local midnight of the clicked day, but RRULE UNTIL is an instant. An 07:30am occurrence on Aug 13 falls *after* midnight UNTIL, so rrule never emits it.

**Fix:** normalize the picked date to end-of-day (23:59:59) in the form's setter. Only user picks are normalized; seeded values from backend/Google are untouched.

## Test plan

- ✅ Updated "can set until date" test to verify end-of-day normalization
- ✅ Added test for clearing until date
- ✅ Existing loop-convergence regression test still passes (Google-authored UNTIL not rewritten)
- ✅ Type-safe: EndsOnDateProps now uses `(date: Date | null) => void` instead of setState

🤖 Generated with Claude