### PR TITLE
fix(sync): require endAt on event occurrences

### DIFF
--- a/packages/sync/src/domain/calendar-repair.service.db.test.ts
+++ b/packages/sync/src/domain/calendar-repair.service.db.test.ts
@@ -185,6 +185,7 @@ describe("repairCalendar", () => {
         calendarId: calendar._id,
         schedule,
         startAt: new Date("2026-07-14T15:00:00.000Z"),
+        endAt: new Date("2026-07-14T16:00:00.000Z"),
         busy: true,
         title: providerEventId ?? "local",
         cancelled: false,

--- a/packages/sync/src/domain/connection-retention.service.db.test.ts
+++ b/packages/sync/src/domain/connection-retention.service.db.test.ts
@@ -175,6 +175,7 @@ describe("purgeExpiredDisconnectedConnections", () => {
         timeZone: "America/Denver",
       },
       startAt: NOW,
+      endAt: new Date(NOW.getTime() + 60 * 60_000),
       busy: true,
       title: "Cached meeting",
       cancelled: false,

--- a/packages/sync/src/domain/event-instance-assembly.test.ts
+++ b/packages/sync/src/domain/event-instance-assembly.test.ts
@@ -67,6 +67,7 @@ const makeOccurrence = (
     calendarId: objectId(),
     schedule: timed("2026-07-14T09:00:00-06:00", "2026-07-14T09:15:00-06:00"),
     startAt,
+    endAt: overrides.endAt ?? new Date(startAt.getTime() + 15 * 60_000),
     busy: true,
     title: "Standup",
     cancelled: false,

--- a/packages/sync/src/server/connection.routes.db.test.ts
+++ b/packages/sync/src/server/connection.routes.db.test.ts
@@ -1213,6 +1213,7 @@ describe("GET /internal/events/full", () => {
       calendarId: objectId(),
       schedule: timed,
       startAt: start,
+      endAt: new Date(start.getTime() + 60 * 60_000),
       busy: true,
       title: "Standup",
       cancelled: false,

--- a/packages/sync/src/storage/contracts/event-occurrence.contracts.ts
+++ b/packages/sync/src/storage/contracts/event-occurrence.contracts.ts
@@ -33,12 +33,10 @@ export const EventOccurrenceRecordSchema = z.strictObject({
   startAt: z.date(),
   // Normalized EXCLUSIVE end instant, paired with startAt as a half-open
   // [startAt, endAt) interval so a busy/overlap query can find an occurrence
-  // that starts before a window but ends inside it. Optional ONLY during the
-  // rollout: the projection always sets it now, and existing occurrences pick it
-  // up on their next reprojection (every import/pull/repair rewrites them), so no
-  // read breaks on a doc that predates the field. Tighten to required once every
-  // occurrence carries it.
-  endAt: z.date().optional(),
+  // that starts before a window but ends inside it. Required: the #2303
+  // rollout gap is closed — steady-state reprojection rewrote every pre-field
+  // doc (prod and staging verified at zero missing on 2026-08-07).
+  endAt: z.date(),
   busy: z.boolean(),
   title: z.string(),
   cancelled: z.boolean(),

--- a/packages/sync/src/storage/repositories/event-occurrence.repository.db.test.ts
+++ b/packages/sync/src/storage/repositories/event-occurrence.repository.db.test.ts
@@ -26,6 +26,7 @@ const occurrence = (
       timeZone: "America/Denver",
     },
     startAt: new Date("2026-07-14T09:00:00-06:00"),
+    endAt: new Date("2026-07-14T10:00:00-06:00"),
     busy: true,
     title: "Standup",
     cancelled: false,

--- a/packages/sync/src/storage/repositories/event-occurrence.repository.ts
+++ b/packages/sync/src/storage/repositories/event-occurrence.repository.ts
@@ -225,9 +225,7 @@ export class EventOccurrenceRepository {
   // The busy occurrences overlapping [start, end) for the given calendars, each
   // read at its active generation, projected to just the interval. Overlap (not
   // start-in-range) so an occurrence that began before the window but ends inside
-  // it is included. Cancelled occurrences are not busy and are excluded; one with
-  // no endAt (predating the field and not yet reprojected) is excluded until it
-  // reprojects — the `endAt > start` filter never matches a missing field.
+  // it is included. Cancelled occurrences are not busy and are excluded.
   //
   // `startAt` is also lower-bounded by (windowStart - BUSY_MAX_LOOKBACK_MS): an
   // unbounded `startAt < end` walks the entire historical calendar_gen_start


### PR DESCRIPTION
## Summary

The deferred S14 slice of the cleanup plan, closed out with operator verification. `endAt` was optional for the #2303 rollout, and occurrences missing it were **silently invisible to busy/overlap queries** (`{endAt: {$gt}}` never matches a missing field).

**Verified before tightening** (2026-08-07, read-only queries): prod has **0 of 147,325** occurrences missing `endAt`; staging **0 of 7,863**. Steady-state reprojection organically backfilled every pre-field row — no migration needed.

- `endAt` is now required in `EventOccurrenceRecordSchema`.
- The busy-query comment documenting the silent exclusion is deleted.
- Test fixtures that built occurrences without `endAt` gain one.

## Test plan
- `bun test:sync` 820 tests, 0 fail ✓; type-check ✓; biome ✓
- Prod + staging counts verified zero before merge (the only risk of a required field is a doc that lacks it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)