### PR TITLE
feat(web): explain export JSON contents for data-governance users

### DIFF
--- a/packages/web/src/common/storage/offline-data/export-user-data.util.test.ts
+++ b/packages/web/src/common/storage/offline-data/export-user-data.util.test.ts
@@ -43,18 +43,28 @@ describe("collectExportData", () => {
     const result = await collectExportData();
 
     expect(ensureOfflineDataStoreReady).toHaveBeenCalledTimes(1);
-    expect(result.version).toBe(1);
+    expect(result.version).toBe(2);
     expect(result.tasks).toEqual([task]);
     expect(result.events).toEqual([userRecord]);
     expect(typeof result.exportedAt).toBe("string");
   });
 
-  it("includes a message inviting pre-cutoff signups to email for their someday events", async () => {
+  it("explains what the export contains and why Google-synced events are absent", async () => {
     const result = await collectExportData();
 
-    expect(result.message).toContain("tyler@switchback.tech");
-    expect(result.message).toContain("July 15, 2026");
-    expect(result.message.toLowerCase()).toContain("someday");
+    expect(result.about.whatThisIs.toLowerCase()).toContain("indexeddb");
+    expect(result.about.whatThisIs.toLowerCase()).toContain("google calendar");
+    expect(result.about.events.toLowerCase()).toContain("locally");
+    expect(result.about.events.toLowerCase()).toContain("google calendar");
+    expect(result.about.tasks.toLowerCase()).toContain("tasks");
+  });
+
+  it("explains someday and invites pre-cutoff signups to email for recovery", async () => {
+    const result = await collectExportData();
+
+    expect(result.about.someday.toLowerCase()).toContain("undated");
+    expect(result.about.someday).toContain("tyler@switchback.tech");
+    expect(result.about.someday).toContain("July 15, 2026");
   });
 
   it("omits _migrations entirely (only tasks/events are read)", async () => {
@@ -112,7 +122,13 @@ describe("runExportMyData", () => {
 
     mockCollectExportData.mockResolvedValue({
       exportedAt: "2026-07-15T00:00:00.000Z",
-      version: 1,
+      version: 2,
+      about: {
+        whatThisIs: "snapshot",
+        events: "local events",
+        tasks: "legacy tasks",
+        someday: "someday notice",
+      },
       tasks: [],
       events: [],
     });
@@ -124,7 +140,7 @@ describe("runExportMyData", () => {
     await runExportMyData();
 
     expect(mockDownloadAsJsonFile).toHaveBeenCalledWith(
-      expect.objectContaining({ version: 1 }),
+      expect.objectContaining({ version: 2 }),
       "compass-export-2026-07-15.json",
     );
     expect(mockClearExportedTasks).toHaveBeenCalledTimes(1);

--- a/packages/web/src/common/storage/offline-data/export-user-data.util.ts
+++ b/packages/web/src/common/storage/offline-data/export-user-data.util.ts
@@ -6,13 +6,21 @@ import {
   getOfflineDataStore,
 } from "@web/common/storage/offline-data/offline-data.store.registry";
 
-const SOMEDAY_EVENTS_NOTICE =
-  "Someday events aren't included in this file. If you signed up before July 15, 2026 and want your Someday events, email tyler@switchback.tech. If you signed up after that date, you never had Someday events, so no action is needed.";
+const EXPORT_ABOUT = {
+  whatThisIs:
+    "Snapshot of data Compass stores in this browser (IndexedDB). It is not a full account or Google Calendar dump.",
+  events:
+    "Only calendar events still stored locally in this browser. If you connected Google Calendar, those events live in Google Calendar (and on Compass's servers when signed in), so they will not appear here.",
+  tasks:
+    "Legacy to-do items from a Tasks feature we removed. Any still retained in this browser are listed below; they are cleared after a successful export.",
+  someday:
+    "Someday was a former Compass feature for undated events. It was removed July 15, 2026, and those events are not in this file. If you signed up before that date and want them, email tyler@switchback.tech. If you signed up after, you never had Someday events.",
+} as const;
 
 interface CompassDataExport {
   exportedAt: string;
-  version: 1;
-  message: string;
+  version: 2;
+  about: typeof EXPORT_ABOUT;
   tasks: unknown[];
   events: unknown[];
 }
@@ -47,8 +55,8 @@ export function createCollectExportData({
 
     return {
       exportedAt: new Date().toISOString(),
-      version: 1,
-      message: SOMEDAY_EVENTS_NOTICE,
+      version: 2,
+      about: EXPORT_ABOUT,
       tasks,
       events: events.filter((record) => !record.isDemo),
     };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Exported data JSON now includes an `about` object so users understand what the file contains and what it deliberately omits.

- Bumps export format from version 1 to 2
- Replaces the single Someday-only `message` with short notes for: what this snapshot is, why Google-synced events are absent, what legacy tasks are, and what Someday was (plus the existing recovery contact/cutoff)
- Does not change what data is collected (still IndexedDB tasks + non-demo local events only)

## Simplicity

Already minimal: copy-only enrichment of the existing client-side export. No simplification commit needed (no new helpers, hooks, or abstractions).

## Automated validation

- Focused unit tests for `collectExportData` / `runExportMyData` (version 2, `about` copy, demo filtering, clear-after-download)
- `bun run lint` — pass (14 pre-existing warnings unrelated to this diff)
- Independent read-only review: **approve**, no confirmed findings
- GitHub CI: all checks SUCCESS (lint, type-check, knip, unit packages, e2e, CodeQL)

## Independent review

Fresh diff-first review against `origin/main`: approve. Confirmed findings: none. Residual non-blocking notes only (external v1 `message` consumers, fire-and-forget task clear, demo exclusion unspoken).

## Test plan

- `bun test packages/web/src/common/storage/offline-data/export-user-data.util.test.ts` — 9 pass
- `bun run lint` — pass (pre-existing warnings only)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9d1d3425-9efe-4d05-974d-976766999517?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9d1d3425-9efe-4d05-974d-976766999517&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

