### PR TITLE
feat(web): dismiss the visible toast on Escape

### DIFF
--- a/packages/web/src/common/utils/form/form.util.ts
+++ b/packages/web/src/common/utils/form/form.util.ts
@@ -11,6 +11,25 @@ export const isContextMenuOpen = () => {
   return !!contextMenuItems;
 };
 
+// A nested floating layer (actions menu, time picker, recurrence selects,
+// confirmation dialogs) handles its own Escape; another Escape consumer
+// acting at the same time would fight it. Two carve-outs for layers that are
+// always present rather than transiently floating: overlays that stay
+// mounted while hidden (the keyboard-shortcuts dialog — display:none in
+// Day's tree, aria-hidden in Week's), and the sidebar's inline month picker,
+// whose react-datepicker month grid is a permanently-visible role="listbox".
+export const isFloatingLayerOpen = () =>
+  Array.from(
+    document.querySelectorAll(
+      '[role="menu"], [role="listbox"], [role="dialog"]',
+    ),
+  ).some(
+    (element) =>
+      element.getAttribute("aria-hidden") !== "true" &&
+      element.getClientRects().length > 0 &&
+      !element.closest('[data-testid="Month picker"]'),
+  );
+
 const EVENT_FORM_SELECTOR = `form[name="${ID_EVENT_FORM}"]`;
 
 // The grid draft card and the sidebar-docked form live in separate component

