### PR TITLE
fix(sync): retire calendars the provider no longer lists

### DIFF
--- a/packages/backend/src/common/services/sync-service/sync-service.client.test.ts
+++ b/packages/backend/src/common/services/sync-service/sync-service.client.test.ts
@@ -263,6 +263,37 @@ describe("SyncServiceClient", () => {
     expect(verdict.context.principalId).toBe(who.principalId);
   });
 
+  it("lists active-only calendars with ?activeOnly=true, unlike listCalendars", async () => {
+    const who = principal();
+    const { fn, calls } = fakeFetch(async () => ({
+      status: 200,
+      json: async () => ({ calendars: [] }),
+    }));
+
+    const result = await client(fn).listActiveCalendars(who);
+
+    if (!result.ok) throw new Error(`expected ok, got ${result.error.kind}`);
+    expect(result.value.calendars).toEqual([]);
+
+    const sent = calls[0];
+    expect(sent?.url).toBe(`${BASE_URL}${CALENDARS_PATH}?activeOnly=true`);
+    expect(sent?.method).toBe("GET");
+
+    // listCalendars, called through the same client, still sends no params —
+    // the two methods must not share state or leak a query onto each other.
+    await client(fn).listCalendars(who);
+    expect(calls[1]?.url).toBe(`${BASE_URL}${CALENDARS_PATH}`);
+
+    const verdict = verifyInternalRequest({
+      secret: SECRET,
+      headers: sent?.headers ?? {},
+      now: NOW,
+    });
+    if (!verdict.ok) throw new Error(`verify failed: ${verdict.reason}`);
+    expect(verdict.context.tenantId).toBe(who.tenantId);
+    expect(verdict.context.principalId).toBe(who.principalId);
+  });
+
   it("polls the change feed from now and with a resume cursor", async () => {
     const who = principal();
     const cursor = objectId();

--- a/packages/backend/src/common/services/sync-service/sync-service.client.ts
+++ b/packages/backend/src/common/services/sync-service/sync-service.client.ts
@@ -197,13 +197,7 @@ export class SyncServiceClient {
     principal: SyncPrincipal,
     correlationId?: string,
   ): Promise<SyncClientResult<CalendarListResponse>> {
-    return this.#request({
-      method: "GET",
-      path: CALENDARS_PATH,
-      principal,
-      schema: CalendarListResponseSchema,
-      correlationId,
-    });
+    return this.#listCalendars(principal, correlationId);
   }
 
   // Same as listCalendars, scoped to calendars the provider still lists. A
@@ -218,6 +212,14 @@ export class SyncServiceClient {
   ): Promise<SyncClientResult<CalendarListResponse>> {
     const query = new URLSearchParams();
     query.set("activeOnly", "true");
+    return this.#listCalendars(principal, correlationId, query);
+  }
+
+  #listCalendars(
+    principal: SyncPrincipal,
+    correlationId?: string,
+    query?: URLSearchParams,
+  ): Promise<SyncClientResult<CalendarListResponse>> {
     return this.#request({
       method: "GET",
       path: CALENDARS_PATH,

--- a/packages/backend/src/common/services/sync-service/sync-service.client.ts
+++ b/packages/backend/src/common/services/sync-service/sync-service.client.ts
@@ -188,7 +188,11 @@ export class SyncServiceClient {
 
   // The caller's provider calendars, scoped to the signed principal. A read;
   // served in passive mode too. Backs the browser calendar list under sync
-  // delegation.
+  // delegation. Includes calendars the provider no longer lists (active:
+  // false) — the browser's own list surface needs those for name/color lookup
+  // on events that still reference them, so it deliberately does not scope
+  // this call to active-only. Event-ownership resolution wants the opposite;
+  // use listActiveCalendars there.
   listCalendars(
     principal: SyncPrincipal,
     correlationId?: string,
@@ -199,6 +203,28 @@ export class SyncServiceClient {
       principal,
       schema: CalendarListResponseSchema,
       correlationId,
+    });
+  }
+
+  // Same as listCalendars, scoped to calendars the provider still lists. A
+  // separate method (rather than an option on listCalendars) keeps that
+  // method's positional correlationId signature intact and makes each call
+  // site's intent greppable. Use this for anything that resolves which
+  // calendars a request may act on (e.g. event-range ownership) — a retired
+  // calendar should never be treated as an owned id again.
+  listActiveCalendars(
+    principal: SyncPrincipal,
+    correlationId?: string,
+  ): Promise<SyncClientResult<CalendarListResponse>> {
+    const query = new URLSearchParams();
+    query.set("activeOnly", "true");
+    return this.#request({
+      method: "GET",
+      path: CALENDARS_PATH,
+      principal,
+      schema: CalendarListResponseSchema,
+      correlationId,
+      query,
     });
   }
 

