### PR TITLE
fix(web): point logout teardown at the real sse and sync-state modules

### DIFF
--- a/packages/web/src/auth/compass/hooks/useLogout.test.ts
+++ b/packages/web/src/auth/compass/hooks/useLogout.test.ts
@@ -17,15 +17,27 @@ const mockUseSession = mock();
 const clearAccountScopedClientState = mock();
 let signOut = spyOn(session, "signOut");
 
+// bun's mock.module is global and leaks into every other test file in the
+// run. Spread the real module so unrelated suites still see its full surface;
+// override only what this file asserts on.
+const actualAuthStateUtil = await import(
+  "@web/auth/compass/state/auth.state.util"
+);
+const actualLogoutTeardown = await import(
+  "@web/auth/compass/session/logout.teardown"
+);
+
 mock.module("@web/auth/compass/session/useSession", () => ({
   useSession: mockUseSession,
 }));
 
 mock.module("@web/auth/compass/state/auth.state.util", () => ({
+  ...actualAuthStateUtil,
   clearAuthenticationState,
 }));
 
 mock.module("@web/auth/compass/session/logout.teardown", () => ({
+  ...actualLogoutTeardown,
   clearAccountScopedClientState,
 }));
 

--- a/packages/web/src/auth/compass/session/logout.teardown.test.ts
+++ b/packages/web/src/auth/compass/session/logout.teardown.test.ts
@@ -9,26 +9,44 @@ const mockClearGoogleSyncIndicatorOverride = mock();
 const mockSseCloseStream = mock();
 const mockDraftActionsDiscard = mock();
 
+// bun's mock.module is global and leaks into every other test file in the
+// run. Spread the real module so unrelated suites still see its full surface;
+// override only what this file asserts on.
+const actualRepositorySource = await import(
+  "@web/events/repositories/event.repository.source.store"
+);
+const actualUserMetadata = await import("@web/auth/state/user-metadata.store");
+const actualSseClient = await import("@web/sse/client/sse.client");
+const actualSyncState = await import("@web/auth/google/state/google.sync.state");
+const actualDraftStore = await import("@web/events/stores/draft.store");
+
 mock.module("@web/events/repositories/event.repository.source.store", () => ({
+  ...actualRepositorySource,
   refreshEventRepositorySource: mockRefreshEventRepositorySource,
 }));
 
 mock.module("@web/auth/state/user-metadata.store", () => ({
+  ...actualUserMetadata,
   userMetadataActions: {
+    ...actualUserMetadata.userMetadataActions,
     clear: mockUserMetadataActionsClear,
   },
 }));
 
 mock.module("@web/auth/google/state/google.sync.state", () => ({
+  ...actualSyncState,
   clearGoogleSyncIndicatorOverride: mockClearGoogleSyncIndicatorOverride,
 }));
 
 mock.module("@web/sse/client/sse.client", () => ({
+  ...actualSseClient,
   closeStream: mockSseCloseStream,
 }));
 
 mock.module("@web/events/stores/draft.store", () => ({
+  ...actualDraftStore,
   draftActions: {
+    ...actualDraftStore.draftActions,
     discard: mockDraftActionsDiscard,
   },
 }));

--- a/packages/web/src/auth/compass/session/logout.teardown.test.ts
+++ b/packages/web/src/auth/compass/session/logout.teardown.test.ts
@@ -19,14 +19,12 @@ mock.module("@web/auth/state/user-metadata.store", () => ({
   },
 }));
 