--- a/packages/web/src/common/utils/toast/useEscapeToDismissToast.test.tsx
+++ b/packages/web/src/common/utils/toast/useEscapeToDismissToast.test.tsx
@@ -1,0 +1,89 @@
+import { HotkeyManager } from "@tanstack/react-hotkeys";
+import { renderHook } from "@testing-library/react";
+import { createTestToastPort } from "@web/__tests__/helpers/web-test-seams";
+import { pressKey } from "@web/__tests__/utils/keyboard.test.util";
+import {
+  ID_CONTEXT_MENU_ITEMS,
+  ID_EVENT_FORM,
+} from "@web/common/constants/web.constants";
+import {
+  registerToastPort,
+  resetToastPort,
+} from "@web/common/utils/toast/toast.port";
+import { useEscapeToDismissToast } from "@web/common/utils/toast/useEscapeToDismissToast";
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
+
+describe("useEscapeToDismissToast", () => {
+  let mocks: ReturnType<typeof createTestToastPort>["mocks"];
+
+  beforeEach(() => {
+    HotkeyManager.resetInstance();
+    document.body.removeAttribute("data-app-locked");
+
+    const testPort = createTestToastPort();
+    mocks = testPort.mocks;
+    registerToastPort(testPort.port);
+  });
+
+  afterEach(() => {
+    resetToastPort();
+    document.body.innerHTML = "";
+  });
+
+  it("dismisses the visible toast on Escape", () => {
+    renderHook(() => useEscapeToDismissToast());
+
+    pressKey("Escape");
+
+    expect(mocks.dismiss).toHaveBeenCalledTimes(1);
+    expect(mocks.dismiss).toHaveBeenCalledWith();
+  });
+
+  it("does not dismiss while a context menu is open", () => {
+    const contextMenu = document.createElement("div");
+    contextMenu.id = ID_CONTEXT_MENU_ITEMS;
+    document.body.appendChild(contextMenu);
+
+    renderHook(() => useEscapeToDismissToast());
+    pressKey("Escape");
+
+    expect(mocks.dismiss).not.toHaveBeenCalled();
+  });
+
+  it("does not dismiss while the event form is open", () => {
+    const form = document.createElement("form");
+    form.setAttribute("name", ID_EVENT_FORM);
+    document.body.appendChild(form);
+
+    renderHook(() => useEscapeToDismissToast());
+    pressKey("Escape");
+
+    expect(mocks.dismiss).not.toHaveBeenCalled();
+  });
+
+  it("does not dismiss while a floating layer (dialog) is open", () => {
+    const dialog = document.createElement("div");
+    dialog.setAttribute("role", "dialog");
+    document.body.appendChild(dialog);
+    // jsdom has no layout engine, so a plain element always reports zero
+    // client rects; stub it to look on-screen, matching a real dialog.
+    const rectsSpy = spyOn(dialog, "getClientRects").mockReturnValue([
+      {} as DOMRect,
+    ] as unknown as DOMRectList);
+
+    renderHook(() => useEscapeToDismissToast());
+    pressKey("Escape");
+
+    expect(mocks.dismiss).not.toHaveBeenCalled();
+    rectsSpy.mockRestore();
+  });
+
+  it("does not dismiss while the app is locked (a modal is open)", () => {
+    document.body.dataset.appLocked = "true";
+
+    renderHook(() => useEscapeToDismissToast());
+    pressKey("Escape");
+
+    expect(mocks.dismiss).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/common/utils/toast/useEscapeToDismissToast.ts
+++ b/packages/web/src/common/utils/toast/useEscapeToDismissToast.ts
@@ -1,0 +1,31 @@
+import {
+  isContextMenuOpen,
+  isEventFormOpen,
+  isFloatingLayerOpen,
+} from "@web/common/utils/form/form.util";
+import { getToast } from "@web/common/utils/toast/toast.port";
+import { useAppShortcut } from "@web/shortcuts/useAppShortcut";
+
+/**
+ * Escape clears the visible toast so a notice never has to be waited out.
+ * Lowest-priority Escape consumer by design: modals are excluded for free by
+ * the app lock (no `ignoreAppLock` here), and the probes below stand this
+ * handler down while the form or a floating layer owns Escape.
+ *
+ * Wart: `dismiss()` clears what is on screen but not react-toastify's waiting
+ * queue (the container runs `limit={1}`), so a queued toast still gets its
+ * turn. That is intended: it is a different message the user has not seen.
+ */
+export const useEscapeToDismissToast = () => {
+  useAppShortcut(
+    "Escape",
+    () => {
+      if (isContextMenuOpen()) return;
+      if (isEventFormOpen()) return;
+      if (isFloatingLayerOpen()) return;
+
+      getToast().dismiss();
+    },
+    { ignoreInputs: false },
+  );
+};

--- a/packages/web/src/components/CompassProvider/CompassProvider.test.tsx
+++ b/packages/web/src/components/CompassProvider/CompassProvider.test.tsx
@@ -1,11 +1,20 @@
+import { HotkeyManager } from "@tanstack/react-hotkeys";
 import { useQueryClient } from "@tanstack/react-query";
 import { render, screen } from "@testing-library/react";
 import { rest } from "msw";
 import { server } from "@web/__tests__/__mocks__/server/mock.server";
+import { createTestToastPort } from "@web/__tests__/helpers/web-test-seams";
+import { pressKey } from "@web/__tests__/utils/keyboard.test.util";
 import { createCompassQueryClient } from "@web/api/query-client";
 import { ENV_WEB } from "@web/common/constants/env.constants";
+import { registerToastPort } from "@web/common/utils/toast/toast.port";
 import { CompassRequiredProviders } from "./CompassProvider";
-import { expect, test } from "bun:test";
+import { beforeEach, expect, test } from "bun:test";
+
+beforeEach(() => {
+  HotkeyManager.resetInstance();
+  document.body.removeAttribute("data-app-locked");
+});
 
 test("provides the injected query client", () => {
   server.use(
@@ -31,4 +40,19 @@ test("provides the injected query client", () => {
   );
 
   expect(screen.getByLabelText("query client match")).toHaveTextContent("true");
+});
+
+test("Escape dismisses the toast (proves the hook is actually mounted)", () => {
+  server.use(
+    rest.get(`${ENV_WEB.API_BASEURL}/config`, (_req, res, ctx) =>
+      res(ctx.json({ google: { isConfigured: false } })),
+    ),
+  );
+  const { port, mocks } = createTestToastPort();
+  registerToastPort(port);
+
+  render(<CompassRequiredProviders>{null}</CompassRequiredProviders>);
+  pressKey("Escape");
+
+  expect(mocks.dismiss).toHaveBeenCalledTimes(1);
 });

--- a/packages/web/src/components/CompassProvider/CompassProvider.tsx
+++ b/packages/web/src/components/CompassProvider/CompassProvider.tsx
@@ -9,6 +9,7 @@ import { SessionProvider } from "@web/auth/compass/session/SessionProvider";
 import { getPosthogClient } from "@web/auth/posthog/posthog.bootstrap";
 import { PostHogProvider } from "@web/auth/posthog/posthog-react";
 import { ENV_WEB } from "@web/common/constants/env.constants";
+import { useEscapeToDismissToast } from "@web/common/utils/toast/useEscapeToDismissToast";
 import { AboutModal } from "@web/components/About/AboutModal";
 import { DeleteAccountConfirmationProvider } from "@web/components/DeleteAccountConfirmation/DeleteAccountConfirmationProvider";
 import { FeedbackDialogHost } from "@web/components/Feedback/FeedbackDialogHost";
@@ -30,6 +31,7 @@ export function GlobalShortcutsHost() {
 
 function ThemeAwareToastContainer() {
   const theme = useThemeStore(selectTheme);
+  useEscapeToDismissToast();
 
   return (
     <ToastContainer

--- a/packages/web/src/views/Forms/hooks/useEscapeToCloseForm.ts
+++ b/packages/web/src/views/Forms/hooks/useEscapeToCloseForm.ts
@@ -1,24 +1,8 @@
-import { isContextMenuOpen } from "@web/common/utils/form/form.util";
+import {
+  isContextMenuOpen,
+  isFloatingLayerOpen,
+} from "@web/common/utils/form/form.util";
 import { useAppShortcut } from "@web/shortcuts/useAppShortcut";
-
-// A nested floating layer (actions menu, time picker, recurrence selects,
-// confirmation dialogs) handles its own Escape; closing the form at the same
-// time would tear down both. Two carve-outs for layers that are always
-// present rather than transiently floating: overlays that stay mounted while
-// hidden (the keyboard-shortcuts dialog — display:none in Day's tree,
-// aria-hidden in Week's), and the sidebar's inline month picker, whose
-// react-datepicker month grid is a permanently-visible role="listbox".
-const isFloatingLayerOpen = () =>
-  Array.from(
-    document.querySelectorAll(
-      '[role="menu"], [role="listbox"], [role="dialog"]',
-    ),
-  ).some(
-    (element) =>
-      element.getAttribute("aria-hidden") !== "true" &&
-      element.getClientRects().length > 0 &&
-      !element.closest('[data-testid="Month picker"]'),
-  );
 
 /**
  * Escape closes the event-details form. The floating forms used to get this


### PR DESCRIPTION
## Summary
- Pressing Escape now dismisses whatever toast is currently visible, app-wide — including the recurring-event "Apply to series?" prompt, which previously could only be cleared by waiting out its 5s `autoClose` timer or dragging it away.
- Escape is the lowest-priority consumer: it stands down while a modal (via the existing app-lock), the event form, a context menu, or a floating menu/listbox/dialog is open, so it never fights the handler that's already using Escape for something else.
- No changes needed to the recurrence-scope toast itself: `react-toastify` fires `onClose` on every close path (autoClose, click, or `dismiss()`), so Escape dismissal already records the same "declined" state that the timeout path does.

## Implementation
- Promoted the private `isFloatingLayerOpen` DOM probe out of `useEscapeToCloseForm.ts` into the shared `form.util.ts` (alongside `isContextMenuOpen` / `isEventFormOpen`) so both Escape hooks can use it.
- New `useEscapeToDismissToast` hook (~15 lines): registers a global Escape shortcut via the existing `useAppShortcut`, guards on the three DOM probes above, then calls `getToast().dismiss()`. No toast-visibility tracking — `dismiss()` is already a safe no-op when nothing is showing.
- Mounted once in `ThemeAwareToastContainer` (`CompassProvider.tsx`), not in the authenticated-only `GlobalShortcutsHost`, since toasts also render pre-auth (session expired, Google OAuth callback, anonymous-save).

## Test plan
- [x] Unit tests for the new hook (`useEscapeToDismissToast.test.tsx`): dismisses on Escape; stands down for a context menu, the event form, a floating dialog, and an app-locked modal.
- [x] Integration test in `CompassProvider.test.tsx` proving the hook is actually mounted when the full provider tree renders.
- [x] Full affected suite (form.util, toast, shortcuts, EventForm hooks, EventDetails, CompassProvider, recurrence): 124 tests pass.
- [x] `bun run type-check` clean.
- [x] `biome check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)