### PR TITLE
refactor(web): remove sidebar prop-drilling and the createSidebar DI factory

### DIFF
--- a/packages/web/src/components/Sidebar/CalendarList/CalendarList.test.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarList.test.tsx
@@ -95,10 +95,9 @@ afterAll(() => {
 });
 
 // CalendarList.tsx is already cached by the time this file runs -
-// Sidebar.test.tsx imports createSidebar from "./Sidebar",
-// and merely loading that file (regardless of the DI stubs it renders with)
-// runs Sidebar.tsx's own top-level `import { CalendarList }`,
-// binding its useSession import to whatever was active at that earlier point.
+// Sidebar.test.tsx imports Sidebar from "./Sidebar", and merely loading that
+// file runs Sidebar.tsx's own top-level `import { CalendarList }`, binding
+// its useSession import to whatever was active at that earlier point.
 // A plain require here would return that stale instance. A cache-busted URL
 // forces a fresh evaluation that re-resolves useSession against the mock
 // above (same technique as useVersionCheck.test.ts).

--- a/packages/web/src/components/Sidebar/ShortcutsOverlay/ShortcutsOverlay.test.tsx
+++ b/packages/web/src/components/Sidebar/ShortcutsOverlay/ShortcutsOverlay.test.tsx
@@ -1,5 +1,10 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it, mock } from "bun:test";
+import {
+  selectIsShortcutsOpen,
+  useViewStore,
+  viewActions,
+} from "@web/events/stores/view.store";
+import { describe, expect, it } from "bun:test";
 import "@testing-library/jest-dom";
 import { ShortcutsOverlay } from "./ShortcutsOverlay";
 
