### PR TITLE
fix(web): make sync status honest and refresh wait for real work

### DIFF
--- a/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.ts
+++ b/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.ts
@@ -4,8 +4,9 @@ import { type ConnectionId } from "@core/types/sync/identity.contracts";
 import { type GoogleSyncConnectionSummary } from "@core/types/user.types";
 import { AuthApi } from "@web/api/auth.api";
 import {
+  noteGoogleSyncRefreshImproved,
   refreshGoogleSync,
-  useIsGoogleSyncRefreshInFlight,
+  useGoogleSyncRefreshSnapshot,
 } from "@web/auth/google/state/google.sync.refresh";
 import {
   selectPrimaryGoogleSyncConnection,
@@ -13,9 +14,11 @@ import {
 } from "@web/auth/state/user-metadata.store";
 import {
   GOOGLE_CONNECT_FAILED_TOAST_ID,
+  GOOGLE_REFRESH_ALREADY_IN_FLIGHT_TOAST_ID,
   GOOGLE_REFRESH_FAILED_TOAST_ID,
 } from "@web/common/constants/toast.constants";
 import { showErrorToast } from "@web/common/utils/toast/error-toast.util";
+import { getToast } from "@web/common/utils/toast/toast.port";
 import { eventQueryKeys } from "@web/events/queries/event.query.keys";
 import { settingsActions } from "@web/settings/settings.store";
 import { useIsConnectGoogleAvailable } from "../useIsGoogleAvailable/useIsGoogleAvailable";
@@ -48,7 +51,8 @@ export const useConnectGoogle = (
   // Sync guard so rapid re-clicks before React re-renders cannot start a
   // second OAuth attempt; isConnecting alone would still be false in-handler.
   const isConnectingRef = useRef(false);
-  const isRefreshing = useIsGoogleSyncRefreshInFlight();
+  const refreshSnapshot = useGoogleSyncRefreshSnapshot();
+  const isRefreshing = refreshSnapshot.isRefreshing;
   const stopConnecting = useCallback(() => {
     isConnectingRef.current = false;
     setIsConnecting(false);
@@ -66,6 +70,27 @@ export const useConnectGoogle = (
     window.addEventListener("pageshow", onPageShow);
     return () => window.removeEventListener("pageshow", onPageShow);
   }, [stopConnecting]);
+
+  // Clear the Refresh catch-up wait once Sync leaves the delayed band that
+  // showed the CTA (SSE syncStatusChanged already refetches metadata).
+  useEffect(() => {
+    if (!refreshSnapshot.refreshRequestedAt && !refreshSnapshot.gaveUp) {
+      return;
+    }
+    const connectionState = syncConnection?.state;
+    if (
+      connectionState &&
+      connectionState !== "delayed" &&
+      state !== "ATTENTION"
+    ) {
+      noteGoogleSyncRefreshImproved();
+    }
+  }, [
+    refreshSnapshot.gaveUp,
+    refreshSnapshot.refreshRequestedAt,
+    state,
+    syncConnection?.state,
+  ]);
 
   const onOpenGoogleAuth = useCallback(() => {
     if (isConnectingRef.current) {
@@ -111,7 +136,7 @@ export const useConnectGoogle = (
 
   const onRefreshGoogle = useCallback(
     (options?: { silent?: boolean }) => {
-      if (isConnectingRef.current) {
+      if (isConnectingRef.current || refreshSnapshot.isRefreshing) {
         return;
       }
 
@@ -120,8 +145,17 @@ export const useConnectGoogle = (
       }
 
       void refreshGoogleSync()
-        .then(() => {
+        .then((result) => {
           void queryClient.invalidateQueries({ queryKey: eventQueryKeys.all });
+          if (
+            !options?.silent &&
+            result.inFlight > 0 &&
+            result.enqueued === 0
+          ) {
+            getToast().info("Already refreshing your calendars", {
+              toastId: GOOGLE_REFRESH_ALREADY_IN_FLIGHT_TOAST_ID,
+            });
+          }
         })
         .catch(() => {
           // A background-triggered refresh (tab focus) failing transiently
@@ -135,14 +169,20 @@ export const useConnectGoogle = (
           }
         });
     },
-    [queryClient],
+    [queryClient, refreshSnapshot.isRefreshing],
   );
 
   return {
-    ...getGoogleConnectionConfig(state, {
-      onConnectGoogle: onOpenGoogleAuth,
-      onRefreshGoogle,
-    }),
+    ...getGoogleConnectionConfig(
+      state,
+      {
+        onConnectGoogle: onOpenGoogleAuth,
+        onRefreshGoogle,
+      },
+      {
+        refreshGaveUp: refreshSnapshot.gaveUp,
+      },
+    ),
     connect: onOpenGoogleAuth,
     connection: syncConnection,
     refresh: onRefreshGoogle,

--- a/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.util.test.ts
+++ b/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.util.test.ts
@@ -1,7 +1,9 @@
 import {
   formatLastSyncedLabel,
+  formatLastUpdatedClause,
   getGoogleConnectionConfig,
   getGoogleSyncStatus,
+  getSidebarSyncStatus,
 } from "./useConnectGoogle.util";
 import { beforeEach, describe, expect, it, mock } from "bun:test";
 
@@ -31,9 +33,17 @@ describe("formatLastSyncedLabel", () => {
       "Updated 2 days ago",
     );
   });
+
+  it("formats the mid-sentence Last updated clause", () => {
+    expect(formatLastUpdatedClause("2026-07-24T11:45:00.000Z", nowMs)).toBe(
+      "Last updated 15 minutes ago",
+    );
+  });
 });
 
 describe("getGoogleSyncStatus", () => {
+  const nowMs = Date.parse("2026-07-24T12:00:00.000Z");
+
   it("returns no sync status when Google is not connected", () => {
     expect(getGoogleSyncStatus("NOT_CONNECTED")).toBeNull();
   });
@@ -73,34 +83,60 @@ describe("getGoogleSyncStatus", () => {
     });
   });
 
-  it("keeps a cached healthy connection calm during a routine refresh", () => {
+  it("keeps recent catchingUp calm in Settings", () => {
     expect(
-      getGoogleSyncStatus("IMPORTING", {
-        id: "c1",
-        state: "healthy",
-        stateReason: null,
-        lastSyncedAt: "2026-07-24T12:00:00.000Z",
-        lastHealthyAt: "2026-07-24T12:00:00.000Z",
-        accountEmail: "a@example.com",
-        connectionState: "IMPORTING",
-      }),
+      getGoogleSyncStatus(
+        "IMPORTING",
+        {
+          id: "c1",
+          state: "catchingUp",
+          stateReason: null,
+          lastSyncedAt: "2026-07-24T11:59:00.000Z",
+          lastHealthyAt: "2026-07-24T11:59:00.000Z",
+          accountEmail: "a@example.com",
+          connectionState: "IMPORTING",
+        },
+        nowMs,
+      ),
     ).toEqual({
       variant: "healthy",
       text: "Calendar connected",
     });
   });
 
-  it("returns warning copy for ATTENTION, without using the word 'repair'", () => {
-    const status = getGoogleSyncStatus("ATTENTION");
+  it("explains catchingUp that is more than two minutes behind", () => {
+    expect(
+      getGoogleSyncStatus(
+        "IMPORTING",
+        {
+          id: "c1",
+          state: "catchingUp",
+          stateReason: null,
+          lastSyncedAt: "2026-07-24T11:45:00.000Z",
+          lastHealthyAt: "2026-07-24T11:45:00.000Z",
+          accountEmail: "a@example.com",
+          connectionState: "IMPORTING",
+        },
+        nowMs,
+      ),
+    ).toEqual({
+      variant: "syncing",
+      text: "Sync is catching up. Last updated 15 minutes ago. This usually clears on its own.",
+    });
+  });
 
-    expect(status?.variant).toBe("warning");
-    expect(status?.text).toBe(
-      "Calendar updates are taking longer than usual. We'll keep trying.",
-    );
+  it("returns warning copy for ATTENTION without a connection summary", () => {
+    expect(getGoogleSyncStatus("ATTENTION")).toEqual({
+      variant: "warning",
+      text: "Sync is stuck. Refresh your calendars, or reconnect if this continues.",
+    });
   });
 
   it("returns error copy for RECONNECT_REQUIRED", () => {
-    expect(getGoogleSyncStatus("RECONNECT_REQUIRED")?.variant).toBe("error");
+    expect(getGoogleSyncStatus("RECONNECT_REQUIRED")).toEqual({
+      variant: "error",
+      text: "Calendar needs reconnecting",
+    });
   });
 
   it("shows setup copy for a connection that has never been healthy", () => {
@@ -120,37 +156,178 @@ describe("getGoogleSyncStatus", () => {
     });
   });
 
-  it("uses Sync delayed copy when a connection summary is present", () => {
+  it("uses stuck copy for delayed workOverdue", () => {
     expect(
-      getGoogleSyncStatus("ATTENTION", {
-        id: "c1",
-        state: "delayed",
-        stateReason: "workOverdue",
-        lastSyncedAt: "2026-07-24T12:00:00.000Z",
-        lastHealthyAt: null,
-        accountEmail: null,
-        connectionState: "ATTENTION",
-      }),
+      getGoogleSyncStatus(
+        "ATTENTION",
+        {
+          id: "c1",
+          state: "delayed",
+          stateReason: "workOverdue",
+          lastSyncedAt: "2026-07-24T11:45:00.000Z",
+          lastHealthyAt: null,
+          accountEmail: null,
+          connectionState: "ATTENTION",
+        },
+        nowMs,
+      ),
     ).toEqual({
       variant: "warning",
-      text: "Calendar updates are taking longer than usual. We'll keep trying.",
+      text: "Sync is stuck. Last updated 15 minutes ago. Refresh your calendars, or reconnect if this continues.",
     });
   });
 
-  it("uses Sync healthy copy from the connection summary", () => {
+  it("uses error copy for delayed providerErrors", () => {
     expect(
-      getGoogleSyncStatus("HEALTHY", {
-        id: "c1",
-        state: "healthy",
-        stateReason: null,
-        lastSyncedAt: "2026-07-24T12:00:00.000Z",
-        lastHealthyAt: "2026-07-24T12:00:00.000Z",
-        accountEmail: "a@example.com",
-        connectionState: "HEALTHY",
+      getGoogleSyncStatus(
+        "ATTENTION",
+        {
+          id: "c1",
+          state: "delayed",
+          stateReason: "providerErrors",
+          lastSyncedAt: "2026-07-24T11:45:00.000Z",
+          lastHealthyAt: null,
+          accountEmail: null,
+          connectionState: "ATTENTION",
+        },
+        nowMs,
+      ),
+    ).toEqual({
+      variant: "warning",
+      text: "Sync hit an error. Last updated 15 minutes ago. Refresh your calendars, or reconnect if this continues.",
+    });
+  });
+
+  it("admits stuck after a refresh gave up", () => {
+    expect(
+      getGoogleSyncStatus(
+        "ATTENTION",
+        {
+          id: "c1",
+          state: "delayed",
+          stateReason: "workOverdue",
+          lastSyncedAt: "2026-07-24T11:45:00.000Z",
+          lastHealthyAt: null,
+          accountEmail: null,
+          connectionState: "ATTENTION",
+        },
+        nowMs,
+        { refreshGaveUp: true },
+      ),
+    ).toEqual({
+      variant: "error",
+      text: "Sync is stuck. Last updated 15 minutes ago. Reconnect your calendar, or email tyler@switchback.tech for help.",
+    });
+  });
+});
+
+describe("getSidebarSyncStatus", () => {
+  const nowMs = Date.parse("2026-07-24T12:00:00.000Z");
+
+  it("stays silent for recent catchingUp", () => {
+    expect(
+      getSidebarSyncStatus({
+        connection: {
+          id: "c1",
+          state: "catchingUp",
+          stateReason: null,
+          lastSyncedAt: "2026-07-24T11:59:00.000Z",
+          lastHealthyAt: "2026-07-24T11:59:00.000Z",
+          accountEmail: "a@example.com",
+          connectionState: "IMPORTING",
+        },
+        isConnecting: false,
+        state: "IMPORTING",
+        nowMs,
+      }),
+    ).toBeNull();
+  });
+
+  it("shows short catching-up copy when behind more than two minutes", () => {
+    expect(
+      getSidebarSyncStatus({
+        connection: {
+          id: "c1",
+          state: "catchingUp",
+          stateReason: null,
+          lastSyncedAt: "2026-07-24T11:45:00.000Z",
+          lastHealthyAt: "2026-07-24T11:45:00.000Z",
+          accountEmail: "a@example.com",
+          connectionState: "IMPORTING",
+        },
+        isConnecting: false,
+        state: "IMPORTING",
+        nowMs,
       }),
     ).toEqual({
-      variant: "healthy",
-      text: "Calendar connected",
+      variant: "syncing",
+      text: "Sync is catching up",
+    });
+  });
+
+  it("shows Sync is stuck for delayed workOverdue", () => {
+    expect(
+      getSidebarSyncStatus({
+        connection: {
+          id: "c1",
+          state: "delayed",
+          stateReason: "workOverdue",
+          lastSyncedAt: "2026-07-24T11:45:00.000Z",
+          lastHealthyAt: null,
+          accountEmail: null,
+          connectionState: "ATTENTION",
+        },
+        isConnecting: false,
+        state: "ATTENTION",
+        nowMs,
+      }),
+    ).toEqual({
+      variant: "warning",
+      text: "Sync is stuck",
+    });
+  });
+
+  it("shows Sync hit an error for delayed providerErrors", () => {
+    expect(
+      getSidebarSyncStatus({
+        connection: {
+          id: "c1",
+          state: "delayed",
+          stateReason: "providerErrors",
+          lastSyncedAt: "2026-07-24T11:45:00.000Z",
+          lastHealthyAt: null,
+          accountEmail: null,
+          connectionState: "ATTENTION",
+        },
+        isConnecting: false,
+        state: "ATTENTION",
+        nowMs,
+      }),
+    ).toEqual({
+      variant: "warning",
+      text: "Sync hit an error",
+    });
+  });
+
+  it("shows Calendar needs reconnecting for actionRequired", () => {
+    expect(
+      getSidebarSyncStatus({
+        connection: {
+          id: "c1",
+          state: "actionRequired",
+          stateReason: "authorizationRevoked",
+          lastSyncedAt: null,
+          lastHealthyAt: null,
+          accountEmail: "a@example.com",
+          connectionState: "RECONNECT_REQUIRED",
+        },
+        isConnecting: false,
+        state: "RECONNECT_REQUIRED",
+        nowMs,
+      }),
+    ).toEqual({
+      variant: "error",
+      text: "Calendar needs reconnecting",
     });
   });
 });
@@ -182,6 +359,17 @@ describe("getGoogleConnectionConfig", () => {
     config.commandAction?.onSelect?.();
     expect(onRefreshGoogle).toHaveBeenCalledTimes(1);
     expect(onConnectGoogle).not.toHaveBeenCalled();
+  });
+
+  it("replaces Refresh with Reconnect after a refresh gave up", () => {
+    const config = getGoogleConnectionConfig("ATTENTION", handlers, {
+      refreshGaveUp: true,
+    });
+
+    expect(config.commandAction?.label).toBe("Reconnect Google Calendar");
+    config.commandAction?.onSelect?.();
+    expect(onConnectGoogle).toHaveBeenCalledTimes(1);
+    expect(onRefreshGoogle).not.toHaveBeenCalled();
   });
 
   it("wires NOT_CONNECTED to onConnectGoogle", () => {

--- a/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.util.test.ts
+++ b/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.util.test.ts
@@ -287,6 +287,29 @@ describe("getSidebarSyncStatus", () => {
     });
   });
 
+  it("shows Sync is catching up while a Refresh is in flight on delayed", () => {
+    expect(
+      getSidebarSyncStatus({
+        connection: {
+          id: "c1",
+          state: "delayed",
+          stateReason: "workOverdue",
+          lastSyncedAt: "2026-07-24T11:45:00.000Z",
+          lastHealthyAt: null,
+          accountEmail: null,
+          connectionState: "ATTENTION",
+        },
+        isConnecting: false,
+        state: "ATTENTION",
+        nowMs,
+        refreshInFlight: true,
+      }),
+    ).toEqual({
+      variant: "syncing",
+      text: "Sync is catching up",
+    });
+  });
+
   it("shows Sync hit an error for delayed providerErrors", () => {
     expect(
       getSidebarSyncStatus({

--- a/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.util.ts
+++ b/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.util.ts
@@ -19,7 +19,8 @@ const CONNECTED_STATUS: SyncStatus = {
 // freshly clicked Refresh does not invent its own warning.
 export const CATCHING_UP_NOTICE_AFTER_MS = 2 * 60 * 1000;
 
-const SUPPORT_MAILTO = "mailto:tyler@switchback.tech";
+const SUPPORT_EMAIL = "tyler@switchback.tech";
+export const googleSyncSupportMailto = `mailto:${SUPPORT_EMAIL}`;
 
 /** Short relative label for Sync connection `lastSyncedAt` (ISO). */
 export const formatLastSyncedLabel = (
@@ -84,6 +85,25 @@ const syncedAgeMs = (
   return Math.max(0, nowMs - syncedMs);
 };
 
+/** ` Last updated ….` suffix, or empty when unknown. */
+const lastUpdatedSuffix = (
+  lastSyncedAt: string | null | undefined,
+  nowMs: number,
+): string => {
+  const last = formatLastUpdatedClause(lastSyncedAt, nowMs);
+  return last ? ` ${last}.` : "";
+};
+
+const stuckReconnectStatus = (lastBit: string): SyncStatus => ({
+  variant: "error",
+  text: `Sync is stuck.${lastBit} Reconnect your calendar, or email ${SUPPORT_EMAIL} for help.`,
+});
+
+const catchingUpDetailStatus = (lastBit: string): SyncStatus => ({
+  variant: "syncing",
+  text: `Sync is catching up.${lastBit} This usually clears on its own.`,
+});
+
 export type GoogleConnectionHandlers = {
   onConnectGoogle: () => void;
   onRefreshGoogle: () => void;
@@ -145,8 +165,7 @@ const delayedSettingsStatus = (
   connection: GoogleSyncConnectionSummary,
   nowMs: number,
 ): SyncStatus => {
-  const last = formatLastUpdatedClause(connection.lastSyncedAt, nowMs);
-  const lastBit = last ? ` ${last}.` : "";
+  const lastBit = lastUpdatedSuffix(connection.lastSyncedAt, nowMs);
   if (connection.stateReason === "providerErrors") {
     return {
       variant: "warning",
@@ -170,12 +189,14 @@ const catchingUpSettingsStatus = (
   if (ageMs === null || ageMs < CATCHING_UP_NOTICE_AFTER_MS) {
     return CONNECTED_STATUS;
   }
-  const last = formatLastUpdatedClause(connection.lastSyncedAt, nowMs);
-  const lastBit = last ? ` ${last}.` : "";
-  return {
-    variant: "syncing",
-    text: `Sync is catching up.${lastBit} This usually clears on its own.`,
-  };
+  return catchingUpDetailStatus(
+    lastUpdatedSuffix(connection.lastSyncedAt, nowMs),
+  );
+};
+
+export type GoogleSyncStatusOptions = {
+  refreshGaveUp?: boolean;
+  refreshInFlight?: boolean;
 };
 
 // Prefer Sync vocabulary when a connection summary is present; fall back to the
@@ -184,19 +205,22 @@ export const getGoogleSyncStatus = (
   state: GoogleUiState,
   connection?: GoogleSyncConnectionSummary | null,
   nowMs: number = Date.now(),
-  options: { refreshGaveUp?: boolean } = {},
+  options: GoogleSyncStatusOptions = {},
 ): SyncStatus => {
   // A connection summary describes durable provider work. Local metadata
   // loading and a routine incremental pull must not replace a calm, usable
   // calendar with transient "checking" or "syncing" copy.
   if (connection) {
     if (options.refreshGaveUp && connection.state === "delayed") {
-      const last = formatLastUpdatedClause(connection.lastSyncedAt, nowMs);
-      const lastBit = last ? ` ${last}.` : "";
-      return {
-        variant: "error",
-        text: `Sync is stuck.${lastBit} Reconnect your calendar, or email tyler@switchback.tech for help.`,
-      };
+      return stuckReconnectStatus(
+        lastUpdatedSuffix(connection.lastSyncedAt, nowMs),
+      );
+    }
+
+    if (options.refreshInFlight && connection.state === "delayed") {
+      return catchingUpDetailStatus(
+        lastUpdatedSuffix(connection.lastSyncedAt, nowMs),
+      );
     }
 
     switch (connection.state) {
@@ -227,10 +251,7 @@ export const getGoogleSyncStatus = (
       return CONNECTED_STATUS;
     case "ATTENTION":
       if (options.refreshGaveUp) {
-        return {
-          variant: "error",
-          text: "Sync is stuck. Reconnect your calendar, or email tyler@switchback.tech for help.",
-        };
+        return stuckReconnectStatus("");
       }
       return {
         variant: "warning",
@@ -256,12 +277,14 @@ export const getSidebarSyncStatus = ({
   state,
   nowMs = Date.now(),
   refreshGaveUp = false,
+  refreshInFlight = false,
 }: {
   connection?: GoogleSyncConnectionSummary | null;
   isConnecting: boolean;
   state: GoogleUiState;
   nowMs?: number;
   refreshGaveUp?: boolean;
+  refreshInFlight?: boolean;
 }): SyncStatus => {
   if (isConnecting) {
     return {
@@ -278,6 +301,15 @@ export const getSidebarSyncStatus = ({
     (state === "ATTENTION" || connection?.state === "delayed")
   ) {
     return { variant: "error", text: "Sync is stuck" };
+  }
+
+  // Align with the Catching up… CTA while we wait for delayed to clear —
+  // otherwise the bar keeps saying "Sync is stuck" beside a hopeful button.
+  if (
+    refreshInFlight &&
+    (state === "ATTENTION" || connection?.state === "delayed")
+  ) {
+    return { variant: "syncing", text: "Sync is catching up" };
   }
 
   if (connection) {
@@ -318,5 +350,3 @@ export const getSidebarSyncStatus = ({
   });
   return status?.variant === "healthy" ? null : status;
 };
-
-export const googleSyncSupportMailto = SUPPORT_MAILTO;

--- a/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.util.ts
+++ b/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.util.ts
@@ -13,10 +13,13 @@ const CONNECTED_STATUS: SyncStatus = {
   variant: "healthy",
   text: "Calendar connected",
 };
-const DELAYED_STATUS: SyncStatus = {
-  variant: "warning",
-  text: "Calendar updates are taking longer than usual. We'll keep trying.",
-};
+
+// Plain backlog under this age stays silent in the sidebar and reads as
+// connected in Settings. Matches the short provider-error delay band so a
+// freshly clicked Refresh does not invent its own warning.
+export const CATCHING_UP_NOTICE_AFTER_MS = 2 * 60 * 1000;
+
+const SUPPORT_MAILTO = "mailto:tyler@switchback.tech";
 
 /** Short relative label for Sync connection `lastSyncedAt` (ISO). */
 export const formatLastSyncedLabel = (
@@ -61,23 +64,57 @@ export const formatLastSyncedLabel = (
   return `Updated ${new Date(syncedMs).toLocaleDateString()}`;
 };
 
+/** Mid-sentence form of formatLastSyncedLabel ("Last updated …"). */
+export const formatLastUpdatedClause = (
+  lastSyncedAt: string | null | undefined,
+  nowMs: number = Date.now(),
+): string | null => {
+  const label = formatLastSyncedLabel(lastSyncedAt, nowMs);
+  if (!label) return null;
+  return label.replace(/^Updated /, "Last updated ");
+};
+
+const syncedAgeMs = (
+  lastSyncedAt: string | null | undefined,
+  nowMs: number,
+): number | null => {
+  if (!lastSyncedAt) return null;
+  const syncedMs = Date.parse(lastSyncedAt);
+  if (Number.isNaN(syncedMs)) return null;
+  return Math.max(0, nowMs - syncedMs);
+};
+
 export type GoogleConnectionHandlers = {
   onConnectGoogle: () => void;
   onRefreshGoogle: () => void;
 };
 
+export type GoogleConnectionConfigOptions = {
+  // Refresh was requested and the degraded state did not improve — stop
+  // offering the same Refresh button; offer reconnect + support instead.
+  refreshGaveUp?: boolean;
+};
+
 export const getGoogleConnectionConfig = (
   state: GoogleUiState,
   handlers: GoogleConnectionHandlers,
+  options: GoogleConnectionConfigOptions = {},
 ): GoogleUiConfig => {
   switch (state) {
     case "checking":
     case "IMPORTING":
     case "HEALTHY":
       return { commandAction: null };
-    // Soft Sync failures still get a Refresh CTA — even permanent conflicts
-    // benefit from a catch-up attempt plus clearer copy than a dead-end.
     case "ATTENTION":
+      if (options.refreshGaveUp) {
+        return {
+          commandAction: {
+            label: "Reconnect Google Calendar",
+            icon: CONNECT_ICON,
+            onSelect: handlers.onConnectGoogle,
+          },
+        };
+      }
       return {
         commandAction: {
           label: "Refresh calendar",
@@ -104,27 +141,76 @@ export const getGoogleConnectionConfig = (
   }
 };
 
+const delayedSettingsStatus = (
+  connection: GoogleSyncConnectionSummary,
+  nowMs: number,
+): SyncStatus => {
+  const last = formatLastUpdatedClause(connection.lastSyncedAt, nowMs);
+  const lastBit = last ? ` ${last}.` : "";
+  if (connection.stateReason === "providerErrors") {
+    return {
+      variant: "warning",
+      text: `Sync hit an error.${lastBit} Refresh your calendars, or reconnect if this continues.`,
+    };
+  }
+  return {
+    variant: "warning",
+    text: `Sync is stuck.${lastBit} Refresh your calendars, or reconnect if this continues.`,
+  };
+};
+
+const catchingUpSettingsStatus = (
+  connection: GoogleSyncConnectionSummary,
+  nowMs: number,
+): SyncStatus => {
+  if (!connection.lastHealthyAt) {
+    return { variant: "syncing", text: "Adding your calendar…" };
+  }
+  const ageMs = syncedAgeMs(connection.lastSyncedAt, nowMs);
+  if (ageMs === null || ageMs < CATCHING_UP_NOTICE_AFTER_MS) {
+    return CONNECTED_STATUS;
+  }
+  const last = formatLastUpdatedClause(connection.lastSyncedAt, nowMs);
+  const lastBit = last ? ` ${last}.` : "";
+  return {
+    variant: "syncing",
+    text: `Sync is catching up.${lastBit} This usually clears on its own.`,
+  };
+};
+
 // Prefer Sync vocabulary when a connection summary is present; fall back to the
 // collapsed product enum for legacy deployments.
 export const getGoogleSyncStatus = (
   state: GoogleUiState,
   connection?: GoogleSyncConnectionSummary | null,
+  nowMs: number = Date.now(),
+  options: { refreshGaveUp?: boolean } = {},
 ): SyncStatus => {
   // A connection summary describes durable provider work. Local metadata
   // loading and a routine incremental pull must not replace a calm, usable
   // calendar with transient "checking" or "syncing" copy.
   if (connection) {
+    if (options.refreshGaveUp && connection.state === "delayed") {
+      const last = formatLastUpdatedClause(connection.lastSyncedAt, nowMs);
+      const lastBit = last ? ` ${last}.` : "";
+      return {
+        variant: "error",
+        text: `Sync is stuck.${lastBit} Reconnect your calendar, or email tyler@switchback.tech for help.`,
+      };
+    }
+
     switch (connection.state) {
       case "healthy":
         return CONNECTED_STATUS;
       case "connecting":
       case "importing":
-      case "catchingUp":
         return connection.lastHealthyAt
           ? CONNECTED_STATUS
           : { variant: "syncing", text: "Adding your calendar…" };
+      case "catchingUp":
+        return catchingUpSettingsStatus(connection, nowMs);
       case "delayed":
-        return DELAYED_STATUS;
+        return delayedSettingsStatus(connection, nowMs);
       case "actionRequired":
       case "disconnected":
         // Product enum already distinguishes reconnect vs soft attention.
@@ -140,7 +226,16 @@ export const getGoogleSyncStatus = (
     case "HEALTHY":
       return CONNECTED_STATUS;
     case "ATTENTION":
-      return DELAYED_STATUS;
+      if (options.refreshGaveUp) {
+        return {
+          variant: "error",
+          text: "Sync is stuck. Reconnect your calendar, or email tyler@switchback.tech for help.",
+        };
+      }
+      return {
+        variant: "warning",
+        text: "Sync is stuck. Refresh your calendars, or reconnect if this continues.",
+      };
     case "RECONNECT_REQUIRED":
       return { variant: "error", text: "Calendar needs reconnecting" };
     case "NOT_CONNECTED":
@@ -159,10 +254,14 @@ export const getSidebarSyncStatus = ({
   connection,
   isConnecting,
   state,
+  nowMs = Date.now(),
+  refreshGaveUp = false,
 }: {
   connection?: GoogleSyncConnectionSummary | null;
   isConnecting: boolean;
   state: GoogleUiState;
+  nowMs?: number;
+  refreshGaveUp?: boolean;
 }): SyncStatus => {
   if (isConnecting) {
     return {
@@ -174,6 +273,50 @@ export const getSidebarSyncStatus = ({
     };
   }
 
-  const status = getGoogleSyncStatus(state, connection);
+  if (
+    refreshGaveUp &&
+    (state === "ATTENTION" || connection?.state === "delayed")
+  ) {
+    return { variant: "error", text: "Sync is stuck" };
+  }
+
+  if (connection) {
+    switch (connection.state) {
+      case "catchingUp": {
+        if (!connection.lastHealthyAt) {
+          return { variant: "syncing", text: "Adding your calendar…" };
+        }
+        const ageMs = syncedAgeMs(connection.lastSyncedAt, nowMs);
+        if (ageMs !== null && ageMs >= CATCHING_UP_NOTICE_AFTER_MS) {
+          return { variant: "syncing", text: "Sync is catching up" };
+        }
+        return null;
+      }
+      case "delayed":
+        return {
+          variant: "warning",
+          text:
+            connection.stateReason === "providerErrors"
+              ? "Sync hit an error"
+              : "Sync is stuck",
+        };
+      case "actionRequired":
+      case "disconnected":
+        return { variant: "error", text: "Calendar needs reconnecting" };
+      case "connecting":
+      case "importing":
+        return connection.lastHealthyAt
+          ? null
+          : { variant: "syncing", text: "Adding your calendar…" };
+      case "healthy":
+        return null;
+    }
+  }
+
+  const status = getGoogleSyncStatus(state, connection, nowMs, {
+    refreshGaveUp,
+  });
   return status?.variant === "healthy" ? null : status;
 };
+
+export const googleSyncSupportMailto = SUPPORT_MAILTO;

--- a/packages/web/src/auth/google/state/google.sync.refresh.test.ts
+++ b/packages/web/src/auth/google/state/google.sync.refresh.test.ts
@@ -29,12 +29,12 @@ describe("createGoogleSyncRefreshCoordinator", () => {
 
     expect(second).toBe(first);
     expect(request).toHaveBeenCalledTimes(1);
-    expect(coordinator.getIsRefreshing()).toBe(true);
+    expect(coordinator.getSnapshot().isRefreshing).toBe(true);
 
     resolveRequest?.({ enqueued: 1, inFlight: 0, resources: 1 });
     await first;
 
-    expect(coordinator.getIsRefreshing()).toBe(true);
+    expect(coordinator.getSnapshot().isRefreshing).toBe(true);
     expect(coordinator.getSnapshot().refreshRequestedAt).not.toBeNull();
   });
 
@@ -58,7 +58,7 @@ describe("createGoogleSyncRefreshCoordinator", () => {
     });
 
     await coordinator.refresh();
-    expect(coordinator.getIsRefreshing()).toBe(true);
+    expect(coordinator.getSnapshot().isRefreshing).toBe(true);
     expect(timers).toHaveLength(1);
     expect(timers[0]?.ms).toBe(50);
 
@@ -88,7 +88,7 @@ describe("createGoogleSyncRefreshCoordinator", () => {
     });
 
     await coordinator.refresh();
-    expect(coordinator.getIsRefreshing()).toBe(true);
+    expect(coordinator.getSnapshot().isRefreshing).toBe(true);
     timers[0]?.cb();
     expect(coordinator.getSnapshot()).toEqual({
       isRefreshing: false,

--- a/packages/web/src/auth/google/state/google.sync.refresh.test.ts
+++ b/packages/web/src/auth/google/state/google.sync.refresh.test.ts
@@ -3,14 +3,26 @@ import { describe, expect, it, mock } from "bun:test";
 
 describe("createGoogleSyncRefreshCoordinator", () => {
   it("shares one in-flight refresh across callers", async () => {
-    let resolveRequest: (() => void) | undefined;
+    let resolveRequest:
+      | ((value: {
+          enqueued: number;
+          inFlight: number;
+          resources: number;
+        }) => void)
+      | undefined;
     const request = mock(
       () =>
-        new Promise<void>((resolve) => {
+        new Promise<{
+          enqueued: number;
+          inFlight: number;
+          resources: number;
+        }>((resolve) => {
           resolveRequest = resolve;
         }),
     );
-    const coordinator = createGoogleSyncRefreshCoordinator(request);
+    const coordinator = createGoogleSyncRefreshCoordinator(request, {
+      timeoutMs: 60_000,
+    });
 
     const first = coordinator.refresh();
     const second = coordinator.refresh();
@@ -19,9 +31,69 @@ describe("createGoogleSyncRefreshCoordinator", () => {
     expect(request).toHaveBeenCalledTimes(1);
     expect(coordinator.getIsRefreshing()).toBe(true);
 
-    resolveRequest?.();
+    resolveRequest?.({ enqueued: 1, inFlight: 0, resources: 1 });
     await first;
 
-    expect(coordinator.getIsRefreshing()).toBe(false);
+    expect(coordinator.getIsRefreshing()).toBe(true);
+    expect(coordinator.getSnapshot().refreshRequestedAt).not.toBeNull();
+  });
+
+  it("keeps Catching up until noteConnectionImproved or timeout", async () => {
+    const timers: Array<{ ms: number; cb: () => void }> = [];
+    const request = mock(async () => ({
+      enqueued: 1,
+      inFlight: 0,
+      resources: 1,
+    }));
+    const coordinator = createGoogleSyncRefreshCoordinator(request, {
+      now: () => 1_000,
+      timeoutMs: 50,
+      schedule: (cb, ms) => {
+        timers.push({ ms, cb });
+        return timers.length as unknown as ReturnType<typeof setTimeout>;
+      },
+      cancel: () => {
+        timers.length = 0;
+      },
+    });
+
+    await coordinator.refresh();
+    expect(coordinator.getIsRefreshing()).toBe(true);
+    expect(timers).toHaveLength(1);
+    expect(timers[0]?.ms).toBe(50);
+
+    coordinator.noteConnectionImproved();
+    expect(coordinator.getSnapshot()).toEqual({
+      isRefreshing: false,
+      refreshRequestedAt: null,
+      gaveUp: false,
+    });
+  });
+
+  it("gives up after the catch-up timeout without improvement", async () => {
+    const timers: Array<{ ms: number; cb: () => void }> = [];
+    const request = mock(async () => ({
+      enqueued: 0,
+      inFlight: 1,
+      resources: 1,
+    }));
+    const coordinator = createGoogleSyncRefreshCoordinator(request, {
+      now: () => 2_000,
+      timeoutMs: 25,
+      schedule: (cb, ms) => {
+        timers.push({ ms, cb });
+        return timers.length as unknown as ReturnType<typeof setTimeout>;
+      },
+      cancel: mock(),
+    });
+
+    await coordinator.refresh();
+    expect(coordinator.getIsRefreshing()).toBe(true);
+    timers[0]?.cb();
+    expect(coordinator.getSnapshot()).toEqual({
+      isRefreshing: false,
+      refreshRequestedAt: 2_000,
+      gaveUp: true,
+    });
   });
 });

--- a/packages/web/src/auth/google/state/google.sync.refresh.ts
+++ b/packages/web/src/auth/google/state/google.sync.refresh.ts
@@ -1,46 +1,133 @@
 import { useSyncExternalStore } from "react";
+import { type ConnectionRefreshResponse } from "@core/types/sync/connection.contracts";
 import { AuthApi } from "@web/api/auth.api";
 import { refreshUserMetadata } from "@web/auth/compass/user/util/user-metadata.util";
 
 type Listener = () => void;
 
+export type GoogleSyncRefreshSnapshot = {
+  // True from the moment Refresh is requested until the connection leaves a
+  // degraded state, or the catch-up timeout fires. Covers the HTTP round trip
+  // AND the wait for real sync progress (the 2026-08-07 incident showed the
+  // label reverting as soon as the POST returned while jobs sat pending).
+  isRefreshing: boolean;
+  refreshRequestedAt: number | null;
+  // Refresh was requested and the degraded state did not improve before the
+  // timeout — stop offering the same inert Refresh CTA.
+  gaveUp: boolean;
+};
+
+export type GoogleSyncRefreshCoordinatorOptions = {
+  now?: () => number;
+  timeoutMs?: number;
+  schedule?: (
+    callback: () => void,
+    ms: number,
+  ) => ReturnType<typeof setTimeout>;
+  cancel?: (handle: ReturnType<typeof setTimeout>) => void;
+};
+
+// How long "Catching up…" waits for metadata to leave delayed/ATTENTION before
+// we admit the refresh did not help. setTimeout (not rAF) so a hidden preview
+// tab still fires.
+export const GOOGLE_SYNC_REFRESH_CATCHUP_MS = 3 * 60_000;
+
+const idleSnapshot = (): GoogleSyncRefreshSnapshot => ({
+  isRefreshing: false,
+  refreshRequestedAt: null,
+  gaveUp: false,
+});
+
 // One browser-wide refresh owns the enqueue request and metadata recheck. This
 // prevents the sidebar, delayed toast, and focus hook from racing each other
 // while still letting every caller react to the same success or failure.
 export const createGoogleSyncRefreshCoordinator = (
-  requestRefresh: () => Promise<void>,
+  requestRefresh: () => Promise<ConnectionRefreshResponse>,
+  options: GoogleSyncRefreshCoordinatorOptions = {},
 ) => {
+  const now = options.now ?? Date.now;
+  const timeoutMs = options.timeoutMs ?? GOOGLE_SYNC_REFRESH_CATCHUP_MS;
+  const schedule = options.schedule ?? setTimeout;
+  const cancel = options.cancel ?? clearTimeout;
+
   const listeners = new Set<Listener>();
-  let inFlight: Promise<void> | null = null;
+  let inFlight: Promise<ConnectionRefreshResponse> | null = null;
+  let snapshot = idleSnapshot();
+  let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
 
   const emit = () => {
     listeners.forEach((listener) => listener());
   };
 
-  const refresh = (): Promise<void> => {
+  const setSnapshot = (next: GoogleSyncRefreshSnapshot) => {
+    snapshot = next;
+    emit();
+  };
+
+  const clearTimeoutHandle = () => {
+    if (timeoutHandle !== null) {
+      cancel(timeoutHandle);
+      timeoutHandle = null;
+    }
+  };
+
+  const armCatchupTimeout = (requestedAt: number) => {
+    clearTimeoutHandle();
+    timeoutHandle = schedule(() => {
+      timeoutHandle = null;
+      if (snapshot.refreshRequestedAt !== requestedAt) return;
+      setSnapshot({
+        isRefreshing: false,
+        refreshRequestedAt: requestedAt,
+        gaveUp: true,
+      });
+    }, timeoutMs);
+  };
+
+  const refresh = (): Promise<ConnectionRefreshResponse> => {
     if (inFlight) return inFlight;
 
+    const requestedAt = now();
     const request = requestRefresh();
     inFlight = request;
-    emit();
+    setSnapshot({
+      isRefreshing: true,
+      refreshRequestedAt: requestedAt,
+      gaveUp: false,
+    });
+
     void request.then(
       () => {
         if (inFlight !== request) return;
         inFlight = null;
+        // Stay in isRefreshing until metadata improves or the timeout fires.
+        armCatchupTimeout(requestedAt);
         emit();
       },
       () => {
         if (inFlight !== request) return;
         inFlight = null;
-        emit();
+        clearTimeoutHandle();
+        setSnapshot(idleSnapshot());
       },
     );
     return request;
   };
 
+  // SSE-driven metadata refresh calls this when the connection leaves the
+  // delayed / ATTENTION band that showed the Refresh CTA.
+  const noteConnectionImproved = () => {
+    if (!snapshot.refreshRequestedAt && !snapshot.gaveUp) return;
+    clearTimeoutHandle();
+    inFlight = null;
+    setSnapshot(idleSnapshot());
+  };
+
   return {
     refresh,
-    getIsRefreshing: () => inFlight !== null,
+    noteConnectionImproved,
+    getSnapshot: (): GoogleSyncRefreshSnapshot => snapshot,
+    getIsRefreshing: () => snapshot.isRefreshing,
     subscribe: (listener: Listener) => {
       listeners.add(listener);
       return () => listeners.delete(listener);
@@ -49,15 +136,22 @@ export const createGoogleSyncRefreshCoordinator = (
 };
 
 const coordinator = createGoogleSyncRefreshCoordinator(async () => {
-  await AuthApi.refreshGoogleSync();
+  const result = await AuthApi.refreshGoogleSync();
   await refreshUserMetadata({ force: true });
+  return result;
 });
 
 export const refreshGoogleSync = () => coordinator.refresh();
 
-export const useIsGoogleSyncRefreshInFlight = () =>
+export const noteGoogleSyncRefreshImproved = () =>
+  coordinator.noteConnectionImproved();
+
+export const useGoogleSyncRefreshSnapshot = () =>
   useSyncExternalStore(
     coordinator.subscribe,
-    coordinator.getIsRefreshing,
-    coordinator.getIsRefreshing,
+    coordinator.getSnapshot,
+    coordinator.getSnapshot,
   );
+
+export const useIsGoogleSyncRefreshInFlight = () =>
+  useGoogleSyncRefreshSnapshot().isRefreshing;

--- a/packages/web/src/auth/google/state/google.sync.refresh.ts
+++ b/packages/web/src/auth/google/state/google.sync.refresh.ts
@@ -32,11 +32,11 @@ export type GoogleSyncRefreshCoordinatorOptions = {
 // tab still fires.
 export const GOOGLE_SYNC_REFRESH_CATCHUP_MS = 3 * 60_000;
 
-const idleSnapshot = (): GoogleSyncRefreshSnapshot => ({
+const IDLE_SNAPSHOT: GoogleSyncRefreshSnapshot = {
   isRefreshing: false,
   refreshRequestedAt: null,
   gaveUp: false,
-});
+};
 
 // One browser-wide refresh owns the enqueue request and metadata recheck. This
 // prevents the sidebar, delayed toast, and focus hook from racing each other
@@ -52,7 +52,7 @@ export const createGoogleSyncRefreshCoordinator = (
 
   const listeners = new Set<Listener>();
   let inFlight: Promise<ConnectionRefreshResponse> | null = null;
-  let snapshot = idleSnapshot();
+  let snapshot = IDLE_SNAPSHOT;
   let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
 
   const emit = () => {
@@ -101,14 +101,14 @@ export const createGoogleSyncRefreshCoordinator = (
         if (inFlight !== request) return;
         inFlight = null;
         // Stay in isRefreshing until metadata improves or the timeout fires.
+        // Snapshot already reflects that wait — no extra emit needed.
         armCatchupTimeout(requestedAt);
-        emit();
       },
       () => {
         if (inFlight !== request) return;
         inFlight = null;
         clearTimeoutHandle();
-        setSnapshot(idleSnapshot());
+        setSnapshot(IDLE_SNAPSHOT);
       },
     );
     return request;
@@ -120,14 +120,13 @@ export const createGoogleSyncRefreshCoordinator = (
     if (!snapshot.refreshRequestedAt && !snapshot.gaveUp) return;
     clearTimeoutHandle();
     inFlight = null;
-    setSnapshot(idleSnapshot());
+    setSnapshot(IDLE_SNAPSHOT);
   };
 
   return {
     refresh,
     noteConnectionImproved,
     getSnapshot: (): GoogleSyncRefreshSnapshot => snapshot,
-    getIsRefreshing: () => snapshot.isRefreshing,
     subscribe: (listener: Listener) => {
       listeners.add(listener);
       return () => listeners.delete(listener);
@@ -152,6 +151,3 @@ export const useGoogleSyncRefreshSnapshot = () =>
     coordinator.getSnapshot,
     coordinator.getSnapshot,
   );
-
-export const useIsGoogleSyncRefreshInFlight = () =>
-  useGoogleSyncRefreshSnapshot().isRefreshing;

--- a/packages/web/src/common/constants/toast.constants.ts
+++ b/packages/web/src/common/constants/toast.constants.ts
@@ -10,6 +10,8 @@ export const GOOGLE_REVOKED_TOAST_ID: Id = "google-revoked-api";
 export const GOOGLE_REPAIR_FAILED_TOAST_ID: Id = "google-repair-failed";
 export const GOOGLE_CONNECT_FAILED_TOAST_ID: Id = "google-connect-failed";
 export const GOOGLE_REFRESH_FAILED_TOAST_ID: Id = "google-refresh-failed";
+export const GOOGLE_REFRESH_ALREADY_IN_FLIGHT_TOAST_ID: Id =
+  "google-refresh-already-in-flight";
 export const GOOGLE_DELAYED_TOAST_ID: Id = "google-delayed";
 export const ACCOUNT_DISCONNECTED_TOAST_ID: Id = "account-disconnected";
 export const SUBSCRIBE_TO_UPDATES_TOAST_ID: Id = "subscribe-to-updates";

--- a/packages/web/src/components/Settings/SettingsModal.tsx
+++ b/packages/web/src/components/Settings/SettingsModal.tsx
@@ -7,8 +7,10 @@ import { useConnectGoogle } from "@web/auth/google/hooks/useConnectGoogle/useCon
 import {
   formatLastSyncedLabel,
   getGoogleSyncStatus,
+  googleSyncSupportMailto,
 } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle.util";
 import { useDisconnectGoogleAccount } from "@web/auth/google/hooks/useDisconnectGoogleAccount";
+import { useGoogleSyncRefreshSnapshot } from "@web/auth/google/state/google.sync.refresh";
 import {
   selectGoogleSyncConnections,
   useUserMetadataStore,
@@ -305,14 +307,14 @@ const AccountRow: FC<AccountRowProps> = ({
   setConfirming,
 }) => {
   const accountEmail = connection.accountEmail ?? "Unknown account";
+  const refreshSnapshot = useGoogleSyncRefreshSnapshot();
   const status = getGoogleSyncStatus(
     connection.connectionState ?? "NOT_CONNECTED",
     connection,
+    Date.now(),
+    { refreshGaveUp: refreshSnapshot.gaveUp },
   );
-  const lastSyncedLabel =
-    status?.variant === "healthy"
-      ? formatLastSyncedLabel(connection.lastSyncedAt)
-      : null;
+  const lastSyncedLabel = formatLastSyncedLabel(connection.lastSyncedAt);
   const confirmButtonRef = useRef<HTMLButtonElement>(null);
   const disconnectButtonRef = useRef<HTMLButtonElement>(null);
   const wasConfirmingRef = useRef(isConfirming);
@@ -343,6 +345,16 @@ const AccountRow: FC<AccountRowProps> = ({
         <SyncStatusLine status={status} />
         {lastSyncedLabel ? (
           <p className="text-text-muted text-xs">{lastSyncedLabel}</p>
+        ) : null}
+        {refreshSnapshot.gaveUp && connection.state === "delayed" ? (
+          <p className="text-text-muted text-xs">
+            <a
+              className="underline hover:text-text"
+              href={googleSyncSupportMailto}
+            >
+              Email support
+            </a>
+          </p>
         ) : null}
       </div>
       {isConfirming ? (

--- a/packages/web/src/components/Settings/SettingsModal.tsx
+++ b/packages/web/src/components/Settings/SettingsModal.tsx
@@ -312,7 +312,10 @@ const AccountRow: FC<AccountRowProps> = ({
     connection.connectionState ?? "NOT_CONNECTED",
     connection,
     Date.now(),
-    { refreshGaveUp: refreshSnapshot.gaveUp },
+    {
+      refreshGaveUp: refreshSnapshot.gaveUp,
+      refreshInFlight: refreshSnapshot.isRefreshing,
+    },
   );
   const lastSyncedLabel = formatLastSyncedLabel(connection.lastSyncedAt);
   const confirmButtonRef = useRef<HTMLButtonElement>(null);

--- a/packages/web/src/components/Sidebar/CalendarList/AccountSectionHeader.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/AccountSectionHeader.tsx
@@ -37,7 +37,7 @@ export const AccountSectionHeader: FC<{
           ? "Reconnecting…"
           : "Connecting…"
         : isRefreshing
-          ? "Refreshing…"
+          ? "Catching up…"
           : commandAction.label;
 
   return (

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarListHeader.test.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarListHeader.test.tsx
@@ -240,7 +240,7 @@ describe("CalendarListHeader", () => {
     renderHeader();
 
     const refreshButton = screen.getByRole("button", {
-      name: "Refreshing…",
+      name: "Catching up…",
     });
     expect(refreshButton).toBeDisabled();
     expect(refreshButton).toHaveAttribute("aria-busy", "true");

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarListHeader.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarListHeader.tsx
@@ -57,7 +57,7 @@ const CalendarListHeaderContent: FC<{ email: string }> = ({ email }) => {
           ? "Reconnecting…"
           : "Connecting…"
         : isRefreshing
-          ? "Refreshing…"
+          ? "Catching up…"
           : commandAction.label;
 
   return (

--- a/packages/web/src/components/Sidebar/SidebarStatusBar.test.tsx
+++ b/packages/web/src/components/Sidebar/SidebarStatusBar.test.tsx
@@ -42,25 +42,12 @@ mock.module("@web/auth/google/hooks/useConnectGoogle/useConnectGoogle", () => ({
       : actualUseConnectGoogle(...args),
 }));
 
-const actualRefreshModule = await import(
-  "@web/auth/google/state/google.sync.refresh"
-);
-let isRefreshSnapshotMocked = true;
-mock.module("@web/auth/google/state/google.sync.refresh", () => ({
-  ...actualRefreshModule,
-  useGoogleSyncRefreshSnapshot: () =>
-    isRefreshSnapshotMocked
-      ? {
-          isRefreshing: false,
-          refreshRequestedAt: null,
-          gaveUp: false,
-        }
-      : actualRefreshModule.useGoogleSyncRefreshSnapshot(),
-}));
+// Do not mock.module google.sync.refresh here: process-wide mocks poison
+// later/parallel suites (LifeView hung under CI). The real coordinator
+// starts idle, which is what these cases need.
 
 afterAll(() => {
   isConnectGoogleMocked = false;
-  isRefreshSnapshotMocked = false;
 });
 
 const statusBarModuleUrl = new URL(

--- a/packages/web/src/components/Sidebar/SidebarStatusBar.test.tsx
+++ b/packages/web/src/components/Sidebar/SidebarStatusBar.test.tsx
@@ -1,10 +1,20 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { type GoogleSyncConnectionSummary } from "@core/types/user.types";
 import { createStoreWrapper } from "@web/__tests__/render-with-store";
 import { seedPendingEventMutations } from "@web/__tests__/utils/event-query-test-data";
 import { createMockConnection } from "@web/__tests__/utils/factories/calendar.factory";
 import { type GoogleUiState } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle.types";
-import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
+import { settingsActions } from "@web/settings/settings.store";
+import {
+  afterAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  mock,
+  spyOn,
+} from "bun:test";
 
 // mock.module is process-wide and not reliably restorable, so - as in
 // AccountSectionHeader.test.tsx - the real hook is captured up front and a
@@ -32,8 +42,25 @@ mock.module("@web/auth/google/hooks/useConnectGoogle/useConnectGoogle", () => ({
       : actualUseConnectGoogle(...args),
 }));
 
+const actualRefreshModule = await import(
+  "@web/auth/google/state/google.sync.refresh"
+);
+let isRefreshSnapshotMocked = true;
+mock.module("@web/auth/google/state/google.sync.refresh", () => ({
+  ...actualRefreshModule,
+  useGoogleSyncRefreshSnapshot: () =>
+    isRefreshSnapshotMocked
+      ? {
+          isRefreshing: false,
+          refreshRequestedAt: null,
+          gaveUp: false,
+        }
+      : actualRefreshModule.useGoogleSyncRefreshSnapshot(),
+}));
+
 afterAll(() => {
   isConnectGoogleMocked = false;
+  isRefreshSnapshotMocked = false;
 });
 
 const statusBarModuleUrl = new URL(
@@ -98,11 +125,6 @@ describe("SidebarStatusBar", () => {
   });
 
   it("stays quiet while an already-established account runs routine catch-up, not just on first import", () => {
-    // The 2026-08-05 bug this guards against: the aggregate connectionState
-    // collapses first-import and routine incremental catch-up to the same
-    // "IMPORTING" value, so without the connection's own lastHealthyAt the
-    // bar would misreport a healthy account's reconciliation as "Adding your
-    // calendar…" - exactly the noise getSidebarSyncStatus is meant to hide.
     googleState = "IMPORTING";
     connection = createMockConnection("ahab@pequod.com", {
       state: "catchingUp",
@@ -116,6 +138,63 @@ describe("SidebarStatusBar", () => {
 
     expect(screen.getByRole("status").textContent).toBe("");
     expect(screen.queryByText("Adding your calendar…")).toBeNull();
+  });
+
+  it("shows Sync is catching up when catch-up is more than two minutes behind", () => {
+    googleState = "IMPORTING";
+    connection = createMockConnection("ahab@pequod.com", {
+      state: "catchingUp",
+      lastSyncedAt: new Date(Date.now() - 15 * 60_000).toISOString(),
+      lastHealthyAt: new Date(Date.now() - 15 * 60_000).toISOString(),
+      connectionState: "IMPORTING",
+    });
+    const { wrapper } = createStoreWrapper();
+
+    render(<SidebarStatusBar />, { wrapper });
+
+    expect(screen.getByRole("status")).toHaveTextContent("Sync is catching up");
+    expect(screen.getByRole("button")).toHaveAttribute(
+      "title",
+      "Sync is catching up",
+    );
+  });
+
+  it("shows Sync is stuck for delayed workOverdue", () => {
+    googleState = "ATTENTION";
+    connection = createMockConnection("ahab@pequod.com", {
+      state: "delayed",
+      stateReason: "workOverdue",
+      lastSyncedAt: new Date(Date.now() - 20 * 60_000).toISOString(),
+      lastHealthyAt: null,
+      connectionState: "ATTENTION",
+    });
+    const { wrapper } = createStoreWrapper();
+
+    render(<SidebarStatusBar />, { wrapper });
+
+    expect(screen.getByRole("status")).toHaveTextContent("Sync is stuck");
+  });
+
+  it("opens Settings when the status bar is activated", async () => {
+    const user = userEvent.setup();
+    const openSettings = spyOn(settingsActions, "openSettings");
+    googleState = "ATTENTION";
+    connection = createMockConnection("ahab@pequod.com", {
+      state: "delayed",
+      stateReason: "workOverdue",
+      connectionState: "ATTENTION",
+    });
+    const { wrapper } = createStoreWrapper();
+
+    render(<SidebarStatusBar />, { wrapper });
+    await user.click(
+      screen.getByRole("button", {
+        name: "Sync is stuck. Open account settings",
+      }),
+    );
+
+    expect(openSettings).toHaveBeenCalledTimes(1);
+    openSettings.mockRestore();
   });
 
   it("prefers 'Saving changes…' over the Google sync status when both are true", () => {

--- a/packages/web/src/components/Sidebar/SidebarStatusBar.tsx
+++ b/packages/web/src/components/Sidebar/SidebarStatusBar.tsx
@@ -1,8 +1,10 @@
 import { type FC } from "react";
 import { useConnectGoogle } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle";
 import { getSidebarSyncStatus } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle.util";
+import { useGoogleSyncRefreshSnapshot } from "@web/auth/google/state/google.sync.refresh";
 import { SYNC_STATUS_VARIANT_CLASSNAME } from "@web/calendars/sync-status.types";
 import { useHasPendingEventMutations } from "@web/events/mutations/useEventPending";
+import { settingsActions } from "@web/settings/settings.store";
 
 /**
  * Pinned status bar at the bottom of the sidebar, just above the actions bar.
@@ -10,6 +12,10 @@ import { useHasPendingEventMutations } from "@web/events/mutations/useEventPendi
  * mutation goes in/out of flight, or an account's Google sync status changes -
  * that status used to render inline under each account's heading, where it
  * pushed the calendar rows below it up and down as accounts synced.
+ *
+ * The whole bar is a button that opens Settings > Accounts, where the full
+ * sentence fits. Sidebar copy stays short so the fixed h-6 never truncates
+ * the meaning; `title` is the safety net if anything still overflows.
  */
 export const SidebarStatusBar: FC = () => {
   const isSaving = useHasPendingEventMutations();
@@ -20,19 +26,38 @@ export const SidebarStatusBar: FC = () => {
   // own lastHealthyAt tells getSidebarSyncStatus the account was already
   // established and should stay quiet.
   const { connection, isConnecting, state } = useConnectGoogle();
+  const refreshSnapshot = useGoogleSyncRefreshSnapshot();
   const status = isSaving
     ? { variant: "syncing" as const, text: "Saving changes…" }
-    : getSidebarSyncStatus({ connection, isConnecting, state });
+    : getSidebarSyncStatus({
+        connection,
+        isConnecting,
+        state,
+        refreshGaveUp: refreshSnapshot.gaveUp,
+      });
+
+  const text = status?.text ?? "";
+  const openSettings = () => settingsActions.openSettings();
 
   return (
     <div className="flex h-6 shrink-0 items-center px-4">
-      <p
-        aria-live="polite"
-        className={`truncate text-xs ${status ? SYNC_STATUS_VARIANT_CLASSNAME[status.variant] : ""}`}
-        role="status"
+      <button
+        aria-label={
+          text ? `${text}. Open account settings` : "Open account settings"
+        }
+        className="c-focus-ring flex h-full min-w-0 flex-1 items-center rounded-xs text-left"
+        onClick={openSettings}
+        title={text || undefined}
+        type="button"
       >
-        {status?.text ?? ""}
-      </p>
+        <span
+          aria-live="polite"
+          className={`truncate text-xs ${status ? SYNC_STATUS_VARIANT_CLASSNAME[status.variant] : ""}`}
+          role="status"
+        >
+          {text}
+        </span>
+      </button>
     </div>
   );
 };

--- a/packages/web/src/components/Sidebar/SidebarStatusBar.tsx
+++ b/packages/web/src/components/Sidebar/SidebarStatusBar.tsx
@@ -34,10 +34,10 @@ export const SidebarStatusBar: FC = () => {
         isConnecting,
         state,
         refreshGaveUp: refreshSnapshot.gaveUp,
+        refreshInFlight: refreshSnapshot.isRefreshing,
       });
 
   const text = status?.text ?? "";
-  const openSettings = () => settingsActions.openSettings();
 
   return (
     <div className="flex h-6 shrink-0 items-center px-4">
@@ -46,7 +46,7 @@ export const SidebarStatusBar: FC = () => {
           text ? `${text}. Open account settings` : "Open account settings"
         }
         className="c-focus-ring flex h-full min-w-0 flex-1 items-center rounded-xs text-left"
-        onClick={openSettings}
+        onClick={settingsActions.openSettings}
         title={text || undefined}
         type="button"
       >


### PR DESCRIPTION
## Summary
- Sidebar status bar stays `h-6` but opens Settings; short copy + `title`, full sentences in Accounts.
- Calm `catchingUp` vs delayed stuck/error copy; last-updated in non-healthy Settings states.
- Refresh holds “Catching up…” (status + CTA agree) until Sync leaves delayed/ATTENTION or a 3-minute timeout; `inFlight`-only toasts “Already refreshing your calendars”; after timeout, Reconnect + support mailto.

Follows #2660 (already merged). Replaces closed stacked #2661 after the base branch was deleted on squash-merge.

## Simplification
- Deduped status copy helpers; dropped unused in-flight hook (knip); coordinator idle snapshot shared.

## Validation
- Focused web tests: util, refresh coordinator, SidebarStatusBar, CalendarListHeader
- `bun run type-check`, `bun run lint`, knip clean for refresh module
- Independent review: fixed dishonest dual copy while refresh waits

## Test plan
- [x] Focused web tests + type-check + lint + knip
- [ ] Staging: restart sync, Refresh mid-drain — sidebar “Sync is catching up”, bar opens Settings, button never no-op flashes