### PR TITLE
refactor(sync): collapse the copy-pasted sweep wiring and repository filters

### DIFF
--- a/packages/sync/src/app.ts
+++ b/packages/sync/src/app.ts
@@ -251,19 +251,11 @@ async function start(): Promise<void> {
         // Stop every drain; each releases only its own owner's held jobs.
         await Promise.all(schedulers.drains.map((drain) => drain.stop()));
       });
-      const sweeps = [
-        ["reconcile", schedulers.reconcile],
-        ["subscription", schedulers.subscription],
-        ["bootstrapRecovery", schedulers.bootstrapRecovery],
-        ["failedJobRequeue", schedulers.failedJobRequeue],
-        ["staleCommandRetry", schedulers.staleCommandRetry],
-        ["calendarListRediscovery", schedulers.calendarListRediscovery],
-      ] as const;
-      for (const [name, sweep] of sweeps) {
+      for (const [name, sweep] of schedulers.sweeps) {
         service.shutdown.register(name, () => sweep.stop());
       }
       for (const drain of schedulers.drains) drain.start();
-      for (const [, sweep] of sweeps) sweep.start();
+      for (const [, sweep] of schedulers.sweeps) sweep.start();
       logger.info(
         "Sync scheduler draining, reconciling, renewing channels, retaining, retrying stale commands, and reporting health",
       );
@@ -387,12 +379,7 @@ function buildSchedulers(
   posthog: PostHogCaptureClient | null,
 ): {
   drains: SyncScheduler[];
-  reconcile: SweepScheduler;
-  subscription: SweepScheduler;
-  bootstrapRecovery: SweepScheduler;
-  failedJobRequeue: SweepScheduler;
-  staleCommandRetry: SweepScheduler;
-  calendarListRediscovery: SweepScheduler;
+  sweeps: ReadonlyArray<readonly [name: string, sweep: SweepScheduler]>;
 } | null {
   if (config.EXECUTION !== "active") return null;
   const authAdapter = buildAuthAdapter(config);
@@ -448,20 +435,33 @@ function buildSchedulers(
     );
   };
   const drains = Array.from({ length: config.MAX_CONCURRENCY }, buildDrain);
-  // The reconcile fallback looks BACK: enqueue a pull for any events resource not
-  // synced within the stale window (negative offset from now).
-  const reconcile = new SweepScheduler(
+
+  // Shared per-resource enqueue-failure logging for the resource sweeps below.
+  const onEnqueueError =
+    (sweep: string) => (error: unknown, resourceId: string) =>
+      logger.error(
+        `Sync ${sweep} sweep could not enqueue resource ${resourceId}; skipping it and continuing`,
+        error,
+      );
+
+  // One row per background sweep: `run` is the sweep's whole distinctive body
+  // (finder, job kind, and its own logging/telemetry — they genuinely differ,
+  // which is why #2588 stopped short of a fully shared implementation).
+  // Everything repeated — scheduler construction, failure logging, shutdown
+  // and start wiring — lives in the loop after the rows.
+  const sweepRows: ReadonlyArray<{
+    name: string;
+    windowMs: number;
+    run: (before: Date) => Promise<number>;
+  }> = [
     {
-      sweep: async (before) => {
+      // The reconcile fallback looks BACK: enqueue a pull for any events
+      // resource not synced within the stale window (negative offset from now).
+      name: "reconcile",
+      windowMs: -RECONCILE_STALE_AFTER_MS,
+      run: async (before) => {
         const enqueued = await enqueueForResources(
-          {
-            jobs,
-            onEnqueueError: (error, resourceId) =>
-              logger.error(
-                `Sync reconcile sweep could not enqueue resource ${resourceId}; skipping it and continuing`,
-                error,
-              ),
-          },
+          { jobs, onEnqueueError: onEnqueueError("reconcile") },
           (b, l) => resources.listStaleEvents(b, l),
           "incrementalPull",
           before,
@@ -492,25 +492,15 @@ function buildSchedulers(
       },
     },
     {
-      windowMs: -RECONCILE_STALE_AFTER_MS,
-      onError: (error) => logger.error("Sync reconcile sweep failed", error),
-    },
-  );
-  // Subscription maintenance looks AHEAD: enqueue a renewal for any push channel
-  // expiring within the renew window (positive offset from now), so a channel is
-  // replaced before it lapses. Aligns with maintainSubscription's renew guard.
-  const subscription = new SweepScheduler(
-    {
-      sweep: (before) =>
+      // Subscription maintenance looks AHEAD: enqueue a renewal for any push
+      // channel expiring within the renew window (positive offset from now),
+      // so a channel is replaced before it lapses. Aligns with
+      // maintainSubscription's renew guard.
+      name: "subscription",
+      windowMs: SUBSCRIPTION_RENEW_BEFORE_MS,
+      run: (before) =>
         enqueueForResources(
-          {
-            jobs,
-            onEnqueueError: (error, resourceId) =>
-              logger.error(
-                `Sync subscription sweep could not enqueue resource ${resourceId}; skipping it and continuing`,
-                error,
-              ),
-          },
+          { jobs, onEnqueueError: onEnqueueError("subscription") },
           (b, l) => resources.listExpiringSubscriptions(b, l),
           "subscriptionMaintain",
           before,
@@ -518,25 +508,14 @@ function buildSchedulers(
         ),
     },
     {
-      windowMs: SUBSCRIPTION_RENEW_BEFORE_MS,
-      onError: (error) =>
-        logger.error("Sync subscription maintenance sweep failed", error),
-    },
-  );
-  // Bootstrap-recovery looks BACK, like reconcile: enqueue a bootstrapCatchup
-  // for any events resource whose bootstrap chain has gone quiet before ready.
-  const bootstrapRecovery = new SweepScheduler(
-    {
-      sweep: async (before) => {
+      // Bootstrap-recovery looks BACK, like reconcile: enqueue a
+      // bootstrapCatchup for any events resource whose bootstrap chain has
+      // gone quiet before ready.
+      name: "bootstrapRecovery",
+      windowMs: -BOOTSTRAP_STALLED_AFTER_MS,
+      run: async (before) => {
         const enqueued = await enqueueForResources(
-          {
-            jobs,
-            onEnqueueError: (error, resourceId) =>
-              logger.error(
-                `Sync bootstrap-recovery sweep could not enqueue resource ${resourceId}; skipping it and continuing`,
-                error,
-              ),
-          },
+          { jobs, onEnqueueError: onEnqueueError("bootstrap-recovery") },
           (b, l) => resources.listStalledBootstraps(b, l),
           "bootstrapCatchup",
           before,
@@ -551,18 +530,13 @@ function buildSchedulers(
       },
     },
     {
-      windowMs: -BOOTSTRAP_STALLED_AFTER_MS,
-      onError: (error) =>
-        logger.error("Sync bootstrap-recovery sweep failed", error),
-    },
-  );
-  // Self-heal sweep: give jobs stuck in state:"failed" a fresh retry ladder
-  // once they have cooled down, and loudly log any that keep re-failing past
-  // the requeue cap. Looks BACK, like reconcile — a job is eligible once it
-  // has been failed since before the cooldown window.
-  const failedJobRequeue = new SweepScheduler(
-    {
-      sweep: async (before) => {
+      // Self-heal sweep: give jobs stuck in state:"failed" a fresh retry
+      // ladder once they have cooled down, and loudly log any that keep
+      // re-failing past the requeue cap. Looks BACK, like reconcile — a job
+      // is eligible once it has been failed since before the cooldown window.
+      name: "failedJobRequeue",
+      windowMs: -FAILED_JOB_REQUEUE_COOLDOWN_MS,
+      run: async (before) => {
         const result = await requeueFailedJobs(
           { jobs },
           before,
@@ -593,18 +567,15 @@ function buildSchedulers(
       },
     },
     {
-      windowMs: -FAILED_JOB_REQUEUE_COOLDOWN_MS,
-      onError: (error) => logger.error("Sync self-heal sweep failed", error),
-    },
-  );
-  // Self-heal sweep for the OTHER kind of stuck work: a cloud-targeted
-  // update/delete command that hit a transient provider failure mid-execute.
-  // Those run inline from the HTTP request (not as a job), and nothing else
-  // ever revisits a command left nonterminal that way - see
-  // stale-command-retry.service.ts. Looks BACK, like reconcile/failedJobRequeue.
-  const staleCommandRetry = new SweepScheduler(
-    {
-      sweep: async (before) => {
+      // Self-heal sweep for the OTHER kind of stuck work: a cloud-targeted
+      // update/delete command that hit a transient provider failure
+      // mid-execute. Those run inline from the HTTP request (not as a job),
+      // and nothing else ever revisits a command left nonterminal that way -
+      // see stale-command-retry.service.ts. Looks BACK, like
+      // reconcile/failedJobRequeue.
+      name: "staleCommandRetry",
+      windowMs: -STALE_COMMAND_RETRY_AFTER_MS,
+      run: async (before) => {
         const result = await retryStaleCommands(
           {
             commands: repos.commands,
@@ -631,28 +602,20 @@ function buildSchedulers(
       },
     },
     {
-      windowMs: -STALE_COMMAND_RETRY_AFTER_MS,
-      onError: (error) =>
-        logger.error("Sync stale-command retry sweep failed", error),
-    },
-  );
-  // Calendar-list rediscovery looks BACK, like reconcile: force a FULL
-  // discovery pass for any connection whose calendar list has not been
-  // re-listed within the staleness window, so a calendar the provider no
-  // longer lists eventually gets retired (deactivateAbsent only fires on a
-  // full pass, and only this sweep forces one after the initial connect).
-  const calendarListRediscovery = new SweepScheduler(
-    {
-      sweep: async (before) => {
+      // Calendar-list rediscovery looks BACK, like reconcile: force a FULL
+      // discovery pass for any connection whose calendar list has not been
+      // re-listed within the staleness window, so a calendar the provider no
+      // longer lists eventually gets retired (deactivateAbsent only fires on
+      // a full pass, and only this sweep forces one after the initial
+      // connect).
+      name: "calendarListRediscovery",
+      windowMs: -CALENDAR_LIST_STALE_AFTER_MS,
+      run: async (before) => {
         const enqueued = await rediscoverStaleCalendarLists(
           {
             resources,
             jobs,
-            onError: (error, resourceId) =>
-              logger.error(
-                `Sync calendar-list rediscovery sweep could not re-list resource ${resourceId}; skipping it and continuing`,
-                error,
-              ),
+            onError: onEnqueueError("calendar-list rediscovery"),
           },
           before,
           () => new Date(),
@@ -665,21 +628,23 @@ function buildSchedulers(
         return enqueued;
       },
     },
-    {
-      windowMs: -CALENDAR_LIST_STALE_AFTER_MS,
-      onError: (error) =>
-        logger.error("Sync calendar-list rediscovery sweep failed", error),
-    },
+  ];
+
+  const sweeps = sweepRows.map(
+    ({ name, windowMs, run }) =>
+      [
+        name,
+        new SweepScheduler(
+          { sweep: run },
+          {
+            windowMs,
+            onError: (error) =>
+              logger.error(`Sync ${name} sweep failed`, error),
+          },
+        ),
+      ] as const,
   );
-  return {
-    drains,
-    reconcile,
-    subscription,
-    bootstrapRecovery,
-    failedJobRequeue,
-    staleCommandRetry,
-    calendarListRediscovery,
-  };
+  return { drains, sweeps };
 }
 
 function registerSignalHandlers(

--- a/packages/sync/src/storage/repositories/command.repository.ts
+++ b/packages/sync/src/storage/repositories/command.repository.ts
@@ -23,6 +23,10 @@ import {
 // (tenant, principal, idempotencyKey): a retried submission returns the
 // existing command rather than creating a duplicate, so an interrupted or
 // replayed submit is safe. Queries are scoped to the owning tenant/principal.
+// A command still owed provider work: not yet applied, failed, or cancelled.
+// One definition so the four nonterminal queries below can never drift.
+const NONTERMINAL_COMMAND_STATES = ["pending", "applying", "reconciling"];
+
 export class CommandRepository {
   private readonly collection: Collection<CommandRecord>;
 
@@ -132,7 +136,7 @@ export class CommandRepository {
         tenantId,
         principalId,
         eventId,
-        "outcome.state": { $in: ["pending", "applying", "reconciling"] },
+        "outcome.state": { $in: NONTERMINAL_COMMAND_STATES },
       },
       { projection: { _id: 1 } },
     );
@@ -193,7 +197,7 @@ export class CommandRepository {
       .find({
         tenantId,
         principalId,
-        "outcome.state": { $in: ["pending", "applying", "reconciling"] },
+        "outcome.state": { $in: NONTERMINAL_COMMAND_STATES },
       })
       .sort({ createdAt: 1 })
       .limit(limit)
@@ -226,7 +230,7 @@ export class CommandRepository {
           $match: {
             tenantId,
             principalId,
-            "outcome.state": { $in: ["pending", "applying", "reconciling"] },
+            "outcome.state": { $in: NONTERMINAL_COMMAND_STATES },
           },
         },
         {
@@ -261,7 +265,7 @@ export class CommandRepository {
   ): Promise<CommandRecord[]> {
     const records = await this.collection
       .find({
-        "outcome.state": { $in: ["pending", "applying", "reconciling"] },
+        "outcome.state": { $in: NONTERMINAL_COMMAND_STATES },
         "input.kind": { $in: kinds },
         updatedAt: { $lt: before },
       })

--- a/packages/sync/src/storage/repositories/provider-calendar.repository.ts
+++ b/packages/sync/src/storage/repositories/provider-calendar.repository.ts
@@ -107,10 +107,7 @@ export class ProviderCalendarRepository {
     principalId: PrincipalId,
     connectionId: ConnectionId,
   ): Promise<ProviderCalendarRecord[]> {
-    const records = await this.collection
-      .find({ tenantId, principalId, connectionId })
-      .toArray();
-    return records.map((r) => ProviderCalendarRecordSchema.parse(r));
+    return this.listByPrincipal(tenantId, principalId, { connectionId });
   }
 
   async findById(

--- a/packages/sync/src/storage/repositories/sync-resource.repository.ts
+++ b/packages/sync/src/storage/repositories/sync-resource.repository.ts
@@ -14,6 +14,35 @@ import {
   SyncResourceUpsertSchema,
 } from "@sync/storage/contracts/sync-resource.contracts";
 
+// Shared tail for the global sweep finders below: drop resources whose
+// connection has no stored credential. Such a resource can never succeed no
+// matter how many sweeps retry it — reconnect is what resumes it
+// (registerConnection's own calendarListSync enqueue), not a sweep. Excluding
+// at the query level, rather than relying on the lastAttemptAt rotation,
+// matters because the rotation only helps AFTER a resource's first attempt:
+// the whole never-attempted population (dead-credential resources alongside
+// genuinely healthy new ones) ties at lastAttemptAt: null, and Mongo's
+// tie-break across that tie is not random — it reproducibly favored the
+// dead-credential cohort (2026-07-29: an isolated post-rotation-fix sweep
+// batch still selected 100 resources with only 1 holding a credential).
+//
+// listExpiringSubscriptions deliberately does NOT use this: it only selects
+// resources that already hold a live channel, which a credential-less
+// connection cannot renew into existence in the first place, and a renewal
+// attempt on one settles as a credential drop rather than burning a ladder.
+const EXCLUDE_CREDENTIALLESS_STAGES = [
+  {
+    $lookup: {
+      from: SYNC_COLLECTIONS.credentials,
+      localField: "connectionId",
+      foreignField: "_id",
+      as: "_credential",
+    },
+  },
+  { $match: { "_credential.0": { $exists: true } } },
+  { $project: { _credential: 0 } },
+];
+
 interface SubscriptionInput {
   subscriptionId: string;
   subscriptionResourceId: string;
@@ -247,19 +276,14 @@ export class SyncResourceRepository {
     principalId: PrincipalId,
     calendarIds: readonly SyncEventCalendarId[],
   ): Promise<Map<SyncEventCalendarId, number>> {
-    const records = await this.collection
-      .find({
-        tenantId,
-        principalId,
-        resourceKind: "events",
-        calendarId: { $in: [...calendarIds] },
-      })
-      .project<{ calendarId: SyncEventCalendarId; activeGeneration: number }>({
-        calendarId: 1,
-        activeGeneration: 1,
-      })
-      .toArray();
-    return new Map(records.map((r) => [r.calendarId, r.activeGeneration]));
+    const freshness = await this.listEventResourceFreshnessByCalendar(
+      tenantId,
+      principalId,
+      calendarIds,
+    );
+    return new Map(
+      [...freshness].map(([calendarId, r]) => [calendarId, r.activeGeneration]),
+    );
   }
 
   // The events resources backing the given calendars, projected to what a busy /
@@ -367,27 +391,7 @@ export class SyncResourceRepository {
             $or: [{ lastSuccessAt: { $lt: before } }, { lastSuccessAt: null }],
           },
         },
-        // A resource whose connection has no stored credential can never
-        // succeed here no matter how many sweeps retry it — reconnect is what
-        // resumes it (registerConnection's own calendarListSync enqueue), not
-        // reconcile. Excluding it at the query level, rather than relying on
-        // the lastAttemptAt rotation below, matters because the rotation only
-        // helps AFTER a resource's first attempt: the whole never-attempted
-        // population (dead-credential resources alongside genuinely healthy
-        // new ones) ties at lastAttemptAt: null, and Mongo's tie-break across
-        // that tie is not random — it reproducibly favored the dead-credential
-        // cohort (2026-07-29: an isolated post-rotation-fix sweep batch still
-        // selected 100 resources with only 1 holding a credential).
-        {
-          $lookup: {
-            from: SYNC_COLLECTIONS.credentials,
-            localField: "connectionId",
-            foreignField: "_id",
-            as: "_credential",
-          },
-        },
-        { $match: { "_credential.0": { $exists: true } } },
-        { $project: { _credential: 0 } },
+        ...EXCLUDE_CREDENTIALLESS_STAGES,
         // Round-robin by ATTEMPT, not success: never-attempted first (null
         // sorts lowest), then least-recently-attempted, so a resource that
         // fails without succeeding still rotates to the back after each try
@@ -424,16 +428,7 @@ export class SyncResourceRepository {
             updatedAt: { $lt: before },
           },
         },
-        {
-          $lookup: {
-            from: SYNC_COLLECTIONS.credentials,
-            localField: "connectionId",
-            foreignField: "_id",
-            as: "_credential",
-          },
-        },
-        { $match: { "_credential.0": { $exists: true } } },
-        { $project: { _credential: 0 } },
+        ...EXCLUDE_CREDENTIALLESS_STAGES,
         { $sort: { updatedAt: 1 } },
         { $limit: limit },
       ])
@@ -486,16 +481,7 @@ export class SyncResourceRepository {
             $or: [{ lastSuccessAt: { $lt: before } }, { lastSuccessAt: null }],
           },
         },
-        {
-          $lookup: {
-            from: SYNC_COLLECTIONS.credentials,
-            localField: "connectionId",
-            foreignField: "_id",
-            as: "_credential",
-          },
-        },
-        { $match: { "_credential.0": { $exists: true } } },
-        { $project: { _credential: 0 } },
+        ...EXCLUDE_CREDENTIALLESS_STAGES,
         { $sort: { lastAttemptAt: 1, lastSuccessAt: 1 } },
         { $limit: limit },
       ])

--- a/packages/sync/src/telemetry/health-snapshot.service.ts
+++ b/packages/sync/src/telemetry/health-snapshot.service.ts
@@ -70,6 +70,11 @@ export async function emitHealthSnapshot(input: {
   return snapshot;
 }
 
+// The counters below read collections directly instead of going through the
+// repositories, on purpose: a fleet gauge must keep reporting even when a doc
+// fails contract parsing (schema drift is exactly the kind of problem the
+// snapshot should surface, not crash on), and $group counts never need
+// hydrated records.
 async function countConnectionsByState(
   db: Db,
 ): Promise<SyncHealthSnapshot["connections"]> {


### PR DESCRIPTION
## Summary

Fourth slice of the cleanup plan: duplication collapses in the sync service, all behavior-neutral.

- **app.ts sweep table**: the six background sweeps become rows — each row's `run()` keeps the sweep's whole distinctive body (they genuinely differ, which is why #2588 stopped short of a shared implementation), while scheduler construction, failure logging, the per-resource enqueue-error logger, and shutdown/start wiring are written once. This wiring was the main source of app.ts's 13-commits-this-week churn.
- **Credential-exclusion $lookup tail** (2026-07-29 tie-break incident): pasted verbatim in 3 sweep finders → one `EXCLUDE_CREDENTIALLESS_STAGES` constant with one canonical incident comment, which also documents why `listExpiringSubscriptions` deliberately lacks it. `$match` heads untouched → index selection unchanged.
- **`activeGenerationByCalendar`** derives from `listEventResourceFreshnessByCalendar` (same filter, subset projection).
- **`NONTERMINAL_COMMAND_STATES`** extracts the 4×-inlined literal, mirroring job.repository's existing pattern.
- **`listByConnection`** delegates to `listByPrincipal`.
- **health-snapshot** raw reads documented as deliberate (gauge must not crash on schema drift).

**Considered and skipped:** filtering retired calendars inside `listExpiringSubscriptions` — it would put a $lookup on a hot sweep to save one well-commented block in calendar-list-sync.

## Test plan
- `bun run type-check` ✓
- Full sync suite: 817 tests, 0 fail ✓
- biome ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)