### PR TITLE
refactor(web): unify the Day/Week interaction registries

### DIFF
--- a/packages/web/src/grid/interaction/dom.ts
+++ b/packages/web/src/grid/interaction/dom.ts
@@ -4,8 +4,17 @@ import {
   GRID_EVENT_TIME_LABEL_FONT_SIZE,
   GRID_EVENT_TIME_LABEL_OPACITY,
 } from "@web/grid/grid.constants";
+import { viewInteractionAttributeNames } from "@web/grid/interaction/view-event-registry";
 import { createDraftEventClone } from "@web/interaction/dom/draft-event.clone";
 import { type FloatingDraftEventMount } from "@web/interaction/interaction.adapter.types";
+
+// A new grid view (beyond Day/Week) that adopts createViewInteractionRegistry
+// needs its name added here too, or its interaction attributes will leak
+// into the draft-event clone.
+const DRAFT_CLONE_STRIPPED_ATTRIBUTES = [
+  viewInteractionAttributeNames("day"),
+  viewInteractionAttributeNames("week"),
+].flatMap(({ idAttribute, typeAttribute }) => [idAttribute, typeAttribute]);
 
 export const EVENT_CONTENT_ATTRIBUTE = "data-calendar-event-content";
 export const EVENT_CONTENT_SELECTOR = `[${EVENT_CONTENT_ATTRIBUTE}='true']`;
