### PR TITLE
feat(web): instrument activation funnel and fix PostHog identity/environment gaps

### DIFF
--- a/.github/docker/Dockerfile.web
+++ b/.github/docker/Dockerfile.web
@@ -8,14 +8,15 @@ ARG GOOGLE_CLIENT_ID=
 ARG POSTHOG_KEY=
 ARG POSTHOG_HOST=
 ARG COMPASS_BUILD_REF=self-host
+ARG NODE_ENV=production
 
 ENV COMPASS_BUILD_REF=${COMPASS_BUILD_REF}
-ENV NODE_ENV=production
+ENV NODE_ENV=${NODE_ENV}
 ENV WEB_PORT=9080
 
 RUN printf '%s\n' \
   'runtime:' \
-  '  nodeEnv: production' \
+  "  nodeEnv: ${NODE_ENV}" \
   '  timezone: Etc/UTC' \
   'web:' \
   '  url: http://localhost:9080' \

--- a/.github/workflows/_deploy-environment.yml
+++ b/.github/workflows/_deploy-environment.yml
@@ -59,6 +59,7 @@ jobs:
             POSTHOG_KEY=${{ (inputs.environment == 'production' || inputs.environment == 'staging-cloud') && vars.POSTHOG_KEY || '' }}
             POSTHOG_HOST=${{ (inputs.environment == 'production' || inputs.environment == 'staging-cloud') && vars.POSTHOG_HOST || '' }}
             COMPASS_BUILD_REF=${{ steps.version.outputs.image_version }}
+            NODE_ENV=${{ inputs.environment == 'production' && 'production' || 'staging' }}
           tags: switchbacktech/compass-web:${{ inputs.environment }}-${{ steps.version.outputs.image_version }}
 
       - name: Deploy release to ${{ inputs.environment }}

--- a/packages/web/src/app.bootstrap.tsx
+++ b/packages/web/src/app.bootstrap.tsx
@@ -3,6 +3,7 @@ import { createRoot } from "react-dom/client";
 import "react-toastify/dist/ReactToastify.css";
 import { sessionInit } from "@web/auth/compass/session/SessionProvider";
 import { configureGoogleRevocationApiHandler } from "@web/auth/google/util/google-revocation-api.config";
