### PR TITLE
feat(backend): report notFound and conflict kinds from the sync client

### DIFF
--- a/packages/backend/src/common/services/sync-service/sync-connection-begin.ts
+++ b/packages/backend/src/common/services/sync-service/sync-connection-begin.ts
@@ -16,9 +16,10 @@ const logger = Logger("app:sync-connection-begin");
  * consent URL the browser should be sent to.
  *
  * Any client failure surfaces as the standard opaque 503 via
- * unwrapSyncResult. The distinctions the sync service makes (409 passive
- * mode, 404 reconnect-not-found) are not yet actionable by the browser; when
- * the reconnect UI is wired, this can grow more specific mappings.
+ * unwrapSyncResult. The client now reports conflict (409 passive mode) and
+ * notFound (404 reconnect-not-found) kinds — visible in the server-side log
+ * line — but the browser response stays the single opaque 503 until the
+ * reconnect UI can act on the distinction.
  */
 export async function beginSyncConnection(
   client: Pick<SyncServiceClient, "beginConnection">,

--- a/packages/backend/src/common/services/sync-service/sync-service.client.test.ts
+++ b/packages/backend/src/common/services/sync-service/sync-service.client.test.ts
@@ -222,7 +222,7 @@ describe("SyncServiceClient", () => {
     expect(verdict.context.principalId).toBe(who.principalId);
   });
 
-  it("reports a disconnect of an unknown connection as a failure", async () => {
+  it("reports a disconnect of an unknown connection as notFound", async () => {
     const { fn } = fakeFetch(async () => ({
       status: 404,
       json: async () => ({ error: "not_found" }),
@@ -234,6 +234,21 @@ describe("SyncServiceClient", () => {
     );
 
     expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.error.kind).toBe("notFound");
+  });
+
+  it("maps a 409 (passive-mode refusal) to conflict", async () => {
+    const { fn } = fakeFetch(async () => ({
+      status: 409,
+      json: async () => ({ error: "passive_mode" }),
+    }));
+
+    const result = await client(fn).beginConnection(principal());
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.error.kind).toBe("conflict");
   });
 
   it("lists calendars with a signed GET the real Sync verifier accepts", async () => {

--- a/packages/backend/src/common/services/sync-service/sync-service.client.ts
+++ b/packages/backend/src/common/services/sync-service/sync-service.client.ts
@@ -76,6 +76,12 @@ export type SyncClientErrorKind =
   | "unauthorized"
   // The Sync service rejected the request shape (400) — a client/contract bug.
   | "badRequest"
+  // The target does not exist for this principal (404) — e.g. disconnecting a
+  // foreign or already-gone connection, or reconnecting an unknown one.
+  | "notFound"
+  // The Sync service refused the operation in its current mode (409) — e.g. a
+  // provider-touching request against a passive deployment.
+  | "conflict"
   // The service is unreachable or not ready (network failure or 503).
   | "unavailable"
   // The request exceeded the deadline.
@@ -219,7 +225,7 @@ export class SyncServiceClient {
   // browser should be sent to. Pass a connectionId to reconnect an existing
   // connection; omit it for a fresh one. The Sync service only mints the URL
   // here (and requires active execution mode, else it returns a 409 mapped to
-  // `unexpectedStatus`); the connection is created when the provider calls back.
+  // `conflict`); the connection is created when the provider calls back.
   beginConnection(
     principal: SyncPrincipal,
     request: ConnectionBeginRequest = {},
@@ -551,6 +557,8 @@ export class SyncServiceClient {
 function statusToKind(status: number): SyncClientErrorKind {
   if (status === 401) return "unauthorized";
   if (status === 400) return "badRequest";
+  if (status === 404) return "notFound";
+  if (status === 409) return "conflict";
   // 429 is sync's own internal rate limiter (internal-http.ts), tripped
   // easily under normal-ish load (a shared 300/min bucket for the whole
   // backend). Treated the same as 503: a retryable service-busy state, not


### PR DESCRIPTION
## Summary

Phase-4 slice B13 of the cleanup plan. `statusToKind` swallowed sync's two meaningful 4xx distinctions into `unexpectedStatus`: **404** (disconnect/reconnect of a connection that doesn't exist for this principal) and **409** (provider-touching request against a passive deployment). Both now map to their own kinds, with tests.

Route behavior is unchanged on purpose — every caller still collapses client errors to its existing response (the opaque 503 / PROVIDER_FAILURE) — but server-side logs and interpolated messages now say `notFound`/`conflict`, and a future reconnect UI can branch on the kind without another client change. This deliberately does NOT change what the browser sees, keeping #2595's disconnect UX intact.

## Test plan
- client tests incl. two new kind assertions ✓ (31 tests), `bun test:backend` 302 ✓, type-check ✓, biome ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)