### PR TITLE
refactor(web): use stable markers for sidebar toggle focus hand-off

### DIFF
--- a/packages/web/src/components/Sidebar/SidebarCloseButton.tsx
+++ b/packages/web/src/components/Sidebar/SidebarCloseButton.tsx
@@ -7,13 +7,18 @@ import {
 } from "@web/events/stores/draft.store";
 import { viewActions } from "@web/events/stores/view.store";
 import { useCloseEventForm } from "@web/views/Forms/hooks/useCloseEventForm";
+import {
+  focusSidebarControl,
+  SIDEBAR_DISMISS_CONTROL,
+  SIDEBAR_TOGGLE_CONTROL,
+} from "./util/sidebarControlFocus.util";
 
 /**
  * Narrow-layout dismiss control rendered inside the sidebar. Uses a distinct
  * accessible name from the header toggle so the two controls do not collide
  * while the panel is open. Closes both the sidebar preference and any open
  * event form (Day/Week keep the panel mounted for event details), then
- * restores focus to the header "Open sidebar" control.
+ * restores focus to the header toggle control.
  */
 export const SidebarCloseButton: FC = () => {
   const closeEventForm = useCloseEventForm();
@@ -27,19 +32,16 @@ export const SidebarCloseButton: FC = () => {
         if (isEventFormOpen) {
           closeEventForm();
         }
-        // The header toggle stays mounted and flips to "Open sidebar"; move
-        // focus there after this in-sidebar control unmounts.
-        window.setTimeout(() => {
-          document
-            .querySelector<HTMLButtonElement>('[aria-label="Open sidebar"]')
-            ?.focus();
-        }, 0);
+        // The header toggle stays mounted; move focus there after this
+        // in-sidebar control unmounts.
+        focusSidebarControl(SIDEBAR_TOGGLE_CONTROL);
       }}
       shortcut="]"
     >
       <button
         type="button"
         aria-label="Dismiss sidebar"
+        data-sidebar-control={SIDEBAR_DISMISS_CONTROL}
         className="c-focus-ring flex h-6 w-6 cursor-pointer items-center justify-center text-text-muted"
       >
         <XIcon aria-hidden="true" size={16} />

--- a/packages/web/src/components/Sidebar/SidebarToggleButton.test.tsx
+++ b/packages/web/src/components/Sidebar/SidebarToggleButton.test.tsx
@@ -1,9 +1,24 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createStoreWrapper } from "@web/__tests__/render-with-store";
-import { viewActions } from "@web/events/stores/view.store";
+import {
+  selectIsSidebarOpen,
+  useViewStore,
+  viewActions,
+} from "@web/events/stores/view.store";
+import { SidebarCloseButton } from "./SidebarCloseButton";
 import { SidebarToggleButton } from "./SidebarToggleButton";
 import { beforeEach, describe, expect, it } from "bun:test";
+
+function Harness() {
+  const isOpen = useViewStore(selectIsSidebarOpen);
+  return (
+    <div>
+      <SidebarToggleButton />
+      {isOpen ? <SidebarCloseButton /> : null}
+    </div>
+  );
+}
 
 describe("SidebarToggleButton", () => {
   beforeEach(() => {
@@ -35,5 +50,20 @@ describe("SidebarToggleButton", () => {
     expect(
       screen.getByRole("button", { name: "Open sidebar" }),
     ).toBeInTheDocument();
+  });
+
+  it("focuses the dismiss control after opening when it is present", async () => {
+    const user = userEvent.setup();
+    const { wrapper } = createStoreWrapper();
+
+    render(<Harness />, { wrapper });
+
+    await user.click(screen.getByRole("button", { name: "Open sidebar" }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Dismiss sidebar" }),
+      ).toHaveFocus();
+    });
   });
 });

--- a/packages/web/src/components/Sidebar/SidebarToggleButton.tsx
+++ b/packages/web/src/components/Sidebar/SidebarToggleButton.tsx
@@ -7,6 +7,11 @@ import {
   useViewStore,
   viewActions,
 } from "@web/events/stores/view.store";
+import {
+  focusSidebarControl,
+  SIDEBAR_DISMISS_CONTROL,
+  SIDEBAR_TOGGLE_CONTROL,
+} from "./util/sidebarControlFocus.util";
 
 /**
  * Shared open/close control for the right sidebar. Lives in the calendar
@@ -25,17 +30,14 @@ export const SidebarToggleButton: FC = () => {
         if (!willOpen) return;
         // On narrow layouts the header control can be clipped once the panel
         // opens; move focus to the in-sidebar dismiss control when present.
-        window.setTimeout(() => {
-          document
-            .querySelector<HTMLButtonElement>('[aria-label="Dismiss sidebar"]')
-            ?.focus();
-        }, 0);
+        focusSidebarControl(SIDEBAR_DISMISS_CONTROL);
       }}
       shortcut="]"
     >
       <button
         type="button"
         aria-label={isSidebarOpen ? "Close sidebar" : "Open sidebar"}
+        data-sidebar-control={SIDEBAR_TOGGLE_CONTROL}
         className="c-focus-ring flex h-6 w-6 cursor-pointer items-center justify-center"
       >
         <SidebarIcon color={colors.textMuted} size={21} />

--- a/packages/web/src/components/Sidebar/util/sidebarControlFocus.util.ts
+++ b/packages/web/src/components/Sidebar/util/sidebarControlFocus.util.ts
@@ -1,0 +1,21 @@
+/**
+ * Focus hand-off between the header sidebar toggle and the in-sidebar
+ * dismiss control. Targets stable data attributes instead of dynamic
+ * aria-labels (Open ↔ Close) so a label change cannot break the hand-off.
+ */
+
+export const SIDEBAR_TOGGLE_CONTROL = "toggle";
+export const SIDEBAR_DISMISS_CONTROL = "dismiss";
+
+type SidebarControl =
+  | typeof SIDEBAR_TOGGLE_CONTROL
+  | typeof SIDEBAR_DISMISS_CONTROL;
+
+/** Focus a sidebar control after the open/close commit (setTimeout 0). */
+export function focusSidebarControl(control: SidebarControl): void {
+  window.setTimeout(() => {
+    document
+      .querySelector<HTMLButtonElement>(`[data-sidebar-control="${control}"]`)
+      ?.focus();
+  }, 0);
+}


### PR DESCRIPTION
## Summary
- Replace `querySelector('[aria-label="…"]')` focus hand-offs between the header sidebar toggle and the in-sidebar dismiss control with stable `data-sidebar-control` markers.
- Keep the same `setTimeout(0)` deferral so floating-ui tooltip teardown still settles before focus moves.
- Add a regression test for the open → dismiss focus path (close → toggle was already covered).

## Test plan
- [x] `bun run type-check`
- [x] `bun test:web` (1793/1793)
- [x] Focused sidebar toggle/close + LifeView narrow-dismiss tests
- [x] `bun test:e2e` (21/21)
- [x] `bun run lint` (no new issues)
- [ ] Manual: narrow viewport, open sidebar via header toggle → focus lands on Dismiss; dismiss → focus lands on Open sidebar