### PR TITLE
fix(web): remove duplicate border above sidebar status bar

### DIFF
--- a/packages/web/src/components/Sidebar/SidebarStatusBar.tsx
+++ b/packages/web/src/components/Sidebar/SidebarStatusBar.tsx
@@ -25,7 +25,7 @@ export const SidebarStatusBar: FC = () => {
     : getSidebarSyncStatus({ connection, isConnecting, state });
 
   return (
-    <div className="flex h-6 shrink-0 items-center border-border border-t px-4">
+    <div className="flex h-6 shrink-0 items-center px-4">
       <p
         aria-live="polite"
         className={`truncate text-xs ${status ? SYNC_STATUS_VARIANT_CLASSNAME[status.variant] : ""}`}


### PR DESCRIPTION
## Summary
- Sidebar had two stacked top borders where `SidebarStatusBar` (border-t) sat directly above `SidebarActions` (border-t), the icon row.
- Removes the border from `SidebarStatusBar`, leaving a single line directly above the icons.

## Test plan
- [x] `bun run type-check` passes
- [x] `SidebarStatusBar.test.tsx` + `SidebarShell.test.tsx` pass (10/10)
- [x] `biome check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)