@@ -24,14 +29,10 @@ const sections = [
 
 describe("ShortcutsOverlay", () => {
   it("renders shortcut sections over the sidebar", () => {
-    render(
-      <ShortcutsOverlay
-        isOpen={true}
-        onClose={mock()}
-        sections={sections}
-        viewLabel="Day"
-      />,
-    );
+    viewActions.setSidebarOpen(true);
+    viewActions.toggleShortcuts();
+
+    render(<ShortcutsOverlay sections={sections} viewLabel="Day" />);
 
     const overlay = screen.getByRole("dialog", { name: "Keyboard shortcuts" });
 
@@ -45,22 +46,19 @@ describe("ShortcutsOverlay", () => {
     expect(screen.queryByText("Empty")).not.toBeInTheDocument();
   });
 
-  it("calls onClose when closed with Escape", () => {
-    const onClose = mock();
+  it("closes when closed with Escape", () => {
+    viewActions.setSidebarOpen(true);
+    viewActions.toggleShortcuts();
 
-    render(
-      <ShortcutsOverlay isOpen={true} onClose={onClose} sections={sections} />,
-    );
+    render(<ShortcutsOverlay sections={sections} />);
 
     fireEvent.keyDown(document, { key: "Escape" });
 
-    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(selectIsShortcutsOpen(useViewStore.getState())).toBe(false);
   });
 
   it("does not render when closed", () => {
-    render(
-      <ShortcutsOverlay isOpen={false} onClose={mock()} sections={sections} />,
-    );
+    render(<ShortcutsOverlay sections={sections} />);
 
     expect(
       screen.queryByRole("dialog", { name: "Keyboard shortcuts" }),

--- a/packages/web/src/components/Sidebar/ShortcutsOverlay/ShortcutsOverlay.tsx
+++ b/packages/web/src/components/Sidebar/ShortcutsOverlay/ShortcutsOverlay.tsx
@@ -2,11 +2,14 @@ import { XIcon } from "@phosphor-icons/react";
 import classNames from "classnames";
 import { useEffect, useRef, useState } from "react";
 import { ShortcutSection } from "@web/components/Shortcuts/ShortcutOverlay/ShortcutSection";
+import {
+  selectIsShortcutsOpen,
+  useViewStore,
+  viewActions,
+} from "@web/events/stores/view.store";
 import { type ShortcutOverlaySection } from "@web/shortcuts/shortcuts-overlay.types";
 
 interface Props {
-  isOpen: boolean;
-  onClose: () => void;
   sections: ShortcutOverlaySection[];
   viewLabel?: string;
 }
@@ -19,12 +22,8 @@ const matchesSearch = (searchTerm: string, text: string): boolean => {
   return normalized.includes(query);
 };
 
-export function ShortcutsOverlay({
-  isOpen,
-  onClose,
-  sections,
-  viewLabel,
-}: Props) {
+export function ShortcutsOverlay({ sections, viewLabel }: Props) {
+  const isOpen = useViewStore(selectIsShortcutsOpen);
   const [searchQuery, setSearchQuery] = useState("");
   const searchInputRef = useRef<HTMLInputElement>(null);
 
@@ -42,14 +41,14 @@ export function ShortcutsOverlay({
         if (searchQuery) {
           setSearchQuery("");
         } else {
-          onClose();
+          viewActions.closeShortcuts();
         }
       }
     };
 
     document.addEventListener("keydown", handleKeyDown);
     return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [isOpen, onClose, searchQuery]);
+  }, [isOpen, searchQuery]);
 
   const filteredSections = sections
     .map((section) => {
@@ -106,7 +105,7 @@ export function ShortcutsOverlay({
           <button
             aria-label="Close shortcuts"
             className="flex size-7 items-center justify-center rounded-default text-text-muted transition-colors hover:bg-surface-panel hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
-            onClick={onClose}
+            onClick={viewActions.closeShortcuts}
             tabIndex={isOpen ? 0 : -1}
             type="button"
           >

--- a/packages/web/src/components/Sidebar/Sidebar.test.tsx
+++ b/packages/web/src/components/Sidebar/Sidebar.test.tsx
@@ -1,28 +1,79 @@
 import { render, screen } from "@testing-library/react";
 import dayjs from "@core/util/date/dayjs";
 import { createStoreWrapper } from "@web/__tests__/render-with-store";
-import { createSidebar } from "./Sidebar";
-import { describe, expect, it, mock } from "bun:test";
+import {
+  createGridEventDraft,
+  timedGridSchedule,
+} from "@web/events/grid-event-draft.adapter";
+import { draftActions } from "@web/events/stores/draft.store";
+import { afterAll, afterEach, describe, expect, it, mock } from "bun:test";
 
-const Sidebar = createSidebar({
-  CalendarList: () => <div>Calendar list</div>,
-  MonthPicker: () => <div>Calendar picker</div>,
-  SidebarActions: () => <div>Sidebar actions</div>,
-  ShortcutsOverlay: () => null,
-  TasksRemovalNotice: () => null,
-  UpNextCard: () => <div>Up next</div>,
+// mock.module is process-wide and not reliably restorable, so - as in
+// SidebarStatusBar.test.tsx - each real component is captured up front and a
+// flag (flipped in afterAll) decides which one runs, keeping the mocks
+// scoped to this file's tests.
+const actual = {
+  CalendarList: (await import("./CalendarList/CalendarList")).CalendarList,
+  MonthPicker: (await import("./MonthPicker/MonthPicker")).MonthPicker,
+  SidebarActions: (await import("./SidebarActions/SidebarActions"))
+    .SidebarActions,
+  ShortcutsOverlay: (await import("./ShortcutsOverlay/ShortcutsOverlay"))
+    .ShortcutsOverlay,
+  TasksRemovalNotice: (await import("./TasksRemovalNotice/TasksRemovalNotice"))
+    .TasksRemovalNotice,
+  UpNextCard: (await import("./UpNextCard/UpNextCard")).UpNextCard,
+};
+let isMocked = true;
+
+mock.module("./CalendarList/CalendarList", () => ({
+  CalendarList: (...args: Parameters<typeof actual.CalendarList>) =>
+    isMocked ? <div>Calendar list</div> : actual.CalendarList(...args),
+}));
+mock.module("./MonthPicker/MonthPicker", () => ({
+  MonthPicker: (...args: Parameters<typeof actual.MonthPicker>) =>
+    isMocked ? <div>Calendar picker</div> : actual.MonthPicker(...args),
+}));
+mock.module("./SidebarActions/SidebarActions", () => ({
+  SidebarActions: (...args: Parameters<typeof actual.SidebarActions>) =>
+    isMocked ? <div>Sidebar actions</div> : actual.SidebarActions(...args),
+}));
+mock.module("./ShortcutsOverlay/ShortcutsOverlay", () => ({
+  ShortcutsOverlay: (...args: Parameters<typeof actual.ShortcutsOverlay>) =>
+    isMocked ? null : actual.ShortcutsOverlay(...args),
+}));
+mock.module("./TasksRemovalNotice/TasksRemovalNotice", () => ({
+  TasksRemovalNotice: (
+    ...args: Parameters<typeof actual.TasksRemovalNotice>
+  ) => (isMocked ? null : actual.TasksRemovalNotice(...args)),
+}));
+mock.module("./UpNextCard/UpNextCard", () => ({
+  UpNextCard: (...args: Parameters<typeof actual.UpNextCard>) =>
+    isMocked ? <div>Up next</div> : actual.UpNextCard(...args),
+}));
+
+afterAll(() => {
+  isMocked = false;
 });
+
+const sidebarModuleUrl = new URL(
+  `./Sidebar.tsx?test=${Math.random().toString(36).slice(2)}`,
+  import.meta.url,
+);
+const { Sidebar } = (await import(
+  sidebarModuleUrl.href
+)) as typeof import("./Sidebar");
 
 const sidebarProps = {
   calendarDate: dayjs("2026-05-12"),
-  isShortcutsOpen: false,
-  onCloseShortcuts: mock(),
-  onToggleShortcuts: mock(),
   onSelectDate: mock(),
   shortcutSections: [],
 };
 
 describe("Sidebar", () => {
+  afterEach(() => {
+    draftActions.discard();
+  });
+
   it("renders the core sidebar sections", () => {
     const { wrapper } = createStoreWrapper();
     render(<Sidebar {...sidebarProps} />, { wrapper });
@@ -32,7 +83,7 @@ describe("Sidebar", () => {
     expect(screen.getByText("Sidebar actions")).toBeTruthy();
   });
 
-  it("shows event details only while the parent says they are open", () => {
+  it("shows event details only while the draft store says the form is open", () => {
     const { wrapper } = createStoreWrapper();
     const { rerender } = render(
       <Sidebar {...sidebarProps} eventDetails={<div>Event details</div>} />,
@@ -42,12 +93,18 @@ describe("Sidebar", () => {
     expect(screen.queryByText("Event details")).toBeNull();
     expect(screen.getByText("Calendar picker")).toBeTruthy();
 
+    draftActions.startGridDraft({
+      activity: "gridClick",
+      draft: createGridEventDraft(
+        timedGridSchedule(
+          new Date("2026-05-12T09:00:00.000Z"),
+          new Date("2026-05-12T10:00:00.000Z"),
+        ),
+      ),
+    });
+    draftActions.setFormOpen(true);
     rerender(
-      <Sidebar
-        {...sidebarProps}
-        eventDetails={<div>Event details</div>}
-        isEventDetailsOpen
-      />,
+      <Sidebar {...sidebarProps} eventDetails={<div>Event details</div>} />,
     );
 
     expect(screen.getByText("Event details")).toBeTruthy();

--- a/packages/web/src/components/Sidebar/Sidebar.tsx
+++ b/packages/web/src/components/Sidebar/Sidebar.tsx
@@ -1,10 +1,12 @@
 import { type HTMLAttributes, type ReactNode } from "react";
 import { type Dayjs } from "@core/util/date/dayjs";
+import {
+  selectIsEventFormOpen,
+  useDraftStore,
+} from "@web/events/stores/draft.store";
 import { type ShortcutOverlaySection } from "@web/shortcuts/shortcuts-overlay.types";
 import { CalendarList } from "./CalendarList/CalendarList";
 import { MonthPicker } from "./MonthPicker/MonthPicker";
-import { ShortcutsOverlay } from "./ShortcutsOverlay/ShortcutsOverlay";
-import { SidebarActions } from "./SidebarActions/SidebarActions";
 import { SidebarShell } from "./SidebarShell";
 import { TasksRemovalNotice } from "./TasksRemovalNotice/TasksRemovalNotice";
 import { UpNextCard } from "./UpNextCard/UpNextCard";
@@ -17,90 +19,51 @@ export interface SidebarProps extends HTMLAttributes<HTMLDivElement> {
    * editing always happens in the sidebar.
    */
   eventDetails?: ReactNode;
-  isEventDetailsOpen?: boolean;
   monthsShown?: number;
-  isShortcutsOpen: boolean;
-  onCloseShortcuts: () => void;
-  onToggleShortcuts: () => void;
   onSelectDate: (date: Dayjs) => void;
   shortcutSections: ShortcutOverlaySection[];
   shortcutsViewLabel?: string;
 }
 
-type SidebarDependencies = {
-  CalendarList: typeof CalendarList;
-  MonthPicker: typeof MonthPicker;
-  TasksRemovalNotice: typeof TasksRemovalNotice;
-  UpNextCard: typeof UpNextCard;
-  SidebarActions: typeof SidebarActions;
-  ShortcutsOverlay: typeof ShortcutsOverlay;
-};
+export function Sidebar({
+  calendarDate,
+  eventDetails,
+  monthsShown = 1,
+  onSelectDate,
+  shortcutSections,
+  shortcutsViewLabel,
+  ...props
+}: SidebarProps) {
+  const isEventFormOpen = useDraftStore(selectIsEventFormOpen);
+  const showEventDetails = Boolean(eventDetails) && isEventFormOpen;
 
-export function createSidebar({
-  CalendarList: CalendarListComponent,
-  MonthPicker: MonthPickerComponent,
-  TasksRemovalNotice: TasksRemovalNoticeComponent,
-  UpNextCard: UpNextCardComponent,
-  SidebarActions: SidebarActionsComponent,
-  ShortcutsOverlay: ShortcutsOverlayComponent,
-}: SidebarDependencies) {
-  return function Sidebar({
-    calendarDate,
-    eventDetails,
-    isEventDetailsOpen = false,
-    monthsShown = 1,
-    isShortcutsOpen,
-    onCloseShortcuts,
-    onToggleShortcuts,
-    onSelectDate,
-    shortcutSections,
-    shortcutsViewLabel,
-    ...props
-  }: SidebarProps) {
-    const showEventDetails = Boolean(eventDetails) && isEventDetailsOpen;
-
-    return (
-      <SidebarShell
-        {...props}
-        isShortcutsOpen={isShortcutsOpen}
-        onCloseShortcuts={onCloseShortcuts}
-        onToggleShortcuts={onToggleShortcuts}
-        shortcutSections={shortcutSections}
-        shortcutsViewLabel={shortcutsViewLabel}
-        SidebarActionsComponent={SidebarActionsComponent}
-        ShortcutsOverlayComponent={ShortcutsOverlayComponent}
-      >
-        {showEventDetails ? (
-          // Scrolling and horizontal padding live inside the event form so
-          // its pinned save footer can span the sidebar's full width.
-          <section
-            aria-label="Event details"
-            className="flex min-h-0 flex-1 flex-col"
-          >
-            {eventDetails}
-          </section>
-        ) : (
-          <div className="flex min-h-0 flex-1 flex-col gap-6 overflow-y-auto px-4 pb-5 [scrollbar-gutter:stable]">
-            <MonthPickerComponent
-              monthsShown={monthsShown}
-              onSelectDate={onSelectDate}
-              selectedDate={calendarDate}
-            />
-            <UpNextCardComponent />
-            <CalendarListComponent />
-            <TasksRemovalNoticeComponent />
-          </div>
-        )}
-      </SidebarShell>
-    );
-  };
+  return (
+    <SidebarShell
+      {...props}
+      shortcutSections={shortcutSections}
+      shortcutsViewLabel={shortcutsViewLabel}
+    >
+      {showEventDetails ? (
+        // Scrolling and horizontal padding live inside the event form so
+        // its pinned save footer can span the sidebar's full width.
+        <section
+          aria-label="Event details"
+          className="flex min-h-0 flex-1 flex-col"
+        >
+          {eventDetails}
+        </section>
+      ) : (
+        <div className="flex min-h-0 flex-1 flex-col gap-6 overflow-y-auto px-4 pb-5 [scrollbar-gutter:stable]">
+          <MonthPicker
+            monthsShown={monthsShown}
+            onSelectDate={onSelectDate}
+            selectedDate={calendarDate}
+          />
+          <UpNextCard />
+          <CalendarList />
+          <TasksRemovalNotice />
+        </div>
+      )}
+    </SidebarShell>
+  );
 }
-
-export const Sidebar = createSidebar({
-  CalendarList,
-  MonthPicker,
-  TasksRemovalNotice,
-  UpNextCard,
-  SidebarActions,
-  ShortcutsOverlay,
-});

--- a/packages/web/src/components/Sidebar/SidebarActions/SidebarActions.test.tsx
+++ b/packages/web/src/components/Sidebar/SidebarActions/SidebarActions.test.tsx
@@ -4,6 +4,7 @@ import {
   resetGoogleSyncUIStateForTests,
   setSyncingSyncIndicatorOverride,
 } from "@web/auth/google/state/google.sync.state";
+import { viewActions } from "@web/events/stores/view.store";
 import { afterAll, afterEach, describe, expect, it, mock } from "bun:test";
 
 // mock.module is process-wide and not reliably restorable, so the real hook
@@ -39,10 +40,7 @@ describe("SidebarActions", () => {
     const { wrapper } = createStoreWrapper();
     setSyncingSyncIndicatorOverride();
 
-    render(
-      <SidebarActions isShortcutsOpen={false} onToggleShortcuts={mock()} />,
-      { wrapper },
-    );
+    render(<SidebarActions />, { wrapper });
 
     expect(
       screen.getByRole("button", {
@@ -54,10 +52,7 @@ describe("SidebarActions", () => {
   it("does not render the background import spinner in the sidebar", () => {
     const { wrapper } = createStoreWrapper();
 
-    render(
-      <SidebarActions isShortcutsOpen={false} onToggleShortcuts={mock()} />,
-      { wrapper },
-    );
+    render(<SidebarActions />, { wrapper });
 
     expect(
       screen.queryByRole("button", {
@@ -71,11 +66,10 @@ describe("SidebarActions", () => {
 
   it("labels the shortcuts button as a close action when shortcuts are open", () => {
     const { wrapper } = createStoreWrapper();
+    viewActions.setSidebarOpen(true);
+    act(() => viewActions.toggleShortcuts());
 
-    render(
-      <SidebarActions isShortcutsOpen={true} onToggleShortcuts={mock()} />,
-      { wrapper },
-    );
+    render(<SidebarActions />, { wrapper });
 
     expect(
       screen.getByRole("button", { name: "Close shortcuts" }),

--- a/packages/web/src/components/Sidebar/SidebarActions/SidebarActions.tsx
+++ b/packages/web/src/components/Sidebar/SidebarActions/SidebarActions.tsx
@@ -2,20 +2,18 @@ import { CommandIcon, KeyboardIcon } from "@phosphor-icons/react";
 import { useGoogleUiState } from "@web/auth/google/hooks/useConnectGoogle/useGoogleUiState";
 import { TooltipWrapper } from "@web/components/Tooltip/TooltipWrapper";
 import {
+  selectIsShortcutsOpen,
+  useViewStore,
+  viewActions,
+} from "@web/events/stores/view.store";
+import {
   selectIsCmdPaletteOpen,
   settingsActions,
   useSettingsStore,
 } from "@web/settings/settings.store";
 
-interface Props {
-  isShortcutsOpen: boolean;
-  onToggleShortcuts: () => void;
-}
-
-export const SidebarActions = ({
-  isShortcutsOpen,
-  onToggleShortcuts,
-}: Props) => {
+export const SidebarActions = () => {
+  const isShortcutsOpen = useViewStore(selectIsShortcutsOpen);
   const isCmdPaletteOpen = useSettingsStore(selectIsCmdPaletteOpen);
   const googleState = useGoogleUiState();
   const isCalendarSyncing = googleState === "IMPORTING";
@@ -38,7 +36,7 @@ export const SidebarActions = ({
         <TooltipWrapper
           description={shortcutsActionLabel}
           shortcut="?"
-          onClick={onToggleShortcuts}
+          onClick={viewActions.toggleShortcuts}
         >
           <button
             aria-label={shortcutsActionLabel}

--- a/packages/web/src/components/Sidebar/SidebarShell.test.tsx
+++ b/packages/web/src/components/Sidebar/SidebarShell.test.tsx
@@ -36,14 +36,7 @@ function mockViewport(isNarrow: boolean) {
 function renderShell() {
   const { wrapper } = createStoreWrapper();
   return render(
-    <SidebarShell
-      isShortcutsOpen={false}
-      onCloseShortcuts={mock()}
-      onToggleShortcuts={mock()}
-      shortcutSections={[]}
-      SidebarActionsComponent={() => <></>}
-      ShortcutsOverlayComponent={() => <></>}
-    >
+    <SidebarShell shortcutSections={[]}>
       <div>Sidebar body</div>
     </SidebarShell>,
     { wrapper },

--- a/packages/web/src/components/Sidebar/SidebarShell.tsx
+++ b/packages/web/src/components/Sidebar/SidebarShell.tsx
@@ -17,24 +17,14 @@ import { SidebarStatusBar } from "./SidebarStatusBar";
 
 interface SidebarShellProps extends HTMLAttributes<HTMLElement> {
   children: ReactNode;
-  isShortcutsOpen: boolean;
-  onCloseShortcuts: () => void;
-  onToggleShortcuts: () => void;
   shortcutSections: ShortcutOverlaySection[];
   shortcutsViewLabel?: string;
-  SidebarActionsComponent?: typeof SidebarActions;
-  ShortcutsOverlayComponent?: typeof ShortcutsOverlay;
 }
 
 export function SidebarShell({
   children,
-  isShortcutsOpen,
-  onCloseShortcuts,
-  onToggleShortcuts,
   shortcutSections,
   shortcutsViewLabel,
-  SidebarActionsComponent = SidebarActions,
-  ShortcutsOverlayComponent = ShortcutsOverlay,
   ...props
 }: SidebarShellProps) {
   const isNarrowLayout = useIsNarrowSidebarLayout();
@@ -58,13 +48,8 @@ export function SidebarShell({
       ) : null}
       {children}
       <SidebarStatusBar />
-      <SidebarActionsComponent
-        isShortcutsOpen={isShortcutsOpen}
-        onToggleShortcuts={onToggleShortcuts}
-      />
-      <ShortcutsOverlayComponent
-        isOpen={isShortcutsOpen}
-        onClose={onCloseShortcuts}
+      <SidebarActions />
+      <ShortcutsOverlay
         sections={shortcutSections}
         viewLabel={shortcutsViewLabel}
       />

--- a/packages/web/src/components/Sidebar/useSidebarShortcuts.test.tsx
+++ b/packages/web/src/components/Sidebar/useSidebarShortcuts.test.tsx
@@ -2,29 +2,29 @@ import { HotkeyManager, HotkeysProvider } from "@tanstack/react-hotkeys";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { type PropsWithChildren } from "react";
 import { pressKey } from "@web/__tests__/utils/keyboard.test.util";
+import {
+  selectIsShortcutsOpen,
+  selectIsSidebarOpen,
+  useViewStore,
+  viewActions,
+} from "@web/events/stores/view.store";
 import { useSidebarShortcuts } from "./useSidebarShortcuts";
-import { beforeEach, describe, expect, it, mock } from "bun:test";
+import { beforeEach, describe, expect, it } from "bun:test";
 
 function wrapper({ children }: PropsWithChildren) {
   return <HotkeysProvider>{children}</HotkeysProvider>;
 }
 
+const isShortcutsOpen = () => selectIsShortcutsOpen(useViewStore.getState());
+
 describe("useSidebarShortcuts", () => {
   beforeEach(() => {
     HotkeyManager.resetInstance();
+    viewActions.setSidebarOpen(false);
   });
 
   it("opens the sidebar before opening shortcuts with ?", async () => {
-    const onToggleSidebar = mock();
-
-    const { result } = renderHook(
-      () =>
-        useSidebarShortcuts({
-          isSidebarOpen: false,
-          onToggleSidebar,
-        }),
-      { wrapper },
-    );
+    renderHook(() => useSidebarShortcuts(), { wrapper });
 
     act(() => {
       pressKey("?", {
@@ -34,22 +34,14 @@ describe("useSidebarShortcuts", () => {
     });
 
     await waitFor(() => {
-      expect(onToggleSidebar).toHaveBeenCalledTimes(1);
-      expect(result.current.isShortcutsOpen).toBe(true);
+      expect(selectIsSidebarOpen(useViewStore.getState())).toBe(true);
+      expect(isShortcutsOpen()).toBe(true);
     });
   });
 
   it("toggles shortcuts closed with ? when they are already open", async () => {
-    const onToggleSidebar = mock();
-
-    const { result } = renderHook(
-      () =>
-        useSidebarShortcuts({
-          isSidebarOpen: true,
-          onToggleSidebar,
-        }),
-      { wrapper },
-    );
+    viewActions.setSidebarOpen(true);
+    renderHook(() => useSidebarShortcuts(), { wrapper });
 
     act(() => {
       pressKey("?", {
@@ -59,7 +51,7 @@ describe("useSidebarShortcuts", () => {
     });
 
     await waitFor(() => {
-      expect(result.current.isShortcutsOpen).toBe(true);
+      expect(isShortcutsOpen()).toBe(true);
     });
 
     act(() => {
@@ -70,22 +62,13 @@ describe("useSidebarShortcuts", () => {
     });
 
     await waitFor(() => {
-      expect(result.current.isShortcutsOpen).toBe(false);
-      expect(onToggleSidebar).not.toHaveBeenCalled();
+      expect(isShortcutsOpen()).toBe(false);
     });
   });
 
   it("opens shortcuts from the shifted slash key event", async () => {
-    const onToggleSidebar = mock();
-
-    const { result } = renderHook(
-      () =>
-        useSidebarShortcuts({
-          isSidebarOpen: true,
-          onToggleSidebar,
-        }),
-      { wrapper },
-    );
+    viewActions.setSidebarOpen(true);
+    renderHook(() => useSidebarShortcuts(), { wrapper });
 
     act(() => {
       pressKey("/", {
@@ -95,52 +78,34 @@ describe("useSidebarShortcuts", () => {
     });
 
     await waitFor(() => {
-      expect(result.current.isShortcutsOpen).toBe(true);
-      expect(onToggleSidebar).not.toHaveBeenCalled();
+      expect(isShortcutsOpen()).toBe(true);
     });
   });
 
   it("closes shortcuts when the sidebar closes", async () => {
-    const onToggleSidebar = mock();
-
-    const { rerender, result } = renderHook(
-      ({ isSidebarOpen }) =>
-        useSidebarShortcuts({
-          isSidebarOpen,
-          onToggleSidebar,
-        }),
-      {
-        initialProps: { isSidebarOpen: true },
-        wrapper,
-      },
-    );
+    viewActions.setSidebarOpen(true);
+    renderHook(() => useSidebarShortcuts(), { wrapper });
 
     act(() => {
-      result.current.toggleShortcuts();
+      viewActions.toggleShortcuts();
     });
 
     await waitFor(() => {
-      expect(result.current.isShortcutsOpen).toBe(true);
+      expect(isShortcutsOpen()).toBe(true);
     });
 
-    rerender({ isSidebarOpen: false });
+    act(() => {
+      viewActions.setSidebarOpen(false);
+    });
 
     await waitFor(() => {
-      expect(result.current.isShortcutsOpen).toBe(false);
+      expect(isShortcutsOpen()).toBe(false);
     });
   });
 
   it("does not toggle shortcuts with ]", async () => {
-    const onToggleSidebar = mock();
-
-    const { result } = renderHook(
-      () =>
-        useSidebarShortcuts({
-          isSidebarOpen: true,
-          onToggleSidebar,
-        }),
-      { wrapper },
-    );
+    viewActions.setSidebarOpen(true);
+    renderHook(() => useSidebarShortcuts(), { wrapper });
 
     act(() => {
       pressKey("]");
@@ -148,7 +113,6 @@ describe("useSidebarShortcuts", () => {
 
     await new Promise((resolve) => setTimeout(resolve, 0));
 
-    expect(result.current.isShortcutsOpen).toBe(false);
-    expect(onToggleSidebar).not.toHaveBeenCalled();
+    expect(isShortcutsOpen()).toBe(false);
   });
 });

--- a/packages/web/src/components/Sidebar/useSidebarShortcuts.ts
+++ b/packages/web/src/components/Sidebar/useSidebarShortcuts.ts
@@ -1,52 +1,25 @@
-import { useCallback, useEffect, useState } from "react";
+import {
+  selectIsShortcutsOpen,
+  useViewStore,
+  viewActions,
+} from "@web/events/stores/view.store";
 import { useAppLockReason } from "@web/shortcuts/app-lock";
 import { useAppShortcutUp } from "@web/shortcuts/useAppShortcut";
 
 const TOGGLE_SHORTCUTS_HOTKEY = { key: "?", shift: true } as const;
 const TOGGLE_SHORTCUTS_SLASH_HOTKEY = { key: "/", shift: true } as const;
 
-interface UseSidebarShortcutsArgs {
-  isSidebarOpen: boolean;
-  onToggleSidebar: () => void;
-}
-
-export function useSidebarShortcuts({
-  isSidebarOpen,
-  onToggleSidebar,
-}: UseSidebarShortcutsArgs) {
-  const [isShortcutsOpen, setIsShortcutsOpen] = useState(false);
+/** Mount once per view: registers the `?`/`/` hotkeys and holds the app-lock
+ * while the overlay is open. State itself lives in view.store, next to
+ * sidebar.isOpen, since opening/closing either one affects the other. */
+export function useSidebarShortcuts() {
+  const isShortcutsOpen = useViewStore(selectIsShortcutsOpen);
   useAppLockReason("shortcutsOverlay", isShortcutsOpen);
 
-  const closeShortcuts = useCallback(() => {
-    setIsShortcutsOpen(false);
-  }, []);
-
-  const toggleShortcuts = useCallback(() => {
-    if (!isSidebarOpen) {
-      onToggleSidebar();
-      setIsShortcutsOpen(true);
-      return;
-    }
-
-    setIsShortcutsOpen((isOpen) => !isOpen);
-  }, [isSidebarOpen, onToggleSidebar]);
-
-  useAppShortcutUp(TOGGLE_SHORTCUTS_HOTKEY, toggleShortcuts, {
+  useAppShortcutUp(TOGGLE_SHORTCUTS_HOTKEY, viewActions.toggleShortcuts, {
     ignoreAppLock: true,
   });
-  useAppShortcutUp(TOGGLE_SHORTCUTS_SLASH_HOTKEY, toggleShortcuts, {
+  useAppShortcutUp(TOGGLE_SHORTCUTS_SLASH_HOTKEY, viewActions.toggleShortcuts, {
     ignoreAppLock: true,
   });
-
-  useEffect(() => {
-    if (!isSidebarOpen) {
-      closeShortcuts();
-    }
-  }, [closeShortcuts, isSidebarOpen]);
-
-  return {
-    closeShortcuts,
-    isShortcutsOpen,
-    toggleShortcuts,
-  };
 }

--- a/packages/web/src/events/stores/view.store.test.ts
+++ b/packages/web/src/events/stores/view.store.test.ts
@@ -1,6 +1,7 @@
 import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
 import {
   initialViewState,
+  selectIsShortcutsOpen,
   selectIsSidebarOpen,
   selectSidebarPreference,
   useViewStore,
@@ -58,5 +59,52 @@ describe("view.store sidebar persistence", () => {
     expect(selectIsSidebarOpen(useViewStore.getState())).toBe(false);
     expect(selectSidebarPreference(useViewStore.getState())).toBe(false);
     expect(localStorage.getItem(STORAGE_KEYS.SIDEBAR_OPEN)).toBe("false");
+  });
+});
+
+describe("view.store shortcuts overlay", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useViewStore.setState(initialViewState, true);
+  });
+
+  it("toggleShortcuts opens the sidebar first when it's closed", () => {
+    viewActions.setSidebarOpen(false);
+
+    viewActions.toggleShortcuts();
+
+    expect(selectIsSidebarOpen(useViewStore.getState())).toBe(true);
+    expect(selectIsShortcutsOpen(useViewStore.getState())).toBe(true);
+  });
+
+  it("toggleShortcuts just toggles the overlay when the sidebar is already open", () => {
+    viewActions.setSidebarOpen(true);
+
+    viewActions.toggleShortcuts();
+    expect(selectIsShortcutsOpen(useViewStore.getState())).toBe(true);
+
+    viewActions.toggleShortcuts();
+    expect(selectIsShortcutsOpen(useViewStore.getState())).toBe(false);
+  });
+
+  it("closing the sidebar through any action also closes the overlay", () => {
+    viewActions.setSidebarOpen(true);
+    viewActions.toggleShortcuts();
+    expect(selectIsShortcutsOpen(useViewStore.getState())).toBe(true);
+
+    viewActions.toggleSidebar();
+
+    expect(selectIsSidebarOpen(useViewStore.getState())).toBe(false);
+    expect(selectIsShortcutsOpen(useViewStore.getState())).toBe(false);
+  });
+
+  it("a breakpoint auto-collapse also closes the overlay", () => {
+    viewActions.setSidebarOpen(true);
+    viewActions.toggleShortcuts();
+    expect(selectIsShortcutsOpen(useViewStore.getState())).toBe(true);
+
+    viewActions.syncSidebarOpen(false);
+
+    expect(selectIsShortcutsOpen(useViewStore.getState())).toBe(false);
   });
 });

--- a/packages/web/src/events/stores/view.store.ts
+++ b/packages/web/src/events/stores/view.store.ts
@@ -19,6 +19,9 @@ interface ViewState {
     // The user's last explicit choice; the only field this store persists.
     preference: boolean;
   };
+  shortcuts: {
+    isOpen: boolean;
+  };
 }
 
 const persistedSidebarPreference = readSidebarOpen();
@@ -34,6 +37,7 @@ export const initialViewState: ViewState = {
     isOpen: persistedSidebarPreference,
     preference: persistedSidebarPreference,
   },
+  shortcuts: { isOpen: false },
 };
 
 // Selectors passed to this hook must return primitives or stable references;
@@ -45,13 +49,20 @@ export const useViewStore = create<ViewState>()(
   }),
 );
 
-// Single writer: `preference` is the only field ever persisted, and this is
-// the only place that calls writeSidebarOpen. `syncSidebarOpen` (used by
-// useResponsiveLayout for breakpoint crossings) never touches `preference`,
-// so it never reaches this subscriber.
+// Two self-correcting invariants, checked after every update so no future
+// write path can violate them by forgetting a special case:
+// - `preference` is the only field ever persisted (`syncSidebarOpen`, used
+//   for breakpoint crossings, never touches it, so it never reaches here).
+// - The shortcuts overlay lives inside the sidebar, so it can't stay open
+//   once the sidebar closes.
 useViewStore.subscribe((state, prevState) => {
   if (state.sidebar.preference !== prevState.sidebar.preference) {
     writeSidebarOpen(state.sidebar.preference);
+  }
+  if (!state.sidebar.isOpen && state.shortcuts.isOpen) {
+    useViewStore.setState({ shortcuts: { isOpen: false } }, false, {
+      type: "autoCloseShortcuts",
+    });
   }
 });
 
@@ -77,9 +88,28 @@ export const viewActions = {
       false,
       { type: "toggleSidebar" },
     ),
+  /** `?` / `/`: opens the sidebar first if it's closed, otherwise toggles the overlay. */
+  toggleShortcuts: () => {
+    const wasSidebarOpen = useViewStore.getState().sidebar.isOpen;
+    if (!wasSidebarOpen) viewActions.setSidebarOpen(true);
+
+    useViewStore.setState(
+      (state) => ({
+        shortcuts: { isOpen: wasSidebarOpen ? !state.shortcuts.isOpen : true },
+      }),
+      false,
+      { type: "toggleShortcuts" },
+    );
+  },
+  closeShortcuts: () =>
+    useViewStore.setState({ shortcuts: { isOpen: false } }, false, {
+      type: "closeShortcuts",
+    }),
   updateDates: (dates: ViewState["dates"]) =>
     useViewStore.setState({ dates }, false, { type: "updateDates" }),
 };
 export const selectIsSidebarOpen = (state: ViewState) => state.sidebar.isOpen;
 export const selectSidebarPreference = (state: ViewState) =>
   state.sidebar.preference;
+export const selectIsShortcutsOpen = (state: ViewState) =>
+  state.shortcuts.isOpen;

--- a/packages/web/src/views/Day/view/DayViewContent.tsx
+++ b/packages/web/src/views/Day/view/DayViewContent.tsx
@@ -57,10 +57,6 @@ export const DayViewContent = memo(() => {
   });
   useDayEvents(dateInView);
 
-  const toggleSidebar = useCallback(() => {
-    viewActions.toggleSidebar();
-  }, []);
-
   // "i" implies the user wants the sidebar; open it first and defer focus a
   // frame so the sidebar exists in the DOM before we target it.
   const handleFocusSidebar = useCallback(() => {
@@ -72,11 +68,7 @@ export const DayViewContent = memo(() => {
     requestAnimationFrame(() => focusFirstSidebarItem());
   }, []);
 
-  const { closeShortcuts, isShortcutsOpen, toggleShortcuts } =
-    useSidebarShortcuts({
-      isSidebarOpen,
-      onToggleSidebar: toggleSidebar,
-    });
+  useSidebarShortcuts();
 
   const shortcutSections = useMemo(() => {
     const focusedEvent = getFocusedDayGridEventTarget();
@@ -133,7 +125,7 @@ export const DayViewContent = memo(() => {
       <CommandPalette
         currentView="day"
         onGoToToday={handleGoToToday}
-        onShowShortcuts={toggleShortcuts}
+        onShowShortcuts={viewActions.toggleShortcuts}
         onShowWelcomeGuide={openWelcomeGuide}
         placeholder={getCommandPalettePlaceholder("day")}
       />
@@ -156,10 +148,6 @@ export const DayViewContent = memo(() => {
         <Sidebar
           calendarDate={dateInView}
           eventDetails={<SidebarEventDetails />}
-          isEventDetailsOpen={isEventDetailsOpen}
-          isShortcutsOpen={isShortcutsOpen}
-          onCloseShortcuts={closeShortcuts}
-          onToggleShortcuts={toggleShortcuts}
           onSelectDate={navigateToDate}
           shortcutSections={shortcutSections}
           shortcutsViewLabel="Day"

--- a/packages/web/src/views/Life/LifeView.tsx
+++ b/packages/web/src/views/Life/LifeView.tsx
@@ -12,7 +12,6 @@ import { useSidebarShortcuts } from "@web/components/Sidebar/useSidebarShortcuts
 import {
   selectIsSidebarOpen,
   useViewStore,
-  viewActions,
 } from "@web/events/stores/view.store";
 import { getShortcutMenuSections } from "@web/shortcuts/data/shortcuts.data";
 import { useAppShortcutUp } from "@web/shortcuts/useAppShortcut";
@@ -97,14 +96,7 @@ export function LifeView({ today }: LifeViewProps) {
     });
   }, [navigate, preferences.lifespan, preferences.variation]);
 
-  const toggleSidebar = useCallback(() => {
-    viewActions.toggleSidebar();
-  }, []);
-  const { closeShortcuts, isShortcutsOpen, toggleShortcuts } =
-    useSidebarShortcuts({
-      isSidebarOpen,
-      onToggleSidebar: toggleSidebar,
-    });
+  useSidebarShortcuts();
   const shortcutSections = useMemo(
     () =>
       getShortcutMenuSections({ view: "life", isViewingCurrentPeriod: true }),
@@ -185,9 +177,6 @@ export function LifeView({ today }: LifeViewProps) {
 
       <ResizableSidebarPanel isOpen={isSidebarOpen}>
         <SidebarShell
-          isShortcutsOpen={isShortcutsOpen}
-          onCloseShortcuts={closeShortcuts}
-          onToggleShortcuts={toggleShortcuts}
           shortcutSections={shortcutSections}
           shortcutsViewLabel="Life"
         >

--- a/packages/web/src/views/Week/WeekView.tsx
+++ b/packages/web/src/views/Week/WeekView.tsx
@@ -48,14 +48,7 @@ export const WeekView = () => {
   // even when the user keeps it collapsed; their persisted preference is
   // untouched and the panel collapses again when the form closes.
   const isEventDetailsOpen = useDraftStore(selectIsEventFormOpen);
-  const toggleSidebar = useCallback(() => {
-    viewActions.toggleSidebar();
-  }, []);
-  const { closeShortcuts, isShortcutsOpen, toggleShortcuts } =
-    useSidebarShortcuts({
-      isSidebarOpen,
-      onToggleSidebar: toggleSidebar,
-    });
+  useSidebarShortcuts();
 
   const { today } = useToday();
 
@@ -156,7 +149,7 @@ export const WeekView = () => {
       <CommandPalette
         currentView="week"
         onGoToToday={goToTodayViaCmd}
-        onShowShortcuts={toggleShortcuts}
+        onShowShortcuts={viewActions.toggleShortcuts}
         onShowWelcomeGuide={openWelcomeGuide}
         placeholder={getCommandPalettePlaceholder("week")}
       />
@@ -209,10 +202,6 @@ export const WeekView = () => {
                 eventDetails={
                   <SidebarEventDetails confirmAllRecurringEdits={false} />
                 }
-                isEventDetailsOpen={isEventDetailsOpen}
-                isShortcutsOpen={isShortcutsOpen}
-                onCloseShortcuts={closeShortcuts}
-                onToggleShortcuts={toggleShortcuts}
                 onSelectDate={goToDateFromSidebar}
                 shortcutSections={shortcutSections}
                 shortcutsViewLabel="Week"


### PR DESCRIPTION
## Summary
- `Sidebar.tsx` no longer takes `isEventDetailsOpen` as a prop; it reads the draft store's `selectIsEventFormOpen` directly, the same selector its callers already read for other purposes.
- Deletes the `createSidebar({...})` dependency-injection factory. `Sidebar` now imports its six child components (`CalendarList`, `MonthPicker`, `SidebarActions`, `ShortcutsOverlay`, `TasksRemovalNotice`, `UpNextCard`) directly; test seams move to `mock.module` (capture-and-flag pattern, matching the existing convention in `SidebarStatusBar.test.tsx`).
- Moves the shortcuts-overlay's open/close state out of a local `useState` in `useSidebarShortcuts` and into `view.store`, next to `sidebar.isOpen`. The two were already coupled (opening shortcuts force-opens the sidebar; closing the sidebar closes the overlay) — centralizing both in one store collapses five props drilled through `Sidebar`/`SidebarShell` (`isShortcutsOpen`, `onCloseShortcuts`, `onToggleShortcuts`, plus the removed `isEventDetailsOpen`) down to zero, with `SidebarActions`/`ShortcutsOverlay` reading/acting on the store directly. `shortcutSections`/`shortcutsViewLabel` deliberately stay as props — they're derived from each view's route/state, not the store's concern.
- A single `useViewStore.subscribe` callback now enforces two self-correcting invariants after every state change: persist `sidebar.preference`, and force `shortcuts.isOpen` closed whenever `sidebar.isOpen` is false. This replaced an earlier version that spread a helper into three separate actions — centralizing it in the subscriber means no future sidebar-closing code path can forget to also close the overlay.

## Simplification performed
- Removed two `afterEach` calls that manually reset `view.store`'s shortcuts state; the global test harness (`resetAllStores()`) already does this after every test.
- Refactored `toggleShortcuts` to call the existing `setSidebarOpen` action when force-opening the sidebar, instead of duplicating its `{ isOpen, preference }` shape inline.

## Test plan
- [x] `bun run type-check` clean
- [x] `bun run test:web` — 1774/1774 passing, including 4 new `view.store.test.ts` cases covering the sidebar/shortcuts coupling (force-open, toggle, close-on-sidebar-close, close-on-breakpoint-collapse)
- [x] `bun run lint` clean
- [x] Independent code review pass found no issues
- [x] Manually verified in a locally-run dev build (anonymous "Start Now" session):
  - `?` force-opens a closed sidebar and shows the shortcuts overlay (search box + shortcut list)
  - Escape closes the overlay, leaving the sidebar open with its normal contents
  - The sidebar's persisted open/closed state is unaffected by opening/closing the overlay
- Live browser/e2e verification of backend-dependent paths was not possible in this worktree (missing `SYNC_SERVICE_URL`/`SYNC_INTERNAL_AUTH_TOKEN`, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)