### PR TITLE
chore(claude): guard against committing to a stale/reused main worktree

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -54,5 +54,33 @@
       "Edit(**/.env.*)"
     ],
     "ask": []
+  },
+  "worktree": {
+    "baseRef": "fresh"
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "{ git fetch origin main -q 2>/dev/null; branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null); if [ \"$branch\" = \"main\" ] || [ \"$branch\" = \"master\" ]; then jq -n --arg b \"$branch\" '{systemMessage:(\"⚠️ This worktree is checked out on \" + $b + \", not a feature branch — do not commit here. Run: git fetch origin \" + $b + \" -q && git checkout -b <name> origin/\" + $b + \" before making any commits.\")}'; else behind=$(git rev-list --count \"HEAD..origin/main\" 2>/dev/null); if [ -n \"$behind\" ] && [ \"$behind\" -gt 0 ] 2>/dev/null; then jq -n --arg b \"$branch\" --arg n \"$behind\" '{systemMessage:(\"Branch \" + $b + \" is \" + $n + \" commit(s) behind origin/main.\")}'; fi; fi; } 2>/dev/null || true",
+            "timeout": 15
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.command // empty' | { read -r cmd; case \"$cmd\" in *\"git commit\"*) branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null); if [ \"$branch\" = \"main\" ] || [ \"$branch\" = \"master\" ]; then jq -n --arg b \"$branch\" '{hookSpecificOutput:{hookEventName:\"PreToolUse\",permissionDecision:\"deny\",permissionDecisionReason:(\"Refusing git commit on branch \" + $b + \" — this worktree may be stale or reused, not necessarily the branch you think you are on. Run: git fetch origin \" + $b + \" -q && git checkout -b <descriptive-name> origin/\" + $b + \" (carries uncommitted changes forward automatically), then commit on that branch instead.\")}}'; fi ;; esac; }",
+            "timeout": 15
+          }
+        ]
+      }
+    ]
   }
 }


### PR DESCRIPTION
## Summary
- We keep hitting stale/reused worktrees: `gh pr merge --delete-branch` leaves the checkout back on local `main`, and with how frequently `main` merges, a worktree idle for even a few minutes is already behind. Relying on remembering to check `git branch --show-current` before every commit isn't durable.
- Adds two hooks (in `.claude/settings.json`, so every session in this repo gets them):
  - **PreToolUse (Bash)**: denies any `git commit` while `HEAD` is on `main`/`master`, with the exact fetch+branch command to run instead.
  - **SessionStart**: fetches `origin/main` and reports whether the worktree is on `main`, or how many commits behind `origin/main` it is.
- Also sets `worktree.baseRef: "fresh"` explicitly (already the default) so new worktrees always branch off `origin/<default-branch>`, not local state — self-documenting rather than relying on the implicit default.

## Test plan
- [x] `jq empty` — valid JSON
- [x] `jq -e` against both hook paths — correct schema shape
- [x] Pipe-tested the PreToolUse command directly: silent on a non-commit command, silent on a commit from a feature branch, correctly emits a `permissionDecision: deny` block when simulated on `main`
- [x] Pipe-tested the SessionStart command directly: correctly reports "not a feature branch" while on `main`, and reported "1 commit behind" for a feature branch mid-session when another PR merged to `origin/main` (caught live, unprompted)
- [ ] Live end-to-end proof (actually triggering the hook via a real tool call) not possible in the session that authored it — Claude Code hooks load at session start, so a hook added mid-session needs `/hooks` or a restart to activate. Verify after merging by starting a fresh session in this repo, checking out `main` directly, and confirming `git commit --allow-empty -m test` is blocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)