+import { track } from "@web/auth/posthog/track";
 import {
   initializeDatabaseWithErrorHandling,
   showDbInitErrorToast,
@@ -12,6 +13,16 @@ import "./index.css";
 
 export async function bootstrapApp(): Promise<void> {
   configureGoogleRevocationApiHandler();
+
+  // Read before the router mounts: validateAuthSearch strips unrecognized
+  // query params (like these) on the first navigation.
+  const connectParams = new URLSearchParams(window.location.search);
+  if (
+    connectParams.get("provider") === "google" &&
+    connectParams.get("status") === "connected"
+  ) {
+    track("calendar_connected");
+  }
 
   const container = document.getElementById("root");
   if (!container) {

--- a/packages/web/src/auth/compass/hooks/useLogout.test.ts
+++ b/packages/web/src/auth/compass/hooks/useLogout.test.ts
@@ -16,6 +16,7 @@ const clearAuthenticationState = mock();
 const setAuthenticated = mock();
 const mockUseSession = mock();
 const clearAccountScopedClientState = mock();
+const posthogReset = mock();
 let signOut = spyOn(session, "signOut");
 
 // bun's mock.module is global and leaks into every other test file in the
@@ -28,6 +29,9 @@ const actualAuthStateUtil = {
 };
 const actualLogoutTeardown = {
   ...(await import("@web/auth/compass/session/logout.teardown")),
+};
+const actualPosthogBootstrap = {
+  ...(await import("@web/auth/posthog/posthog.bootstrap")),
 };
 let isLogoutMocked = true;
 
@@ -51,6 +55,14 @@ mock.module("@web/auth/compass/session/logout.teardown", () => ({
       : actualLogoutTeardown.clearAccountScopedClientState(),
 }));
 
+mock.module("@web/auth/posthog/posthog.bootstrap", () => ({
+  ...actualPosthogBootstrap,
+  getPosthogClient: () =>
+    isLogoutMocked
+      ? { reset: posthogReset }
+      : actualPosthogBootstrap.getPosthogClient(),
+}));
+
 afterAll(() => {
   isLogoutMocked = false;
 });
@@ -62,6 +74,7 @@ describe("useLogout", () => {
     signOut = spyOn(session, "signOut").mockResolvedValue(undefined);
     clearAuthenticationState.mockClear();
     clearAccountScopedClientState.mockClear();
+    posthogReset.mockClear();
     setAuthenticated.mockClear();
     mockUseSession.mockReset();
     mockUseSession.mockReturnValue({
@@ -86,6 +99,7 @@ describe("useLogout", () => {
     expect(signOut).toHaveBeenCalledTimes(1);
     expect(clearAuthenticationState).toHaveBeenCalledTimes(1);
     expect(clearAccountScopedClientState).toHaveBeenCalledTimes(1);
+    expect(posthogReset).toHaveBeenCalledTimes(1);
     expect(setAuthenticated).toHaveBeenCalledWith(false);
   });
 

--- a/packages/web/src/auth/compass/hooks/useLogout.ts
+++ b/packages/web/src/auth/compass/hooks/useLogout.ts
@@ -3,6 +3,7 @@ import { clearAccountScopedClientState } from "@web/auth/compass/session/logout.
 import { session } from "@web/auth/compass/session/Session";
 import { useSession } from "@web/auth/compass/session/useSession";
 import { clearAuthenticationState } from "@web/auth/compass/state/auth.state.util";
+import { getPosthogClient } from "@web/auth/posthog/posthog.bootstrap";
 
 const SIGN_OUT_TIMEOUT_MS = 4000;
 
@@ -35,6 +36,11 @@ export function useLogout() {
     // failed, handleSessionMissing never ran, so this is the only place that
     // tears down the SSE stream, metadata, and source.
     clearAccountScopedClientState();
+
+    // A deliberate logout, not an expired session (that path is
+    // handleSessionMissing, which doesn't call this hook) - safe to detach
+    // the device identity so the next person on this browser starts fresh.
+    getPosthogClient()?.reset();
 
     // Signal the UI that local logout is complete.
     setAuthenticated(false);

--- a/packages/web/src/auth/posthog/posthog.bootstrap.ts
+++ b/packages/web/src/auth/posthog/posthog.bootstrap.ts
@@ -42,6 +42,11 @@ export function initPosthog(): PostHog | undefined {
     opt_in_site_apps: true,
     person_profiles: "always",
   });
+  // Staging and production share this PostHog project with the same key, so
+  // without this, staging traffic is indistinguishable from production in
+  // every insight (env.constants.ts NODE_ENV mirrors sync/backend's
+  // `environment` property for the same reason).
+  posthog.register({ environment: ENV_WEB.NODE_ENV });
 
   client = posthog;
   return client;

--- a/packages/web/src/auth/posthog/track.test.ts
+++ b/packages/web/src/auth/posthog/track.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, mock } from "bun:test";
+
+const capture = mock();
+let client: { capture: typeof capture } | undefined = { capture };
+
+mock.module("@web/auth/posthog/posthog.bootstrap", () => ({
+  getPosthogClient: () => client,
+}));
+
+const { track } = await import("./track");
+
+describe("track", () => {
+  it("forwards the event name and properties to the PostHog client", () => {
+    track("signup_started", { source: "welcome_modal" });
+
+    expect(capture).toHaveBeenCalledWith("signup_started", {
+      source: "welcome_modal",
+    });
+  });
+
+  it("no-ops when PostHog is not initialized", () => {
+    client = undefined;
+
+    expect(() => track("event_created")).not.toThrow();
+  });
+});

--- a/packages/web/src/auth/posthog/track.test.ts
+++ b/packages/web/src/auth/posthog/track.test.ts
@@ -1,11 +1,26 @@
-import { describe, expect, it, mock } from "bun:test";
+import { afterAll, describe, expect, it, mock } from "bun:test";
 
 const capture = mock();
 let client: { capture: typeof capture } | undefined = { capture };
 
+// bun's mock.module is global and leaks into every other test file in the
+// run. Spread the real module so unrelated suites still see its full
+// surface, and only override getPosthogClient while this file runs - the
+// flag flips back to the real implementation in afterAll.
+const actualPosthogBootstrap = {
+  ...(await import("@web/auth/posthog/posthog.bootstrap")),
+};
+let isClientMocked = true;
+
 mock.module("@web/auth/posthog/posthog.bootstrap", () => ({
-  getPosthogClient: () => client,
+  ...actualPosthogBootstrap,
+  getPosthogClient: () =>
+    isClientMocked ? client : actualPosthogBootstrap.getPosthogClient(),
 }));
+
+afterAll(() => {
+  isClientMocked = false;
+});
 
 const { track } = await import("./track");
 

--- a/packages/web/src/auth/posthog/track.ts
+++ b/packages/web/src/auth/posthog/track.ts
@@ -1,0 +1,21 @@
+import { getPosthogClient } from "@web/auth/posthog/posthog.bootstrap";
+
+export type ProductEvent =
+  | "welcome_modal_shown"
+  | "welcome_modal_dismissed"
+  | "signup_started"
+  | "signup_completed"
+  | "login_completed"
+  | "event_created"
+  | "calendar_connected";
+
+/**
+ * Fire-and-forget capture for the small set of product-activation events.
+ * No-ops when PostHog isn't initialized (disabled, or not yet booted).
+ */
+export function track(
+  event: ProductEvent,
+  properties?: Record<string, string>,
+): void {
+  getPosthogClient()?.capture(event, properties);
+}

--- a/packages/web/src/auth/posthog/useIdentifyUser.test.ts
+++ b/packages/web/src/auth/posthog/useIdentifyUser.test.ts
@@ -1,0 +1,30 @@
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+
+const identify = mock();
+const usePostHog = mock(() => ({ identify }));
+
+mock.module("@web/auth/posthog/posthog-react", () => ({ usePostHog }));
+
+const { useIdentifyUser } = await import("./useIdentifyUser");
+
+describe("useIdentifyUser", () => {
+  beforeEach(() => {
+    identify.mockClear();
+  });
+
+  it("identifies with userId as the distinct_id and email as a property", () => {
+    renderHook(() => useIdentifyUser("user@example.com", "user-123"));
+
+    expect(identify).toHaveBeenCalledWith("user-123", {
+      email: "user@example.com",
+      user_id: "user-123",
+    });
+  });
+
+  it("does not identify when userId or email is missing", () => {
+    renderHook(() => useIdentifyUser(null, null));
+
+    expect(identify).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/auth/posthog/useIdentifyUser.test.ts
+++ b/packages/web/src/auth/posthog/useIdentifyUser.test.ts
@@ -1,10 +1,32 @@
 import { renderHook } from "@testing-library/react";
-import { beforeEach, describe, expect, it, mock } from "bun:test";
+import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
 
 const identify = mock();
 const usePostHog = mock(() => ({ identify }));
 
-mock.module("@web/auth/posthog/posthog-react", () => ({ usePostHog }));
+// bun's mock.module is global and leaks into every other test file in the
+// run. Spread the real module so unrelated suites (e.g. anything rendering
+// PostHogProvider) still see its full surface, and only override usePostHog
+// while this file runs - the flag flips back to the real implementation in
+// afterAll.
+const actualPosthogReact = {
+  ...(await import("@web/auth/posthog/posthog-react")),
+};
+let isUsePostHogMocked = true;
+
+mock.module("@web/auth/posthog/posthog-react", () => ({
+  ...actualPosthogReact,
+  usePostHog: () => {
+    const impl = isUsePostHogMocked
+      ? usePostHog
+      : actualPosthogReact.usePostHog;
+    return impl();
+  },
+}));
+
+afterAll(() => {
+  isUsePostHogMocked = false;
+});
 
 const { useIdentifyUser } = await import("./useIdentifyUser");
 

--- a/packages/web/src/auth/posthog/useIdentifyUser.ts
+++ b/packages/web/src/auth/posthog/useIdentifyUser.ts
@@ -16,7 +16,7 @@ export function useIdentifyUser(
       posthog &&
       typeof posthog.identify === "function"
     ) {
-      posthog.identify(profileEmail, { email: profileEmail, userId });
+      posthog.identify(userId, { email: profileEmail, user_id: userId });
     }
   }, [profileEmail, posthog, userId]);
 }

--- a/packages/web/src/common/utils/event/event.util.test.ts
+++ b/packages/web/src/common/utils/event/event.util.test.ts
@@ -24,8 +24,15 @@ import {
 
 const mockCaptureException = mock();
 
+// `capture` is a no-op here (not a mock) so a `track()` call elsewhere in the
+// same test run - the module registration is process-global - doesn't crash
+// on a stubbed client shaped only for captureException.
 mock.module("@web/auth/posthog/posthog.bootstrap", () => ({
-  getPosthogClient: () => ({ captureException: mockCaptureException }),
+  getPosthogClient: () => ({
+    captureException: mockCaptureException,
+    capture: () => undefined,
+    reset: () => undefined,
+  }),
 }));
 
 const { handleError } = await import("@web/common/utils/event/event.util");

--- a/packages/web/src/common/utils/toast/anonymous-save.toast.tsx
+++ b/packages/web/src/common/utils/toast/anonymous-save.toast.tsx
@@ -1,5 +1,6 @@
 import { createElement } from "react";
 import { type Id } from "react-toastify";
+import { track } from "@web/auth/posthog/track";
 import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
 import { persistentBrowserStore } from "@web/common/storage/browser-key-value.store";
 import { showStatusToast } from "@web/common/utils/toast/status-toast.util";
@@ -47,6 +48,7 @@ async function openSignUpFromOutsideRouter(): Promise<void> {
 
 const AnonymousSaveToast = ({ toastId }: AnonymousSaveToastProps) => {
   const handleSignUp = () => {
+    track("signup_started", { source: "anon_nudge" });
     void openSignUpFromOutsideRouter();
     getToast().dismiss(toastId);
   };

--- a/packages/web/src/components/AuthModal/hooks/useAuthFormHandlers.ts
+++ b/packages/web/src/components/AuthModal/hooks/useAuthFormHandlers.ts
@@ -8,6 +8,7 @@ import {
   type ResetPasswordFormData,
   type SignUpFormData,
 } from "@web/auth/compass/schemas/auth.schemas";
+import { track } from "@web/auth/posthog/track";
 import { releaseNotesPromptActions } from "@web/components/ReleaseNotesPrompt/release-notes-prompt.store";
 import { getAuthSubmitErrorMessage } from "./useAuthFormHandlers.util";
 import { type AuthView } from "./useAuthModal";
@@ -73,6 +74,7 @@ export function useAuthFormHandlers({
             await completeAuthentication({
               email: response.user.emails[0] ?? data.email,
             });
+            track("signup_completed", { method: "email" });
             closeModal();
             releaseNotesPromptActions.scheduleOpen();
             return;
@@ -112,6 +114,7 @@ export function useAuthFormHandlers({
               email: response.user.emails[0] ?? data.email,
               onComplete: closeModal,
             });
+            track("login_completed", { method: "email" });
             return;
           case "WRONG_CREDENTIALS_ERROR":
             setSubmitError("Incorrect email or password.");

--- a/packages/web/src/components/CommandPalette/hooks/useAuthCmdItems.ts
+++ b/packages/web/src/components/CommandPalette/hooks/useAuthCmdItems.ts
@@ -1,5 +1,6 @@
 import { SignInIcon, UserPlusIcon } from "@phosphor-icons/react";
 import { useSession } from "@web/auth/compass/session/useSession";
+import { track } from "@web/auth/posthog/track";
 import { useAuthModal } from "@web/components/AuthModal/hooks/useAuthModal";
 import { type CommandItem } from "@web/components/CommandPalette/command-palette.types";
 
@@ -21,7 +22,10 @@ export const useAuthCmdItems = (): CommandItem[] => {
       label: "Sign Up",
       icon: UserPlusIcon,
       keywords: ["register", "create account"],
-      onClick: () => openModal("signUp"),
+      onClick: () => {
+        track("signup_started", { source: "command_palette" });
+        openModal("signUp");
+      },
     },
     {
       id: "log-in",

--- a/packages/web/src/components/ErrorBoundary/ErrorBoundary.test.tsx
+++ b/packages/web/src/components/ErrorBoundary/ErrorBoundary.test.tsx
@@ -16,8 +16,15 @@ const mockReload = mock();
 
 // The boundary reports through the PostHog singleton (no hook), so stub the
 // bootstrap accessor to observe the report without initializing PostHog.
+// `capture` is a no-op here (not a mock) so a `track()` call elsewhere in the
+// same test run - the module registration is process-global - doesn't crash
+// on a stubbed client shaped only for captureException.
 mock.module("@web/auth/posthog/posthog.bootstrap", () => ({
-  getPosthogClient: () => ({ captureException: mockCaptureException }),
+  getPosthogClient: () => ({
+    captureException: mockCaptureException,
+    capture: () => undefined,
+    reset: () => undefined,
+  }),
 }));
 
 mock.module("@web/common/utils/browser/browser-navigation.util", () => ({

--- a/packages/web/src/components/Sidebar/CalendarList/AnonymousCalendarRow.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/AnonymousCalendarRow.tsx
@@ -5,6 +5,7 @@ import {
   shouldShowAnonymousCalendarChangeSignUpPrompt,
   subscribeToAuthState,
 } from "@web/auth/compass/state/auth.state.util";
+import { track } from "@web/auth/posthog/track";
 import { useAuthModal } from "@web/components/AuthModal/hooks/useAuthModal";
 import {
   Tooltip,
@@ -31,6 +32,7 @@ export const AnonymousCalendarRow: FC<AnonymousCalendarRowProps> = ({
     shouldShowAnonymousCalendarChangeSignUpPrompt,
   );
   const handleOpenSignUp = useCallback(() => {
+    track("signup_started", { source: "anon_nudge" });
     openModal("signUp");
   }, [openModal]);
 

--- a/packages/web/src/components/WelcomeModal/WelcomeModal.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeModal.tsx
@@ -12,6 +12,7 @@ import {
   useState,
 } from "react";
 import { SessionContext } from "@web/auth/compass/session/session.context";
+import { track } from "@web/auth/posthog/track";
 import { SOCIAL_LINKS } from "@web/common/constants/social.constants";
 import { Z_INDEX_MODAL } from "@web/common/constants/web.constants";
 import { useAuthModal } from "@web/components/AuthModal/hooks/useAuthModal";
@@ -42,9 +43,14 @@ export function WelcomeModal() {
   const visible = isOpen && !isAuthModalOpen && !authenticated;
   useAppLockReason("welcomeModal", visible);
 
+  const shownRef = useRef(false);
   useEffect(() => {
     if (visible) {
       backdropRef.current?.focus();
+      if (!shownRef.current) {
+        shownRef.current = true;
+        track("welcome_modal_shown");
+      }
     }
   }, [visible]);
 
@@ -52,10 +58,11 @@ export function WelcomeModal() {
 
   // Fade the backdrop and gently scale the panel before unmounting, so the
   // first reveal of the sidebar underneath feels smooth rather than abrupt.
-  const dismiss = () => {
+  const dismiss = (cta: "start_now" | "dismissed" = "dismissed") => {
     if (closing) return;
     markWelcomeSeen();
     maybeShowCmdPaletteHint();
+    track("welcome_modal_dismissed", { cta });
     setClosing(true);
     const reduceMotion =
       window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
@@ -65,12 +72,15 @@ export function WelcomeModal() {
   const handleLogIn = () => {
     markWelcomeSeen();
     maybeShowCmdPaletteHint();
+    track("welcome_modal_dismissed", { cta: "log_in" });
     openModal("login");
   };
 
   const handleSignUp = () => {
     markWelcomeSeen();
     maybeShowCmdPaletteHint();
+    track("welcome_modal_dismissed", { cta: "sign_up" });
+    track("signup_started", { source: "welcome_modal" });
     openModal("signUp");
   };
 
@@ -143,7 +153,7 @@ export function WelcomeModal() {
         <div className="flex justify-center">
           <button
             type="button"
-            onClick={dismiss}
+            onClick={() => dismiss("start_now")}
             className="c-button c-button-primary c-button-elevated rounded-full px-10"
           >
             Start Now

--- a/packages/web/src/events/mutations/useEventMutations.test.tsx
+++ b/packages/web/src/events/mutations/useEventMutations.test.tsx
@@ -1,13 +1,22 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { renderHook, waitFor } from "@testing-library/react";
 import { act, type PropsWithChildren } from "react";
-import { DateOnlySchema, type EventId } from "@core/types/domain-primitives";
+import {
+  DateOnlySchema,
+  DateTimeSchema,
+  type EventId,
+} from "@core/types/domain-primitives";
 import { type Event } from "@core/types/event.contracts";
 import {
   type CreateEventInput,
   type ReplaceEventInput,
 } from "@core/types/event-command.contracts";
 import { createTestToastPort } from "@web/__tests__/helpers/web-test-seams";
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+const track = mock();
+mock.module("@web/auth/posthog/track", () => ({ track }));
+
 import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
 import { EVENT_DELETED_TOAST_ID } from "@web/common/constants/toast.constants";
 import { RECURRENCE_SCOPE_TOAST_ID } from "@web/common/utils/toast/recurrence-scope.toast";
@@ -165,6 +174,7 @@ const replacePayload = (
 describe("useEventMutations", () => {
   afterEach(() => {
     recurrenceScopeOpportunityActions.reset();
+    track.mockClear();
   });
 
   test("promotes a deleted occurrence even after the narrow optimistic delete removes it from cache", async () => {
@@ -383,13 +393,13 @@ describe("useEventMutations", () => {
         )!;
       expect(week.entities[first.id].schedule).toEqual({
         kind: "allDay",
-        start: "2026-07-02",
-        end: "2026-07-03",
+        start: DateOnlySchema.parse("2026-07-02"),
+        end: DateOnlySchema.parse("2026-07-03"),
       });
       expect(week.entities[second.id].schedule).toEqual({
         kind: "allDay",
-        start: "2026-07-03",
-        end: "2026-07-04",
+        start: DateOnlySchema.parse("2026-07-03"),
+        end: DateOnlySchema.parse("2026-07-04"),
       });
     });
 
@@ -430,9 +440,15 @@ describe("useEventMutations", () => {
         const schedule = cached.entities[id].schedule;
         return schedule.kind === "timed" ? schedule.start : null;
       };
-      expect(scheduleOf(instances[0].id)).toBe("2026-07-01T16:00:00.000Z");
-      expect(scheduleOf(instances[1].id)).toBe("2026-07-02T18:00:00+00:00");
-      expect(scheduleOf(instances[2].id)).toBe("2026-07-03T18:00:00+00:00");
+      expect(scheduleOf(instances[0].id)).toBe(
+        DateTimeSchema.parse("2026-07-01T16:00:00.000Z"),
+      );
+      expect(scheduleOf(instances[1].id)).toBe(
+        DateTimeSchema.parse("2026-07-02T18:00:00+00:00"),
+      );
+      expect(scheduleOf(instances[2].id)).toBe(
+        DateTimeSchema.parse("2026-07-03T18:00:00+00:00"),
+      );
     });
 
     context.pending.resolve();
@@ -1537,6 +1553,61 @@ describe("undo history recording", () => {
     });
 
     expect(useUndoHistoryStore.getState().past).toHaveLength(0);
+    context.pending.resolve();
+  });
+
+  test("tracks event_created for a genuine create", () => {
+    track.mockClear();
+    const context = setup();
+    context.queryClient.setQueryData(calendarKey, normalized());
+
+    act(() =>
+      context.hook.result.current.mutations.create({
+        calendarId: event().calendarId,
+        content: {
+          kind: "details",
+          title: "New",
+          description: "",
+          location: "",
+        },
+        schedule: timedSchedule(
+          "2026-07-02T16:00:00.000Z",
+          "2026-07-02T17:00:00.000Z",
+        ),
+        recurrence: { kind: "single" },
+      }),
+    );
+
+    expect(track).toHaveBeenCalledWith("event_created", {
+      event_source: "local",
+      recurrence: "single",
+    });
+    context.pending.resolve();
+  });
+
+  test("does not track event_created for an undo/redo replay create", () => {
+    track.mockClear();
+    const context = setup();
+    const original = event();
+    context.queryClient.setQueryData(calendarKey, normalized(original));
+
+    act(() =>
+      context.hook.result.current.mutations.create({
+        id: original.id,
+        calendarId: original.calendarId,
+        content: original.content as {
+          kind: "details";
+          title: string;
+          description: string;
+          location: string;
+        },
+        schedule: original.schedule as never,
+        recurrence: { kind: "single" },
+        restore: true,
+      }),
+    );
+
+    expect(track).not.toHaveBeenCalled();
     context.pending.resolve();
   });
 

--- a/packages/web/src/events/mutations/useEventMutations.test.tsx
+++ b/packages/web/src/events/mutations/useEventMutations.test.tsx
@@ -12,10 +12,26 @@ import {
   type ReplaceEventInput,
 } from "@core/types/event-command.contracts";
 import { createTestToastPort } from "@web/__tests__/helpers/web-test-seams";
-import { afterEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, afterEach, describe, expect, mock, test } from "bun:test";
 
 const track = mock();
-mock.module("@web/auth/posthog/track", () => ({ track }));
+
+// bun's mock.module is global and leaks into every other test file in the
+// run. Spread the real module so unrelated suites still see its full
+// surface, and only override track while this file runs - the flag flips
+// back to the real implementation in afterAll.
+const actualTrack = { ...(await import("@web/auth/posthog/track")) };
+let isTrackMocked = true;
+
+mock.module("@web/auth/posthog/track", () => ({
+  ...actualTrack,
+  track: (...args: Parameters<typeof actualTrack.track>) =>
+    isTrackMocked ? track(...args) : actualTrack.track(...args),
+}));
+
+afterAll(() => {
+  isTrackMocked = false;
+});
 
 import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
 import { EVENT_DELETED_TOAST_ID } from "@web/common/constants/toast.constants";

--- a/packages/web/src/events/mutations/useEventMutations.ts
+++ b/packages/web/src/events/mutations/useEventMutations.ts
@@ -12,6 +12,7 @@ import {
   type RecurrenceScope,
   type ReplaceEventInput,
 } from "@core/types/event-command.contracts";
+import { track } from "@web/auth/posthog/track";
 import { calendarQueryKeys } from "@web/calendars/calendar.query";
 import {
   buildCalendarLookup,
@@ -630,6 +631,11 @@ export function useEventMutations(
         const finalInput = { ...input, id };
         recordEventCreateHistory({
           event: optimisticEventFromCreate(finalInput),
+        });
+        track("event_created", {
+          event_source: source,
+          recurrence:
+            finalInput.recurrence.kind === "series" ? "series" : "single",
         });
         // callbacks rides along in two places: inside the variables so
         // onMutate can run onOptimisticApplied in the same task as the cache

--- a/packages/web/src/events/mutations/useEventMutations.ts
+++ b/packages/web/src/events/mutations/useEventMutations.ts
@@ -632,11 +632,15 @@ export function useEventMutations(
         recordEventCreateHistory({
           event: optimisticEventFromCreate(finalInput),
         });
-        track("event_created", {
-          event_source: source,
-          recurrence:
-            finalInput.recurrence.kind === "series" ? "series" : "single",
-        });
+        // `restore: true` marks an undo-of-delete or redo-of-create replay,
+        // not a genuine user action - only count real creates.
+        if (!finalInput.restore) {
+          track("event_created", {
+            event_source: source,
+            recurrence:
+              finalInput.recurrence.kind === "series" ? "series" : "single",
+          });
+        }
         // callbacks rides along in two places: inside the variables so
         // onMutate can run onOptimisticApplied in the same task as the cache
         // write, and as mutate options so onSuccess/onError still fire per

--- a/packages/web/src/views/GoogleAuthCallback/GoogleAuthCallback.tsx
+++ b/packages/web/src/views/GoogleAuthCallback/GoogleAuthCallback.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef } from "react";
 import { AuthApi } from "@web/api/auth.api";
 import { useCompleteAuthentication } from "@web/auth/compass/hooks/useCompleteAuthentication";
 import { completeGoogleAuthorization } from "@web/auth/google/authorization/complete-google-authorization";
+import { track } from "@web/auth/posthog/track";
 import { showErrorToast } from "@web/common/utils/toast/error-toast.util";
 import { OverlayPanel } from "@web/components/OverlayPanel/OverlayPanel";
 import { releaseNotesPromptActions } from "@web/components/ReleaseNotesPrompt/release-notes-prompt.store";
@@ -29,7 +30,10 @@ export async function completeGoogleAuthCallback({
   if (result.status === "failed") {
     showErrorToast(result.message);
   } else if (result.isNewUser) {
+    track("signup_completed", { method: "google" });
     releaseNotesPromptActions.scheduleOpen();
+  } else {
+    track("login_completed", { method: "google" });
   }
 
   navigate(result.returnPath, { replace: true });


### PR DESCRIPTION
## Summary

PostHog's dashboards assumed a landing page and "Simplify Your Day" CTA that no longer exist, and the app had zero product-analytics events beyond autocapture. This adds:

- 7 activation-funnel events (`welcome_modal_shown`/`dismissed`, `signup_started`/`completed`, `login_completed`, `event_created`, `calendar_connected`) via a thin `track()` wrapper (`packages/web/src/auth/posthog/track.ts`)
- An `environment` super property (from `NODE_ENV`, plumbed through `Dockerfile.web` and `_deploy-environment.yml`) so staging no longer pollutes production insights in the shared PostHog project
- `posthog.identify()` fixed to key on `userId` instead of email
- `posthog.reset()` on logout so shared browsers don't merge identities

PostHog-side cleanup (deleting the 8 stale insights/dashboards referencing the removed landing page/CTA, fixing the test-account filter) was done directly in PostHog and isn't part of this diff.

## Simplicity

`track()` is a ~10-line wrapper with no registry/provider — every capture call is inline at its call site. Rejected `posthog.alias()` for the identity cutover (over-engineering at current scale); rejected inventing a new `COMPASS_ENV` concept for the environment property once `NODE_ENV` (already `NodeEnv.Staging`-capable and already used by backend/sync for the same purpose) was confirmed to work end-to-end.

## Automated validation

Verified in the browser (`bun run dev:web`, anon local session, no backend):
- Welcome modal renders with all instrumented elements intact
- "Sign up" click → `?auth=signup` opens the real signup form (confirms `signup_started` + `welcome_modal_dismissed` fire without breaking navigation)
- Escape/backdrop dismiss → returns to `/week` cleanly
- "Start Now" → `markWelcomeSeen()` persists to localStorage, modal closes with no console errors beyond the expected backend-connection-refused noise (no backend running locally)

## Independent review

Two fresh review rounds against the full diff:
1. First round caught `event_created` firing on undo-of-delete/redo-of-create replays (the `CreateEventInput.restore` marker was ignored) — fixed with a guard + two regression tests, and caught no issues elsewhere (dismiss-cta wiring, calendar_connected timing, identity/logout ordering, Dockerfile ARG/ENV ordering all confirmed correct).
2. Second round (post-fix) found one low-confidence consistency nit — a new test's `mock.module` call didn't follow the spread-and-flag pattern used elsewhere in the PR — fixed for consistency. No other findings.

Along the way, running the full web test suite surfaced that two **pre-existing** test files (`ErrorBoundary.test.tsx`, `event.util.test.ts`) bare-mocked `posthog.bootstrap` with a client object missing `capture`/`reset` — harmless until this PR's `track()`/`useLogout` became the first real consumers of those methods, at which point the leaked `mock.module` registration (global for the whole test run) crashed unrelated suites later in file-scan order. Fixed both to return a complete stub shape.

## Test plan

- `bun run type-check` — clean
- `biome check` on every changed file — clean
- `cd packages/web && TZ=UTC NODE_ENV=test PORT=3006 bun test src` — 1789 pass, 3 fail (confirmed pre-existing on a clean `origin/main` checkout via a disposable worktree: `useConnectGoogle`'s `spyOn` hitting a `does not support accessor properties yet` bun limitation, unrelated to this change)
- `bun test self-host/docker-compose.test.ts` — 44 pass (confirms the `Dockerfile.web` NODE_ENV change doesn't conflict with the existing staging-deploy regression test)