@@ -69,10 +78,9 @@ export const createDraftEventMount = ({
   const clone = createDraftEventClone(source);
 
   for (const element of [clone, ...clone.querySelectorAll<HTMLElement>("*")]) {
-    element.removeAttribute("data-day-interaction-event-id");
-    element.removeAttribute("data-day-interaction-event-type");
-    element.removeAttribute("data-week-interaction-event-id");
-    element.removeAttribute("data-week-interaction-event-type");
+    for (const attribute of DRAFT_CLONE_STRIPPED_ATTRIBUTES) {
+      element.removeAttribute(attribute);
+    }
     element.style.animation = "none";
     element.style.transition = "none";
   }

--- a/packages/web/src/grid/interaction/view-event-registry.test.ts
+++ b/packages/web/src/grid/interaction/view-event-registry.test.ts
@@ -1,0 +1,78 @@
+import { createViewInteractionRegistry } from "./view-event-registry";
+import { afterEach, describe, expect, it } from "bun:test";
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("createViewInteractionRegistry", () => {
+  it("namespaces the id/type attributes by view name", () => {
+    const day = createViewInteractionRegistry("day");
+    const week = createViewInteractionRegistry("week");
+
+    expect(day.idAttribute).toBe("data-day-interaction-event-id");
+    expect(day.typeAttribute).toBe("data-day-interaction-event-type");
+    expect(week.idAttribute).toBe("data-week-interaction-event-id");
+    expect(week.typeAttribute).toBe("data-week-interaction-event-type");
+  });
+
+  it("keeps each view's registry from resolving the other view's elements", () => {
+    const day = createViewInteractionRegistry("day");
+    const week = createViewInteractionRegistry("week");
+
+    const dayEl = document.body.appendChild(document.createElement("div"));
+    const weekEl = document.body.appendChild(document.createElement("div"));
+
+    day.registry.register({
+      element: dayEl,
+      eventId: "shared-id",
+      eventType: "timed",
+    });
+    week.registry.register({
+      element: weekEl,
+      eventId: "shared-id",
+      eventType: "timed",
+    });
+
+    expect(day.registry.resolve("shared-id", "timed")).toBe(dayEl);
+    expect(week.registry.resolve("shared-id", "timed")).toBe(weekEl);
+    expect(dayEl.hasAttribute(week.idAttribute)).toBe(false);
+    expect(weekEl.hasAttribute(day.idAttribute)).toBe(false);
+  });
+
+  it("getInteractionTargetAttributes returns nothing for an undefined eventId", () => {
+    const day = createViewInteractionRegistry("day");
+
+    expect(
+      day.getInteractionTargetAttributes({
+        eventId: undefined,
+        eventType: "timed",
+      }),
+    ).toEqual({});
+  });
+
+  it("getInteractionTargetAttributes stamps both attributes for a defined eventId", () => {
+    const day = createViewInteractionRegistry("day");
+
+    expect(
+      day.getInteractionTargetAttributes({
+        eventId: "event-1",
+        eventType: "all-day",
+      }),
+    ).toEqual({
+      "data-day-interaction-event-id": "event-1",
+      "data-day-interaction-event-type": "all-day",
+    });
+  });
+
+  it("createRegistry produces a fresh, independent registry each call", () => {
+    const day = createViewInteractionRegistry("day");
+    const isolated = day.createRegistry();
+
+    const el = document.body.appendChild(document.createElement("div"));
+    isolated.register({ element: el, eventId: "isolated", eventType: "timed" });
+
+    expect(isolated.resolve("isolated", "timed")).toBe(el);
+    expect(day.registry.resolve("isolated", "timed")).toBeNull();
+  });
+});

--- a/packages/web/src/grid/interaction/view-event-registry.ts
+++ b/packages/web/src/grid/interaction/view-event-registry.ts
@@ -1,0 +1,97 @@
+import { type ForwardedRef } from "react";
+import {
+  createEventRegistry,
+  type EventRegistry,
+  type RegisteredEventTarget,
+} from "@web/grid/interaction/event.registry";
+import { useEventRegistrationRef } from "@web/grid/interaction/use-event-registration-ref";
+
+export type ViewInteractionEventType = "all-day" | "timed";
+
+const isViewInteractionEventType = (
+  value: string | null,
+): value is ViewInteractionEventType =>
+  value === "all-day" || value === "timed";
+
+export type ViewRegisteredEventTarget =
+  RegisteredEventTarget<ViewInteractionEventType>;
+
+export type ViewEventRegistry = EventRegistry<ViewInteractionEventType>;
+
+/**
+ * The `data-${viewName}-interaction-event-*` attribute names alone, with no
+ * registry attached - for call sites (like stripping these attributes off a
+ * cloned draft-event node) that need the naming scheme but have no reason to
+ * instantiate a registry.
+ */
+export const viewInteractionAttributeNames = (viewName: string) => ({
+  idAttribute: `data-${viewName}-interaction-event-id`,
+  typeAttribute: `data-${viewName}-interaction-event-type`,
+});
+
+/**
+ * One interaction registry per calendar view (Day, Week), namespaced by
+ * `data-${viewName}-interaction-event-*` attributes so a view only ever
+ * resolves its own DOM nodes. Day and Week previously hand-rolled identical
+ * copies of this wiring; this factory is the single source of it.
+ */
+export const createViewInteractionRegistry = (viewName: string) => {
+  const { idAttribute, typeAttribute } =
+    viewInteractionAttributeNames(viewName);
+
+  const createRegistry = (): ViewEventRegistry =>
+    createEventRegistry<ViewInteractionEventType>({
+      eventIdAttribute: idAttribute,
+      eventTypeAttribute: typeAttribute,
+      isEventType: isViewInteractionEventType,
+    });
+
+  const getInteractionTargetAttributes = ({
+    eventId,
+    eventType,
+  }: {
+    eventId: string | undefined;
+    eventType: ViewInteractionEventType;
+  }) => {
+    if (!eventId) {
+      return {};
+    }
+
+    return {
+      [idAttribute]: eventId,
+      [typeAttribute]: eventType,
+    };
+  };
+
+  const registry = createRegistry();
+
+  const useRegistrationRef = ({
+    eventId,
+    eventType,
+    forwardedRef,
+    isEnabled,
+    registry: registryOverride = registry,
+  }: {
+    eventId: string | undefined;
+    eventType: ViewInteractionEventType;
+    forwardedRef?: ForwardedRef<HTMLDivElement>;
+    isEnabled: boolean;
+    registry?: ViewEventRegistry;
+  }) =>
+    useEventRegistrationRef({
+      eventId,
+      eventType,
+      forwardedRef,
+      isEnabled,
+      registry: registryOverride,
+    });
+
+  return {
+    idAttribute,
+    typeAttribute,
+    createRegistry,
+    registry,
+    getInteractionTargetAttributes,
+    useRegistrationRef,
+  };
+};

--- a/packages/web/src/views/Day/interaction/registry/day-event.registry.ts
+++ b/packages/web/src/views/Day/interaction/registry/day-event.registry.ts
@@ -1,70 +1,24 @@
-import { type ForwardedRef } from "react";
 import {
-  createEventRegistry,
-  type EventRegistry,
-  type RegisteredEventTarget,
-} from "@web/grid/interaction/event.registry";
-import { useEventRegistrationRef } from "@web/grid/interaction/use-event-registration-ref";
+  createViewInteractionRegistry,
+  type ViewEventRegistry,
+  type ViewInteractionEventType,
+  type ViewRegisteredEventTarget,
+} from "@web/grid/interaction/view-event-registry";
 
-export const DAY_INTERACTION_EVENT_ID_ATTRIBUTE =
-  "data-day-interaction-event-id";
-export const DAY_INTERACTION_EVENT_TYPE_ATTRIBUTE =
-  "data-day-interaction-event-type";
+const day = createViewInteractionRegistry("day");
 
-export type DayInteractionEventType = "all-day" | "timed";
+export const DAY_INTERACTION_EVENT_ID_ATTRIBUTE = day.idAttribute;
+export const DAY_INTERACTION_EVENT_TYPE_ATTRIBUTE = day.typeAttribute;
 
-export type DayRegisteredEventTarget =
-  RegisteredEventTarget<DayInteractionEventType>;
+export type DayInteractionEventType = ViewInteractionEventType;
+export type DayRegisteredEventTarget = ViewRegisteredEventTarget;
+export type DayEventRegistry = ViewEventRegistry;
 
-export type DayEventRegistry = EventRegistry<DayInteractionEventType>;
+export const getDayInteractionTargetAttributes =
+  day.getInteractionTargetAttributes;
 
-const isDayInteractionEventType = (
-  value: string | null,
-): value is DayInteractionEventType => value === "all-day" || value === "timed";
+export const createDayEventRegistry = day.createRegistry;
 
-export const getDayInteractionTargetAttributes = ({
-  eventId,
-  eventType,
-}: {
-  eventId: string | undefined;
-  eventType: DayInteractionEventType;
-}) => {
-  if (!eventId) {
-    return {};
-  }
+export const dayEventRegistry = day.registry;
 
-  return {
-    [DAY_INTERACTION_EVENT_ID_ATTRIBUTE]: eventId,
-    [DAY_INTERACTION_EVENT_TYPE_ATTRIBUTE]: eventType,
-  };
-};
-
-export const createDayEventRegistry = (): DayEventRegistry =>
-  createEventRegistry<DayInteractionEventType>({
-    eventIdAttribute: DAY_INTERACTION_EVENT_ID_ATTRIBUTE,
-    eventTypeAttribute: DAY_INTERACTION_EVENT_TYPE_ATTRIBUTE,
-    isEventType: isDayInteractionEventType,
-  });
-
-export const dayEventRegistry = createDayEventRegistry();
-
-export const useDayEventRegistrationRef = ({
-  eventId,
-  eventType,
-  forwardedRef,
-  isEnabled,
-  registry = dayEventRegistry,
-}: {
-  eventId: string | undefined;
-  eventType: DayInteractionEventType;
-  forwardedRef?: ForwardedRef<HTMLDivElement>;
-  isEnabled: boolean;
-  registry?: DayEventRegistry;
-}) =>
-  useEventRegistrationRef({
-    eventId,
-    eventType,
-    forwardedRef,
-    isEnabled,
-    registry,
-  });
+export const useDayEventRegistrationRef = day.useRegistrationRef;

--- a/packages/web/src/views/Day/interaction/targeting/day-event.targeting.test.ts
+++ b/packages/web/src/views/Day/interaction/targeting/day-event.targeting.test.ts
@@ -1,0 +1,107 @@
+import { dayEventRegistry } from "@web/views/Day/interaction/registry/day-event.registry";
+import {
+  clearHoveredDayGridEventTarget,
+  focusDayGridEventTarget,
+  getFirstVisibleDayGridEventTarget,
+  getFocusedDayGridEventTarget,
+  getHoveredDayGridEventTarget,
+  listVisibleDayGridEventTargets,
+  setHoveredDayGridEventTarget,
+} from "./day-event.targeting";
+import { afterEach, describe, expect, it } from "bun:test";
+
+afterEach(() => {
+  clearHoveredDayGridEventTarget();
+  dayEventRegistry.clear();
+  document.body.innerHTML = "";
+});
+
+const addEventButton = ({
+  eventId,
+  eventType = "timed",
+  isVisible = true,
+}: {
+  eventId?: string;
+  eventType?: "all-day" | "timed";
+  isVisible?: boolean;
+}) => {
+  const button = document.createElement("button");
+  if (isVisible) {
+    Object.defineProperty(button, "offsetParent", {
+      configurable: true,
+      get: () => document.body,
+    });
+  }
+  document.body.appendChild(button);
+
+  if (eventId) {
+    dayEventRegistry.register({
+      element: button,
+      eventId,
+      eventType,
+    });
+  }
+
+  return button;
+};
+
+describe("dayGridEventTargeting", () => {
+  it("prefers the focused calendar event", () => {
+    addEventButton({ eventId: "first" });
+    const focused = addEventButton({
+      eventId: "focused",
+      eventType: "all-day",
+    });
+    focused.focus();
+
+    expect(getFocusedDayGridEventTarget()).toMatchObject({
+      element: focused,
+      eventId: "focused",
+      eventType: "all-day",
+    });
+  });
+
+  it("uses the hovered calendar event when nothing is focused", () => {
+    const hovered = addEventButton({ eventId: "hovered" });
+    setHoveredDayGridEventTarget(hovered);
+
+    expect(getHoveredDayGridEventTarget()).toMatchObject({
+      element: hovered,
+      eventId: "hovered",
+      eventType: "timed",
+    });
+  });
+
+  it("falls back to the first visible registered event", () => {
+    addEventButton({});
+    addEventButton({ eventId: "hidden", isVisible: false });
+    const firstVisible = addEventButton({ eventId: "visible" });
+
+    expect(getFirstVisibleDayGridEventTarget()).toMatchObject({
+      element: firstVisible,
+      eventId: "visible",
+      eventType: "timed",
+    });
+  });
+
+  it("focuses a returned calendar target", () => {
+    const button = addEventButton({ eventId: "target" });
+    const target = getFirstVisibleDayGridEventTarget();
+
+    if (!target) throw new Error("expected target");
+    focusDayGridEventTarget(target);
+
+    expect(document.activeElement).toBe(button);
+  });
+
+  it("lists every visible registered event", () => {
+    addEventButton({ eventId: "hidden", isVisible: false });
+    const first = addEventButton({ eventId: "first" });
+    const second = addEventButton({ eventId: "second" });
+
+    expect(listVisibleDayGridEventTargets()).toEqual([
+      expect.objectContaining({ element: first, eventId: "first" }),
+      expect.objectContaining({ element: second, eventId: "second" }),
+    ]);
+  });
+});

--- a/packages/web/src/views/Day/interaction/targeting/day-event.targeting.ts
+++ b/packages/web/src/views/Day/interaction/targeting/day-event.targeting.ts
@@ -9,7 +9,9 @@ import {
   dayEventRegistry,
 } from "@web/views/Day/interaction/registry/day-event.registry";
 
-export type DayGridEventTarget = SharedGridEventTarget<DayInteractionEventType>;
+export type DayGridEventTargetType = DayInteractionEventType;
+
+export type DayGridEventTarget = SharedGridEventTarget<DayGridEventTargetType>;
 
 const TARGET_SELECTOR = `[${DAY_INTERACTION_EVENT_ID_ATTRIBUTE}][${DAY_INTERACTION_EVENT_TYPE_ATTRIBUTE}]`;
 
@@ -28,6 +30,9 @@ export const clearHoveredDayGridEventTarget =
 
 export const getFocusedDayGridEventTarget =
   dayGridEventTargeting.getFocusedGridEventTarget;
+
+export const getHoveredDayGridEventTarget =
+  dayGridEventTargeting.getHoveredGridEventTarget;
 
 export const getFirstVisibleDayGridEventTarget =
   dayGridEventTargeting.getFirstVisibleGridEventTarget;

--- a/packages/web/src/views/Week/interaction/registry/week-event.registry.test.tsx
+++ b/packages/web/src/views/Week/interaction/registry/week-event.registry.test.tsx
@@ -391,6 +391,8 @@ describe("createDraftEventMount", () => {
     source.className = "event-class transition-[background-color]";
     source.setAttribute("tabindex", "0");
     source.setAttribute("aria-describedby", "description-id");
+    source.setAttribute(WEEK_INTERACTION_EVENT_ID_ATTRIBUTE, "event-1");
+    source.setAttribute(WEEK_INTERACTION_EVENT_TYPE_ATTRIBUTE, "timed");
     source.style.width = "100px";
     source.getBoundingClientRect = () =>
       ({
@@ -401,6 +403,7 @@ describe("createDraftEventMount", () => {
       }) as DOMRect;
     child.id = "child-id";
     child.setAttribute("aria-controls", "menu-id");
+    child.setAttribute(WEEK_INTERACTION_EVENT_ID_ATTRIBUTE, "event-1");
     child.style.transition = "opacity 150ms ease";
     source.append(child);
 
@@ -422,10 +425,19 @@ describe("createDraftEventMount", () => {
     expect(mount.clone.id).toBe("");
     expect(mount.clone.getAttribute("tabindex")).toBeNull();
     expect(mount.clone.getAttribute("aria-describedby")).toBeNull();
+    expect(
+      mount.clone.getAttribute(WEEK_INTERACTION_EVENT_ID_ATTRIBUTE),
+    ).toBeNull();
+    expect(
+      mount.clone.getAttribute(WEEK_INTERACTION_EVENT_TYPE_ATTRIBUTE),
+    ).toBeNull();
     expect(mount.clone).toHaveAttribute("aria-hidden", "true");
     expect(mount.clone.style.transition).toBe("none");
     expect(clonedChild?.id).toBe("");
     expect(clonedChild?.getAttribute("aria-controls")).toBeNull();
+    expect(
+      clonedChild?.getAttribute(WEEK_INTERACTION_EVENT_ID_ATTRIBUTE),
+    ).toBeNull();
     expect(clonedChild?.style.transition).toBe("none");
     expect(draftEvent.getNode()?.style.width).toBe("140px");
     expect(draftEvent.getNode()?.style.height).toBe("44px");

--- a/packages/web/src/views/Week/interaction/registry/week-event.registry.ts
+++ b/packages/web/src/views/Week/interaction/registry/week-event.registry.ts
@@ -1,71 +1,24 @@
-import { type ForwardedRef } from "react";
 import {
-  createEventRegistry,
-  type EventRegistry,
-  type RegisteredEventTarget,
-} from "@web/grid/interaction/event.registry";
-import { useEventRegistrationRef } from "@web/grid/interaction/use-event-registration-ref";
+  createViewInteractionRegistry,
+  type ViewEventRegistry,
+  type ViewInteractionEventType,
+  type ViewRegisteredEventTarget,
+} from "@web/grid/interaction/view-event-registry";
 
-export const WEEK_INTERACTION_EVENT_ID_ATTRIBUTE =
-  "data-week-interaction-event-id";
-export const WEEK_INTERACTION_EVENT_TYPE_ATTRIBUTE =
-  "data-week-interaction-event-type";
+const week = createViewInteractionRegistry("week");
 
-export type WeekInteractionEventType = "all-day" | "timed";
+export const WEEK_INTERACTION_EVENT_ID_ATTRIBUTE = week.idAttribute;
+export const WEEK_INTERACTION_EVENT_TYPE_ATTRIBUTE = week.typeAttribute;
 
-export type WeekRegisteredEventTarget =
-  RegisteredEventTarget<WeekInteractionEventType>;
+export type WeekInteractionEventType = ViewInteractionEventType;
+export type WeekRegisteredEventTarget = ViewRegisteredEventTarget;
+export type WeekEventRegistry = ViewEventRegistry;
 
-const isWeekInteractionEventType = (
-  value: string | null,
-): value is WeekInteractionEventType =>
-  value === "all-day" || value === "timed";
+export const getWeekInteractionTargetAttributes =
+  week.getInteractionTargetAttributes;
 
-export const getWeekInteractionTargetAttributes = ({
-  eventId,
-  eventType,
-}: {
-  eventId: string | undefined;
-  eventType: WeekInteractionEventType;
-}) => {
-  if (!eventId) {
-    return {};
-  }
+export const createWeekEventRegistry = week.createRegistry;
 
-  return {
-    [WEEK_INTERACTION_EVENT_ID_ATTRIBUTE]: eventId,
-    [WEEK_INTERACTION_EVENT_TYPE_ATTRIBUTE]: eventType,
-  };
-};
+export const weekEventRegistry = week.registry;
 
-export type WeekEventRegistry = EventRegistry<WeekInteractionEventType>;
-
-export const createWeekEventRegistry = (): WeekEventRegistry =>
-  createEventRegistry<WeekInteractionEventType>({
-    eventIdAttribute: WEEK_INTERACTION_EVENT_ID_ATTRIBUTE,
-    eventTypeAttribute: WEEK_INTERACTION_EVENT_TYPE_ATTRIBUTE,
-    isEventType: isWeekInteractionEventType,
-  });
-
-export const weekEventRegistry = createWeekEventRegistry();
-
-export const useWeekEventRegistrationRef = ({
-  eventId,
-  eventType,
-  forwardedRef,
-  isEnabled,
-  registry = weekEventRegistry,
-}: {
-  eventId: string | undefined;
-  eventType: WeekInteractionEventType;
-  forwardedRef?: ForwardedRef<HTMLDivElement>;
-  isEnabled: boolean;
-  registry?: WeekEventRegistry;
-}) =>
-  useEventRegistrationRef({
-    eventId,
-    eventType,
-    forwardedRef,
-    isEnabled,
-    registry,
-  });
+export const useWeekEventRegistrationRef = week.useRegistrationRef;


### PR DESCRIPTION
## Summary
- `day-event.registry.ts` and `week-event.registry.ts` were byte-for-byte forks (~55-60 lines each) differing only in DOM attribute namespace (`data-day-...` vs `data-week-...`) and export names. Both now delegate to a shared `createViewInteractionRegistry(viewName)` factory (`packages/web/src/grid/interaction/view-event-registry.ts`), re-exporting the exact same public symbols each file had before — every existing importer across the codebase (~30 files) needs zero changes.
- Fixes a targeting export-parity gap: `day-event.targeting.ts` was missing `getHoveredDayGridEventTarget` and a `DayGridEventTargetType` type alias that `week-event.targeting.ts` already had, despite both being thin wrappers over the same shared `createGridEventTargeting` factory (which already provides the hover getter — Day's wrapper just wasn't re-exporting it).
- `dom.ts`'s `createDraftEventMount` used to hardcode 4 separate `removeAttribute` calls with literal attribute-name strings when stripping interaction attributes off a cloned draft-event node. These now derive from the same naming source the registries use, via a new pure `viewInteractionAttributeNames(viewName)` helper (kept separate from the registry factory so `dom.ts` depends only on the naming convention, not on the live registry singletons).

## Test coverage added
- `view-event-registry.test.ts` — new, tests the shared factory directly: attribute namespacing, that two views' registries never cross-resolve each other's elements, and that `createRegistry()` produces a genuinely fresh instance each call.
- `day-event.targeting.test.ts` — new. Day's targeting layer had **no dedicated test file at all** before this (only indirect coverage), unlike Week's 107-line `week-event.targeting.test.ts`. Mirrors it.
- Strengthened the existing `createDraftEventMount` test in `week-event.registry.test.tsx`: it previously asserted attributes that are stripped unconditionally by `createDraftEventClone` (`id`, `tabindex`, `aria-describedby`), never actually exercising the interaction-attribute-stripping this change touches. Now sets `WEEK_INTERACTION_EVENT_ID_ATTRIBUTE`/`_TYPE_ATTRIBUTE` on the source elements and asserts they're gone from the clone — verified this actually catches a regression by temporarily reverting the stripping logic and confirming the test fails.

## Test plan
- [x] `bun run type-check` clean (both `packages/web` scopes; a pre-existing, unrelated `packages/backend` TypeScript error reproduces identically on a clean `origin/main` checkout, confirmed before and after this change)
- [x] `bun run test:web` — 1784/1784 passing
- [x] `bun run lint` clean
- [x] Independent code review passes (2 rounds, one after the `dom.ts` attribute-derivation addition) found no issues
- [x] Manually verified in a locally-run dev build: interaction registry attributes (`data-week-interaction-event-id`/`-type`) are correctly stamped on live event cards and match `data-event-id`; the `u` shortcut correctly focuses the first visible event via the refactored registry/targeting resolve path

🤖 Generated with [Claude Code](https://claude.com/claude-code)