### PR TITLE
fix(sync): prioritize user refresh over restart backlog

### DIFF
--- a/.github/workflows/_deploy-environment.yml
+++ b/.github/workflows/_deploy-environment.yml
@@ -196,7 +196,8 @@ jobs:
               "  internalAuthToken: \"${SYNC_INTERNAL_AUTH_TOKEN}\"" \
               "  callbackBaseUrl: \"${FRONTEND_URL}\"" \
               '  serviceUrl: "http://sync:3010"' \
-              "  enforceLeastPrivilege: ${SYNC_ENFORCE_LEAST_PRIVILEGE}"
+              "  enforceLeastPrivilege: ${SYNC_ENFORCE_LEAST_PRIVILEGE}" \
+              '  maxConcurrency: 12'
             # Optional per-environment execution/mutation-mode knobs (GitHub
             # Environment vars). Empty → schema defaults (enabled / passive).
             if [ -n "$SYNC_CLOUD_MUTATION_MODE" ]; then

--- a/packages/backend/src/common/services/sync-service/unwrap-sync-result.test.ts
+++ b/packages/backend/src/common/services/sync-service/unwrap-sync-result.test.ts
@@ -14,13 +14,21 @@ const deps = {
 
 describe("unwrapSyncResult", () => {
   it("returns the value on success", () => {
-    const result: SyncClientResult<{ enqueued: number }> = {
+    const result: SyncClientResult<{
+      enqueued: number;
+      inFlight: number;
+      resources: number;
+    }> = {
       ok: true,
-      value: { enqueued: 3 },
+      value: { enqueued: 3, inFlight: 0, resources: 3 },
       correlationId: "corr-1",
     };
 
-    expect(unwrapSyncResult(result, deps)).toEqual({ enqueued: 3 });
+    expect(unwrapSyncResult(result, deps)).toEqual({
+      enqueued: 3,
+      inFlight: 0,
+      resources: 3,
+    });
   });
 
   it("throws a 503 that hides the sync-internal error kind and status", () => {

--- a/packages/core/src/types/sync/connection.contracts.ts
+++ b/packages/core/src/types/sync/connection.contracts.ts
@@ -198,8 +198,10 @@ export type ConnectionBeginResponse = z.infer<
 //   never corrupted)
 export const ConnectionRefreshResponseSchema = z.strictObject({
   enqueued: z.number().int().nonnegative(),
-  inFlight: z.number().int().nonnegative(),
-  resources: z.number().int().nonnegative(),
+  // Defaults so a web/backend build that lands before sync still accepts the
+  // old `{ enqueued }` body instead of failing Refresh closed.
+  inFlight: z.number().int().nonnegative().default(0),
+  resources: z.number().int().nonnegative().default(0),
 });
 export type ConnectionRefreshResponse = z.infer<
   typeof ConnectionRefreshResponseSchema

--- a/packages/core/src/types/sync/connection.contracts.ts
+++ b/packages/core/src/types/sync/connection.contracts.ts
@@ -189,11 +189,17 @@ export type ConnectionBeginResponse = z.infer<
   typeof ConnectionBeginResponseSchema
 >;
 
-// User-triggered catch-up: enqueue an incremental pull for each events
-// resource owned by the signed principal. `enqueued` is how many jobs were
-// accepted (coalesced duplicates still count as one acceptance each).
+// User-triggered catch-up: enqueue (or boost) an incremental pull for each
+// events resource owned by the signed principal.
+// - `enqueued`: jobs that will actually run (created + boosted + revived failed)
+// - `inFlight`: already claimed; Refresh left the lease alone
+// - `resources`: events resources considered (may exceed enqueued+inFlight when
+//   a coalesced key races between the three writes — outcome is then mislabeled,
+//   never corrupted)
 export const ConnectionRefreshResponseSchema = z.strictObject({
   enqueued: z.number().int().nonnegative(),
+  inFlight: z.number().int().nonnegative(),
+  resources: z.number().int().nonnegative(),
 });
 export type ConnectionRefreshResponse = z.infer<
   typeof ConnectionRefreshResponseSchema

--- a/packages/sync/src/app.ts
+++ b/packages/sync/src/app.ts
@@ -303,6 +303,11 @@ const RETENTION_SWEEP_INTERVAL_MS = 60 * 60_000;
 const CALENDAR_LIST_STALE_AFTER_MS = 24 * 60 * 60_000;
 // Architecture: one sync_health_snapshot every five minutes.
 const HEALTH_SNAPSHOT_INTERVAL_MS = 5 * 60_000;
+// Cap on how long each background sweep waits before its first tick after
+// process start. Spreads the boot burst across the fleet of sweeps so they do
+// not all enqueue at t=0; it does not shrink total work. User-priority claim
+// arms are what protect Refresh clicks during the drain.
+const STARTUP_SWEEP_JITTER_MS = 60_000;
 
 function buildPostHogClient(config: SyncConfig): PostHogCaptureClient | null {
   if (!config.POSTHOG_KEY) return null;
@@ -638,6 +643,7 @@ function buildSchedulers(
           { sweep: run },
           {
             windowMs,
+            startupJitterMs: STARTUP_SWEEP_JITTER_MS,
             onError: (error) =>
               logger.error(`Sync ${name} sweep failed`, error),
           },

--- a/packages/sync/src/domain/calendar-list-rediscovery.service.ts
+++ b/packages/sync/src/domain/calendar-list-rediscovery.service.ts
@@ -1,4 +1,5 @@
 import { enqueueForResources } from "@sync/domain/resource-sweep-enqueue";
+import { JOB_PRIORITY } from "@sync/storage/contracts/job.contracts";
 import { type JobRepository } from "@sync/storage/repositories/job.repository";
 import { type SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
 
@@ -59,7 +60,7 @@ export function rediscoverStaleCalendarLists(
         resourceId: null,
         commandId: null,
         kind: "calendarListSync",
-        priority: 0,
+        priority: JOB_PRIORITY.background,
         runAfter: nowFn(),
         coalescingKey: `calendarListSync:${resource.connectionId}`,
       };

--- a/packages/sync/src/domain/calendar-list-sync.service.ts
+++ b/packages/sync/src/domain/calendar-list-sync.service.ts
@@ -4,6 +4,7 @@ import {
   type ProviderCalendarAdapter,
   ProviderCalendarError,
 } from "@sync/providers/provider-calendar.port";
+import { JOB_PRIORITY } from "@sync/storage/contracts/job.contracts";
 import { type ProviderConnectionRecord } from "@sync/storage/contracts/provider-connection.contracts";
 import { type JobRepository } from "@sync/storage/repositories/job.repository";
 import { type ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
@@ -201,7 +202,7 @@ export async function syncCalendarList(
       resourceId: eventsResource._id,
       commandId: null,
       kind: "initialImport",
-      priority: 0,
+      priority: JOB_PRIORITY.background,
       runAfter: now(),
       coalescingKey: `initialImport:${eventsResource._id}`,
     });

--- a/packages/sync/src/domain/connection-refresh.service.test.ts
+++ b/packages/sync/src/domain/connection-refresh.service.test.ts
@@ -2,12 +2,16 @@ import {
   type PrincipalId,
   type TenantId,
 } from "@core/types/sync/identity.contracts";
+import { JOB_PRIORITY } from "@sync/storage/contracts/job.contracts";
 import { refreshPrincipalCalendars } from "./connection-refresh.service";
 import { describe, expect, it, mock } from "bun:test";
 
 describe("refreshPrincipalCalendars", () => {
-  it("enqueues an incrementalPull for each events resource", async () => {
-    const enqueue = mock(async () => undefined);
+  it("enqueues an incrementalPull for each events resource at user priority", async () => {
+    const enqueueUrgent = mock(async () => ({
+      job: {},
+      outcome: "created" as const,
+    }));
     const resources = [
       {
         _id: "r1",
@@ -23,24 +27,70 @@ describe("refreshPrincipalCalendars", () => {
       },
     ];
 
-    const enqueued = await refreshPrincipalCalendars(
+    const tally = await refreshPrincipalCalendars(
       {
         resources: {
           listEventsByPrincipal: mock(async () => resources),
         } as never,
-        jobs: { enqueue } as never,
+        jobs: { enqueueUrgent } as never,
       },
       "t1" as TenantId,
       "p1" as PrincipalId,
       () => new Date("2026-07-31T12:00:00.000Z"),
     );
 
-    expect(enqueued).toBe(2);
-    expect(enqueue).toHaveBeenCalledTimes(2);
-    expect(enqueue.mock.calls[0]?.[0]).toMatchObject({
+    expect(tally).toEqual({
+      resources: 2,
+      created: 2,
+      boosted: 0,
+      requeuedFailed: 0,
+      inFlight: 0,
+    });
+    expect(enqueueUrgent).toHaveBeenCalledTimes(2);
+    expect(enqueueUrgent.mock.calls[0]?.[0]).toMatchObject({
       kind: "incrementalPull",
       resourceId: "r1",
       coalescingKey: "incrementalPull:r1",
+      priority: JOB_PRIORITY.user,
+    });
+  });
+
+  it("tallies mixed enqueueUrgent outcomes", async () => {
+    const outcomes = [
+      "created",
+      "boosted",
+      "requeuedFailed",
+      "inFlight",
+    ] as const;
+    let i = 0;
+    const enqueueUrgent = mock(async () => ({
+      job: {},
+      outcome: outcomes[i++]!,
+    }));
+    const resources = outcomes.map((id) => ({
+      _id: id,
+      tenantId: "t1" as TenantId,
+      principalId: "p1" as PrincipalId,
+      connectionId: "c1",
+    }));
+
+    const tally = await refreshPrincipalCalendars(
+      {
+        resources: {
+          listEventsByPrincipal: mock(async () => resources),
+        } as never,
+        jobs: { enqueueUrgent } as never,
+      },
+      "t1" as TenantId,
+      "p1" as PrincipalId,
+    );
+
+    expect(tally).toEqual({
+      resources: 4,
+      created: 1,
+      boosted: 1,
+      requeuedFailed: 1,
+      inFlight: 1,
     });
   });
 });

--- a/packages/sync/src/domain/connection-refresh.service.ts
+++ b/packages/sync/src/domain/connection-refresh.service.ts
@@ -2,8 +2,14 @@ import {
   type PrincipalId,
   type TenantId,
 } from "@core/types/sync/identity.contracts";
-import { type JobEnqueue } from "@sync/storage/contracts/job.contracts";
-import { type JobRepository } from "@sync/storage/repositories/job.repository";
+import {
+  JOB_PRIORITY,
+  type JobEnqueue,
+} from "@sync/storage/contracts/job.contracts";
+import {
+  type EnqueueUrgentOutcome,
+  type JobRepository,
+} from "@sync/storage/repositories/job.repository";
 import { type SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
 
 export interface ConnectionRefreshDeps {
@@ -11,10 +17,34 @@ export interface ConnectionRefreshDeps {
   jobs: JobRepository;
 }
 
+export type ConnectionRefreshTally = {
+  resources: number;
+  created: number;
+  boosted: number;
+  requeuedFailed: number;
+  inFlight: number;
+};
+
+const emptyTally = (): ConnectionRefreshTally => ({
+  resources: 0,
+  created: 0,
+  boosted: 0,
+  requeuedFailed: 0,
+  inFlight: 0,
+});
+
+function countOutcome(
+  tally: ConnectionRefreshTally,
+  outcome: EnqueueUrgentOutcome,
+): void {
+  tally[outcome === "requeuedFailed" ? "requeuedFailed" : outcome] += 1;
+}
+
 /**
- * Enqueue an incremental pull for every events resource owned by the
- * principal. Coalesces with webhook/reconcile pulls on the same key so a
- * user "Refresh" during an already-running catch-up does not double work.
+ * Enqueue (or boost) an incremental pull for every events resource owned by
+ * the principal. Uses enqueueUrgent so a repeat Refresh pulls runAfter forward
+ * and raises priority; coalesces with webhook/reconcile pulls on the same key
+ * so work already in flight is reported rather than double-started.
  * Resources without a sync cursor become `initialImport` via the pull
  * dispatch followup (`notImported`).
  */
@@ -23,14 +53,17 @@ export async function refreshPrincipalCalendars(
   tenantId: TenantId,
   principalId: PrincipalId,
   now: () => Date = () => new Date(),
-): Promise<number> {
+): Promise<ConnectionRefreshTally> {
   const resources = await deps.resources.listEventsByPrincipal(
     tenantId,
     principalId,
   );
   const runAfter = now();
-  await Promise.all(
-    resources.map((resource) => {
+  const tally = emptyTally();
+  tally.resources = resources.length;
+
+  const outcomes = await Promise.all(
+    resources.map(async (resource) => {
       const enqueue: JobEnqueue = {
         tenantId: resource.tenantId,
         principalId: resource.principalId,
@@ -38,12 +71,14 @@ export async function refreshPrincipalCalendars(
         resourceId: resource._id,
         commandId: null,
         kind: "incrementalPull",
-        priority: 0,
+        priority: JOB_PRIORITY.user,
         runAfter,
         coalescingKey: `incrementalPull:${resource._id}`,
       };
-      return deps.jobs.enqueue(enqueue);
+      const { outcome } = await deps.jobs.enqueueUrgent(enqueue);
+      return outcome;
     }),
   );
-  return resources.length;
+  for (const outcome of outcomes) countOutcome(tally, outcome);
+  return tally;
 }

--- a/packages/sync/src/domain/connection-refresh.service.ts
+++ b/packages/sync/src/domain/connection-refresh.service.ts
@@ -6,10 +6,7 @@ import {
   JOB_PRIORITY,
   type JobEnqueue,
 } from "@sync/storage/contracts/job.contracts";
-import {
-  type EnqueueUrgentOutcome,
-  type JobRepository,
-} from "@sync/storage/repositories/job.repository";
+import { type JobRepository } from "@sync/storage/repositories/job.repository";
 import { type SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
 
 export interface ConnectionRefreshDeps {
@@ -24,21 +21,6 @@ export type ConnectionRefreshTally = {
   requeuedFailed: number;
   inFlight: number;
 };
-
-const emptyTally = (): ConnectionRefreshTally => ({
-  resources: 0,
-  created: 0,
-  boosted: 0,
-  requeuedFailed: 0,
-  inFlight: 0,
-});
-
-function countOutcome(
-  tally: ConnectionRefreshTally,
-  outcome: EnqueueUrgentOutcome,
-): void {
-  tally[outcome === "requeuedFailed" ? "requeuedFailed" : outcome] += 1;
-}
 
 /**
  * Enqueue (or boost) an incremental pull for every events resource owned by
@@ -59,8 +41,13 @@ export async function refreshPrincipalCalendars(
     principalId,
   );
   const runAfter = now();
-  const tally = emptyTally();
-  tally.resources = resources.length;
+  const tally: ConnectionRefreshTally = {
+    resources: resources.length,
+    created: 0,
+    boosted: 0,
+    requeuedFailed: 0,
+    inFlight: 0,
+  };
 
   const outcomes = await Promise.all(
     resources.map(async (resource) => {
@@ -79,6 +66,8 @@ export async function refreshPrincipalCalendars(
       return outcome;
     }),
   );
-  for (const outcome of outcomes) countOutcome(tally, outcome);
+  for (const outcome of outcomes) {
+    tally[outcome] += 1;
+  }
   return tally;
 }

--- a/packages/sync/src/domain/connection-state.test.ts
+++ b/packages/sync/src/domain/connection-state.test.ts
@@ -1,4 +1,5 @@
 import {
+  BACKLOG_DELAYED_THRESHOLD_MS,
   type ConnectionStateEvidence,
   DELAYED_THRESHOLD_MS,
   deriveConnectionState,
@@ -101,11 +102,22 @@ describe("deriveConnectionState", () => {
     });
   });
 
-  it("is delayed when work is overdue by the threshold (workOverdue)", () => {
-    expect(derive({ oldestDueWorkAt: agoMs(DELAYED_THRESHOLD_MS) })).toEqual({
+  it("is delayed when work is overdue by the backlog threshold (workOverdue)", () => {
+    expect(
+      derive({ oldestDueWorkAt: agoMs(BACKLOG_DELAYED_THRESHOLD_MS) }),
+    ).toEqual({
       state: "delayed",
       reason: "workOverdue",
     });
+  });
+
+  it("stays catchingUp for plain backlog under the backlog threshold", () => {
+    expect(
+      derive({
+        catchingUp: true,
+        oldestDueWorkAt: agoMs(DELAYED_THRESHOLD_MS),
+      }),
+    ).toEqual({ state: "catchingUp", reason: null });
   });
 
   it("is delayed with providerErrors when recent provider errors caused the backlog", () => {
@@ -117,21 +129,37 @@ describe("deriveConnectionState", () => {
     ).toEqual({ state: "delayed", reason: "providerErrors" });
   });
 
-  it("stays healthy when overdue work is under the threshold", () => {
+  it("stays healthy when overdue work is under the backlog threshold", () => {
     expect(
-      derive({ oldestDueWorkAt: agoMs(DELAYED_THRESHOLD_MS - 1) }),
+      derive({ oldestDueWorkAt: agoMs(BACKLOG_DELAYED_THRESHOLD_MS - 1) }),
     ).toEqual({ state: "healthy", reason: null });
   });
 
-  it("becomes delayed exactly at the threshold boundary", () => {
+  it("becomes delayed exactly at the backlog threshold boundary", () => {
     const justUnder = derive({
-      oldestDueWorkAt: agoMs(DELAYED_THRESHOLD_MS - 1),
+      oldestDueWorkAt: agoMs(BACKLOG_DELAYED_THRESHOLD_MS - 1),
     });
     const atThreshold = derive({
-      oldestDueWorkAt: agoMs(DELAYED_THRESHOLD_MS),
+      oldestDueWorkAt: agoMs(BACKLOG_DELAYED_THRESHOLD_MS),
     });
     expect(justUnder.state).toBe("healthy");
     expect(atThreshold.state).toBe("delayed");
+  });
+
+  it("alarms at the short threshold when recent provider errors are present", () => {
+    const justUnder = derive({
+      oldestDueWorkAt: agoMs(DELAYED_THRESHOLD_MS - 1),
+      recentProviderErrors: true,
+    });
+    const atThreshold = derive({
+      oldestDueWorkAt: agoMs(DELAYED_THRESHOLD_MS),
+      recentProviderErrors: true,
+    });
+    expect(justUnder.state).toBe("healthy");
+    expect(atThreshold).toEqual({
+      state: "delayed",
+      reason: "providerErrors",
+    });
   });
 
   describe("priority ordering", () => {
@@ -182,7 +210,7 @@ describe("deriveConnectionState", () => {
       expect(
         derive({
           initialImportComplete: false,
-          oldestDueWorkAt: agoMs(DELAYED_THRESHOLD_MS + 1000),
+          oldestDueWorkAt: agoMs(BACKLOG_DELAYED_THRESHOLD_MS + 1000),
         }).state,
       ).toBe("delayed");
     });
@@ -191,7 +219,7 @@ describe("deriveConnectionState", () => {
       expect(
         derive({
           catchingUp: true,
-          oldestDueWorkAt: agoMs(DELAYED_THRESHOLD_MS + 1000),
+          oldestDueWorkAt: agoMs(BACKLOG_DELAYED_THRESHOLD_MS + 1000),
         }).state,
       ).toBe("delayed");
     });

--- a/packages/sync/src/domain/connection-state.ts
+++ b/packages/sync/src/domain/connection-state.ts
@@ -8,8 +8,14 @@ import {
 // (or any state) directly. Health is earned: valid authority, no overdue
 // required work, and a recently verified path.
 
-// Work overdue by at least this long stops a connection from looking healthy.
+// Work overdue by at least this long stops a connection from looking healthy
+// when recent provider errors are the cause — surface breakage quickly.
 export const DELAYED_THRESHOLD_MS = 2 * 60 * 1000;
+// Plain backlog (no recent provider errors) uses a longer band so a normally
+// draining restart queue reports catchingUp rather than delayed, and a user
+// Refresh click does not trip its own warning two minutes later. Matches
+// BOOTSTRAP_STALLED_AFTER_MS. See the 2026-08-07 Refresh starvation incident.
+export const BACKLOG_DELAYED_THRESHOLD_MS = 15 * 60 * 1000;
 // An active calendar still bootstrapping after this long since it last
 // advanced is delayed rather than perpetually "importing", even with no
 // retrying/overdue job to point to (a chain that keeps settling every job
@@ -104,10 +110,18 @@ export function deriveConnectionState(
   }
 
   // Do not let a failed or overdue bootstrap hide behind a perpetual
-  // "importing"/"syncing" message. The normal threshold preserves a calm
-  // progress state for active work, while terminal jobs are immediately
-  // overdue (their original runAfter is in the past).
-  if (isOverdue(evidence.oldestDueWorkAt, now)) {
+  // "importing"/"syncing" message. Provider-error backlog alarms quickly;
+  // plain backlog waits longer so a draining restart queue stays catchingUp.
+  // Terminal failed jobs are immediately overdue (runAfter is in the past).
+  if (
+    isOverdue(
+      evidence.oldestDueWorkAt,
+      now,
+      evidence.recentProviderErrors
+        ? DELAYED_THRESHOLD_MS
+        : BACKLOG_DELAYED_THRESHOLD_MS,
+    )
+  ) {
     return {
       state: "delayed",
       reason: evidence.recentProviderErrors ? "providerErrors" : "workOverdue",
@@ -132,7 +146,11 @@ export function deriveConnectionState(
   return { state: "healthy", reason: null };
 }
 
-function isOverdue(oldestDueWorkAt: Date | null, now: Date): boolean {
+function isOverdue(
+  oldestDueWorkAt: Date | null,
+  now: Date,
+  thresholdMs: number,
+): boolean {
   if (!oldestDueWorkAt) return false;
-  return now.getTime() - oldestDueWorkAt.getTime() >= DELAYED_THRESHOLD_MS;
+  return now.getTime() - oldestDueWorkAt.getTime() >= thresholdMs;
 }

--- a/packages/sync/src/domain/poll-loop.ts
+++ b/packages/sync/src/domain/poll-loop.ts
@@ -12,6 +12,10 @@ export interface PollLoopOptions {
   tick: () => Promise<boolean>;
   // How long to wait before the next tick, given whether the last one did work.
   nextDelayMs: (didWork: boolean) => number;
+  // Awaited once before the first tick. Placing the delay here (rather than
+  // in SweepScheduler.start) means stop() during the wait tears down cleanly
+  // via the existing #idle/#wake path.
+  initialDelayMs?: number;
   // A tick failure must never kill the loop; surfaced here and the loop
   // continues to the next tick.
   onError?: (error: unknown) => void;
@@ -23,6 +27,7 @@ export interface PollLoopOptions {
 export class PollLoop {
   readonly #tick: () => Promise<boolean>;
   readonly #nextDelayMs: (didWork: boolean) => number;
+  readonly #initialDelayMs: number;
   readonly #onError: (error: unknown) => void;
   readonly #onStop: (() => Promise<void>) | undefined;
 
@@ -34,6 +39,7 @@ export class PollLoop {
   constructor(options: PollLoopOptions) {
     this.#tick = options.tick;
     this.#nextDelayMs = options.nextDelayMs;
+    this.#initialDelayMs = options.initialDelayMs ?? 0;
     this.#onError = options.onError ?? (() => {});
     this.#onStop = options.onStop;
   }
@@ -65,6 +71,10 @@ export class PollLoop {
   }
 
   async #run(): Promise<void> {
+    if (this.#initialDelayMs > 0) {
+      await this.#idle(this.#initialDelayMs);
+      if (!this.#running) return;
+    }
     while (this.#running) {
       let didWork = false;
       try {

--- a/packages/sync/src/domain/resource-sweep-enqueue.ts
+++ b/packages/sync/src/domain/resource-sweep-enqueue.ts
@@ -1,4 +1,5 @@
 import {
+  JOB_PRIORITY,
   type JobEnqueue,
   type JobKind,
 } from "@sync/storage/contracts/job.contracts";
@@ -57,7 +58,7 @@ export async function enqueueForResources(
             resourceId: resource._id,
             commandId: null,
             kind,
-            priority: 0,
+            priority: JOB_PRIORITY.background,
             runAfter: now(),
             coalescingKey: `${kind}:${resource._id}`,
           };

--- a/packages/sync/src/domain/sweep-scheduler.service.test.ts
+++ b/packages/sync/src/domain/sweep-scheduler.service.test.ts
@@ -100,4 +100,43 @@ describe("SweepScheduler", () => {
     expect(errors).toHaveLength(1);
     expect(sweeper.calls.length).toBeGreaterThanOrEqual(2);
   });
+
+  it("delays the first sweep by startupJitterMs * random", async () => {
+    const sweeper = new FakeSweeper();
+    const scheduler = new SweepScheduler(
+      { sweep: sweeper.sweep },
+      {
+        intervalMs: 10_000,
+        jitterRatio: 0,
+        startupJitterMs: 40,
+        random: () => 0.5,
+        now,
+      },
+    );
+
+    const firstSweep = sweeper.nextSweep();
+    scheduler.start();
+    expect(sweeper.calls).toHaveLength(0);
+    await firstSweep;
+    await scheduler.stop();
+    expect(sweeper.calls).toHaveLength(1);
+  });
+
+  it("stop during the initial delay sweeps zero times", async () => {
+    const sweeper = new FakeSweeper();
+    const scheduler = new SweepScheduler(
+      { sweep: sweeper.sweep },
+      {
+        intervalMs: 10_000,
+        jitterRatio: 0,
+        startupJitterMs: 60_000,
+        random: () => 1,
+        now,
+      },
+    );
+
+    scheduler.start();
+    await scheduler.stop();
+    expect(sweeper.calls).toHaveLength(0);
+  });
 });

--- a/packages/sync/src/domain/sweep-scheduler.service.ts
+++ b/packages/sync/src/domain/sweep-scheduler.service.ts
@@ -23,6 +23,10 @@ export interface SweepSchedulerOptions {
   // NEGATIVE looks BACK (reconcile: resources not synced since now - 15m).
   // POSITIVE looks AHEAD (subscription: channels expiring before now + 24h).
   windowMs?: number;
+  // Cap on the first-tick delay after start. Default 0 preserves the historical
+  // "sweep immediately on start" behavior for callers and tests. Spreads a
+  // multi-sweep boot burst; it does not shrink the total work enqueued.
+  startupJitterMs?: number;
   now?: () => Date;
   // Injectable [0,1) source so a test can pin the jitter; defaults to Math.random.
   random?: () => number;
@@ -41,6 +45,7 @@ export class SweepScheduler {
     const intervalMs = options.intervalMs ?? DEFAULT_INTERVAL_MS;
     const jitterRatio = options.jitterRatio ?? DEFAULT_JITTER_RATIO;
     const windowMs = options.windowMs ?? 0;
+    const startupJitterMs = options.startupJitterMs ?? 0;
     const now = options.now ?? (() => new Date());
     const random = options.random ?? Math.random;
 
@@ -51,6 +56,8 @@ export class SweepScheduler {
     };
 
     this.#loop = new PollLoop({
+      initialDelayMs:
+        startupJitterMs > 0 ? Math.floor(random() * startupJitterMs) : 0,
       tick: async () => {
         const before = new Date(now().getTime() + windowMs);
         await deps.sweep(before);
@@ -63,14 +70,15 @@ export class SweepScheduler {
     });
   }
 
-  // Begin sweeping. Runs a sweep immediately (so a restart promptly catches
-  // anything missed while down), then on jittered intervals. Idempotent.
+  // Begin sweeping. With the default startupJitterMs of 0, runs a sweep
+  // immediately (so a restart promptly catches anything missed while down),
+  // then on jittered intervals. Idempotent.
   start(): void {
     this.#loop.start();
   }
 
-  // Stop sweeping. Waits for an in-flight sweep to finish so nothing is torn
-  // down mid-enqueue. Idempotent and safe when never started.
+  // Stop sweeping. Waits for an in-flight sweep (or initial delay) to finish
+  // so nothing is torn down mid-enqueue. Idempotent and safe when never started.
   async stop(): Promise<void> {
     await this.#loop.stop();
   }

--- a/packages/sync/src/domain/sync-job-dispatch.service.ts
+++ b/packages/sync/src/domain/sync-job-dispatch.service.ts
@@ -12,6 +12,7 @@ import {
 } from "@sync/providers/provider-event-reader.port";
 import { type ProviderNotificationAdapter } from "@sync/providers/provider-notifications.port";
 import {
+  JOB_PRIORITY,
   type JobEnqueue,
   type JobRecord,
 } from "@sync/storage/contracts/job.contracts";
@@ -373,7 +374,7 @@ function repairFollowup(
     resourceId: resource._id,
     commandId: null,
     kind: "repair",
-    priority: 0,
+    priority: JOB_PRIORITY.background,
     runAfter: now(),
     coalescingKey: `repair:${resource._id}`,
   };
@@ -390,7 +391,7 @@ function importFollowup(
     resourceId: resource._id,
     commandId: null,
     kind: "initialImport",
-    priority: 0,
+    priority: JOB_PRIORITY.background,
     runAfter: now(),
     coalescingKey: `initialImport:${resource._id}`,
   };
@@ -407,7 +408,7 @@ function bootstrapCatchupFollowup(
     resourceId: resource._id,
     commandId: null,
     kind: "bootstrapCatchup",
-    priority: 0,
+    priority: JOB_PRIORITY.background,
     runAfter: now(),
     coalescingKey: `bootstrapCatchup:${resource._id}`,
   };
@@ -445,7 +446,7 @@ function subscriptionFollowup(
     resourceId: resource._id,
     commandId: null,
     kind: "subscriptionMaintain",
-    priority: 0,
+    priority: JOB_PRIORITY.background,
     runAfter: now(),
     // The same key the expiry sweep uses, so a bootstrap watch and a renewal
     // never double up into two channels.

--- a/packages/sync/src/server/connection.routes.db.test.ts
+++ b/packages/sync/src/server/connection.routes.db.test.ts
@@ -7,6 +7,10 @@ import {
   type TenantId,
 } from "@core/types/sync/identity.contracts";
 import dayjs from "@core/util/date/dayjs";
+import {
+  ensureEventsResource,
+  seedProviderCalendar,
+} from "@sync/__tests__/helpers/fixtures";
 import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
 import { createSyncService, type SyncService } from "@sync/app";
 import { signInternalRequest } from "@sync/auth/internal-auth";
@@ -29,6 +33,7 @@ import {
   CONNECTIONS_PATH,
   EVENTS_FULL_PATH,
   OAUTH_CALLBACK_PATH,
+  REFRESH_PATH,
 } from "@sync/server/connection.routes";
 import { SYNC_COLLECTIONS } from "@sync/storage/collections";
 import {
@@ -39,7 +44,9 @@ import {
   type EventOccurrenceRecord,
   EventOccurrenceRecordSchema,
 } from "@sync/storage/contracts/event-occurrence.contracts";
+import { JOB_PRIORITY } from "@sync/storage/contracts/job.contracts";
 import { CredentialRepository } from "@sync/storage/repositories/credential.repository";
+import { JobRepository } from "@sync/storage/repositories/job.repository";
 import { ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
 import { ProviderConnectionRepository } from "@sync/storage/repositories/provider-connection.repository";
 import { SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
@@ -1470,5 +1477,125 @@ describe("GET /internal/events/full", () => {
         (i) => i.eventId === eventId && i.recurrence.kind === "series",
       ),
     ).toBe(true);
+  });
+});
+
+describe("POST /internal/connections/refresh", () => {
+  let mongo: SyncMongoService;
+  let connections: ProviderConnectionRepository;
+  let resources: SyncResourceRepository;
+  let jobs: JobRepository;
+  let service: SyncService;
+  let base: string;
+
+  const startService = async () => {
+    service = createSyncService(testConfig({ EXECUTION: "active" }), { mongo });
+    await new Promise<void>((resolve) => service.httpServer.listen(0, resolve));
+    const { port } = service.httpServer.address() as AddressInfo;
+    base = `http://127.0.0.1:${port}`;
+  };
+
+  beforeEach(() => {
+    mongo = storage.mongo();
+    connections = new ProviderConnectionRepository(mongo.db);
+    resources = new SyncResourceRepository(mongo.db);
+    jobs = new JobRepository(mongo.db);
+  });
+
+  afterEach(async () => {
+    await service?.stop();
+  });
+
+  const seedEventsResource = async (tenantId: string, principalId: string) => {
+    const connection = await seedConnection(
+      connections,
+      tenantId,
+      principalId,
+      "me@example.com",
+    );
+    const calendar = await seedProviderCalendar(
+      new ProviderCalendarRepository(mongo.db),
+      {
+        tenantId: connection.tenantId,
+        principalId: connection.principalId,
+        connectionId: connection._id,
+      },
+    );
+    const resource = await ensureEventsResource(resources, calendar);
+    return { connection, resource };
+  };
+
+  it("second POST over a pending job returns enqueued: 1 (boosted, not silent 0)", async () => {
+    const tenantId = objectId();
+    const principalId = objectId();
+    await seedEventsResource(tenantId, principalId);
+    await startService();
+
+    const first = await fetch(`${base}${REFRESH_PATH}`, {
+      method: "POST",
+      headers: signedHeaders(tenantId, principalId),
+    });
+    expect(first.status).toBe(200);
+    expect(await first.json()).toEqual({
+      enqueued: 1,
+      inFlight: 0,
+      resources: 1,
+    });
+
+    const second = await fetch(`${base}${REFRESH_PATH}`, {
+      method: "POST",
+      headers: signedHeaders(tenantId, principalId),
+    });
+    expect(second.status).toBe(200);
+    expect(await second.json()).toEqual({
+      enqueued: 1,
+      inFlight: 0,
+      resources: 1,
+    });
+
+    const pending = await mongo.db.collection("jobs").findOne({
+      kind: "incrementalPull",
+      state: "pending",
+    });
+    expect(pending?.["priority"]).toBe(JOB_PRIORITY.user);
+  });
+
+  it("returns inFlight: 1 when the job is already claimed", async () => {
+    const tenantId = objectId();
+    const principalId = objectId();
+    const { resource } = await seedEventsResource(tenantId, principalId);
+    await jobs.enqueue({
+      tenantId: resource.tenantId,
+      principalId: resource.principalId,
+      connectionId: resource.connectionId,
+      resourceId: resource._id,
+      commandId: null,
+      kind: "incrementalPull",
+      priority: JOB_PRIORITY.background,
+      runAfter: new Date(Date.now() - 1000),
+      coalescingKey: `incrementalPull:${resource._id}`,
+    });
+    const claimed = await jobs.claimDueJob("worker-1", new Date(), 60_000);
+    expect(claimed?.state).toBe("claimed");
+
+    await startService();
+    const res = await fetch(`${base}${REFRESH_PATH}`, {
+      method: "POST",
+      headers: signedHeaders(tenantId, principalId),
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      enqueued: 0,
+      inFlight: 1,
+      resources: 1,
+    });
+
+    const still = await jobs.findById(
+      resource.tenantId,
+      resource.principalId,
+      claimed!._id,
+    );
+    expect(still?.leaseOwner).toBe("worker-1");
+    expect(still?.state).toBe("claimed");
   });
 });

--- a/packages/sync/src/server/connection.routes.ts
+++ b/packages/sync/src/server/connection.routes.ts
@@ -54,6 +54,7 @@ import {
   respondInternalError,
 } from "@sync/server/internal-http";
 import { type EventOccurrenceRecord } from "@sync/storage/contracts/event-occurrence.contracts";
+import { JOB_PRIORITY } from "@sync/storage/contracts/job.contracts";
 import { type ProviderCalendarRecord } from "@sync/storage/contracts/provider-calendar.contracts";
 import { type ProviderConnectionRecord } from "@sync/storage/contracts/provider-connection.contracts";
 import { CredentialRepository } from "@sync/storage/repositories/credential.repository";
@@ -582,15 +583,26 @@ export function registerConnectionRoutes(
 
       try {
         const repos = syncRepositories(deps.mongo);
-        const enqueued = await refreshPrincipalCalendars(
+        const tally = await refreshPrincipalCalendars(
           { resources: repos.syncResources, jobs: repos.jobs },
           auth.tenantId,
           auth.principalId,
           () => new Date((deps.now ?? Date.now)()),
         );
-        res
-          .status(Status.OK)
-          .json(ConnectionRefreshResponseSchema.parse({ enqueued }));
+        const enqueued = tally.created + tally.boosted + tally.requeuedFailed;
+        logger.info(
+          `Refresh calendars for ${auth.tenantId}/${auth.principalId}: ` +
+            `resources=${tally.resources} created=${tally.created} ` +
+            `boosted=${tally.boosted} requeuedFailed=${tally.requeuedFailed} ` +
+            `inFlight=${tally.inFlight}`,
+        );
+        res.status(Status.OK).json(
+          ConnectionRefreshResponseSchema.parse({
+            enqueued,
+            inFlight: tally.inFlight,
+            resources: tally.resources,
+          }),
+        );
       } catch (error) {
         logger.error(
           `Failed to refresh calendars for ${auth.tenantId}/${auth.principalId}`,
@@ -830,7 +842,7 @@ async function linkConnection(
     resourceId: null,
     commandId: null,
     kind: "calendarListSync",
-    priority: 0,
+    priority: JOB_PRIORITY.user,
     runAfter: new Date(),
     coalescingKey: `calendarListSync:${connection._id}`,
   });

--- a/packages/sync/src/server/notification.routes.ts
+++ b/packages/sync/src/server/notification.routes.ts
@@ -7,6 +7,7 @@ import { verifyNotification } from "@sync/notifications/notification-verificatio
 import { GoogleNotificationAdapter } from "@sync/providers/google/google-notifications.adapter";
 import { type NotificationSubscription } from "@sync/providers/provider-notifications.port";
 import { redactedCause } from "@sync/safety/redact-error";
+import { JOB_PRIORITY } from "@sync/storage/contracts/job.contracts";
 import { type SyncResourceRecord } from "@sync/storage/contracts/sync-resource.contracts";
 import { JobRepository } from "@sync/storage/repositories/job.repository";
 import { SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
@@ -83,7 +84,10 @@ export function registerNotificationRoutes(
           resourceId: resource._id,
           commandId: null,
           kind: "incrementalPull",
-          priority: 0,
+          // Background on purpose: webhooks are provider-paced. Promoting them
+          // to user priority would make the entire steady state urgent and
+          // defeat the tier that protects Refresh / post-OAuth work.
+          priority: JOB_PRIORITY.background,
           runAfter: now,
           coalescingKey: `incrementalPull:${resource._id}`,
         });

--- a/packages/sync/src/storage/contracts/job.contracts.ts
+++ b/packages/sync/src/storage/contracts/job.contracts.ts
@@ -29,6 +29,15 @@ export type JobState = z.infer<typeof JobStateSchema>;
 export const JobFailureClassSchema = z.literal("retryableTransient");
 export type JobFailureClass = z.infer<typeof JobFailureClassSchema>;
 
+// Claim order is arm order in claimDueJob, not a Mongo sort on this field.
+// Keep this to two rungs — each additional rung needs its own claim arm.
+// See the 2026-08-07 restart-burst / Refresh starvation incident.
+export const JOB_PRIORITY = {
+  background: 0,
+  user: 10,
+} as const;
+export type JobPriority = (typeof JOB_PRIORITY)[keyof typeof JOB_PRIORITY];
+
 // Persistence record for `jobs` — a small internal work item pointing at a
 // connection and (optionally) a resource or command. A unique coalescing key
 // collapses a storm of equivalent notifications into one job. Jobs hold no
@@ -42,6 +51,10 @@ export const JobRecordSchema = z.strictObject({
   resourceId: z.string().trim().min(1).nullable(),
   commandId: SyncCommandIdSchema.nullable(),
   kind: JobKindSchema,
+  // Two-rung ladder only. Adding a third rung costs another claim arm in
+  // claimDueJob (priority is a filter, not a sort key — see job.repository.ts).
+  // Introduced after the 2026-08-07 restart burst left user Refresh clicks
+  // queued behind ~440 background jobs for 15+ minutes.
   priority: z.number().int(),
   state: JobStateSchema,
   runAfter: z.date(),

--- a/packages/sync/src/storage/index-manifest.ts
+++ b/packages/sync/src/storage/index-manifest.ts
@@ -220,12 +220,15 @@ export const SYNC_INDEX_MANIFEST: IndexManifest = {
       options: { unique: true },
     },
     {
-      // Due-job claim filters `{ state, runAfter: { $lte: now } }`. Leading with
-      // runAfter (not priority) means pending-but-not-due backoff jobs are NOT
-      // examined — the previous `{ state, priority, runAfter }` ordering walked
-      // every pending row on every idle claim, which is what kept Atlas Query
-      // Targeting above 1000 after the events COLLSCAN fix (#2473). Due matches
-      // are usually few, so an in-memory priority sort of that small set is fine.
+      // Due-job claim filters `{ state, runAfter: { $lte: now } }` (+ optional
+      // priority residual). Leading with runAfter (not priority) means
+      // pending-but-not-due backoff jobs are NOT examined — the previous
+      // `{ state, priority, runAfter }` ordering walked every pending row on
+      // every idle claim, which is what kept Atlas Query Targeting above 1000
+      // after the events COLLSCAN fix (#2473). Priority is a claim-arm FILTER
+      // (user rung before background), not a sort key; within a rung
+      // oldest-due wins via `{ runAfter: 1 }` sort, which this index serves
+      // directly (no SORT stage).
       name: "state_runafter_priority",
       key: { state: 1, runAfter: 1, priority: -1 },
     },

--- a/packages/sync/src/storage/repositories/job.repository.db.test.ts
+++ b/packages/sync/src/storage/repositories/job.repository.db.test.ts
@@ -248,6 +248,34 @@ describe("JobRepository", () => {
       expect(job.priority).toBe(claimed!.priority);
     });
 
+    it("enqueueUrgent boosts a pending job left by scheduleRetry", async () => {
+      const coalescingKey = "urgent:after-retry";
+      await repo.enqueue(
+        enqueue({
+          coalescingKey,
+          priority: JOB_PRIORITY.background,
+          runAfter: past(1000),
+        }),
+      );
+      const claimed = await repo.claimDueJob("owner", NOW, LEASE_MS);
+      expect(claimed).not.toBeNull();
+      expect(
+        await repo.scheduleRetry(claimed!._id, "owner", future(60_000)),
+      ).toBe(true);
+
+      const { job, outcome } = await repo.enqueueUrgent(
+        enqueue({
+          coalescingKey,
+          priority: JOB_PRIORITY.user,
+          runAfter: NOW,
+        }),
+      );
+      expect(outcome).toBe("boosted");
+      expect(job.state).toBe("pending");
+      expect(job.priority).toBe(JOB_PRIORITY.user);
+      expect(job.runAfter).toEqual(NOW);
+    });
+
     it("enqueueUrgent creates when the coalescing key is free", async () => {
       const { job, outcome } = await repo.enqueueUrgent(
         enqueue({

--- a/packages/sync/src/storage/repositories/job.repository.db.test.ts
+++ b/packages/sync/src/storage/repositories/job.repository.db.test.ts
@@ -2,7 +2,10 @@ import { faker } from "@faker-js/faker";
 import { type Db } from "mongodb";
 import { type SyncJobId } from "@core/types/sync/identity.contracts";
 import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
-import { type JobEnqueue } from "@sync/storage/contracts/job.contracts";
+import {
+  JOB_PRIORITY,
+  type JobEnqueue,
+} from "@sync/storage/contracts/job.contracts";
 import { JobRepository } from "@sync/storage/repositories/job.repository";
 
 const objectId = () => faker.database.mongodbObjectId();
@@ -126,15 +129,136 @@ describe("JobRepository", () => {
       expect(claimed).toHaveLength(1);
     });
 
-    it("claims jobs in priority then age order", async () => {
+    it("claims user-priority work ahead of background work, oldest first within a tier", async () => {
       await repo.enqueue(
-        enqueue({ coalescingKey: "low", priority: 1, runAfter: past(2000) }),
+        enqueue({
+          coalescingKey: "bg-older",
+          priority: JOB_PRIORITY.background,
+          runAfter: past(3000),
+        }),
       );
       await repo.enqueue(
-        enqueue({ coalescingKey: "high", priority: 9, runAfter: past(1000) }),
+        enqueue({
+          coalescingKey: "user-newer",
+          priority: JOB_PRIORITY.user,
+          runAfter: past(1000),
+        }),
+      );
+      await repo.enqueue(
+        enqueue({
+          coalescingKey: "user-older",
+          priority: JOB_PRIORITY.user,
+          runAfter: past(2000),
+        }),
       );
       const first = await repo.claimDueJob("w", NOW, LEASE_MS);
-      expect(first?.coalescingKey).toBe("high");
+      expect(first?.coalescingKey).toBe("user-older");
+      const second = await repo.claimDueJob("w", NOW, LEASE_MS);
+      expect(second?.coalescingKey).toBe("user-newer");
+      const third = await repo.claimDueJob("w", NOW, LEASE_MS);
+      expect(third?.coalescingKey).toBe("bg-older");
+    });
+
+    it("enqueueUrgent boosts a pending job without pushing back an earlier runAfter", async () => {
+      const coalescingKey = "urgent:pending";
+      const earlier = past(5000);
+      await repo.enqueue(
+        enqueue({
+          coalescingKey,
+          priority: JOB_PRIORITY.background,
+          runAfter: earlier,
+        }),
+      );
+      const { job, outcome } = await repo.enqueueUrgent(
+        enqueue({
+          coalescingKey,
+          priority: JOB_PRIORITY.user,
+          runAfter: past(1000),
+        }),
+      );
+      expect(outcome).toBe("boosted");
+      expect(job.priority).toBe(JOB_PRIORITY.user);
+      expect(job.runAfter).toEqual(earlier);
+    });
+
+    it("enqueueUrgent pulls a future runAfter forward on boost", async () => {
+      const coalescingKey = "urgent:future";
+      await repo.enqueue(
+        enqueue({
+          coalescingKey,
+          priority: JOB_PRIORITY.background,
+          runAfter: future(60_000),
+        }),
+      );
+      const { job, outcome } = await repo.enqueueUrgent(
+        enqueue({
+          coalescingKey,
+          priority: JOB_PRIORITY.user,
+          runAfter: NOW,
+        }),
+      );
+      expect(outcome).toBe("boosted");
+      expect(job.runAfter).toEqual(NOW);
+      expect(job.priority).toBe(JOB_PRIORITY.user);
+    });
+
+    it("enqueueUrgent revives a failed job without spending requeuedCount", async () => {
+      const coalescingKey = "urgent:failed";
+      const created = await repo.enqueue(
+        enqueue({ coalescingKey, runAfter: past(1000) }),
+      );
+      const claimed = await repo.claimDueJob("owner", NOW, LEASE_MS);
+      expect(claimed?._id).toBe(created._id);
+      expect(await repo.fail(created._id, "owner")).toBe(true);
+      await db
+        .collection("jobs")
+        .updateOne({ _id: created._id }, { $set: { requeuedCount: 3 } });
+
+      const { job, outcome } = await repo.enqueueUrgent(
+        enqueue({
+          coalescingKey,
+          priority: JOB_PRIORITY.user,
+          runAfter: NOW,
+        }),
+      );
+      expect(outcome).toBe("requeuedFailed");
+      expect(job.state).toBe("pending");
+      expect(job.attempt).toBe(0);
+      expect(job.requeuedCount).toBe(3);
+      expect(job.priority).toBe(JOB_PRIORITY.user);
+    });
+
+    it("enqueueUrgent leaves a claimed row's lease untouched", async () => {
+      const coalescingKey = "urgent:claimed";
+      await repo.enqueue(enqueue({ coalescingKey, runAfter: past(1000) }));
+      const claimed = await repo.claimDueJob("owner", NOW, LEASE_MS);
+      expect(claimed).not.toBeNull();
+
+      const { job, outcome } = await repo.enqueueUrgent(
+        enqueue({
+          coalescingKey,
+          priority: JOB_PRIORITY.user,
+          runAfter: NOW,
+        }),
+      );
+      expect(outcome).toBe("inFlight");
+      expect(job.state).toBe("claimed");
+      expect(job.leaseOwner).toBe("owner");
+      expect(job.leaseExpiresAt).toEqual(claimed!.leaseExpiresAt);
+      expect(job.priority).toBe(claimed!.priority);
+    });
+
+    it("enqueueUrgent creates when the coalescing key is free", async () => {
+      const { job, outcome } = await repo.enqueueUrgent(
+        enqueue({
+          coalescingKey: "urgent:new",
+          priority: JOB_PRIORITY.user,
+          runAfter: NOW,
+        }),
+      );
+      expect(outcome).toBe("created");
+      expect(job.state).toBe("pending");
+      expect(job.priority).toBe(JOB_PRIORITY.user);
     });
 
     it("reclaims a job whose lease has expired (previous owner crashed)", async () => {
@@ -454,7 +578,7 @@ describe("JobRepository", () => {
       const plan = await db
         .collection("jobs")
         .find({ state: "pending", runAfter: { $lte: NOW } })
-        .sort({ priority: -1, runAfter: 1 })
+        .sort({ runAfter: 1 })
         .explain("executionStats");
       const winning = JSON.stringify(plan);
       expect(winning).toContain("state_runafter_priority");

--- a/packages/sync/src/storage/repositories/job.repository.ts
+++ b/packages/sync/src/storage/repositories/job.repository.ts
@@ -89,26 +89,30 @@ export class JobRepository {
 
   // User-initiated enqueue that must do something even when a coalescing key
   // already exists. Three ordered, state-guarded writes (no transaction): the
-  // unique coalescingKey index makes each path idempotent. A state flip
-  // between the three writes can only mislabel the outcome, never corrupt a
-  // row — each update is scoped to the state it expects.
+  // unique coalescingKey index makes each path idempotent. A state flip can
+  // mislabel the outcome; the late boost after enqueue closes the
+  // claimed→pending race that would otherwise leave background priority
+  // untouched (see scheduleRetry).
   async enqueueUrgent(
     input: JobEnqueue,
   ): Promise<{ job: JobRecord; outcome: EnqueueUrgentOutcome }> {
     const fields = JobEnqueueSchema.parse(input);
     const now = fields.runAfter;
 
+    const boostPending = () =>
+      this.collection.updateOne(
+        { coalescingKey: fields.coalescingKey, state: "pending" },
+        {
+          $min: { runAfter: now },
+          $max: { priority: fields.priority },
+          $currentDate: { updatedAt: true },
+        },
+      );
+
     // pending → boost. $min pulls a future runAfter back without robbing an
     // older job of its place; $max can never demote. Wart: this short-circuits
     // retry backoff, but attempt is untouched so the ladder still terminates.
-    const boosted = await this.collection.updateOne(
-      { coalescingKey: fields.coalescingKey, state: "pending" },
-      {
-        $min: { runAfter: now },
-        $max: { priority: fields.priority },
-        $currentDate: { updatedAt: true },
-      },
-    );
+    const boosted = await boostPending();
     if (boosted.matchedCount === 1) {
       const job = await this.collection.findOne({
         coalescingKey: fields.coalescingKey,
@@ -155,8 +159,30 @@ export class JobRepository {
       return { job: JobRecordSchema.parse(inFlight), outcome: "inFlight" };
     }
 
-    const job = await this.enqueue(fields);
-    return { job, outcome: "created" };
+    const created = await this.enqueue(fields);
+
+    // claimed→pending (scheduleRetry) or a concurrent insert may have landed
+    // a background-priority / future-runAfter row that enqueue's $setOnInsert
+    // left untouched. Only boost when the returned row still needs it —
+    // $currentDate would make modifiedCount unreliable as the signal.
+    if (
+      created.state === "pending" &&
+      (created.priority < fields.priority ||
+        created.runAfter.getTime() > now.getTime())
+    ) {
+      await boostPending();
+      const job = await this.collection.findOne({
+        coalescingKey: fields.coalescingKey,
+      });
+      if (!job) throw new Error("Job disappeared after late boost");
+      return { job: JobRecordSchema.parse(job), outcome: "boosted" };
+    }
+
+    if (created.state === "claimed") {
+      return { job: created, outcome: "inFlight" };
+    }
+
+    return { job: created, outcome: "created" };
   }
 
   async findById(

--- a/packages/sync/src/storage/repositories/job.repository.ts
+++ b/packages/sync/src/storage/repositories/job.repository.ts
@@ -99,6 +99,17 @@ export class JobRepository {
     const fields = JobEnqueueSchema.parse(input);
     const now = fields.runAfter;
 
+    const requireByKey = async (
+      outcome: EnqueueUrgentOutcome,
+      missing: string,
+    ) => {
+      const job = await this.collection.findOne({
+        coalescingKey: fields.coalescingKey,
+      });
+      if (!job) throw new Error(missing);
+      return { job: JobRecordSchema.parse(job), outcome };
+    };
+
     const boostPending = () =>
       this.collection.updateOne(
         { coalescingKey: fields.coalescingKey, state: "pending" },
@@ -114,11 +125,7 @@ export class JobRepository {
     // retry backoff, but attempt is untouched so the ladder still terminates.
     const boosted = await boostPending();
     if (boosted.matchedCount === 1) {
-      const job = await this.collection.findOne({
-        coalescingKey: fields.coalescingKey,
-      });
-      if (!job) throw new Error("Boosted job disappeared after update");
-      return { job: JobRecordSchema.parse(job), outcome: "boosted" };
+      return requireByKey("boosted", "Boosted job disappeared after update");
     }
 
     // failed → revive. Frees the coalescing key that durable failures hold
@@ -141,11 +148,10 @@ export class JobRepository {
       },
     );
     if (revived.matchedCount === 1) {
-      const job = await this.collection.findOne({
-        coalescingKey: fields.coalescingKey,
-      });
-      if (!job) throw new Error("Revived job disappeared after update");
-      return { job: JobRecordSchema.parse(job), outcome: "requeuedFailed" };
+      return requireByKey(
+        "requeuedFailed",
+        "Revived job disappeared after update",
+      );
     }
 
     // claimed → inFlight. Touch nothing: releaseOwned/complete/scheduleRetry
@@ -171,11 +177,7 @@ export class JobRepository {
         created.runAfter.getTime() > now.getTime())
     ) {
       await boostPending();
-      const job = await this.collection.findOne({
-        coalescingKey: fields.coalescingKey,
-      });
-      if (!job) throw new Error("Job disappeared after late boost");
-      return { job: JobRecordSchema.parse(job), outcome: "boosted" };
+      return requireByKey("boosted", "Job disappeared after late boost");
     }
 
     if (created.state === "claimed") {

--- a/packages/sync/src/storage/repositories/job.repository.ts
+++ b/packages/sync/src/storage/repositories/job.repository.ts
@@ -7,6 +7,7 @@ import {
 } from "@core/types/sync/identity.contracts";
 import { SYNC_COLLECTIONS } from "@sync/storage/collections";
 import {
+  JOB_PRIORITY,
   type JobEnqueue,
   JobEnqueueSchema,
   type JobRecord,
@@ -21,6 +22,12 @@ export type ExhaustedFailedJob = {
   requeuedCount: number;
   updatedAt: Date;
 };
+
+export type EnqueueUrgentOutcome =
+  | "created"
+  | "boosted"
+  | "requeuedFailed"
+  | "inFlight";
 
 // The exact complement of listFailedForRequeue's eligibility filter: {$gte}
 // does not match a missing requeuedCount, so a legacy job counts as eligible
@@ -80,6 +87,78 @@ export class JobRepository {
     return JobRecordSchema.parse(result);
   }
 
+  // User-initiated enqueue that must do something even when a coalescing key
+  // already exists. Three ordered, state-guarded writes (no transaction): the
+  // unique coalescingKey index makes each path idempotent. A state flip
+  // between the three writes can only mislabel the outcome, never corrupt a
+  // row — each update is scoped to the state it expects.
+  async enqueueUrgent(
+    input: JobEnqueue,
+  ): Promise<{ job: JobRecord; outcome: EnqueueUrgentOutcome }> {
+    const fields = JobEnqueueSchema.parse(input);
+    const now = fields.runAfter;
+
+    // pending → boost. $min pulls a future runAfter back without robbing an
+    // older job of its place; $max can never demote. Wart: this short-circuits
+    // retry backoff, but attempt is untouched so the ladder still terminates.
+    const boosted = await this.collection.updateOne(
+      { coalescingKey: fields.coalescingKey, state: "pending" },
+      {
+        $min: { runAfter: now },
+        $max: { priority: fields.priority },
+        $currentDate: { updatedAt: true },
+      },
+    );
+    if (boosted.matchedCount === 1) {
+      const job = await this.collection.findOne({
+        coalescingKey: fields.coalescingKey,
+      });
+      if (!job) throw new Error("Boosted job disappeared after update");
+      return { job: JobRecordSchema.parse(job), outcome: "boosted" };
+    }
+
+    // failed → revive. Frees the coalescing key that durable failures hold
+    // (see sync-job-dispatch.service.ts). Leaves requeuedCount alone: that is
+    // the sweep's budget, and a human should neither spend it nor be blocked
+    // by an exhausted one.
+    const revived = await this.collection.updateOne(
+      { coalescingKey: fields.coalescingKey, state: "failed" },
+      {
+        $set: {
+          state: "pending",
+          runAfter: now,
+          attempt: 0,
+          leaseOwner: null,
+          leaseExpiresAt: null,
+          failureClass: null,
+        },
+        $max: { priority: fields.priority },
+        $currentDate: { updatedAt: true },
+      },
+    );
+    if (revived.matchedCount === 1) {
+      const job = await this.collection.findOne({
+        coalescingKey: fields.coalescingKey,
+      });
+      if (!job) throw new Error("Revived job disappeared after update");
+      return { job: JobRecordSchema.parse(job), outcome: "requeuedFailed" };
+    }
+
+    // claimed → inFlight. Touch nothing: releaseOwned/complete/scheduleRetry
+    // are owner-scoped and racing them is how a finished job gets flipped
+    // back to pending.
+    const inFlight = await this.collection.findOne({
+      coalescingKey: fields.coalescingKey,
+      state: "claimed",
+    });
+    if (inFlight) {
+      return { job: JobRecordSchema.parse(inFlight), outcome: "inFlight" };
+    }
+
+    const job = await this.enqueue(fields);
+    return { job, outcome: "created" };
+  }
+
   async findById(
     tenantId: TenantId,
     principalId: PrincipalId,
@@ -101,15 +180,24 @@ export class JobRepository {
     return result.deletedCount === 1;
   }
 
-  // Atomically claim the highest-priority due job for one worker. A job is due
-  // when it's pending and its runAfter has passed, OR it's claimed but its
-  // lease has expired (the previous owner crashed). The two arms are claimed
-  // separately so each can use its own index (state_runafter_priority /
-  // lease_expiry) — a single $or + sort forced the planner to walk every
-  // pending-not-due backoff job on every idle poll. Expired-lease reclaim
-  // runs FIRST so a sustained pending backlog cannot starve crash recovery
-  // (a coalesced resource stuck in claimed-with-expired-lease would otherwise
-  // never get a fresh pending row). Within each arm, priority then age wins.
+  // Atomically claim the next due job for one worker. A job is due when it's
+  // pending and its runAfter has passed, OR it's claimed but its lease has
+  // expired (the previous owner crashed).
+  //
+  // Arms, in order (arm order IS the priority ladder):
+  //   1. expired lease reclaim — must run first so a sustained pending backlog
+  //      cannot starve crash recovery (a coalesced resource stuck in
+  //      claimed-with-expired-lease would otherwise never get a fresh pending
+  //      row).
+  //   2. user-priority pending (priority > background) — Refresh / post-OAuth.
+  //   3. any remaining due pending (background sweeps, webhooks, followups).
+  //
+  // Priority is a residual FILTER inside the pending arms, not a sort key.
+  // The index `state_runafter_priority` is `{state, runAfter, priority:-1}`
+  // and serves `state` equality + `runAfter` range in index order; sorting by
+  // `{priority:-1, runAfter:1}` cannot use that index and forced an in-memory
+  // sort over every due job on every idle poll (440 docs after the 2026-08-07
+  // restart burst). Sort is `{runAfter:1}` so oldest-due wins within a rung.
   // findOneAndUpdate stays atomic per arm, so two workers still never both
   // win the same job. Returns null when no job is due.
   async claimDueJob(
@@ -124,12 +212,17 @@ export class JobRepository {
       $currentDate: { updatedAt: true as const },
     };
     const claimOpts = {
-      sort: { priority: -1 as const, runAfter: 1 as const },
+      sort: { runAfter: 1 as const },
       returnDocument: "after" as const,
     };
 
     for (const filter of [
       { state: "claimed" as const, leaseExpiresAt: { $lt: now } },
+      {
+        state: "pending" as const,
+        runAfter: { $lte: now },
+        priority: { $gt: JOB_PRIORITY.background },
+      },
       { state: "pending" as const, runAfter: { $lte: now } },
     ]) {
       const claimed = await this.collection.findOneAndUpdate(

--- a/packages/sync/src/storage/repositories/sync-resource.repository.ts
+++ b/packages/sync/src/storage/repositories/sync-resource.repository.ts
@@ -407,13 +407,16 @@ export class SyncResourceRepository {
   }
 
   // Events resources owned by the signed principal — input for a user-
-  // triggered refresh (enqueue one incrementalPull per resource).
+  // triggered refresh (enqueue one incrementalPull per resource). Bounded so a
+  // pathological principal cannot enqueue an unbounded refresh burst.
   async listEventsByPrincipal(
     tenantId: TenantId,
     principalId: PrincipalId,
+    limit = 200,
   ): Promise<SyncResourceRecord[]> {
     const records = await this.collection
       .find({ tenantId, principalId, resourceKind: "events" })
+      .limit(limit)
       .toArray();
     return records.map((r) => SyncResourceRecordSchema.parse(r));
   }


### PR DESCRIPTION
## Summary
- Two-rung job priority (`background` / `user`) with claim arms so Refresh and post-OAuth work run ahead of restart/sweep backlog.
- `enqueueUrgent` boosts pending jobs, revives failed ones, reports `inFlight`, and late-boosts after coalesce so a claimed→pending race cannot leave background priority untouched.
- 15-minute backlog delay threshold (2 minutes with provider errors), staggered first sweep ticks, deploy yaml `maxConcurrency: 12`.
- Refresh response `{ enqueued, inFlight, resources }` with defaults on the new fields so a skewed deploy cannot fail Refresh closed.

## Simplification
- Deduped `enqueueUrgent` find-after-update and refresh tally scaffolding after review.

## Validation
- `bun test:sync` — job.repository (incl. scheduleRetry boost), connection.routes refresh, connection-state, sweep-scheduler, failed-job-requeue, sync-job-worker
- `bun test:backend` — unwrap-sync-result
- `bun run type-check`, `bun run lint` (pre-existing warnings only)
- Independent review: fixed claimed→pending race + response defaults

## Test plan
- [x] Focused sync/backend tests + type-check + lint
- [ ] Staging after merge: restart sync mid-drain, click Refresh, confirm user-priority claim within seconds and plain backlog stays catchingUp under 15m