### PR TITLE
fix(sync): resolve all-day recurring instances by date, not datetime

### DIFF
--- a/packages/sync/src/domain/provider-command.service.db.test.ts
+++ b/packages/sync/src/domain/provider-command.service.db.test.ts
@@ -2063,7 +2063,15 @@ describe("provider-linked recurring scopes (this / thisAndFollowing)", () => {
     content: content(title),
     schedule: instanceSchedule,
     busy: true,
-    recurrence: { kind: "single" },
+    // Matches what the real normalizer reports for an event resolved off a
+    // series via fetchInstanceAt — NOT "single". A prior version of this
+    // fixture used "single", which papered over a bug where the replay
+    // short-circuit could never match a real instance read.
+    recurrence: {
+      kind: "instance",
+      seriesProviderId: "g-series-1",
+      recurrenceId: SECOND_START,
+    },
   });
   const providerSeries = (
     title: string,
@@ -2271,9 +2279,13 @@ describe("provider-linked recurring scopes (this / thisAndFollowing)", () => {
       expect(writer.fetchInstanceCalls[0]).toMatchObject({
         seriesProviderEventId: "g-series-1",
         originalStartAt: SECOND_START,
+        scheduleKind: "timed",
       });
       // Patched the INSTANCE's own resolved id, never the master's.
       expect(writer.patchCalls[0]?.providerEventId).toBe("g-inst-1");
+      // "instance", not "single" — Google rejects a recurrence key at all on
+      // an event resolved off a series via fetchInstanceAt.
+      expect(writer.patchCalls[0]?.recurrence).toEqual({ kind: "instance" });
 
       const exceptions = await events.findSeriesExceptions(
         tenantId,

--- a/packages/sync/src/domain/provider-command.service.ts
+++ b/packages/sync/src/domain/provider-command.service.ts
@@ -728,6 +728,7 @@ export async function executeProviderOccurrenceUpdate(
       calendarId: calendar.providerCalendarId,
       seriesProviderEventId,
       originalStartAt: recurrenceId,
+      scheduleKind: master.schedule.kind,
     });
     instance = read?.kind === "event" ? read : null;
   } catch (error) {
@@ -751,10 +752,14 @@ export async function executeProviderOccurrenceUpdate(
     providerEventId,
   };
 
-  // An occurrence override is always a standalone provider event, never
-  // itself carrying recurrence rules.
+  // An occurrence override is always a standalone provider event, resolved
+  // off the series by fetchInstanceAt — "instance", not "single": Google
+  // rejects a `recurrence` key at all on that kind of event (see
+  // ProviderWriteRecurrence).
   if (
-    matchesIntendedEdit(instance, content, input.schedule, { kind: "single" })
+    matchesIntendedEdit(instance, content, input.schedule, {
+      kind: "instance",
+    })
   ) {
     return commitProviderOccurrenceUpdate(
       deps,
@@ -775,7 +780,7 @@ export async function executeProviderOccurrenceUpdate(
       expectedVersion: command.expectedVersion,
       content,
       schedule: input.schedule,
-      recurrence: { kind: "single" },
+      recurrence: { kind: "instance" },
       invitation: input.invitation,
     });
   } catch (error) {
@@ -900,6 +905,7 @@ export async function executeProviderOccurrenceDelete(
       calendarId: calendar.providerCalendarId,
       seriesProviderEventId,
       originalStartAt: recurrenceId,
+      scheduleKind: master.schedule.kind,
     });
     instance = read?.kind === "event" ? read : null;
   } catch (error) {
@@ -1403,7 +1409,9 @@ function recurrenceMatches(
   current: ProviderEvent["recurrence"],
   intended: ProviderWriteRecurrence,
 ): boolean {
-  if (intended.kind === "single") return current.kind === "single";
+  // "single" and "instance" both address a non-recurring event; only "series"
+  // carries rules to compare, so anything else is a bare kind match.
+  if (intended.kind !== "series") return current.kind === intended.kind;
   if (current.kind !== "seriesMaster") return false;
   if (current.rules.length !== intended.rules.length) return false;
   const currentCanonical = current.rules.map(canonicalRule).sort();

--- a/packages/sync/src/providers/google/google-event-writer.adapter.test.ts
+++ b/packages/sync/src/providers/google/google-event-writer.adapter.test.ts
@@ -403,6 +403,18 @@ describe("GoogleEventWriter", () => {
     expect(api.calls.patch[0].requestBody.recurrence).toBeNull();
   });
 
+  it("omits the recurrence key entirely when patching a resolved instance", async () => {
+    // Google rejects a `recurrence` key on an event resolved off a series via
+    // fetchInstanceAt — unlike a single edit, this must OMIT the key, not
+    // clear it with null.
+    const api = new FakeEventsApi();
+    const { writer } = writerWith(api);
+
+    await writer.patchEvent({ ...basePatch, recurrence: { kind: "instance" } });
+
+    expect(api.calls.patch[0].requestBody).not.toHaveProperty("recurrence");
+  });
+
   it("nulls the unused schedule keys so Google never sees both a date and a dateTime", async () => {
     const api = new FakeEventsApi();
     const { writer } = writerWith(api);
@@ -492,6 +504,7 @@ describe("GoogleEventWriter", () => {
       calendarId: "cal",
       seriesProviderEventId: "series-1",
       originalStartAt: "2025-01-15T09:00:00-05:00",
+      scheduleKind: "timed",
     });
 
     expect(api.calls.instances[0]).toMatchObject({
@@ -501,6 +514,45 @@ describe("GoogleEventWriter", () => {
     });
     expect(read?.kind).toBe("event");
     expect(read?.providerEventId).toBe("series-1_instance");
+  });
+
+  it("truncates an all-day instance's originalStart to a bare date, matching how Google reports it", async () => {
+    const api = new FakeEventsApi({
+      instances: {
+        kind: "calendar#events",
+        items: [
+          {
+            kind: "calendar#event",
+            id: "series-1_instance",
+            etag: '"v1"',
+            status: "confirmed",
+            summary: "T",
+            recurringEventId: "series-1",
+            originalStartTime: { date: "2026-08-08" },
+            start: { date: "2026-08-08" },
+            end: { date: "2026-08-09" },
+          },
+        ],
+      },
+    });
+    const { writer } = writerWith(api);
+
+    await writer.fetchInstanceAt({
+      accessToken: "at",
+      calendarId: "cal",
+      seriesProviderEventId: "series-1",
+      // Compass mints every recurrenceId as a full ISO datetime, all-day
+      // instants included (UTC midnight) — the adapter must still send the
+      // date-only form Google's originalStartTime.date reports.
+      originalStartAt: "2026-08-08T00:00:00.000Z",
+      scheduleKind: "allDay",
+    });
+
+    expect(api.calls.instances[0]).toMatchObject({
+      calendarId: "cal",
+      eventId: "series-1",
+      originalStart: "2026-08-08",
+    });
   });
 
   it("returns null when no instance exists at that instant", async () => {
@@ -514,6 +566,7 @@ describe("GoogleEventWriter", () => {
       calendarId: "cal",
       seriesProviderEventId: "series-1",
       originalStartAt: "2025-01-15T09:00:00-05:00",
+      scheduleKind: "timed",
     });
 
     expect(read).toBeNull();
@@ -528,6 +581,7 @@ describe("GoogleEventWriter", () => {
       calendarId: "cal",
       seriesProviderEventId: "gone",
       originalStartAt: "2025-01-15T09:00:00-05:00",
+      scheduleKind: "timed",
     });
 
     expect(read).toBeNull();
@@ -556,6 +610,7 @@ describe("GoogleEventWriter", () => {
       calendarId: "cal",
       seriesProviderEventId: "series-1",
       originalStartAt: "2025-01-15T09:00:00-05:00",
+      scheduleKind: "timed",
     });
 
     expect(read?.kind).toBe("cancellation");

--- a/packages/sync/src/providers/google/google-event-writer.adapter.ts
+++ b/packages/sync/src/providers/google/google-event-writer.adapter.ts
@@ -7,6 +7,7 @@ import {
   type gSchema$Events,
 } from "@core/types/gcal";
 import { type SyncEventContent } from "@core/types/sync/event.contracts";
+import dayjs from "@core/util/date/dayjs";
 import { googleColorIdFields } from "@sync/providers/google/google-color.map";
 import { normalizeGoogleEvent } from "@sync/providers/google/google-event.normalizer";
 import { GOOGLE_REQUEST_TIMEOUT_MS } from "@sync/providers/google/google-http.constants";
@@ -218,7 +219,10 @@ export class GoogleEventWriter implements ProviderEventWriter {
       const page = await api.instances({
         calendarId: input.calendarId,
         eventId: input.seriesProviderEventId,
-        originalStart: input.originalStartAt,
+        originalStart: toOriginalStartFilter(
+          input.originalStartAt,
+          input.scheduleKind,
+        ),
       });
       const item = page.items?.[0];
       // No instance at that instant: never materialized (a rule that never
@@ -274,8 +278,21 @@ function toGoogleBody(
     location: content.location,
     ...googleColorIdFields(content.color),
     ...scheduleFields(schedule),
-    recurrence: recurrence.kind === "series" ? [...recurrence.rules] : null,
+    ...recurrenceField(recurrence),
   };
+}
+
+// "series" writes rules; "single" clears them with an explicit null (patch
+// merges by key, so an omitted key would leave a prior series' rules on a
+// converted event); "instance" omits the key — Google rejects a `recurrence`
+// key at all on an event resolved off a series via fetchInstanceAt.
+function recurrenceField(
+  recurrence: ProviderWriteRecurrence,
+): Partial<Pick<calendar_v3.Schema$Event, "recurrence">> {
+  if (recurrence.kind === "series")
+    return { recurrence: [...recurrence.rules] };
+  if (recurrence.kind === "single") return { recurrence: null };
+  return {};
 }
 
 function scheduleFields(
@@ -295,6 +312,23 @@ function scheduleFields(
     start: { date: schedule.start, dateTime: null, timeZone: null },
     end: { date: schedule.end, dateTime: null, timeZone: null },
   };
+}
+
+// Google reports an all-day instance's original start as a bare date
+// (`originalStartTime: { date: "2026-08-08" }`), never a dateTime — so the
+// `originalStart` filter on events.instances must be sent in that same date
+// form, or it matches nothing and the occurrence resolves to null. Compass's
+// recurrenceId is always a full ISO datetime (`2026-08-08T00:00:00.000Z` for
+// an all-day instant), so an all-day lookup truncates to its date component;
+// a timed lookup is sent through unchanged.
+function toOriginalStartFilter(
+  originalStartAt: string,
+  scheduleKind: "timed" | "allDay",
+): string {
+  if (scheduleKind === "timed") return originalStartAt;
+  return dayjs
+    .utc(originalStartAt)
+    .format(dayjs.DateFormat.YEAR_MONTH_DAY_FORMAT);
 }
 
 // Google's sendUpdates values are exactly the neutral invitation intents.

--- a/packages/sync/src/providers/provider-event-writer.port.ts
+++ b/packages/sync/src/providers/provider-event-writer.port.ts
@@ -7,11 +7,21 @@ import { type ProviderEventRead } from "@sync/providers/provider-event.port";
 // Whether the provider should notify attendees of a mutation.
 export type InvitationIntent = "all" | "externalOnly" | "none";
 
-// Recurrence to write: a standalone or single occurrence, or a series carrying
-// its rules. "this and following" is not a primitive — the caller composes it
-// from a series truncation plus a new create — so it is deliberately absent.
+// Recurrence to write: a standalone single event, one materialized occurrence
+// override, or a series carrying its rules. "this and following" is not a
+// primitive — the caller composes it from a series truncation plus a new
+// create — so it is deliberately absent.
+//
+// "single" and "instance" both address a non-recurring provider event, but
+// only "single" may clear an existing series (writing an explicit null
+// `recurrence` key, which converts a series master to a standalone event).
+// An "instance" addresses an occurrence Google already resolved off a series
+// master (fetchInstanceAt); Google rejects a `recurrence` key on that kind of
+// event at all, so the adapter must omit the key entirely rather than send
+// null.
 export type ProviderWriteRecurrence =
   | { readonly kind: "single" }
+  | { readonly kind: "instance" }
   | { readonly kind: "series"; readonly rules: readonly string[] };
 
 interface ProviderWriteBody {
@@ -62,8 +72,15 @@ export interface ProviderInstanceFetchInput {
   // The instance's original scheduled start (its recurrence identity) — the
   // same instant a this/thisAndFollowing scope's recurrenceId names. An
   // instance that was itself rescheduled keeps this original identity, so it
-  // still resolves correctly even after being moved.
+  // still resolves correctly even after being moved. Always full ISO datetime
+  // form (Compass mints every recurrenceId via Date#toISOString(), timed or
+  // all-day alike) — the adapter reshapes it to match how the provider itself
+  // reports that instant, per `scheduleKind`.
   readonly originalStartAt: string;
+  // The series master's schedule kind. Google reports an all-day instance's
+  // original start as a bare date, not a dateTime — the adapter needs this to
+  // send a matching lookup key, or the instance resolves to nothing.
+  readonly scheduleKind: "timed" | "allDay";
 }
 
 export interface ProviderWriteResult {


### PR DESCRIPTION
## Summary

Right-click → change color on an occurrence of an all-day recurring
event (e.g. "Rest (Sabbath)") failed in production with:

```json
{"code":"PROVIDER_FAILURE","message":"Sync command failed (permanentProviderError)","retryable":true}
```

Root cause: a scope-"this" edit first resolves the occurrence's own
Google event id via `events.instances` filtered by `originalStart`.
Compass always mints a recurrence id as a full ISO datetime
(`2026-08-08T00:00:00.000Z` for an all-day instant), but Google
reports an all-day instance's `originalStartTime` as a bare date
(`2026-08-08`). The lookup matched nothing, and "no live instance" was
classified as `permanentProviderError` — this broke every scope-"this"
mutation (color, title, delete-one) on all-day recurring events synced
to Google, in production.

Two more bugs sat on the same code path, fixed alongside since they'd
surface immediately once the lookup was fixed:
- The instance patch sent an explicit `recurrence: null`, which Google
  rejects on an event resolved via `fetchInstanceAt` (only a master
  conversion may clear that key).
- The replay short-circuit (skip re-patching an edit that already
  landed) compared the resolved instance's recurrence against
  `{kind: "single"}`, but a real Google-resolved instance always
  normalizes to `{kind: "instance"}` — so it could never match, and a
  landed edit always re-attempted the write.

Fix: a new `{kind: "instance"}` `ProviderWriteRecurrence` variant so
the adapter omits the `recurrence` key entirely (vs. `single`, which
nulls it), and a `scheduleKind` on the instance-lookup input so the
Google adapter sends a date-form filter for all-day series.

## Simplicity

Ran `/simplify` across the diff (4 parallel review angles — reuse,
simplification, efficiency, altitude). Fixed: the all-day date
truncation now reuses the codebase's existing `dayjs.utc(...).format(YEAR_MONTH_DAY_FORMAT)`
pattern (matching `google-event.normalizer.ts`) instead of a hand-rolled
string slice; collapsed two near-identical `recurrenceMatches` branches
(`"single"`/`"instance"`) into one bare-kind comparison; tightened the
new `recurrenceField` helper's return type. Efficiency and altitude
reviews found nothing to change — the new `scheduleKind`/`instance`
plumbing sits at the right layer (the port), matching real,
distinct Google API constraints rather than special-casing shared code.

## Automated validation

No UI changed — this is a sync-engine provider-write fix, and full
end-to-end validation needs a live Google Calendar OAuth connection
this environment doesn't have. Validated instead with:
- `bun run type-check` — clean.
- Full `packages/sync` test suite — 819 pass, 0 fail, including new
  regression tests for the all-day instance lookup and the
  recurrence-key omission.

## Independent review

A fresh diff-first review (no access to this branch's implementation
notes) checked: all-day date-truncation correctness against how
Compass mints recurrence ids (client and server), that `{kind:
"instance"}` is used only where it should be, replay-match
false-positive/negative risk, the delete path's parallel `fetchInstanceAt`
call, exhaustiveness of every `ProviderWriteRecurrence` consumer, and
whether the new test is meaningfully non-circular. No confirmed
findings.

## Test plan

- `bun run type-check`
- `bun run test:sync -- packages/sync/src/providers/google/google-event-writer.adapter.test.ts`
- `bun run test:sync -- packages/sync/src/domain/provider-command.service.db.test.ts`
- `bun run test:sync` (full package: 819 pass, 0 fail)
- `./node_modules/.bin/biome check` on all changed files