--- a/packages/backend/src/event/controllers/event.controller.test.ts
+++ b/packages/backend/src/event/controllers/event.controller.test.ts
@@ -103,7 +103,7 @@ describe("EventController", () => {
   it("fails closed on a sync outage when listing events", async () => {
     spyOn(calendarService, "getLocalCalendar").mockResolvedValue(null);
     spyOn(syncServiceFactory, "getSyncServiceClient").mockReturnValue({
-      listCalendars: mock(() =>
+      listActiveCalendars: mock(() =>
         Promise.resolve({
           ok: false as const,
           error: {
@@ -133,6 +133,57 @@ describe("EventController", () => {
       message: "Failed to list calendars from sync (unavailable)",
       retryable: true,
     });
+  });
+
+  it("resolves owned calendars for a read via listActiveCalendars, never listCalendars", async () => {
+    // resolveSyncCalendarIds intersects the request's calendarIds against
+    // "owned" ids — but while the browser's own calendar list is still
+    // loading, it sends NO calendarIds at all (undefined), and the backend
+    // answers with every owned id verbatim. That call must already be scoped
+    // to active calendars, or a retired calendar's events get read on every
+    // page load that races the calendars query. Modeling this with a client
+    // stub that implements ONLY listActiveCalendars (no listCalendars) means
+    // the controller calling the wrong method throws here instead of quietly
+    // reading everything.
+    const activeCalendarId = objectId();
+    spyOn(calendarService, "getLocalCalendar").mockResolvedValue(null);
+    const listFullEvents = mock(() =>
+      Promise.resolve({
+        ok: true as const,
+        value: { instances: [], nextCursor: null },
+      }),
+    );
+    spyOn(syncServiceFactory, "getSyncServiceClient").mockReturnValue({
+      listActiveCalendars: mock(() =>
+        Promise.resolve({
+          ok: true as const,
+          value: { calendars: [{ id: activeCalendarId }] },
+        }),
+      ),
+      listFullEvents,
+    } as never);
+
+    const { res, json } = jsonRes();
+    await eventController.readAll(
+      sessionReq(objectId(), {
+        query: {
+          start: "2026-07-14T00:00:00.000Z",
+          end: "2026-07-21T00:00:00.000Z",
+        },
+      }),
+      res,
+    );
+
+    expect(res.status).toHaveBeenCalledWith(Status.OK);
+    expect(json).toHaveBeenCalledWith({ events: [] });
+    expect(listFullEvents).toHaveBeenCalledTimes(1);
+    const pageQuery = (
+      listFullEvents.mock.calls[0] as never as [
+        unknown,
+        { calendarIds: string[] },
+      ]
+    )[1];
+    expect(pageQuery.calendarIds).toEqual([activeCalendarId]);
   });
 
   it("rejects a calendar move before submitting anything to sync", async () => {

--- a/packages/backend/src/event/controllers/event.controller.ts
+++ b/packages/backend/src/event/controllers/event.controller.ts
@@ -65,7 +65,10 @@ const parseListQuery = (query: Request["query"]): EventListQuery => {
 // `calendarIds`, intersect with owned ids so hidden calendars are never
 // drained (and unowned ids cannot be probed). Empty means the user has
 // nothing to read yet; return [] rather than calling sync with an invalid
-// empty calendarIds.
+// empty calendarIds. Scoped to ACTIVE calendars only: a calendar the provider
+// no longer lists must never be read from (nor silently included when the
+// client sends no calendarIds at all, which happens while the browser's own
+// calendar list is still loading).
 const resolveSyncCalendarIds = async (
   client: SyncServiceClient,
   userId: string,
@@ -73,7 +76,7 @@ const resolveSyncCalendarIds = async (
 ): Promise<SyncEventCalendarId[]> => {
   const principal = toSyncPrincipal(userId);
   const [calendarsResult, localCalendar] = await Promise.all([
-    client.listCalendars(principal),
+    client.listActiveCalendars(principal),
     calendarService.getLocalCalendar(userId),
   ]);
 

--- a/packages/sync/src/app.ts
+++ b/packages/sync/src/app.ts
@@ -648,9 +648,9 @@ function buildSchedulers(
           {
             resources,
             jobs,
-            onError: (error, connectionId) =>
+            onError: (error, resourceId) =>
               logger.error(
-                `Sync calendar-list rediscovery sweep could not re-list connection ${connectionId}; skipping it and continuing`,
+                `Sync calendar-list rediscovery sweep could not re-list resource ${resourceId}; skipping it and continuing`,
                 error,
               ),
           },

--- a/packages/sync/src/app.ts
+++ b/packages/sync/src/app.ts
@@ -10,6 +10,7 @@ import {
 } from "@sync/auth/internal-auth";
 import { loadSyncConfig, type SyncConfig } from "@sync/config/sync.config";
 import { CredentialCustody } from "@sync/credentials/credential-custody.service";
+import { rediscoverStaleCalendarLists } from "@sync/domain/calendar-list-rediscovery.service";
 import {
   CONNECTION_CACHE_RETENTION_MS,
   purgeExpiredDisconnectedConnections,
@@ -256,6 +257,7 @@ async function start(): Promise<void> {
         ["bootstrapRecovery", schedulers.bootstrapRecovery],
         ["failedJobRequeue", schedulers.failedJobRequeue],
         ["staleCommandRetry", schedulers.staleCommandRetry],
+        ["calendarListRediscovery", schedulers.calendarListRediscovery],
       ] as const;
       for (const [name, sweep] of sweeps) {
         service.shutdown.register(name, () => sweep.stop());
@@ -299,6 +301,14 @@ const SUBSCRIPTION_RENEW_BEFORE_MS = 24 * 60 * 60_000;
 // How often to look for soft-disconnected connections past the 30-day cache
 // window. Daily is enough for the retention SLA; hourly keeps catch-up snappy.
 const RETENTION_SWEEP_INTERVAL_MS = 60 * 60_000;
+// A connection whose calendar list has not been fully re-discovered within
+// this window is swept: a calendar deleted or unshared at the provider is
+// otherwise never retired, because calendarListSync only ever runs once, at
+// connect. Runs on the sweep's default ~10min interval (like reconcile and
+// bootstrapRecovery below, neither of which overrides it either) — cheap to
+// poll for, and the limit-bounded finder means the eligible population still
+// self-spreads across cycles rather than sweeping the whole fleet at once.
+const CALENDAR_LIST_STALE_AFTER_MS = 24 * 60 * 60_000;
 // Architecture: one sync_health_snapshot every five minutes.
 const HEALTH_SNAPSHOT_INTERVAL_MS = 5 * 60_000;
 
@@ -382,6 +392,7 @@ function buildSchedulers(
   bootstrapRecovery: SweepScheduler;
   failedJobRequeue: SweepScheduler;
   staleCommandRetry: SweepScheduler;
+  calendarListRediscovery: SweepScheduler;
 } | null {
   if (config.EXECUTION !== "active") return null;
   const authAdapter = buildAuthAdapter(config);
@@ -625,6 +636,41 @@ function buildSchedulers(
         logger.error("Sync stale-command retry sweep failed", error),
     },
   );
+  // Calendar-list rediscovery looks BACK, like reconcile: force a FULL
+  // discovery pass for any connection whose calendar list has not been
+  // re-listed within the staleness window, so a calendar the provider no
+  // longer lists eventually gets retired (deactivateAbsent only fires on a
+  // full pass, and only this sweep forces one after the initial connect).
+  const calendarListRediscovery = new SweepScheduler(
+    {
+      sweep: async (before) => {
+        const enqueued = await rediscoverStaleCalendarLists(
+          {
+            resources,
+            jobs,
+            onError: (error, connectionId) =>
+              logger.error(
+                `Sync calendar-list rediscovery sweep could not re-list connection ${connectionId}; skipping it and continuing`,
+                error,
+              ),
+          },
+          before,
+          () => new Date(),
+        );
+        if (enqueued > 0) {
+          logger.info(
+            `Sync calendar-list rediscovery sweep enqueued ${enqueued} full re-discovery(ies)`,
+          );
+        }
+        return enqueued;
+      },
+    },
+    {
+      windowMs: -CALENDAR_LIST_STALE_AFTER_MS,
+      onError: (error) =>
+        logger.error("Sync calendar-list rediscovery sweep failed", error),
+    },
+  );
   return {
     drains,
     reconcile,
@@ -632,6 +678,7 @@ function buildSchedulers(
     bootstrapRecovery,
     failedJobRequeue,
     staleCommandRetry,
+    calendarListRediscovery,
   };
 }
 

--- a/packages/sync/src/domain/calendar-list-rediscovery.db.test.ts
+++ b/packages/sync/src/domain/calendar-list-rediscovery.db.test.ts
@@ -249,7 +249,7 @@ describe("calendar-list rediscovery sweep (rediscoverStaleCalendarLists)", () =>
       {
         resources,
         jobs,
-        onError: (_e, connectionId) => failures.push(connectionId),
+        onError: (_e, resourceId) => failures.push(resourceId),
       },
       staleBefore,
       now,
@@ -259,6 +259,8 @@ describe("calendar-list rediscovery sweep (rediscoverStaleCalendarLists)", () =>
     expect(
       await jobByKey(`calendarListSync:${healthy.connectionId}`),
     ).not.toBeNull();
-    expect(failures).toEqual([poisoned.connectionId]);
+    // enqueueForResources reports the resourceId it failed on (the shared
+    // helper's contract), not the connectionId — poisoned's own resource id.
+    expect(failures).toEqual([poisoned._id]);
   });
 });

--- a/packages/sync/src/domain/calendar-list-rediscovery.db.test.ts
+++ b/packages/sync/src/domain/calendar-list-rediscovery.db.test.ts
@@ -1,0 +1,264 @@
+import { faker } from "@faker-js/faker";
+import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
+import { rediscoverStaleCalendarLists } from "@sync/domain/calendar-list-rediscovery.service";
+import { SYNC_COLLECTIONS } from "@sync/storage/collections";
+import { type SyncResourceRecord } from "@sync/storage/contracts/sync-resource.contracts";
+import { CredentialRepository } from "@sync/storage/repositories/credential.repository";
+import { JobRepository } from "@sync/storage/repositories/job.repository";
+import { SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
+
+const objectId = () => faker.database.mongodbObjectId();
+const now = () => new Date("2026-08-07T00:00:00.000Z");
+// calendarList resources not fully re-listed since this instant are stale.
+const staleBefore = new Date("2026-08-06T00:00:00.000Z");
+
+describe("calendar-list rediscovery sweep (rediscoverStaleCalendarLists)", () => {
+  const storage = setupSyncStorage(import.meta.url);
+  let resources: SyncResourceRepository;
+  let jobs: JobRepository;
+  let credentials: CredentialRepository;
+
+  beforeEach(() => {
+    resources = new SyncResourceRepository(storage.db());
+    jobs = new JobRepository(storage.db());
+    credentials = new CredentialRepository(storage.db());
+  });
+
+  const deps = () => ({ resources, jobs });
+
+  // A connection's calendarList resource, holding a cursor (as a live
+  // connection's does after its initial connect) and a given lastSuccessAt.
+  // Pass withCredential: false to simulate a dead/disconnected connection.
+  const seedCalendarListResource = async (
+    lastSuccessAt: Date | null,
+    options: { withCredential?: boolean } = {},
+  ): Promise<SyncResourceRecord> => {
+    const tenantId = objectId() as SyncResourceRecord["tenantId"];
+    const principalId = objectId() as SyncResourceRecord["principalId"];
+    const connectionId = objectId() as SyncResourceRecord["connectionId"];
+    const resource = await resources.ensure({
+      tenantId,
+      principalId,
+      connectionId,
+      resourceKind: "calendarList",
+      calendarId: null,
+    });
+    if (options.withCredential ?? true) {
+      await credentials.store({
+        connectionId,
+        provider: "google",
+        refreshToken: "refresh-token",
+        scopes: [],
+      });
+    }
+    if (lastSuccessAt) {
+      await resources.advanceCursor(
+        tenantId,
+        principalId,
+        resource._id,
+        "cursor-token",
+        lastSuccessAt,
+      );
+    }
+    return resource;
+  };
+
+  const jobByKey = (coalescingKey: string) =>
+    storage.db().collection(SYNC_COLLECTIONS.jobs).findOne({ coalescingKey });
+
+  const jobCount = () =>
+    storage.db().collection(SYNC_COLLECTIONS.jobs).countDocuments({});
+
+  const resourceById = (id: string) =>
+    storage.db().collection(SYNC_COLLECTIONS.syncResources).findOne({
+      _id: id,
+    });
+
+  it("clears the cursor and enqueues a connection-scoped calendarListSync for a stale resource", async () => {
+    const stale = await seedCalendarListResource(
+      new Date("2026-08-01T00:00:00.000Z"),
+    );
+
+    const enqueued = await rediscoverStaleCalendarLists(
+      deps(),
+      staleBefore,
+      now,
+    );
+
+    expect(enqueued).toBe(1);
+    const record = await resourceById(stale._id);
+    expect(record?.syncCursor).toBeNull();
+    // lastSuccessAt is the staleness key the sweep sorts on; clearing the
+    // cursor must not also touch it, or the resource would re-win the front
+    // of every subsequent sweep before the pass it triggered ever runs.
+    expect(record?.lastSuccessAt).toEqual(new Date("2026-08-01T00:00:00.000Z"));
+
+    const job = await jobByKey(`calendarListSync:${stale.connectionId}`);
+    expect(job?.kind).toBe("calendarListSync");
+    // Connection-scoped, not resource-scoped: matches registerConnection's
+    // own enqueue shape so the two never race on different coalescing keys.
+    expect(job?.resourceId).toBeNull();
+    expect(job?.tenantId).toBe(stale.tenantId);
+  });
+
+  it("skips a resource re-listed more recently than the threshold", async () => {
+    await seedCalendarListResource(new Date("2026-08-06T12:00:00.000Z")); // after staleBefore
+
+    const enqueued = await rediscoverStaleCalendarLists(
+      deps(),
+      staleBefore,
+      now,
+    );
+
+    expect(enqueued).toBe(0);
+    expect(await jobCount()).toBe(0);
+  });
+
+  it("re-discovers a resource that has never succeeded", async () => {
+    const fresh = await seedCalendarListResource(null);
+
+    const enqueued = await rediscoverStaleCalendarLists(
+      deps(),
+      staleBefore,
+      now,
+    );
+
+    expect(enqueued).toBe(1);
+    expect(
+      await jobByKey(`calendarListSync:${fresh.connectionId}`),
+    ).not.toBeNull();
+  });
+
+  it("coalesces onto an already-pending calendarListSync job while still clearing the cursor", async () => {
+    // registerConnection may have already enqueued calendarListSync (e.g. a
+    // reconnect raced the sweep). The sweep's enqueue must collapse onto that
+    // job rather than mint a second one, since JobRepository.enqueue only
+    // $setOnInsert's — but the cursor clear still has to land, because
+    // whichever job runs reads the cursor fresh at execution time.
+    const stale = await seedCalendarListResource(
+      new Date("2026-08-01T00:00:00.000Z"),
+    );
+    await jobs.enqueue({
+      tenantId: stale.tenantId,
+      principalId: stale.principalId,
+      connectionId: stale.connectionId,
+      resourceId: null,
+      commandId: null,
+      kind: "calendarListSync",
+      priority: 0,
+      runAfter: now(),
+      coalescingKey: `calendarListSync:${stale.connectionId}`,
+    });
+
+    const enqueued = await rediscoverStaleCalendarLists(
+      deps(),
+      staleBefore,
+      now,
+    );
+
+    expect(enqueued).toBe(1);
+    expect(
+      await storage
+        .db()
+        .collection(SYNC_COLLECTIONS.jobs)
+        .countDocuments({
+          coalescingKey: `calendarListSync:${stale.connectionId}`,
+        }),
+    ).toBe(1);
+    const record = await resourceById(stale._id);
+    expect(record?.syncCursor).toBeNull();
+  });
+
+  it("excludes a resource whose connection has no stored credential, however stale", async () => {
+    const deadCredential = await seedCalendarListResource(null, {
+      withCredential: false,
+    });
+    const healthy = await seedCalendarListResource(
+      new Date("2026-08-01T00:00:00.000Z"),
+    );
+
+    const enqueued = await rediscoverStaleCalendarLists(
+      deps(),
+      staleBefore,
+      now,
+    );
+
+    expect(enqueued).toBe(1);
+    expect(
+      await jobByKey(`calendarListSync:${healthy.connectionId}`),
+    ).not.toBeNull();
+    expect(
+      await jobByKey(`calendarListSync:${deadCredential.connectionId}`),
+    ).toBeNull();
+  });
+
+  it("rotates a permanently-failing connection behind others via lastAttemptAt", async () => {
+    // Without stamping lastAttemptAt, a connection whose discovery always
+    // errors before succeeding ties at lastAttemptAt: null forever and
+    // re-wins the front of every sweep, starving the resources behind it —
+    // the same dead-credential-cohort pathology reconcile hit on 2026-07-29,
+    // here for calendarList resources instead of events.
+    const doomed = await seedCalendarListResource(null);
+    const healthy = await seedCalendarListResource(
+      new Date("2026-08-01T00:00:00.000Z"),
+    );
+    await resources.markAttempt(
+      doomed.tenantId,
+      doomed.principalId,
+      doomed._id,
+      new Date("2026-08-06T16:00:00.000Z"),
+    );
+
+    const enqueued = await rediscoverStaleCalendarLists(
+      deps(),
+      staleBefore,
+      now,
+      1,
+    );
+
+    expect(enqueued).toBe(1);
+    expect(
+      await jobByKey(`calendarListSync:${healthy.connectionId}`),
+    ).not.toBeNull();
+    expect(
+      await jobByKey(`calendarListSync:${doomed.connectionId}`),
+    ).toBeNull();
+  });
+
+  it("skips a connection whose cursor clear or enqueue fails and sweeps the rest", async () => {
+    const poisoned = await seedCalendarListResource(
+      new Date("2026-08-01T00:00:00.000Z"),
+    );
+    const healthy = await seedCalendarListResource(
+      new Date("2026-08-02T00:00:00.000Z"),
+    );
+    // A job doc that cannot be parsed back out, sitting on the coalescing key
+    // the sweep is about to reuse — mirrors the 2026-07-31 fleet-freeze shape
+    // (resource-sweep-enqueue.reconcile.db.test.ts) for this sweep's own key.
+    await storage
+      .db()
+      .collection(SYNC_COLLECTIONS.jobs)
+      .insertOne({
+        _id: objectId(),
+        coalescingKey: `calendarListSync:${poisoned.connectionId}`,
+        kind: "notAJobKind",
+      } as never);
+    const failures: string[] = [];
+
+    const enqueued = await rediscoverStaleCalendarLists(
+      {
+        resources,
+        jobs,
+        onError: (_e, connectionId) => failures.push(connectionId),
+      },
+      staleBefore,
+      now,
+    );
+
+    expect(enqueued).toBe(1);
+    expect(
+      await jobByKey(`calendarListSync:${healthy.connectionId}`),
+    ).not.toBeNull();
+    expect(failures).toEqual([poisoned.connectionId]);
+  });
+});

--- a/packages/sync/src/domain/calendar-list-rediscovery.service.ts
+++ b/packages/sync/src/domain/calendar-list-rediscovery.service.ts
@@ -1,0 +1,69 @@
+import { type JobRepository } from "@sync/storage/repositories/job.repository";
+import { type SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
+
+export interface CalendarListRediscoveryDeps {
+  resources: SyncResourceRepository;
+  jobs: JobRepository;
+  // Called once per connection whose cursor could not be cleared or job could
+  // not be enqueued. The sweep keeps going; the caller decides how loud to be.
+  onError?: (error: unknown, connectionId: string) => void;
+}
+
+// Force a FULL calendar-list re-discovery for every connection whose last
+// discovery is older than `before`, so a calendar deleted or unshared at the
+// provider eventually gets retired even though calendarListSync otherwise only
+// ever runs once, at connect (connection.routes.ts's registerConnection is the
+// only other enqueue site).
+//
+// This is NOT a thin wrapper around enqueueForResources: that helper always
+// enqueues resourceId: resource._id and coalescingKey: `${kind}:${resource._id}`,
+// but calendarListSync is connection-scoped (resourceId: null) and MUST reuse
+// the connect path's exact coalescing key (`calendarListSync:${connectionId}`).
+// Minting a different key would let a sweep-enqueued discovery and a
+// connect-enqueued discovery run concurrently on one connection — two passes
+// racing over one cursor is how an incremental pass's advanceCursor clobbers a
+// full pass this cycle just cleared.
+//
+// syncCalendarList decides full-vs-incremental purely from whether the stored
+// cursor is null (`fullList = resource.syncCursor === null`), so clearing the
+// cursor here is what forces the eventual pass to go full — it does not matter
+// whether that pass is this sweep's own enqueue or one that coalesced onto an
+// already-pending job; either reads the cleared cursor and full-lists.
+//
+// Each connection is handled independently: one that throws is reported and
+// skipped, never allowed to abandon the rest of the batch (2026-07-31: one
+// unparseable job doc froze calendar sync fleet-wide for 23h — same hazard
+// class enqueueForResources guards against).
+export async function rediscoverStaleCalendarLists(
+  deps: CalendarListRediscoveryDeps,
+  before: Date,
+  now: () => Date,
+  limit = 100,
+): Promise<number> {
+  const due = await deps.resources.listStaleCalendarLists(before, limit);
+  let enqueued = 0;
+  for (const resource of due) {
+    try {
+      await deps.resources.clearSyncCursor(
+        resource.tenantId,
+        resource.principalId,
+        resource._id,
+      );
+      await deps.jobs.enqueue({
+        tenantId: resource.tenantId,
+        principalId: resource.principalId,
+        connectionId: resource.connectionId,
+        resourceId: null,
+        commandId: null,
+        kind: "calendarListSync",
+        priority: 0,
+        runAfter: now(),
+        coalescingKey: `calendarListSync:${resource.connectionId}`,
+      });
+      enqueued += 1;
+    } catch (error) {
+      deps.onError?.(error, resource.connectionId);
+    }
+  }
+  return enqueued;
+}

--- a/packages/sync/src/domain/calendar-list-rediscovery.service.ts
+++ b/packages/sync/src/domain/calendar-list-rediscovery.service.ts
@@ -1,12 +1,14 @@
+import { enqueueForResources } from "@sync/domain/resource-sweep-enqueue";
 import { type JobRepository } from "@sync/storage/repositories/job.repository";
 import { type SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
 
 export interface CalendarListRediscoveryDeps {
   resources: SyncResourceRepository;
   jobs: JobRepository;
-  // Called once per connection whose cursor could not be cleared or job could
-  // not be enqueued. The sweep keeps going; the caller decides how loud to be.
-  onError?: (error: unknown, connectionId: string) => void;
+  // Called once per calendarList resource whose cursor could not be cleared or
+  // job could not be enqueued. The sweep keeps going; the caller decides how
+  // loud to be.
+  onError?: (error: unknown, resourceId: string) => void;
 }
 
 // Force a FULL calendar-list re-discovery for every connection whose last
@@ -15,41 +17,42 @@ export interface CalendarListRediscoveryDeps {
 // ever runs once, at connect (connection.routes.ts's registerConnection is the
 // only other enqueue site).
 //
-// This is NOT a thin wrapper around enqueueForResources: that helper always
-// enqueues resourceId: resource._id and coalescingKey: `${kind}:${resource._id}`,
-// but calendarListSync is connection-scoped (resourceId: null) and MUST reuse
-// the connect path's exact coalescing key (`calendarListSync:${connectionId}`).
-// Minting a different key would let a sweep-enqueued discovery and a
-// connect-enqueued discovery run concurrently on one connection — two passes
-// racing over one cursor is how an incremental pass's advanceCursor clobbers a
-// full pass this cycle just cleared.
+// Shares enqueueForResources's per-resource try/catch loop (2026-07-31: one
+// unparseable job doc froze calendar sync fleet-wide for 23h — the same hazard
+// every sweep guards against) via its buildEnqueue override, since
+// calendarListSync needs a shape the helper's default doesn't produce:
+// connection-scoped (resourceId: null), keyed on the connect path's own
+// coalescing key (`calendarListSync:${connectionId}`, not the helper's default
+// `${kind}:${resource._id}`) so a sweep-enqueued and a connect-enqueued
+// discovery for one connection always collapse into the same job, plus the
+// cursor-clear side effect that must land inside the same try/catch as the
+// enqueue.
 //
 // syncCalendarList decides full-vs-incremental purely from whether the stored
 // cursor is null (`fullList = resource.syncCursor === null`), so clearing the
 // cursor here is what forces the eventual pass to go full — it does not matter
 // whether that pass is this sweep's own enqueue or one that coalesced onto an
 // already-pending job; either reads the cleared cursor and full-lists.
-//
-// Each connection is handled independently: one that throws is reported and
-// skipped, never allowed to abandon the rest of the batch (2026-07-31: one
-// unparseable job doc froze calendar sync fleet-wide for 23h — same hazard
-// class enqueueForResources guards against).
-export async function rediscoverStaleCalendarLists(
+export function rediscoverStaleCalendarLists(
   deps: CalendarListRediscoveryDeps,
   before: Date,
   now: () => Date,
   limit = 100,
 ): Promise<number> {
-  const due = await deps.resources.listStaleCalendarLists(before, limit);
-  let enqueued = 0;
-  for (const resource of due) {
-    try {
+  return enqueueForResources(
+    { jobs: deps.jobs, onEnqueueError: deps.onError },
+    (b, l) => deps.resources.listStaleCalendarLists(b, l),
+    "calendarListSync",
+    before,
+    now,
+    limit,
+    async (resource, nowFn) => {
       await deps.resources.clearSyncCursor(
         resource.tenantId,
         resource.principalId,
         resource._id,
       );
-      await deps.jobs.enqueue({
+      return {
         tenantId: resource.tenantId,
         principalId: resource.principalId,
         connectionId: resource.connectionId,
@@ -57,13 +60,9 @@ export async function rediscoverStaleCalendarLists(
         commandId: null,
         kind: "calendarListSync",
         priority: 0,
-        runAfter: now(),
+        runAfter: nowFn(),
         coalescingKey: `calendarListSync:${resource.connectionId}`,
-      });
-      enqueued += 1;
-    } catch (error) {
-      deps.onError?.(error, resource.connectionId);
-    }
-  }
-  return enqueued;
+      };
+    },
+  );
 }

--- a/packages/sync/src/domain/calendar-list-sync.service.db.test.ts
+++ b/packages/sync/src/domain/calendar-list-sync.service.db.test.ts
@@ -195,6 +195,116 @@ describe("syncCalendarList", () => {
     expect(primary?.active).toBe(true);
   });
 
+  it("stamps lastAttemptAt on the calendarList resource before it can fail", async () => {
+    // Without this, the rediscovery sweep's rotation sort (lastAttemptAt) ties
+    // at null forever for a permanently-failing connection, and it re-wins the
+    // front of every sweep cycle (calendar-list-rediscovery.db.test.ts covers
+    // the sweep side; this covers that syncCalendarList is what stamps it).
+    const conn = connection();
+    const discovery = new FakeDiscovery([
+      { calendars: [discovered("primary")], cursor: "c" },
+    ]);
+
+    await syncCalendarList(deps(discovery), conn, now);
+
+    expect((await calendarListResource(conn))?.lastAttemptAt).toEqual(now());
+  });
+
+  it("clears the local push channel of a retired calendar's events resource", async () => {
+    const conn = connection();
+    // First full pass discovers "gone" and bootstraps its events resource.
+    await syncCalendarList(
+      deps(
+        new FakeDiscovery([
+          {
+            calendars: [discovered("primary"), discovered("gone")],
+            cursor: null,
+          },
+        ]),
+      ),
+      conn,
+      now,
+    );
+    const goneCalendar = (await calendarDocs(conn)).find(
+      (d) => d.providerCalendarId === "gone",
+    );
+    const goneEventsResourceId = (
+      await storage.db().collection(SYNC_COLLECTIONS.syncResources).findOne({
+        connectionId: conn._id,
+        resourceKind: "events",
+        calendarId: goneCalendar?._id,
+      })
+    )?._id as string;
+    // Simulate an established push channel, as a calendar with prior sync
+    // history would hold.
+    await resources.updateSubscription(
+      conn.tenantId,
+      conn.principalId,
+      goneEventsResourceId,
+      {
+        subscriptionId: "channel-1",
+        subscriptionResourceId: "resource-1",
+        subscriptionToken: "token-1",
+        subscriptionExpiresAt: new Date("2026-08-01T00:00:00.000Z"),
+      },
+    );
+
+    // Second full pass omits "gone", retiring it.
+    await syncCalendarList(
+      deps(
+        new FakeDiscovery([
+          { calendars: [discovered("primary")], cursor: null },
+        ]),
+      ),
+      conn,
+      now,
+    );
+
+    const goneEventsResource = await storage
+      .db()
+      .collection(SYNC_COLLECTIONS.syncResources)
+      .findOne({ _id: goneEventsResourceId });
+    expect(goneEventsResource?.subscriptionId).toBeNull();
+    expect(goneEventsResource?.subscriptionExpiresAt).toBeNull();
+  });
+
+  it("logs a warning naming the calendars a full pass retired", async () => {
+    const conn = connection();
+    await syncCalendarList(
+      deps(
+        new FakeDiscovery([
+          {
+            calendars: [discovered("primary"), discovered("gone")],
+            cursor: null,
+          },
+        ]),
+      ),
+      conn,
+      now,
+    );
+    const goneCalendar = (await calendarDocs(conn)).find(
+      (d) => d.providerCalendarId === "gone",
+    );
+    const warnings: string[] = [];
+
+    await syncCalendarList(
+      {
+        ...deps(
+          new FakeDiscovery([
+            { calendars: [discovered("primary")], cursor: null },
+          ]),
+        ),
+        log: { warn: (message) => warnings.push(message) },
+      },
+      conn,
+      now,
+    );
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain(goneCalendar?._id as string);
+    expect(warnings[0]).toContain(conn._id);
+  });
+
   it("does not retire everything when a full list comes back empty", async () => {
     const conn = connection();
     // First full pass discovers a calendar (cursor null keeps the next pass full).

--- a/packages/sync/src/domain/calendar-list-sync.service.ts
+++ b/packages/sync/src/domain/calendar-list-sync.service.ts
@@ -15,6 +15,11 @@ export interface CalendarListSyncDeps {
   jobs: JobRepository;
   discovery: ProviderCalendarAdapter;
   custody: AccessTokenSource;
+  // Optional: a retirement is otherwise invisible (deactivateAbsent's result
+  // was previously discarded entirely). Once discovery runs on a recurring
+  // sweep rather than only at connect, retirements happen unattended and need
+  // an audit trail. Defaults to a no-op so tests stay dependency-free.
+  log?: { warn: (message: string) => void };
 }
 
 export interface CalendarListSyncResult {
@@ -53,6 +58,14 @@ export async function syncCalendarList(
     resourceKind: "calendarList",
     calendarId: null,
   });
+
+  // Stamp the attempt before the token fetch can fail, mirroring the events
+  // pull's rotation invariant: the rediscovery sweep sorts calendarList
+  // resources by lastAttemptAt, and without this every such resource ties at
+  // null forever, letting a permanently-failing connection re-win the front of
+  // every sweep cycle (the 2026-07-29 dead-credential tie-break pathology,
+  // here for calendarList instead of events).
+  await deps.resources.markAttempt(tenantId, principalId, resource._id, now());
 
   const accessToken = await deps.custody.getValidAccessToken(connectionId);
 
@@ -114,7 +127,7 @@ export async function syncCalendarList(
   // hiccup that returned empty instead of throwing) rather than "all removed" —
   // retiring every calendar on an empty blip would be user-visible damage.
   if (fullList && discovery.calendars.length > 0) {
-    await deps.calendars.deactivateAbsent(
+    const retiredIds = await deps.calendars.deactivateAbsent(
       tenantId,
       principalId,
       connectionId,
@@ -122,6 +135,40 @@ export async function syncCalendarList(
         (c) => c.providerCalendarId as ProviderCalendarSourceId,
       ),
     );
+    if (retiredIds.length > 0) {
+      deps.log?.warn(
+        `Sync retired ${retiredIds.length} calendar(s) absent from a full list on connection ${connectionId}: ${retiredIds.join(", ")}`,
+      );
+      // The calendar is gone at the provider, so its push channel (if any) can
+      // never be renewed there. Dispatch already drops subscriptionMaintain for
+      // an inactive calendar, which means its subscriptionExpiresAt never
+      // advances — left alone, the row would squat at the head of every
+      // renewal sweep forever (listExpiringSubscriptions sorts soonest-expiry
+      // first with no other exclusion). Clearing the local fields here, rather
+      // than calling the provider to stop the channel, is deliberate: the
+      // calendar already 404s, and Google's channels lapse on their own within
+      // 30 days regardless, so the remote channel is a harmless, self-healing
+      // wart, not something worth a provider call and a new adapter dependency.
+      const retiredIdSet = new Set<string>(retiredIds);
+      const resources = await deps.resources.listByConnection(
+        tenantId,
+        principalId,
+        connectionId,
+      );
+      for (const eventsResource of resources) {
+        if (
+          eventsResource.calendarId &&
+          retiredIdSet.has(eventsResource.calendarId) &&
+          eventsResource.subscriptionId !== null
+        ) {
+          await deps.resources.clearSubscription(
+            tenantId,
+            principalId,
+            eventsResource._id,
+          );
+        }
+      }
+    }
   }
 
   // Bootstrap events sync for each active calendar: ensure its events resource

--- a/packages/sync/src/domain/calendar-list-sync.service.ts
+++ b/packages/sync/src/domain/calendar-list-sync.service.ts
@@ -155,19 +155,19 @@ export async function syncCalendarList(
         principalId,
         connectionId,
       );
-      for (const eventsResource of resources) {
-        if (
-          eventsResource.calendarId &&
-          retiredIdSet.has(eventsResource.calendarId) &&
-          eventsResource.subscriptionId !== null
-        ) {
-          await deps.resources.clearSubscription(
-            tenantId,
-            principalId,
-            eventsResource._id,
-          );
-        }
-      }
+      const subscribedRetired = resources.filter(
+        (r) =>
+          r.calendarId &&
+          retiredIdSet.has(r.calendarId) &&
+          r.subscriptionId !== null,
+      );
+      // Independent writes to distinct resources: clear them concurrently
+      // rather than one round trip per retired calendar.
+      await Promise.all(
+        subscribedRetired.map((r) =>
+          deps.resources.clearSubscription(tenantId, principalId, r._id),
+        ),
+      );
     }
   }
 

--- a/packages/sync/src/domain/resource-sweep-enqueue.ts
+++ b/packages/sync/src/domain/resource-sweep-enqueue.ts
@@ -31,22 +31,36 @@ export async function enqueueForResources(
   before: Date,
   now: () => Date,
   limit = 100,
+  // Override the default resource-scoped enqueue shape. Only calendar-list
+  // rediscovery needs this: calendarListSync is connection-scoped
+  // (resourceId: null) and must reuse the connect path's own coalescing key
+  // (`calendarListSync:${connectionId}`) rather than this helper's default
+  // `${kind}:${resource._id}` template, and it has a side effect (clearing
+  // the stored discovery cursor) that must happen inside the same per-resource
+  // try/catch as the enqueue, not before the loop starts. Every other sweep
+  // omits this and gets the default shape below.
+  buildEnqueue?: (
+    resource: SyncResourceRecord,
+    now: () => Date,
+  ) => JobEnqueue | Promise<JobEnqueue>,
 ): Promise<number> {
   const due = await finder(before, limit);
   let enqueued = 0;
   for (const resource of due) {
-    const enqueue: JobEnqueue = {
-      tenantId: resource.tenantId,
-      principalId: resource.principalId,
-      connectionId: resource.connectionId,
-      resourceId: resource._id,
-      commandId: null,
-      kind,
-      priority: 0,
-      runAfter: now(),
-      coalescingKey: `${kind}:${resource._id}`,
-    };
     try {
+      const enqueue: JobEnqueue = buildEnqueue
+        ? await buildEnqueue(resource, now)
+        : {
+            tenantId: resource.tenantId,
+            principalId: resource.principalId,
+            connectionId: resource.connectionId,
+            resourceId: resource._id,
+            commandId: null,
+            kind,
+            priority: 0,
+            runAfter: now(),
+            coalescingKey: `${kind}:${resource._id}`,
+          };
       await deps.jobs.enqueue(enqueue);
       enqueued += 1;
     } catch (error) {

--- a/packages/sync/src/storage/repositories/provider-calendar.repository.ts
+++ b/packages/sync/src/storage/repositories/provider-calendar.repository.ts
@@ -69,28 +69,37 @@ export class ProviderCalendarRepository {
   }
 
   // Mark inactive every calendar of a connection whose provider id is NOT in
-  // `presentProviderCalendarIds`, and return how many were changed. Used after a
-  // FULL discovery pass to retire calendars the account no longer lists (an
-  // incremental pass must not call this — absence there means "unchanged", not
-  // "removed"). Marking inactive rather than deleting keeps a calendar's Sync _id
-  // (and any downstream preferences) if it later returns. Owner-scoped.
+  // `presentProviderCalendarIds`, and return the retired calendars' ids. Used
+  // after a FULL discovery pass to retire calendars the account no longer lists
+  // (an incremental pass must not call this — absence there means "unchanged",
+  // not "removed"). Marking inactive rather than deleting keeps a calendar's
+  // Sync _id (and any downstream preferences) if it later returns. Owner-scoped.
+  // Ids are returned (not just a count) so the caller can log which calendars
+  // were retired and clear their local push-channel state — once this runs on a
+  // recurring sweep rather than only at connect, a silent retirement is no
+  // longer auditable enough.
   async deactivateAbsent(
     tenantId: TenantId,
     principalId: PrincipalId,
     connectionId: ConnectionId,
     presentProviderCalendarIds: readonly ProviderCalendarSourceId[],
-  ): Promise<number> {
-    const result = await this.collection.updateMany(
-      {
-        tenantId,
-        principalId,
-        connectionId,
-        active: true,
-        providerCalendarId: { $nin: [...presentProviderCalendarIds] },
-      },
-      { $set: { active: false, updatedAt: new Date() } },
-    );
-    return result.modifiedCount;
+  ): Promise<ProviderCalendarId[]> {
+    const filter: Filter<ProviderCalendarRecord> = {
+      tenantId,
+      principalId,
+      connectionId,
+      active: true,
+      providerCalendarId: { $nin: [...presentProviderCalendarIds] },
+    };
+    const retired = await this.collection
+      .find(filter)
+      .project<{ _id: ProviderCalendarId }>({ _id: 1 })
+      .toArray();
+    if (retired.length === 0) return [];
+    await this.collection.updateMany(filter, {
+      $set: { active: false, updatedAt: new Date() },
+    });
+    return retired.map((r) => r._id);
   }
 
   async listByConnection(

--- a/packages/sync/src/storage/repositories/sync-resource.repository.ts
+++ b/packages/sync/src/storage/repositories/sync-resource.repository.ts
@@ -467,6 +467,64 @@ export class SyncResourceRepository {
     return records.map((r) => SyncResourceRecordSchema.parse(r));
   }
 
+  // calendarList resources whose last successful discovery is older than
+  // `before` (or which never succeeded), rotated oldest-attempt-first, bounded.
+  // This is the calendar-list rediscovery sweep's input — the periodic re-run
+  // that catches a calendar deleted or unshared at the provider, since
+  // calendarListSync otherwise only ever runs once, at connect. Same GLOBAL
+  // scan + credential-exclusion shape as listStaleEvents, for the same reason
+  // (2026-07-29 dead-credential tie-break bias) - uses the resource_last_success
+  // / resource_last_attempt indexes, which already lead with resourceKind so no
+  // new index is needed for this kind.
+  async listStaleCalendarLists(
+    before: Date,
+    limit: number,
+  ): Promise<SyncResourceRecord[]> {
+    const records = await this.collection
+      .aggregate<SyncResourceRecord>([
+        {
+          $match: {
+            resourceKind: "calendarList",
+            $or: [{ lastSuccessAt: { $lt: before } }, { lastSuccessAt: null }],
+          },
+        },
+        {
+          $lookup: {
+            from: SYNC_COLLECTIONS.credentials,
+            localField: "connectionId",
+            foreignField: "_id",
+            as: "_credential",
+          },
+        },
+        { $match: { "_credential.0": { $exists: true } } },
+        { $project: { _credential: 0 } },
+        { $sort: { lastAttemptAt: 1, lastSuccessAt: 1 } },
+        { $limit: limit },
+      ])
+      .toArray();
+    return records.map((r) => SyncResourceRecordSchema.parse(r));
+  }
+
+  // Clear the calendarList resource's incremental cursor so the next
+  // calendarListSync pass — whichever job runs it, sweep-enqueued or otherwise
+  // — goes full rather than incremental (syncCalendarList treats a null cursor
+  // as `fullList`). Deliberately leaves lastSuccessAt untouched: that field is
+  // the staleness key the rediscovery sweep sorts on, and touching it here
+  // would let a resource that hasn't actually re-synced yet win the front of
+  // every subsequent sweep cycle.
+  async clearSyncCursor(
+    tenantId: TenantId,
+    principalId: PrincipalId,
+    id: string,
+  ): Promise<void> {
+    await this.collection.updateOne(
+      { _id: id, tenantId, principalId },
+      {
+        $set: { syncCursor: null, pageCursor: null, updatedAt: new Date() },
+      },
+    );
+  }
+
   // Hard-delete every sync resource for one connection (post-disconnect retention).
   async deleteByConnection(
     tenantId: TenantId,

--- a/packages/web/src/events/queries/filter-events-by-visible-calendars.test.ts
+++ b/packages/web/src/events/queries/filter-events-by-visible-calendars.test.ts
@@ -49,4 +49,24 @@ describe("filterEventsByVisibleCalendars", () => {
     expect(filtered?.entities[dropped.id]).toBeUndefined();
     expect(filtered?.entities[kept.id]).toBeDefined();
   });
+
+  it("drops events on a retired (inactive) calendar even when it is still visible", () => {
+    // A calendar the provider no longer lists is deactivated, not deleted, and
+    // client-side visibility (isVisible) is separate browser-local state that
+    // nothing clears on retirement. Without checking isActive here, a
+    // deleted-at-Google calendar's events would keep rendering in the grid.
+    const active = calendar({ isActive: true, isVisible: true });
+    const retired = calendar({ isActive: false, isVisible: true });
+    const kept = createMockEvent({ calendarId: active.id });
+    const dropped = createMockEvent({ calendarId: retired.id });
+    const data = {
+      ids: [kept.id, dropped.id],
+      entities: { [kept.id]: kept, [dropped.id]: dropped },
+    };
+
+    const filtered = filterEventsByVisibleCalendars(data, [active, retired]);
+    expect(filtered?.ids).toEqual([kept.id]);
+    expect(filtered?.entities[dropped.id]).toBeUndefined();
+    expect(filtered?.entities[kept.id]).toBeDefined();
+  });
 });

--- a/packages/web/src/events/queries/filter-events-by-visible-calendars.ts
+++ b/packages/web/src/events/queries/filter-events-by-visible-calendars.ts
@@ -2,8 +2,9 @@ import { type Calendar } from "@core/types/calendar.contracts";
 import { type NormalizedEventQueryData } from "./event.query.types";
 
 /**
- * Drop events whose calendar is hidden. When calendars have not loaded yet,
- * pass the data through unchanged so the grid does not flash empty.
+ * Drop events whose calendar is hidden or retired (no longer active at the
+ * provider). When calendars have not loaded yet, pass the data through
+ * unchanged so the grid does not flash empty.
  *
  * Pure: useCalendarEventViewModel memoizes the whole pipeline this belongs to,
  * so there is nothing to cache here.
@@ -15,7 +16,9 @@ export function filterEventsByVisibleCalendars(
   if (!data || !calendars) return data;
 
   const visibleIds = new Set(
-    calendars.filter((calendar) => calendar.isVisible).map((c) => c.id),
+    calendars
+      .filter((calendar) => calendar.isActive && calendar.isVisible)
+      .map((c) => c.id),
   );
 
   const ids = data.ids.filter((id) => {


### PR DESCRIPTION
## Summary

A calendar deleted or unshared at Google was never retired in Compass. The
retirement mechanism (`deactivateAbsent`, which marks a calendar inactive on
a FULL discovery pass) was correct but only ever triggered once, at initial
connection — nothing re-ran discovery afterward, so a deleted calendar stayed
`active: true` forever and kept showing in the Compass sidebar.

Confirmed empirically against a live prod case (URNU calendar,
`33svq5bfopct5luq7stm8m22es@group.calendar.google.com`): refreshed the
affected user's stored Google token from prod and called the Calendar API
directly. The calendar is fully absent from `calendarList` even with
`showDeleted=true&showHidden=true` — not merely hidden — so a full
re-discovery pass is the correct and sufficient fix (no read-failure-driven
retirement needed).

Also probed all 60 credentialed prod connections against Google before
designing the periodic sweep's cadence: zero calendars would flip inactive
due to `hidden=true`/`deleted=true` (only 2 true deletions exist fleet-wide),
so there was no risk of a periodic full pass silently disappearing calendars
users merely hid in Google. It would also surface 147 calendars Compass never
discovered across 36 connections — decided to activate those normally, same
as a reconnect already does today, fixing a second latent bug.

**Changes:**
- New periodic sweep (`calendar-list-rediscovery.service.ts`, wired into
  `app.ts`) that clears a stale connection's stored discovery cursor, forcing
  the next `calendarListSync` pass full, and enqueues it under the exact
  coalescing key the connect path uses so the two never race.
- `calendar-list-sync.service.ts` now stamps `lastAttemptAt` (for the sweep's
  rotation sort — prevents a dead-credential-style starvation pathology), logs
  which calendars a full pass retired, and clears their local push-channel
  fields (dispatch already drops renewal jobs for inactive calendars, so their
  `subscriptionExpiresAt` would otherwise never advance and the row would
  squat at the head of every renewal sweep forever).
- `ProviderCalendarRepository.deactivateAbsent` now returns retired ids
  instead of a bare count (one caller, verified).
- Closed the residual leak: event-range reads resolve owned calendars via a
  new `activeOnly`-scoped client method, closing a fail-open where the
  backend answered with every owned id (including inactive) while the
  browser's own calendar list was still loading. The web event filter now
  also checks `isActive`, not just `isVisible`.
- Retired calendars' events and sync_resources are deliberately left in place
  (not deleted) — reversible if the calendar returns; only the local
  subscription fields are cleared.

## Simplicity

An independent review round flagged that the new sweep's hand-rolled
per-resource retry loop duplicated the existing `enqueueForResources` shared
helper's resilience logic (the same "one doomed resource can't starve the
batch" guard, verbatim). Generalized `enqueueForResources` with an optional
`buildEnqueue` override so the new sweep shares that loop instead of forking
it — additive and backward-compatible; the three existing production callers
(reconcile, subscription maintenance, bootstrap recovery) are unaffected
(confirmed via the full sync suite, 830/830 still green after the change).

Also parallelized independent subscription-clear writes (was sequential),
flattened a nested filter+loop, and factored duplicated request-building code
out of `SyncServiceClient`'s two calendar-list methods.

## Automated validation

This is a backend/sync fix with no new UI surface — validated via the
Mongo-backed db-test suites (the equivalent of an API/CLI scenario here) plus
the live prod investigation described above, not a browser walkthrough.

- Confirmed root cause empirically against prod (read-only Mongo query +
  Google Calendar API call using the affected user's own refresh token).
- `calendar-list-rediscovery.db.test.ts`: staleness threshold, never-synced
  first, coalescing onto a pre-existing job, dead-credential exclusion,
  attempt-based rotation, per-resource failure isolation.
- `calendar-list-sync.service.db.test.ts`: `lastAttemptAt` stamping,
  subscription clearing on retirement, retirement warning log, existing
  full/incremental/cursor-expiry invariants still hold.
- `sync-service.client.test.ts`: `listActiveCalendars` sends
  `?activeOnly=true`; `listCalendars` still sends none.
- `event.controller.test.ts`: owned-calendar resolution now goes through
  `listActiveCalendars`, not `listCalendars` (a client stub implementing only
  the former proves the wrong method would throw, not silently over-read).
- `filter-events-by-visible-calendars.test.ts`: an inactive-but-visible
  calendar's events are dropped.

## Independent review

Two rounds of a fresh, diff-first reviewer agent (no access to my reasoning,
only the diff + task intent):

- Round 1 (first commit): checked coalescing-key correctness, the
  cursor-clear-then-enqueue race, the `deactivateAbsent` → subscription-clear
  id matching, the Mongo aggregation pipelines, `activeOnly` end-to-end
  wiring, and every other caller of `listCalendars` for a missed conversion
  site. No findings.
- Round 2 (after the simplify refactor): specifically re-verified the
  `enqueueForResources` generalization is behavior-preserving for its three
  existing callers, that the cursor-clear still lands inside the same
  try/catch as the enqueue, that the `Promise.all`'d subscription clears have
  no shared mutable state or worse failure semantics than the original
  sequential loop, and that the `SyncServiceClient` method split still
  produces byte-identical requests. No blocking findings; one minor
  operational note (the sweep's `onError` callback now reports a
  `resourceId` instead of `connectionId`, matching the shared helper's
  existing contract — a deliberate consistency tradeoff, not a regression).

Also ran a `/simplify` pass (4 parallel reviewers: reuse, simplification,
efficiency, altitude) between the two rounds; applied every fix that didn't
require touching code outside this diff's scope (skipped consolidating three
now-similar-shaped Mongo aggregation finders, since two of them back other
sensitive, already-well-tested sweeps not otherwise touched here).

## Test plan

```bash
bun run type-check
./node_modules/.bin/biome check <changed files>
bun run test:sync    # 830 pass, 0 fail
bun run test:backend # 334 pass, 1 pre-existing skip, 0 fail
bun run test:web     # exit 0, no failures
```