### PR TITLE
refactor(web): converge Week create-shortcuts on the view command bus, dedupe minute tickers

### DIFF
--- a/packages/web/src/common/hooks/useMinuteTick.test.ts
+++ b/packages/web/src/common/hooks/useMinuteTick.test.ts
@@ -1,0 +1,73 @@
+import { renderHook } from "@testing-library/react";
+import { act } from "react";
+import { useMinuteTick } from "@web/common/hooks/useMinuteTick";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  setSystemTime,
+  spyOn,
+} from "bun:test";
+
+const TICK_INTERVAL_MS = 60_000;
+
+describe("useMinuteTick", () => {
+  let intervalCallback: (() => void) | undefined;
+  let setIntervalSpy: ReturnType<typeof spyOn>;
+  let clearIntervalSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    setSystemTime(new Date("2026-02-05T00:00:00.000Z"));
+    intervalCallback = undefined;
+    setIntervalSpy = spyOn(globalThis, "setInterval").mockImplementation(((
+      callback: TimerHandler,
+    ) => {
+      if (typeof callback === "function") {
+        intervalCallback = () => callback();
+      }
+
+      return 1 as unknown as ReturnType<typeof setInterval>;
+    }) as unknown as typeof setInterval);
+    clearIntervalSpy = spyOn(globalThis, "clearInterval").mockImplementation(
+      () => {},
+    );
+  });
+
+  afterEach(() => {
+    setSystemTime();
+    setIntervalSpy.mockRestore();
+    clearIntervalSpy.mockRestore();
+  });
+
+  it("returns the current time on mount", () => {
+    const { result } = renderHook(() => useMinuteTick());
+
+    expect(result.current.toISOString()).toBe("2026-02-05T00:00:00.000Z");
+  });
+
+  it("advances once per minute-tick without changing more often", () => {
+    const { result } = renderHook(() => useMinuteTick());
+
+    expect(setIntervalSpy).toHaveBeenCalledWith(
+      expect.any(Function),
+      TICK_INTERVAL_MS,
+    );
+
+    setSystemTime(new Date("2026-02-05T00:01:00.000Z"));
+    act(() => {
+      intervalCallback?.();
+    });
+
+    expect(result.current.toISOString()).toBe("2026-02-05T00:01:00.000Z");
+  });
+
+  it("stops ticking after unmount", () => {
+    const { unmount } = renderHook(() => useMinuteTick());
+
+    unmount();
+
+    expect(clearIntervalSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/web/src/common/hooks/useMinuteTick.ts
+++ b/packages/web/src/common/hooks/useMinuteTick.ts
@@ -1,0 +1,17 @@
+import { useEffect, useState } from "react";
+import dayjs, { type Dayjs } from "@core/util/date/dayjs";
+
+const TICK_INTERVAL_MS = 60_000;
+
+/** Re-renders every 60s with the current time. Shared by anything that
+ * needs to notice the clock moving (today rollover, now-line, up-next). */
+export function useMinuteTick(): Dayjs {
+  const [now, setNow] = useState<Dayjs>(() => dayjs());
+
+  useEffect(() => {
+    const interval = setInterval(() => setNow(dayjs()), TICK_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, []);
+
+  return now;
+}

--- a/packages/web/src/common/utils/grid/grid.util.test.ts
+++ b/packages/web/src/common/utils/grid/grid.util.test.ts
@@ -5,7 +5,32 @@ import {
   FLEX_TMRW,
   FLEX_TODAY,
 } from "@web/views/Week/layout.constants";
-import { getFlexBasis, getLineClamp, getPrevDayWidth } from "./grid.util";
+import {
+  getFlexBasis,
+  getLineClamp,
+  getMinuteHeight,
+  getPrevDayWidth,
+  getScrollToNowTop,
+} from "./grid.util";
+import { afterEach, describe, expect, it, setSystemTime, test } from "bun:test";
+
+describe("getScrollToNowTop", () => {
+  afterEach(() => {
+    setSystemTime();
+  });
+
+  it("positions the current time 150px below the viewport top", () => {
+    setSystemTime(new Date("2026-02-05T12:00:00.000Z"));
+
+    const clientHeight = 1440;
+    const minuteHeight = getMinuteHeight(clientHeight);
+    const currentMinute = 12 * 60;
+
+    expect(getScrollToNowTop(clientHeight)).toBe(
+      currentMinute * minuteHeight - 150,
+    );
+  });
+});
 
 describe("getLineClamp", () => {
   it("uses a minimum value of 1", () => {

--- a/packages/web/src/common/utils/grid/grid.util.ts
+++ b/packages/web/src/common/utils/grid/grid.util.ts
@@ -48,6 +48,13 @@ export const getCurrentPercentOfDay = () => {
   return (getCurrentMinute() / 1440) * 100;
 };
 
+// Scrolls the current time to just below the viewport top, not flush with
+// it, so the now-line isn't hidden behind the header.
+const SCROLL_TO_NOW_BUFFER_PX = 150;
+
+export const getScrollToNowTop = (clientHeight: number) =>
+  getCurrentMinute() * getMinuteHeight(clientHeight) - SCROLL_TO_NOW_BUFFER_PX;
+
 // #mainGrid/#allDayRow are <section> elements, not <div>s, so an
 // HTMLDivElement-only check made every lookup on them return null and
 // silently no-op event listeners (drag never started). Widened to accept

--- a/packages/web/src/components/Sidebar/UpNextCard/useUpNextEvent.ts
+++ b/packages/web/src/components/Sidebar/UpNextCard/useUpNextEvent.ts
@@ -1,20 +1,10 @@
-import { useCallback, useEffect, useState } from "react";
-import dayjs, { type Dayjs } from "@core/util/date/dayjs";
+import { useCallback } from "react";
+import dayjs from "@core/util/date/dayjs";
+import { useMinuteTick } from "@web/common/hooks/useMinuteTick";
 import { editGridEventDraft } from "@web/events/grid-event-draft.adapter";
 import { useDayEventViewModel } from "@web/events/queries/useDayEventsQuery";
 import { draftActions } from "@web/events/stores/draft.store";
 import { dayEventQueryRange } from "@web/views/Day/hooks/events/useDayEvents";
-
-function useMinuteTick(): Dayjs {
-  const [now, setNow] = useState(() => dayjs());
-
-  useEffect(() => {
-    const interval = setInterval(() => setNow(dayjs()), 60000);
-    return () => clearInterval(interval);
-  }, []);
-
-  return now;
-}
 
 export function useUpNextEvent() {
   const now = useMinuteTick();

--- a/packages/web/src/grid/components/TimedGrid.tsx
+++ b/packages/web/src/grid/components/TimedGrid.tsx
@@ -3,17 +3,16 @@ import {
   type MouseEventHandler,
   type ReactNode,
   type RefCallback,
-  useEffect,
   useMemo,
-  useState,
 } from "react";
-import dayjs, { type Dayjs } from "@core/util/date/dayjs";
+import { type Dayjs } from "@core/util/date/dayjs";
 import {
   DATA_TIMED_GRID_ROW,
   ID_GRID_COLUMNS_TIMED,
   ID_GRID_MAIN,
   ZIndex,
 } from "@web/common/constants/web.constants";
+import { useMinuteTick } from "@web/common/hooks/useMinuteTick";
 import { type CSSVariables } from "@web/common/styles/css.types";
 import { accentGradient } from "@web/common/styles/theme.util";
 import {
@@ -128,21 +127,9 @@ export const TimedGrid: FC<TimedGridProps> = ({
 };
 
 const CalendarTimeColumn = () => {
-  const [currentHour, setCurrentHour] = useState(() => dayjs().hour());
+  const currentHour = useMinuteTick().hour();
   const colors = useMemo(() => getColorsByHour(currentHour), [currentHour]);
   const hourLabels = useMemo(() => getHourLabels(), []);
-
-  useEffect(() => {
-    const interval = setInterval(() => {
-      const hour = dayjs().hour();
-
-      if (hour !== currentHour) {
-        setCurrentHour(hour);
-      }
-    }, 60000);
-
-    return () => clearInterval(interval);
-  }, [currentHour]);
 
   return (
     <div
@@ -173,17 +160,8 @@ const CalendarNowLine = ({
   columnCount: number;
   columnIndex: number;
 }) => {
-  const [percentOfDay, setPercentOfDay] = useState(() =>
-    getCurrentPercentOfDay(),
-  );
-
-  useEffect(() => {
-    const interval = setInterval(() => {
-      setPercentOfDay(getCurrentPercentOfDay());
-    }, 60000);
-
-    return () => clearInterval(interval);
-  }, []);
+  useMinuteTick();
+  const percentOfDay = getCurrentPercentOfDay();
 
   return (
     <div

--- a/packages/web/src/views/Day/components/Calendar/useDayCalendarScrollToNow.ts
+++ b/packages/web/src/views/Day/components/Calendar/useDayCalendarScrollToNow.ts
@@ -1,9 +1,6 @@
 import { type RefObject, useCallback, useEffect } from "react";
 import { onViewCommand } from "@web/common/utils/dom/view-command-bus";
-import {
-  getCurrentMinute,
-  getMinuteHeight,
-} from "@web/common/utils/grid/grid.util";
+import { getScrollToNowTop } from "@web/common/utils/grid/grid.util";
 
 export const useDayCalendarScrollToNow = (
   mainGridRef: RefObject<HTMLElement | null>,
@@ -12,10 +9,9 @@ export const useDayCalendarScrollToNow = (
     const timedGrid = mainGridRef.current;
     if (!timedGrid) return;
 
-    const minuteHeight = getMinuteHeight(timedGrid.clientHeight);
     timedGrid.scroll({
       behavior: "smooth",
-      top: getCurrentMinute() * minuteHeight - 150,
+      top: getScrollToNowTop(timedGrid.clientHeight),
     });
   }, [mainGridRef]);
 

--- a/packages/web/src/views/Week/hooks/grid/useScroll.ts
+++ b/packages/web/src/views/Week/hooks/grid/useScroll.ts
@@ -1,26 +1,16 @@
 import { type MutableRefObject, useCallback, useEffect } from "react";
-import {
-  getCurrentMinute,
-  getMinuteHeight,
-} from "@web/common/utils/grid/grid.util";
+import { getScrollToNowTop } from "@web/common/utils/grid/grid.util";
 
 export const useScroll = (
   timedGridRef: MutableRefObject<HTMLElement | null>,
 ) => {
   const scrollToNow = useCallback(() => {
-    const minuteHeight = getMinuteHeight(
-      timedGridRef.current?.clientHeight || 0,
-    );
+    if (!timedGridRef.current) return;
 
-    const buffer = 150;
-    const top = getCurrentMinute() * minuteHeight - buffer;
-
-    if (timedGridRef.current) {
-      timedGridRef.current.scroll({
-        top,
-        behavior: "smooth",
-      });
-    }
+    timedGridRef.current.scroll({
+      top: getScrollToNowTop(timedGridRef.current.clientHeight),
+      behavior: "smooth",
+    });
   }, [timedGridRef]);
 
   // Optional: scroll to now on mount. "t" (today) owns scroll-to-now while

--- a/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcuts.test.tsx
+++ b/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcuts.test.tsx
@@ -678,6 +678,33 @@ describe("useWeekShortcuts sidebar focus", () => {
   });
 });
 
+// D6: "C"/"A" used to call the create functions directly *and* subscribe to
+// the view command bus (two paths to the same result). They now only emit
+// on the bus, matching Day's convention - these presses exercise that path.
+describe("useWeekShortcuts create shortcuts", () => {
+  it("starts a timed createShortcut draft when C is pressed", async () => {
+    renderShortcuts();
+    pressKey("C");
+
+    await waitFor(() => {
+      const { gridDraft, status } = useDraftStore.getState();
+      expect(status?.activity).toBe("createShortcut");
+      expect(gridDraft?.values.calendarId).toBe(writableCalendar.id);
+    });
+  });
+
+  it("starts an all-day createShortcut draft when A is pressed", async () => {
+    renderShortcuts();
+    pressKey("A");
+
+    await waitFor(() => {
+      const { gridDraft, status } = useDraftStore.getState();
+      expect(status?.activity).toBe("createShortcut");
+      expect(gridDraft?.values.calendarId).toBe(writableCalendar.id);
+    });
+  });
+});
+
 // The command palette's "Create event"/"Create all-day event" rows emit
 // these same view commands (event.cmd.constants.ts) instead of calling Week
 // code directly - this is what lets one shared list serve every view.

--- a/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcuts.ts
+++ b/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcuts.ts
@@ -2,7 +2,10 @@ import { useCallback, useEffect } from "react";
 import { type Dayjs } from "@core/util/date/dayjs";
 import { useCalendarsQuery } from "@web/calendars/calendar.query";
 import { useDefaultTargetCalendar } from "@web/calendars/useDefaultTargetCalendar";
-import { onViewCommand } from "@web/common/utils/dom/view-command-bus";
+import {
+  emitViewCommand,
+  onViewCommand,
+} from "@web/common/utils/dom/view-command-bus";
 import {
   createAlldayDraft,
   createTimedDraft,
@@ -117,8 +120,18 @@ export const useWeekShortcuts = ({
     );
   }, [defaultTargetCalendarId, isCalendarsPending, isCurrentWeek, startOfView]);
 
-  // The command palette's create-event rows emit these same commands
-  // (event.cmd.constants.ts) so the "C"/"A" keys and the palette rows run
+  const emitCreateAllDayDraft = useCallback(
+    () => emitViewCommand("CREATE_ALLDAY_DRAFT"),
+    [],
+  );
+  const emitCreateTimedDraft = useCallback(
+    () => emitViewCommand("CREATE_TIMED_DRAFT"),
+    [],
+  );
+
+  // The "C"/"A" keys and the command palette's create-event rows
+  // (event.cmd.constants.ts) both just emit these commands; this effect is
+  // the one place that turns them into a draft, so every trigger runs
   // identical code. Resubscribes when the create handlers change (week in
   // view or default target calendar).
   useEffect(() => {
@@ -163,7 +176,7 @@ export const useWeekShortcuts = ({
   useAppShortcutUp("Shift+J", shiftViewBackward);
   useAppShortcutUp("Shift+K", shiftViewForward);
   useAppShortcutUp("T", toToday);
-  useAppShortcutUp("A", createAllDayDraftEvent);
-  useAppShortcutUp("C", createTimedDraftEvent);
+  useAppShortcutUp("A", emitCreateAllDayDraft);
+  useAppShortcutUp("C", emitCreateTimedDraft);
   useAppShortcutUp("U", focusFirstCalendarEvent);
 };

--- a/packages/web/src/views/Week/hooks/useToday.test.ts
+++ b/packages/web/src/views/Week/hooks/useToday.test.ts
@@ -1,0 +1,61 @@
+import { renderHook } from "@testing-library/react";
+import { act } from "react";
+import { useToday } from "@web/views/Week/hooks/useToday";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  setSystemTime,
+  spyOn,
+} from "bun:test";
+
+describe("useToday", () => {
+  let intervalCallback: (() => void) | undefined;
+  let setIntervalSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    setSystemTime(new Date("2026-02-05T23:59:00.000Z"));
+    intervalCallback = undefined;
+    setIntervalSpy = spyOn(globalThis, "setInterval").mockImplementation(((
+      callback: TimerHandler,
+    ) => {
+      if (typeof callback === "function") {
+        intervalCallback = () => callback();
+      }
+
+      return 1 as unknown as ReturnType<typeof setInterval>;
+    }) as unknown as typeof setInterval);
+    spyOn(globalThis, "clearInterval").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    setSystemTime();
+    setIntervalSpy.mockRestore();
+  });
+
+  it("keeps the same `today` reference across a tick within the same day", () => {
+    const { result } = renderHook(() => useToday());
+    const initialToday = result.current.today;
+
+    setSystemTime(new Date("2026-02-05T23:59:30.000Z"));
+    act(() => {
+      intervalCallback?.();
+    });
+
+    expect(result.current.today).toBe(initialToday);
+  });
+
+  it("swaps `today` once the day rolls over on a tick", () => {
+    const { result } = renderHook(() => useToday());
+
+    setSystemTime(new Date("2026-02-06T00:01:00.000Z"));
+    act(() => {
+      intervalCallback?.();
+    });
+
+    expect(result.current.today.isSame("2026-02-06", "day")).toBe(true);
+    expect(result.current.todayIndex).toBe(result.current.today.get("day"));
+  });
+});

--- a/packages/web/src/views/Week/hooks/useToday.ts
+++ b/packages/web/src/views/Week/hooks/useToday.ts
@@ -1,28 +1,22 @@
-import { useEffect, useState } from "react";
-import dayjs, { type Dayjs } from "@core/util/date/dayjs";
-
-const CHECK_INTERVAL_MS = 60_000;
+import { useRef } from "react";
+import { type Dayjs } from "@core/util/date/dayjs";
+import { useMinuteTick } from "@web/common/hooks/useMinuteTick";
 
 // A fresh dayjs() every render permanently invalidates every memo/comparator
 // downstream that takes `today` as a dependency (weekProps, grid layout,
 // etc.), since it never equals the previous render's instance even though
 // the calendar day hasn't changed. Keep the same reference across renders
-// within a day; only swap it (checked once a minute) when the day rolls
-// over.
+// within a day; only swap it (checked once a minute, via the shared tick)
+// when the day rolls over.
 export const useToday = () => {
-  const [today, setToday] = useState<Dayjs>(() => dayjs());
+  const tick = useMinuteTick();
+  const todayRef = useRef<Dayjs>(tick);
 
-  useEffect(() => {
-    const interval = setInterval(() => {
-      setToday((current) => {
-        const next = dayjs();
-        return current.isSame(next, "day") ? current : next;
-      });
-    }, CHECK_INTERVAL_MS);
+  if (!todayRef.current.isSame(tick, "day")) {
+    todayRef.current = tick;
+  }
 
-    return () => clearInterval(interval);
-  }, []);
-
+  const today = todayRef.current;
   const todayIndex = today.get("day");
 
   return { today, todayIndex };


### PR DESCRIPTION
## Summary
- Week's "C"/"A" keyboard shortcuts previously called the create-draft functions directly AND subscribed to the same view-command-bus commands (used by the command palette) - now they only emit on the bus, matching Day's existing convention, so every trigger (keyboard or palette) runs through one path.
- Consolidates four independent `setInterval(fn, 60000)` "minute tick" implementations (`useToday`, `useUpNextEvent`, `TimedGrid`'s `CalendarTimeColumn`/`CalendarNowLine`) into one shared `useMinuteTick()` hook.
- Extracts a shared `getScrollToNowTop(clientHeight)` helper to replace duplicated 150px-buffer scroll math in Week's and Day's scroll-to-now hooks.

Behavior-preserving refactor; no functional changes.

## Test plan
- [x] `bun run type-check` clean
- [x] Full `bun run test:web`: 1786/1786 pass
- [x] Full Playwright e2e suite: 21/21 pass
- [x] `biome check` clean on all touched files
- [x] 4-agent simplify pass (reuse/simplification/efficiency/altitude) + independent code review, findings applied where in scope
- [x] Manual browser verification: "C"/"A" create drafts via the bus on both Day and Week, now-line/time-column render correctly, no new console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)