### PR TITLE
feat(sync): persist the unwatchable-calendar verdict instead of retrying every pull

### DIFF
--- a/packages/sync/src/domain/calendar-list-sync.service.db.test.ts
+++ b/packages/sync/src/domain/calendar-list-sync.service.db.test.ts
@@ -162,6 +162,48 @@ describe("syncCalendarList", () => {
     expect(job?.coalescingKey).toBe(`initialImport:${eventsResources[0]?._id}`);
   });
 
+  it("clears persisted unwatchable verdicts on a full pass so each gets one retry", async () => {
+    const conn = connection();
+    // First full pass discovers the calendar and bootstraps its events resource.
+    await syncCalendarList(
+      deps(
+        new FakeDiscovery([
+          { calendars: [discovered("primary")], cursor: null },
+        ]),
+      ),
+      conn,
+      now,
+    );
+    const eventsResource = await storage
+      .db()
+      .collection(SYNC_COLLECTIONS.syncResources)
+      .findOne({ connectionId: conn._id, resourceKind: "events" });
+    await resources.markWatchUnsupported(
+      conn.tenantId,
+      conn.principalId,
+      String(eventsResource?.["_id"]),
+      now(),
+    );
+
+    // Next pass is full again (no cursor stored) - the verdict is cleared for
+    // one fresh watch attempt.
+    await syncCalendarList(
+      deps(
+        new FakeDiscovery([
+          { calendars: [discovered("primary")], cursor: null },
+        ]),
+      ),
+      conn,
+      now,
+    );
+
+    const after = await storage
+      .db()
+      .collection(SYNC_COLLECTIONS.syncResources)
+      .findOne({ connectionId: conn._id, resourceKind: "events" });
+    expect(after?.["watchUnsupportedAt"]).toBeNull();
+  });
+
   it("retires a calendar no longer present on a full list", async () => {
     const conn = connection();
     // First full pass discovers two calendars.

--- a/packages/sync/src/domain/calendar-list-sync.service.ts
+++ b/packages/sync/src/domain/calendar-list-sync.service.ts
@@ -127,6 +127,16 @@ export async function syncCalendarList(
   // hiccup that returned empty instead of throwing) rather than "all removed" —
   // retiring every calendar on an empty blip would be user-visible damage.
   if (fullList && discovery.calendars.length > 0) {
+    // A full pass is the retry cadence for unwatchable calendars: clear the
+    // persisted watchUnsupportedAt verdicts so each gets one fresh watch
+    // attempt (the pull path re-marks any the provider still refuses). Runs
+    // daily via the rediscovery sweep — the pre-marker behavior was one
+    // futile watch attempt per pull, forever.
+    await deps.resources.clearWatchUnsupportedByConnection(
+      tenantId,
+      principalId,
+      connectionId,
+    );
     const retiredIds = await deps.calendars.deactivateAbsent(
       tenantId,
       principalId,

--- a/packages/sync/src/domain/subscription-maintenance.service.db.test.ts
+++ b/packages/sync/src/domain/subscription-maintenance.service.db.test.ts
@@ -248,6 +248,42 @@ describe("maintainSubscription", () => {
     const saved = await reload(resource);
     expect(saved?.subscriptionId).toBeNull();
     expect(saved?.subscriptionExpiresAt).toBeNull();
+    // The verdict is persisted so the pull path stops re-attempting a watch
+    // every cycle.
+    expect(saved?.watchUnsupportedAt).toEqual(now());
+  });
+
+  it("clears a persisted unsupported verdict when a later watch succeeds", async () => {
+    const cal = calendar(objectId());
+    const resource = await seedResource(cal);
+    await resources.markWatchUnsupported(
+      cal.tenantId,
+      cal.principalId,
+      resource._id,
+      now(),
+    );
+
+    const outcome = await maintainSubscription(
+      {
+        resources,
+        notifications: new FakeNotifications({
+          channel: {
+            channelId: "",
+            resourceId: "res-retry",
+            expiresAt: new Date("2026-07-17T00:00:00.000Z"),
+          },
+        }),
+        custody,
+        callbackUrl: "https://sync/cb",
+      },
+      cal,
+      resource,
+      now,
+    );
+
+    expect(outcome).toEqual({ status: "watched" });
+    const saved = await reload(resource);
+    expect(saved?.watchUnsupportedAt).toBeNull();
   });
 
   it("reports authRevoked, discards the credential, and leaves the subscription", async () => {

--- a/packages/sync/src/domain/subscription-maintenance.service.ts
+++ b/packages/sync/src/domain/subscription-maintenance.service.ts
@@ -115,6 +115,15 @@ export async function maintainSubscription(
             resource._id,
           );
         }
+        // Persist the verdict so the pull path stops re-attempting a watch on
+        // every cycle; the daily calendar-list full pass clears it for one
+        // fresh attempt.
+        await deps.resources.markWatchUnsupported(
+          resource.tenantId,
+          resource.principalId,
+          resource._id,
+          now(),
+        );
         return { status: "unsupported" };
       }
       if (error.reason === "authorizationRevoked") {

--- a/packages/sync/src/domain/sync-job-dispatch.service.db.test.ts
+++ b/packages/sync/src/domain/sync-job-dispatch.service.db.test.ts
@@ -352,6 +352,29 @@ describe("dispatchSyncJob", () => {
     expect(outcome.followup.resourceId).toBe(resource._id);
   });
 
+  it("skips the channel bootstrap when the provider has terminally refused a watch", async () => {
+    // Once maintainSubscription persists watchUnsupportedAt, re-attempting a
+    // watch on every pull is pure waste; the daily calendar-list full pass
+    // clears the marker for one fresh attempt.
+    const calendar = await seedCalendar();
+    const resource = await seedResource(calendar, "cursor-0");
+    await resources.markWatchUnsupported(
+      resource.tenantId,
+      resource.principalId,
+      resource._id,
+      now(),
+    );
+    const reader = new FakeReader([page([single("new-1")], "cursor-1")]);
+
+    const outcome = await dispatchSyncJob(
+      deps(reader),
+      jobFor(resource, "incrementalPull"),
+      now,
+    );
+
+    expect(outcome).toEqual({ result: "done" });
+  });
+
   it("hands off an expired-cursor pull to a repair followup", async () => {
     const calendar = await seedCalendar();
     const resource = await seedResource(calendar, "stale-cursor");

--- a/packages/sync/src/domain/sync-job-dispatch.service.ts
+++ b/packages/sync/src/domain/sync-job-dispatch.service.ts
@@ -244,11 +244,14 @@ async function runSyncJob(
         // (2026-08-01). Pulls already run for every stale calendar, so
         // piggybacking here needs no new sweep and heals the whole fleet.
         //
-        // Wart: a calendar the provider refuses to watch reports "unsupported"
-        // and is not recorded as such, so it re-attempts one watch per pull
-        // (~1/100min at current sweep cadence). Cheap, bounded, and self-
-        // limiting in practice since unwatchable calendars are rare.
-        if (pull.resource.subscriptionId === null) {
+        // watchUnsupportedAt gates the followup: once the provider has
+        // terminally refused a watch, re-attempting one per pull is pure
+        // waste. The daily calendar-list full pass clears the marker for one
+        // fresh attempt.
+        if (
+          pull.resource.subscriptionId === null &&
+          pull.resource.watchUnsupportedAt === null
+        ) {
           return {
             result: "done",
             followup: subscriptionFollowup(pull.resource, now),

--- a/packages/sync/src/storage/contracts/sync-resource.contracts.ts
+++ b/packages/sync/src/storage/contracts/sync-resource.contracts.ts
@@ -71,6 +71,15 @@ export const SyncResourceRecordSchema = z.strictObject({
   // that predated the field) - no default here, so a row silently missing it
   // fails to parse instead of quietly defaulting.
   bootstrapState: ResourceBootstrapStateSchema,
+  // Set when the provider terminally refused to open a push channel for this
+  // calendar (watch unsupported/durably rejected — see maintainSubscription's
+  // "unsupported" outcome). While set, the incremental-pull path stops
+  // re-attempting a watch on every cycle; the daily calendar-list full pass
+  // clears it so a provider-side change is eventually retried. A successful
+  // watch also clears it. Defaults tolerate rows written before the field —
+  // REQUIRED for any new field here: enqueue/sweeps re-parse whatever row
+  // exists, and a required field froze the fleet for 23h (2026-07-31).
+  watchUnsupportedAt: z.date().nullable().default(null),
   // Push subscription: the provider channel id, its opaque resource id, the
   // per-channel secret the provider echoes back on callbacks, and when it
   // expires. All null when no subscription is active.

--- a/packages/sync/src/storage/repositories/sync-resource.repository.ts
+++ b/packages/sync/src/storage/repositories/sync-resource.repository.ts
@@ -87,6 +87,7 @@ export class SyncResourceRepository {
           lastSuccessAt: null,
           lastReadFailureAt: null,
           lastReadFailureDetail: null,
+          watchUnsupportedAt: null,
           bootstrapState:
             fields.resourceKind === "events" ? "importing" : "ready",
           subscriptionId: null,
@@ -203,7 +204,53 @@ export class SyncResourceRepository {
   ): Promise<void> {
     await this.collection.updateOne(
       { _id: id, tenantId, principalId },
-      { $set: { ...subscription, updatedAt: new Date() } },
+      {
+        $set: {
+          ...subscription,
+          // A watch just succeeded, so any earlier unsupported verdict is
+          // stale by definition.
+          watchUnsupportedAt: null,
+          updatedAt: new Date(),
+        },
+      },
+    );
+  }
+
+  // Record the provider's terminal refusal to open a push channel for this
+  // resource (maintainSubscription's "unsupported" outcome). While set, the
+  // pull path stops re-attempting a watch every cycle; cleared by the daily
+  // calendar-list full pass (clearWatchUnsupportedByConnection) or by a
+  // successful watch (updateSubscription).
+  async markWatchUnsupported(
+    tenantId: TenantId,
+    principalId: PrincipalId,
+    id: string,
+    at: Date,
+  ): Promise<void> {
+    await this.collection.updateOne(
+      { _id: id, tenantId, principalId },
+      { $set: { watchUnsupportedAt: at, updatedAt: new Date() } },
+    );
+  }
+
+  // Give every unwatchable-marked resource on a connection one fresh watch
+  // attempt. Called from the calendar-list FULL discovery pass, which the
+  // rediscovery sweep forces daily — so a calendar the provider starts
+  // supporting is retried at that cadence rather than never (or on every
+  // pull, which was the pre-marker wart).
+  async clearWatchUnsupportedByConnection(
+    tenantId: TenantId,
+    principalId: PrincipalId,
+    connectionId: ConnectionId,
+  ): Promise<void> {
+    await this.collection.updateMany(
+      {
+        tenantId,
+        principalId,
+        connectionId,
+        watchUnsupportedAt: { $ne: null },
+      },
+      { $set: { watchUnsupportedAt: null, updatedAt: new Date() } },
     );
   }
 


### PR DESCRIPTION
## Summary

Phase-4 slice S13 of the cleanup plan — kills the acknowledged "Wart" in sync-job-dispatch. Today "is this calendar unwatchable" is decided in four places, never persisted, so the pull path re-attempts a watch every cycle (~1/100min per unwatchable calendar, forever).

- `sync_resources.watchUnsupportedAt` (nullable, **defaulted** — per the 2026-07-31 required-field incident).
- `maintainSubscription`'s `unsupported` outcome stamps it.
- The pull path's channel-bootstrap followup skips marked resources.
- A calendar-list **full** pass clears the connection's markers → one fresh attempt per day (rediscovery sweep cadence) instead of one per pull; a successful watch also clears it.

Kept the port's `watchUnsupported`/`watchFailed` reason split as-is (documents provider semantics); the persistence alone removes the runtime waste.

## Behavior change

Watch retry cadence for terminally-refused calendars drops from per-pull to daily. Bootstrap flow unchanged (unsupported still completes bootstrap without a channel; reconcile-sweep polling covers the calendar).

## Test plan
- New/extended tests: verdict stamped on unsupported, cleared on later successful watch, pull skips marked resources, full pass clears markers ✓
- Full sync suite 820 tests, 0 fail ✓; type-check ✓; biome ✓
- Staging soak after merge: watch `sync_health_snapshot` subscriptions.missing and the soak accounts' Holidays calendars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)