### PR TITLE
fix(web): make event-form-open state and sidebar persistence single-sourced

### DIFF
--- a/packages/web/src/common/utils/form/form.util.test.ts
+++ b/packages/web/src/common/utils/form/form.util.test.ts
@@ -7,7 +7,6 @@ import {
   isContextMenuOpen,
   isEditableKeyboardTarget,
   isEventFormKeyboardTarget,
-  isEventFormOpen,
   shouldDeferEnterToTarget,
 } from "./form.util";
 import {
@@ -20,71 +19,20 @@ import {
   spyOn,
 } from "bun:test";
 
-const mockGetElementsByName = mock();
 const mockGetElementById = mock();
 
 describe("form.util", () => {
   let getElementByIdSpy: ReturnType<typeof spyOn>;
-  let getElementsByNameSpy: ReturnType<typeof spyOn>;
 
   beforeEach(() => {
     mockGetElementById.mockClear();
-    mockGetElementsByName.mockClear();
     getElementByIdSpy = spyOn(document, "getElementById").mockImplementation(
       mockGetElementById as typeof document.getElementById,
-    );
-    getElementsByNameSpy = spyOn(
-      document,
-      "getElementsByName",
-    ).mockImplementation(
-      mockGetElementsByName as typeof document.getElementsByName,
     );
   });
 
   afterEach(() => {
     getElementByIdSpy.mockRestore();
-    getElementsByNameSpy.mockRestore();
-  });
-
-  describe("isEventFormOpen", () => {
-    it("should return true when event form is open", () => {
-      // Mock getElementsByName to return a single element for ID_EVENT_FORM
-      mockGetElementsByName.mockImplementation((name) => {
-        if (name === ID_EVENT_FORM) {
-          return [{ name: ID_EVENT_FORM }]; // Mock HTMLCollection with one element
-        }
-        return []; // Empty HTMLCollection for other names
-      });
-
-      const result = isEventFormOpen();
-
-      expect(result).toBe(true);
-      expect(mockGetElementsByName).toHaveBeenCalledWith(ID_EVENT_FORM);
-    });
-
-    it("should return false when no forms are open", () => {
-      // Mock getElementsByName to return empty HTMLCollection for all names
-      mockGetElementsByName.mockReturnValue([]);
-
-      const result = isEventFormOpen();
-
-      expect(result).toBe(false);
-      expect(mockGetElementsByName).toHaveBeenCalledWith(ID_EVENT_FORM);
-    });
-
-    it("should return false when forms exist but length is not 1", () => {
-      // Mock getElementsByName to return multiple elements (length !== 1)
-      mockGetElementsByName.mockImplementation((name) => {
-        if (name === ID_EVENT_FORM) {
-          return [{ name: ID_EVENT_FORM }, { name: ID_EVENT_FORM }]; // 2 elements
-        }
-        return []; // Empty HTMLCollection for other names
-      });
-
-      const result = isEventFormOpen();
-
-      expect(result).toBe(false);
-    });
   });
 
   describe("isContextMenuOpen", () => {

--- a/packages/web/src/common/utils/form/form.util.ts
+++ b/packages/web/src/common/utils/form/form.util.ts
@@ -3,9 +3,6 @@ import {
   ID_EVENT_FORM,
 } from "../../constants/web.constants";
 
-export const isEventFormOpen = () =>
-  document.getElementsByName(ID_EVENT_FORM).length === 1;
-
 export const isContextMenuOpen = () => {
   const contextMenuItems = document.getElementById(ID_CONTEXT_MENU_ITEMS);
   return !!contextMenuItems;

--- a/packages/web/src/common/utils/toast/useEscapeToDismissToast.test.tsx
+++ b/packages/web/src/common/utils/toast/useEscapeToDismissToast.test.tsx
@@ -2,15 +2,17 @@ import { HotkeyManager } from "@tanstack/react-hotkeys";
 import { renderHook } from "@testing-library/react";
 import { createTestToastPort } from "@web/__tests__/helpers/web-test-seams";
 import { pressKey } from "@web/__tests__/utils/keyboard.test.util";
-import {
-  ID_CONTEXT_MENU_ITEMS,
-  ID_EVENT_FORM,
-} from "@web/common/constants/web.constants";
+import { ID_CONTEXT_MENU_ITEMS } from "@web/common/constants/web.constants";
 import {
   registerToastPort,
   resetToastPort,
 } from "@web/common/utils/toast/toast.port";
 import { useEscapeToDismissToast } from "@web/common/utils/toast/useEscapeToDismissToast";
+import {
+  createGridEventDraft,
+  timedGridSchedule,
+} from "@web/events/grid-event-draft.adapter";
+import { draftActions } from "@web/events/stores/draft.store";
 import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
 
 describe("useEscapeToDismissToast", () => {
@@ -28,6 +30,7 @@ describe("useEscapeToDismissToast", () => {
   afterEach(() => {
     resetToastPort();
     document.body.innerHTML = "";
+    draftActions.discard();
   });
 
   it("dismisses the visible toast on Escape", () => {
@@ -51,9 +54,16 @@ describe("useEscapeToDismissToast", () => {
   });
 
   it("does not dismiss while the event form is open", () => {
-    const form = document.createElement("form");
-    form.setAttribute("name", ID_EVENT_FORM);
-    document.body.appendChild(form);
+    draftActions.startGridDraft({
+      activity: "gridClick",
+      draft: createGridEventDraft(
+        timedGridSchedule(
+          new Date("2026-05-20T09:00:00.000Z"),
+          new Date("2026-05-20T10:00:00.000Z"),
+        ),
+      ),
+    });
+    draftActions.setFormOpen(true);
 
     renderHook(() => useEscapeToDismissToast());
     pressKey("Escape");

--- a/packages/web/src/common/utils/toast/useEscapeToDismissToast.ts
+++ b/packages/web/src/common/utils/toast/useEscapeToDismissToast.ts
@@ -1,9 +1,9 @@
 import {
   isContextMenuOpen,
-  isEventFormOpen,
   isFloatingLayerOpen,
 } from "@web/common/utils/form/form.util";
 import { getToast } from "@web/common/utils/toast/toast.port";
+import { isEventFormOpen } from "@web/events/stores/draft.store";
 import { useAppShortcut } from "@web/shortcuts/useAppShortcut";
 
 /**

--- a/packages/web/src/components/AuthenticatedLayout/useResponsiveLayout.test.ts
+++ b/packages/web/src/components/AuthenticatedLayout/useResponsiveLayout.test.ts
@@ -1,5 +1,4 @@
 import { act, renderHook } from "@testing-library/react";
-import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
 import { SIDEBAR_AUTO_COLLAPSE_BREAKPOINT } from "@web/components/AuthenticatedLayout/responsive.constants";
 import {
   selectIsSidebarOpen,
@@ -138,7 +137,7 @@ describe("useResponsiveLayout sidebar", () => {
   });
 
   it("should respect a saved closed preference on mount when screen is wide", () => {
-    localStorage.setItem(STORAGE_KEYS.SIDEBAR_OPEN, "false");
+    viewActions.setSidebarOpen(false);
     setupMatchMedia({ sidebarMatches: true });
 
     renderHook(() => useResponsiveLayout());
@@ -147,7 +146,7 @@ describe("useResponsiveLayout sidebar", () => {
   });
 
   it("should ignore a saved open preference on mount when screen is narrow", () => {
-    localStorage.setItem(STORAGE_KEYS.SIDEBAR_OPEN, "true");
+    viewActions.setSidebarOpen(true);
     setupMatchMedia({ sidebarMatches: false });
 
     renderHook(() => useResponsiveLayout());
@@ -156,7 +155,7 @@ describe("useResponsiveLayout sidebar", () => {
   });
 
   it("should restore a saved closed preference when crossing back to wide", () => {
-    localStorage.setItem(STORAGE_KEYS.SIDEBAR_OPEN, "false");
+    viewActions.setSidebarOpen(false);
     const { sidebarQuery } = setupMatchMedia({
       sidebarMatches: false,
     });

--- a/packages/web/src/components/AuthenticatedLayout/useResponsiveLayout.ts
+++ b/packages/web/src/components/AuthenticatedLayout/useResponsiveLayout.ts
@@ -1,15 +1,18 @@
 import { useLayoutEffect } from "react";
-import { readSidebarOpen } from "@web/common/storage/sidebar-open.storage";
 import { SIDEBAR_AUTO_COLLAPSE_BREAKPOINT } from "@web/components/AuthenticatedLayout/responsive.constants";
-import { viewActions } from "@web/events/stores/view.store";
+import {
+  selectSidebarPreference,
+  useViewStore,
+  viewActions,
+} from "@web/events/stores/view.store";
 
 /**
  * Syncs sidebar visibility in the view store with the window size. The sidebar
  * auto-collapses below its breakpoint regardless of any saved preference, but
  * reopening above it restores the user's last manual choice (persisted via
- * toggleSidebar), so a breakpoint crossing never overrides a preference a
- * refresh would otherwise honor. Mount once per app (AuthenticatedLayout) so
- * overrides survive view switches.
+ * setSidebarOpen/toggleSidebar), so a breakpoint crossing never overrides a
+ * preference a refresh would otherwise honor. Mount once per app
+ * (AuthenticatedLayout) so overrides survive view switches.
  */
 export function useResponsiveLayout() {
   useLayoutEffect(() => {
@@ -19,7 +22,9 @@ export function useResponsiveLayout() {
           `(min-width: ${SIDEBAR_AUTO_COLLAPSE_BREAKPOINT}px)`,
         ),
         setOpen: (matches: boolean) =>
-          viewActions.setSidebarOpen(matches && readSidebarOpen()),
+          viewActions.syncSidebarOpen(
+            matches && selectSidebarPreference(useViewStore.getState()),
+          ),
       },
     ];
 

--- a/packages/web/src/events/stores/draft.store.ts
+++ b/packages/web/src/events/stores/draft.store.ts
@@ -156,5 +156,9 @@ export const selectDraftStatus = (state: State_DraftEvent) => state.status;
 export const selectIsEventFormOpen = (state: State_DraftEvent) =>
   Boolean(state.status?.isFormOpen) && state.gridDraft !== null;
 
+/** Imperative read for keyboard/pointer handlers outside React's render cycle. */
+export const isEventFormOpen = () =>
+  selectIsEventFormOpen(useDraftStore.getState());
+
 export const selectIsDrafting = (state: State_DraftEvent) =>
   state.status?.isDrafting;

--- a/packages/web/src/events/stores/view.store.test.ts
+++ b/packages/web/src/events/stores/view.store.test.ts
@@ -1,0 +1,62 @@
+import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
+import {
+  initialViewState,
+  selectIsSidebarOpen,
+  selectSidebarPreference,
+  useViewStore,
+  viewActions,
+} from "@web/events/stores/view.store";
+import { beforeEach, describe, expect, it } from "bun:test";
+
+describe("view.store sidebar persistence", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useViewStore.setState(initialViewState, true);
+  });
+
+  it("toggleSidebar persists the new preference", () => {
+    viewActions.toggleSidebar();
+
+    expect(selectIsSidebarOpen(useViewStore.getState())).toBe(false);
+    expect(selectSidebarPreference(useViewStore.getState())).toBe(false);
+    expect(localStorage.getItem(STORAGE_KEYS.SIDEBAR_OPEN)).toBe("false");
+  });
+
+  it("setSidebarOpen persists the new preference", () => {
+    viewActions.setSidebarOpen(false);
+
+    expect(selectIsSidebarOpen(useViewStore.getState())).toBe(false);
+    expect(selectSidebarPreference(useViewStore.getState())).toBe(false);
+    expect(localStorage.getItem(STORAGE_KEYS.SIDEBAR_OPEN)).toBe("false");
+  });
+
+  it("syncSidebarOpen renders without touching the saved preference", () => {
+    viewActions.syncSidebarOpen(false);
+
+    expect(selectIsSidebarOpen(useViewStore.getState())).toBe(false);
+    expect(selectSidebarPreference(useViewStore.getState())).toBe(true);
+    expect(localStorage.getItem(STORAGE_KEYS.SIDEBAR_OPEN)).toBeNull();
+
+    viewActions.syncSidebarOpen(true);
+
+    expect(selectIsSidebarOpen(useViewStore.getState())).toBe(true);
+    expect(selectSidebarPreference(useViewStore.getState())).toBe(true);
+    expect(localStorage.getItem(STORAGE_KEYS.SIDEBAR_OPEN)).toBeNull();
+  });
+
+  it("a breakpoint crossing never overwrites a preference set while narrow", () => {
+    // User explicitly closes the sidebar (persists), then narrows the
+    // viewport (auto-collapse, no-op here since it's already closed) and
+    // widens it again - useResponsiveLayout reads the still-closed
+    // preference rather than force-opening.
+    viewActions.setSidebarOpen(false);
+    viewActions.syncSidebarOpen(false);
+    viewActions.syncSidebarOpen(
+      selectSidebarPreference(useViewStore.getState()),
+    );
+
+    expect(selectIsSidebarOpen(useViewStore.getState())).toBe(false);
+    expect(selectSidebarPreference(useViewStore.getState())).toBe(false);
+    expect(localStorage.getItem(STORAGE_KEYS.SIDEBAR_OPEN)).toBe("false");
+  });
+});

--- a/packages/web/src/events/stores/view.store.ts
+++ b/packages/web/src/events/stores/view.store.ts
@@ -13,9 +13,15 @@ interface ViewState {
     end: string;
   };
   sidebar: {
+    // What's rendered right now - can differ from `preference` while a
+    // narrow-viewport breakpoint auto-collapses the sidebar.
     isOpen: boolean;
+    // The user's last explicit choice; the only field this store persists.
+    preference: boolean;
   };
 }
+
+const persistedSidebarPreference = readSidebarOpen();
 
 export const initialViewState: ViewState = {
   dates: {
@@ -24,7 +30,10 @@ export const initialViewState: ViewState = {
   },
   // Seed from the persisted preference so a collapsed sidebar never mounts
   // (and animates closed) on the first render after a refresh.
-  sidebar: { isOpen: readSidebarOpen() },
+  sidebar: {
+    isOpen: persistedSidebarPreference,
+    preference: persistedSidebarPreference,
+  },
 };
 
 // Selectors passed to this hook must return primitives or stable references;
@@ -36,17 +45,34 @@ export const useViewStore = create<ViewState>()(
   }),
 );
 
+// Single writer: `preference` is the only field ever persisted, and this is
+// the only place that calls writeSidebarOpen. `syncSidebarOpen` (used by
+// useResponsiveLayout for breakpoint crossings) never touches `preference`,
+// so it never reaches this subscriber.
+useViewStore.subscribe((state, prevState) => {
+  if (state.sidebar.preference !== prevState.sidebar.preference) {
+    writeSidebarOpen(state.sidebar.preference);
+  }
+});
+
 export const viewActions = {
+  /** An explicit user choice (toggle button, close button, `i` shortcut): renders and persists. */
   setSidebarOpen: (isOpen: boolean) =>
-    useViewStore.setState({ sidebar: { isOpen } }, false, {
+    useViewStore.setState({ sidebar: { isOpen, preference: isOpen } }, false, {
       type: "setSidebarOpen",
     }),
+  /** A breakpoint crossing auto-collapsing/-restoring the sidebar: renders only, leaves the saved preference untouched. */
+  syncSidebarOpen: (isOpen: boolean) =>
+    useViewStore.setState(
+      (state) => ({ sidebar: { ...state.sidebar, isOpen } }),
+      false,
+      { type: "syncSidebarOpen" },
+    ),
   toggleSidebar: () =>
     useViewStore.setState(
       (state) => {
         const isOpen = !state.sidebar.isOpen;
-        writeSidebarOpen(isOpen);
-        return { sidebar: { isOpen } };
+        return { sidebar: { isOpen, preference: isOpen } };
       },
       false,
       { type: "toggleSidebar" },
@@ -55,3 +81,5 @@ export const viewActions = {
     useViewStore.setState({ dates }, false, { type: "updateDates" }),
 };
 export const selectIsSidebarOpen = (state: ViewState) => state.sidebar.isOpen;
+export const selectSidebarPreference = (state: ViewState) =>
+  state.sidebar.preference;

--- a/packages/web/src/grid/shortcuts/useGridEventEditShortcuts.ts
+++ b/packages/web/src/grid/shortcuts/useGridEventEditShortcuts.ts
@@ -13,7 +13,6 @@ import {
   isDeleteTextEditingTarget,
   isEditableKeyboardTarget,
   isEventFormKeyboardTarget,
-  isEventFormOpen,
 } from "@web/common/utils/form/form.util";
 import { duplicateGridEventDraft } from "@web/events/grid-event-draft.adapter";
 import {
@@ -22,7 +21,7 @@ import {
 } from "@web/events/mutations/useEventMutations";
 import { useUpdateEvent } from "@web/events/mutations/useUpdateEvent";
 import { findEventInCache } from "@web/events/queries/event.query.cache";
-import { draftActions } from "@web/events/stores/draft.store";
+import { draftActions, isEventFormOpen } from "@web/events/stores/draft.store";
 import {
   type FocusableGridEventTarget,
   type GridEventShortcutTarget,

--- a/packages/web/src/views/Week/WeekView.tsx
+++ b/packages/web/src/views/Week/WeekView.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useMemo, useRef } from "react";
 import { ID_MAIN } from "@web/common/constants/web.constants";
 import { useHorizontalNavigation } from "@web/common/hooks/useHorizontalNavigation";
-import { isEventFormOpen } from "@web/common/utils/form/form.util";
 import { CommandPalette } from "@web/components/CommandPalette/CommandPalette";
 import { getCommandPalettePlaceholder } from "@web/components/CommandPalette/more.cmd.constants";
 import { ContextMenuWrapper } from "@web/components/ContextMenu/GridContextMenuWrapper";
@@ -14,6 +13,7 @@ import { welcomeGuideActions } from "@web/components/WelcomeModal/welcome.guide.
 import { toDemoEventsRange } from "@web/events/demo-events.util";
 import {
   draftActions,
+  isEventFormOpen,
   selectIsEventFormOpen,
   useDraftStore,
 } from "@web/events/stores/draft.store";

--- a/packages/web/src/views/Week/hooks/grid/useGridEventMouseDown.ts
+++ b/packages/web/src/views/Week/hooks/grid/useGridEventMouseDown.ts
@@ -1,7 +1,7 @@
 import { type MouseEvent as ReactMouseEvent, useRef } from "react";
 import { type PartialMouseEvent } from "@web/common/types/util.types";
 import { type GridEvent } from "@web/common/types/web.event.types";
-import { isEventFormOpen } from "@web/common/utils/form/form.util";
+import { isEventFormOpen } from "@web/events/stores/draft.store";
 
 export const GRID_EVENT_MOUSE_HOLD_DELAY = 750; // ms
 export const GRID_EVENT_MOUSE_HOLD_MOVE_THRESHOLD = 25; // pixels

--- a/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcuts.ts
+++ b/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcuts.ts
@@ -7,10 +7,9 @@ import {
   createAlldayDraft,
   createTimedDraft,
 } from "@web/common/utils/draft/draft.util";
-import { isEventFormOpen } from "@web/common/utils/form/form.util";
 import { focusFirstSidebarItem } from "@web/components/Sidebar/util/sidebarFocus.util";
 import { useWeekEventViewModel } from "@web/events/queries/useWeekEventsQuery";
-import { draftActions } from "@web/events/stores/draft.store";
+import { draftActions, isEventFormOpen } from "@web/events/stores/draft.store";
 import {
   selectIsSidebarOpen,
   useViewStore,


### PR DESCRIPTION
## Summary
- Replaces the `isEventFormOpen()` DOM probe (`document.getElementsByName(...).length === 1`) with the draft store's `selectIsEventFormOpen` selector at all 7 call sites, so keyboard/pointer handlers read the same synchronous state the renderer uses instead of a post-commit DOM query.
- Splits `view.store`'s sidebar boolean into `isOpen` (what's rendered) and `preference` (what's persisted), with a single store subscriber as the only writer to storage. Fixes a real bug: dismissing the sidebar via the narrow-layout close button or the `i` shortcut previously never persisted, so it silently reopened on refresh. `useResponsiveLayout`'s breakpoint-driven auto-collapse/-restore now goes through a new non-persisting `syncSidebarOpen` action instead of round-tripping through storage on every check.

## Simplification performed
- Restored a single-call-site imperative helper (`isEventFormOpen()` in `draft.store.ts`, delegating to the selector) instead of repeating `selectIsEventFormOpen(useDraftStore.getState())` at 7 sites.
- Removed a redundant double `readSidebarOpen()` call when seeding `view.store`'s initial state.

## Test plan
- [x] `bun run type-check` clean
- [x] `bun run test:web` — 1769/1769 passing, including new `view.store.test.ts` and updated `useEscapeToDismissToast.test.tsx` / `useResponsiveLayout.test.ts`
- [x] `bun run lint` clean
- [x] Manually verified in a locally-run dev build (anonymous "Start Now" session, backend not required for this frontend-only change):
  - `]` toggles the sidebar and the closed state survives a fresh page load
  - `i` shortcut opens the sidebar and now also persists (previously did not)
  - Opening an event form and pressing Escape closes the form without dismissing an active "ends in N minutes" toast; a second Escape (form closed) dismisses the toast
- Live browser/e2e verification of the backend-dependent paths was not possible in this worktree (missing `SYNC_SERVICE_URL`/`SYNC_INTERNAL_AUTH_TOKEN`, unrelated to this change) — flagging this rather than claiming it was covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)