-mock.module("@web/auth/google/util/google.auth.util", () => ({
+mock.module("@web/auth/google/state/google.sync.state", () => ({
   clearGoogleSyncIndicatorOverride: mockClearGoogleSyncIndicatorOverride,
 }));
 
-mock.module("@web/events/sse/sse.client", () => ({
-  sse: {
-    closeStream: mockSseCloseStream,
-  },
+mock.module("@web/sse/client/sse.client", () => ({
+  closeStream: mockSseCloseStream,
 }));
 
 mock.module("@web/events/stores/draft.store", () => ({
@@ -62,7 +60,7 @@ describe("logout.teardown", () => {
         callOrder.push("clearGoogleSyncIndicatorOverride");
       });
       mockSseCloseStream.mockImplementation(() => {
-        callOrder.push("sse.closeStream");
+        callOrder.push("closeStream");
       });
       mockDraftActionsDiscard.mockImplementation(() => {
         callOrder.push("draftActions.discard");
@@ -74,7 +72,7 @@ describe("logout.teardown", () => {
         "refreshEventRepositorySource",
         "userMetadataActions.clear",
         "clearGoogleSyncIndicatorOverride",
-        "sse.closeStream",
+        "closeStream",
         "draftActions.discard",
       ]);
     });

--- a/packages/web/src/auth/compass/session/logout.teardown.ts
+++ b/packages/web/src/auth/compass/session/logout.teardown.ts
@@ -12,8 +12,8 @@ import { calendarQueryKeys } from "@web/calendars/calendar.query";
 import { draftActions } from "@web/events/stores/draft.store";
 import { eventQueryKeys } from "@web/events/queries/event.query.keys";
 import { refreshEventRepositorySource } from "@web/events/repositories/event.repository.source.store";
-import { sse } from "@web/events/sse/sse.client";
-import { clearGoogleSyncIndicatorOverride } from "@web/auth/google/util/google.auth.util";
+import { closeStream } from "@web/sse/client/sse.client";
+import { clearGoogleSyncIndicatorOverride } from "@web/auth/google/state/google.sync.state";
 import { userMetadataActions } from "@web/auth/state/user-metadata.store";
 
 /**
@@ -33,7 +33,7 @@ export function clearAccountScopedClientState(): void {
   clearGoogleSyncIndicatorOverride();
 
   // Close the SSE stream (idempotent).
-  sse.closeStream();
+  closeStream();
 
   // Discard any open event form for a remote event.
   draftActions.discard();

--- a/packages/web/src/components/LogoutConfirmation/LogoutConfirmationProvider.test.tsx
+++ b/packages/web/src/components/LogoutConfirmation/LogoutConfirmationProvider.test.tsx
@@ -80,29 +80,19 @@ describe("LogoutConfirmationProvider", () => {
     expect(overlay).not.toHaveAttribute("aria-busy");
     expect(showStatusToast).not.toHaveBeenCalled();
 
-    // Resolve the one production timer immediately.
-    const setTimeoutSpy = spyOn(globalThis, "setTimeout").mockImplementation(
-      ((callback: TimerHandler) => {
-        if (typeof callback === "function") callback();
-        return 0;
-      }) as typeof setTimeout,
-    );
-    try {
-      finishLogout();
-      await Promise.resolve();
-      await Promise.resolve();
-      await Promise.resolve();
+    // The provider holds the overlay for a 400ms minimum, well inside
+    // waitFor's default 1s budget. Do not stub global setTimeout here:
+    // waitFor schedules its own timers on it, and a synchronous stub fires
+    // them before waitFor has initialized them.
+    finishLogout();
 
-      await waitFor(() => {
-        expect(screen.queryByRole("status")).not.toBeInTheDocument();
-      });
-      expect(showStatusToast).toHaveBeenCalledWith(
-        "logged-out",
-        "You're logged out",
-      );
-    } finally {
-      setTimeoutSpy.mockRestore();
-    }
+    await waitFor(() => {
+      expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    });
+    expect(showStatusToast).toHaveBeenCalledWith(
+      "logged-out",
+      "You're logged out",
+    );
   });
 
   it("closes Settings and the command palette on confirm", async () => {
@@ -116,53 +106,28 @@ describe("LogoutConfirmationProvider", () => {
   });
 
   it("fires the success toast after the overlay unmounts", async () => {
-    const setTimeoutSpy = spyOn(globalThis, "setTimeout").mockImplementation(
-      ((callback: TimerHandler) => {
-        if (typeof callback === "function") callback();
-        return 0;
-      }) as typeof setTimeout,
+    await confirmLogout();
+
+    await waitFor(() => {
+      expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    });
+    expect(showStatusToast).toHaveBeenCalledWith(
+      "logged-out",
+      "You're logged out",
     );
-
-    try {
-      await confirmLogout();
-      await Promise.resolve();
-      await Promise.resolve();
-      await Promise.resolve();
-
-      expect(showStatusToast).toHaveBeenCalledWith(
-        "logged-out",
-        "You're logged out",
-      );
-    } finally {
-      setTimeoutSpy.mockRestore();
-    }
   });
 
   it("shows error toast and takes down overlay when signedOutRemotely is false", async () => {
     signOut.mockRejectedValueOnce(new Error("offline"));
 
-    const setTimeoutSpy = spyOn(globalThis, "setTimeout").mockImplementation(
-      ((callback: TimerHandler) => {
-        if (typeof callback === "function") callback();
-        return 0;
-      }) as typeof setTimeout,
+    await confirmLogout();
+
+    await waitFor(() => {
+      expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    });
+    expect(showErrorToast).toHaveBeenCalledWith(
+      "Logged out on this device. We couldn't reach the server to end the session everywhere.",
     );
-
-    try {
-      await confirmLogout();
-      await Promise.resolve();
-      await Promise.resolve();
-      await Promise.resolve();
-
-      await waitFor(() => {
-        expect(screen.queryByRole("status")).not.toBeInTheDocument();
-      });
-      expect(showErrorToast).toHaveBeenCalledWith(
-        "Logged out on this device. We couldn't reach the server to end the session everywhere.",
-      );
-    } finally {
-      setTimeoutSpy.mockRestore();
-    }
   });
 
   it("raises no overlay on cancel", async () => {


### PR DESCRIPTION
Unblocks `type-check` on main.

`logout.teardown.ts` (from #2627) imports two things that do not exist:

- `sse` from `@web/events/sse/sse.client` — that directory does not exist; the SSE client lives at `@web/sse/client/sse.client` and exports `closeStream` as a named function, not an `sse` namespace object
- `clearGoogleSyncIndicatorOverride` from `@web/auth/google/util/google.auth.util` — not exported there; it lives in `@web/auth/google/state/google.sync.state`

Its test mocked those same two phantom paths, so the mocks intercepted nothing and the suite failed.

## Verification

- `bun run type-check` passes (was 2 errors)
- `bun test ./src/auth/compass/session/logout.teardown.test.ts` — 3 pass, 0 fail

Part of restoring main, which has been red since #2617 broke `bun install --frozen-lockfile` and 11 PRs merged without CI signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)