### PR TITLE
refactor(web): consolidate interaction gesture constants and z-index escapes

### DIFF
--- a/packages/web/src/components/DatePicker/DatePicker.tsx
+++ b/packages/web/src/components/DatePicker/DatePicker.tsx
@@ -3,6 +3,7 @@ import type React from "react";
 import * as ReactDatePickerModule from "react-datepicker";
 import { type ReactDatePickerProps } from "react-datepicker";
 import dayjs from "@core/util/date/dayjs";
+import { Z_INDEX_FLOATING_MENU } from "@web/common/constants/web.constants";
 import { darken, isDark } from "@web/common/styles/color.utils";
 import { colors, lightColors } from "@web/common/styles/colors";
 import { type CSSVariables } from "@web/common/styles/css.types";
@@ -82,7 +83,7 @@ export const DatePicker: React.FC<Props> = (datePickerProps) => {
 
   return (
     <ReactDatePicker
-      popperClassName="!z-22"
+      popperProps={{ style: { zIndex: Z_INDEX_FLOATING_MENU } }}
       calendarClassName={classNames("calendar", calendarClassName, {
         "calendar--open": isOpen,
         "calendar--animation": animationOnToggle,

--- a/packages/web/src/components/DatePicker/DatePicker.tsx
+++ b/packages/web/src/components/DatePicker/DatePicker.tsx
@@ -3,7 +3,6 @@ import type React from "react";
 import * as ReactDatePickerModule from "react-datepicker";
 import { type ReactDatePickerProps } from "react-datepicker";
 import dayjs from "@core/util/date/dayjs";
-import { Z_INDEX_FLOATING_MENU } from "@web/common/constants/web.constants";
 import { darken, isDark } from "@web/common/styles/color.utils";
 import { colors, lightColors } from "@web/common/styles/colors";
 import { type CSSVariables } from "@web/common/styles/css.types";
@@ -81,9 +80,12 @@ export const DatePicker: React.FC<Props> = (datePickerProps) => {
         ? "var(--text)"
         : "var(--on-accent)";
 
+  // react-datepicker paints z-index via popperClassName on the positioned
+  // node (popperProps.style is ignored by react-popper). "!z-22" equals
+  // Z_INDEX_FLOATING_MENU; keep the literal static so Tailwind can see it.
   return (
     <ReactDatePicker
-      popperProps={{ style: { zIndex: Z_INDEX_FLOATING_MENU } }}
+      popperClassName="!z-22"
       calendarClassName={classNames("calendar", calendarClassName, {
         "calendar--open": isOpen,
         "calendar--animation": animationOnToggle,

--- a/packages/web/src/components/SelectView/SelectView.tsx
+++ b/packages/web/src/components/SelectView/SelectView.tsx
@@ -11,6 +11,7 @@ import { useLocation, useNavigate } from "@tanstack/react-router";
 import classNames from "classnames";
 import { useRef, useState } from "react";
 import { ROOT_ROUTES } from "@web/common/constants/routes";
+import { Z_INDEX_FLOATING_MENU } from "@web/common/constants/web.constants";
 import { ShortcutKeys } from "@web/components/Shortcuts/ShortcutKeys";
 import {
   LIFE_SHORTCUT,
@@ -173,8 +174,9 @@ export const SelectView = ({ label, onToday }: SelectViewProps) => {
           })}
           id={dropdownId}
           data-testid="view-select-dropdown"
-          className="absolute inset-inline-start-0 top-full z-50 mt-1 min-w-[180px] rounded border border-border bg-surface py-1 shadow-lg"
+          className="absolute inset-inline-start-0 top-full mt-1 min-w-[180px] rounded border border-border bg-surface py-1 shadow-lg"
           role="listbox"
+          style={{ zIndex: Z_INDEX_FLOATING_MENU }}
         >
           {options.map((option, index) => {
             const isSelected =

--- a/packages/web/src/components/Sidebar/ShortcutsOverlay/ShortcutsOverlay.tsx
+++ b/packages/web/src/components/Sidebar/ShortcutsOverlay/ShortcutsOverlay.tsx
@@ -1,6 +1,7 @@
 import { XIcon } from "@phosphor-icons/react";
 import classNames from "classnames";
 import { useEffect, useRef, useState } from "react";
+import { ZIndex } from "@web/common/constants/web.constants";
 import { ShortcutSection } from "@web/components/Shortcuts/ShortcutOverlay/ShortcutSection";
 import {
   selectIsShortcutsOpen,
@@ -84,10 +85,11 @@ export function ShortcutsOverlay({ sections, viewLabel }: Props) {
       aria-hidden={!isOpen}
       aria-label="Keyboard shortcuts"
       className={classNames(
-        "absolute inset-0 z-20 overflow-hidden",
+        "absolute inset-0 overflow-hidden",
         isOpen ? "" : "pointer-events-none",
       )}
       role="dialog"
+      style={{ zIndex: ZIndex.MAX }}
     >
       <div
         className={classNames(

--- a/packages/web/src/grid/components/EventGrid.tsx
+++ b/packages/web/src/grid/components/EventGrid.tsx
@@ -4,6 +4,7 @@ import {
   type ReactNode,
 } from "react";
 import { type Dayjs } from "@core/util/date/dayjs";
+import { ZIndex } from "@web/common/constants/web.constants";
 import { AbsoluteOverflowLoader } from "@web/components/AbsoluteOverflowLoader/AbsoluteOverflowLoader";
 import {
   type GridRefs,
@@ -81,17 +82,19 @@ export const EventGrid: FC<EventGridProps> = ({
         aria-label="Loading events"
         className={
           isErrorEvents
-            ? "z-20 bg-background [&>div]:my-0"
+            ? "bg-background [&>div]:my-0"
             : "pointer-events-none bg-background [&>div]:my-0"
         }
         role="status"
+        style={{ zIndex: ZIndex.MAX }}
       />
     )}
     {isImportingEmpty && !isLoadingEvents && !isErrorEvents && (
       <div
         aria-live="polite"
-        className="pointer-events-none absolute inset-0 z-10 flex items-center justify-center px-4"
+        className="pointer-events-none absolute inset-0 flex items-center justify-center px-4"
         role="status"
+        style={{ zIndex: ZIndex.MAX }}
       >
         <p className="max-w-sm text-center text-sm text-text-muted">
           Importing from Google — events usually appear within a minute.
@@ -99,7 +102,10 @@ export const EventGrid: FC<EventGridProps> = ({
       </div>
     )}
     {isErrorEvents && !isLoadingEvents && (
-      <div className="absolute inset-0 z-20 flex items-center justify-center bg-background px-4">
+      <div
+        className="absolute inset-0 flex items-center justify-center bg-background px-4"
+        style={{ zIndex: ZIndex.MAX }}
+      >
         <div className="flex max-w-sm flex-col items-center gap-3 rounded-md border border-border-strong bg-surface-raised px-5 py-4 text-center shadow-[0_8px_24px_var(--color-shadow-default)]">
           <p className="text-sm text-text" role="alert">
             Couldn&apos;t load events.

--- a/packages/web/src/grid/hooks/useTimedDraftCreation.ts
+++ b/packages/web/src/grid/hooks/useTimedDraftCreation.ts
@@ -14,12 +14,11 @@ import {
   useDraftStore,
 } from "@web/events/stores/draft.store";
 import { DRAFT_DURATION_MIN, GRID_TIME_STEP } from "@web/grid/grid.constants";
+import { TIMED_DRAFT_CREATE_MOVE_THRESHOLD_PX } from "@web/interaction/interaction.constants";
 import {
   hasExceededInteractionMoveThreshold,
   isEligibleInteractionPointerDown,
 } from "@web/interaction/interaction.pointer";
-
-const TIMED_DRAFT_CREATE_MOVE_THRESHOLD_PX = 4;
 
 interface TimedDraftCreationGesture {
   cancel(): void;

--- a/packages/web/src/grid/interaction/dom.ts
+++ b/packages/web/src/grid/interaction/dom.ts
@@ -1,3 +1,4 @@
+import { ZIndex } from "@web/common/constants/web.constants";
 import { type GridEvent } from "@web/common/types/web.event.types";
 import { getTimesLabel } from "@web/common/utils/datetime/web.date.util";
 import {
@@ -111,7 +112,7 @@ const getOrCreateDraftEventTimeLabel = (node: HTMLElement) => {
   label.style.opacity = GRID_EVENT_TIME_LABEL_OPACITY;
   label.style.whiteSpace = "nowrap";
   label.style.position = "relative";
-  label.style.zIndex = "3";
+  label.style.zIndex = `${ZIndex.LAYER_3}`;
 
   const parent = getDraftEventTimeLabelParent(node);
   const resizeHandle = getFirstDirectResizeHandle(parent);

--- a/packages/web/src/interaction/interaction.constants.ts
+++ b/packages/web/src/interaction/interaction.constants.ts
@@ -1,0 +1,13 @@
+/**
+ * Shared gesture timings for grid interaction.
+ *
+ * `INTERACTION_MOVE_THRESHOLD_PX` (25) gates motion on an existing event/draft —
+ * the pointer must clearly intend a drag before the card moves.
+ * `TIMED_DRAFT_CREATE_MOVE_THRESHOLD_PX` (4) is intentionally tighter: on empty
+ * grid it distinguishes a click-to-create from a drag-to-resize-duration. Do
+ * not unify these values; they measure different products of the gesture.
+ */
+export const INTERACTION_HOLD_DELAY_MS = 750;
+export const INTERACTION_MOVE_THRESHOLD_PX = 25;
+export const INTERACTION_COMMIT_TEARDOWN_DEADLINE_MS = 250;
+export const TIMED_DRAFT_CREATE_MOVE_THRESHOLD_PX = 4;

--- a/packages/web/src/interaction/interaction.engine.ts
+++ b/packages/web/src/interaction/interaction.engine.ts
@@ -9,6 +9,11 @@ import {
   type InteractionAdapter,
 } from "./interaction.adapter.types";
 import {
+  INTERACTION_COMMIT_TEARDOWN_DEADLINE_MS,
+  INTERACTION_HOLD_DELAY_MS,
+  INTERACTION_MOVE_THRESHOLD_PX,
+} from "./interaction.constants";
+import {
   createInteractionMetrics,
   type InteractionMetrics,
 } from "./interaction.metrics";
@@ -67,11 +72,11 @@ const defaultOptions = {
   clearTimer: (timer: unknown) => {
     clearTimeout(timer as ReturnType<typeof setTimeout>);
   },
-  commitTeardownDeadlineMs: 250,
+  commitTeardownDeadlineMs: INTERACTION_COMMIT_TEARDOWN_DEADLINE_MS,
   createMetrics: createInteractionMetrics,
   createDraftEvent: () => new FloatingDraftEvent(),
-  holdDelayMs: 750,
-  moveThresholdPx: 25,
+  holdDelayMs: INTERACTION_HOLD_DELAY_MS,
+  moveThresholdPx: INTERACTION_MOVE_THRESHOLD_PX,
   now: () => performance.now(),
   requestFrame: (callback: FrameRequestCallback) =>
     requestAnimationFrame(callback),

--- a/packages/web/src/views/Forms/EventForm/CalendarSelect/CalendarSelect.tsx
+++ b/packages/web/src/views/Forms/EventForm/CalendarSelect/CalendarSelect.tsx
@@ -20,6 +20,7 @@ import {
   useConnectedAccountEmails,
   useDefaultTargetCalendar,
 } from "@web/calendars/useDefaultTargetCalendar";
+import { Z_INDEX_FLOATING_MENU } from "@web/common/constants/web.constants";
 
 interface CalendarSelectProps {
   value: CalendarId | null;
@@ -208,8 +209,9 @@ export const CalendarSelect = ({
           })}
           id={dropdownId}
           aria-label="Calendar"
-          className="absolute top-full left-0 z-50 mt-1 min-w-[200px] rounded border border-border bg-surface py-1 shadow-lg"
+          className="absolute top-full left-0 mt-1 min-w-[200px] rounded border border-border bg-surface py-1 shadow-lg"
           role="listbox"
+          style={{ zIndex: Z_INDEX_FLOATING_MENU }}
         >
           {writableCalendars.map((calendar, index) => {
             const isSelected = calendar.id === displayedCalendar?.id;

--- a/packages/web/src/views/Week/hooks/grid/useGridEventMouseDown.ts
+++ b/packages/web/src/views/Week/hooks/grid/useGridEventMouseDown.ts
@@ -2,9 +2,11 @@ import { type MouseEvent as ReactMouseEvent, useRef } from "react";
 import { type PartialMouseEvent } from "@web/common/types/util.types";
 import { type GridEvent } from "@web/common/types/web.event.types";
 import { isEventFormOpen } from "@web/events/stores/draft.store";
-
-export const GRID_EVENT_MOUSE_HOLD_DELAY = 750; // ms
-export const GRID_EVENT_MOUSE_HOLD_MOVE_THRESHOLD = 25; // pixels
+import {
+  INTERACTION_HOLD_DELAY_MS,
+  INTERACTION_MOVE_THRESHOLD_PX,
+} from "@web/interaction/interaction.constants";
+import { hasExceededInteractionMoveThreshold } from "@web/interaction/interaction.pointer";
 
 type HandleDragHandlers = {
   onMouseMove: (e: MouseEvent) => void;
@@ -24,25 +26,11 @@ type HandleDragHandlers = {
 export const useGridEventMouseDown = (
   onClick: (event: GridEvent) => void,
   onDrag: (event: GridEvent, moveEvent: PartialMouseEvent) => void,
-  delay: number = GRID_EVENT_MOUSE_HOLD_DELAY,
+  delay: number = INTERACTION_HOLD_DELAY_MS,
 ) => {
   const timeoutId = useRef<NodeJS.Timeout | null>(null);
   const mouseMoved = useRef<boolean>(false);
   const targetRef = useRef<EventTarget | null>(null);
-
-  const hasExceededMoveThreshold = (
-    currentX: number,
-    currentY: number,
-    initialX: number,
-    initialY: number,
-  ) => {
-    const deltaX = Math.abs(currentX - initialX);
-    const deltaY = Math.abs(currentY - initialY);
-    return (
-      deltaX > GRID_EVENT_MOUSE_HOLD_MOVE_THRESHOLD ||
-      deltaY > GRID_EVENT_MOUSE_HOLD_MOVE_THRESHOLD
-    );
-  };
 
   const cleanup = (
     onMouseMove: (e: MouseEvent) => void,
@@ -86,11 +74,10 @@ export const useGridEventMouseDown = (
 
     const onMouseMove = (moveEvent: MouseEvent) => {
       if (
-        hasExceededMoveThreshold(
-          moveEvent.clientX,
-          moveEvent.clientY,
-          initialX,
-          initialY,
+        hasExceededInteractionMoveThreshold(
+          { x: moveEvent.clientX, y: moveEvent.clientY },
+          { x: initialX, y: initialY },
+          INTERACTION_MOVE_THRESHOLD_PX,
         )
       ) {
         mouseMoved.current = true;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

UI declutter G1 + G2 (behavior-preserving).

**G1 — interaction constants**
- Add `interaction.constants.ts` for shared hold delay (750ms), move threshold (25px), and commit teardown (250ms).
- Wire `interaction.engine` and `useGridEventMouseDown` to those values; reuse `hasExceededInteractionMoveThreshold` in the mousedown hook.
- Keep `TIMED_DRAFT_CREATE_MOVE_THRESHOLD_PX` at **4** on purpose: empty-grid click-vs-drag-create is intentionally tighter than the 25px event/draft motion gate. Documented in the constants module (do not unify).
- Skipped G3 (`useGridEventMouseDown` listener cleanup) and broad motion/CSS duration consolidation.

**G2 — ZIndex scale escapes**
- CalendarSelect / SelectView dropdowns: `z-50` → `Z_INDEX_FLOATING_MENU`.
- DatePicker: keep static `!z-22` (equals `Z_INDEX_FLOATING_MENU`); `popperProps.style` is a no-op under react-popper — documented.
- Draft time label in `grid/interaction/dom.ts`: `"3"` → `ZIndex.LAYER_3`.
- EventGrid loading/import/error overlays and ShortcutsOverlay: Tailwind `z-10`/`z-20` → `ZIndex.MAX`.
- Left local stacking (`z-1`/`z-2`, UpNext Join `z-10`, datepicker CSS decorations) alone.

## Simplicity

- Removed the local move-threshold helper in favor of `hasExceededInteractionMoveThreshold`.
- Skipped promoting ShortcutsOverlay to `Z_INDEX_MODAL` (sidebar-local cover; prior value was `z-20` / `ZIndex.MAX`).
- Skipped folding the three 50px edge-scroll thresholds into this module.

## Automated validation

- `bun run type-check` — clean
- `bun test:web` — 1794/1794
- `bun test:e2e` — 21/21 (twice)
- `bun run lint` — 14 pre-existing warnings, no new issues
- Manual browser: week view draft create-by-click, view selector stacking above grid, day/week switch; only expected localhost:3000 config connection errors without backend
- `/simplify` (quality / performance / reuse) — no material quality or performance findings; reuse note on ShortcutsOverlay modal z-index skipped to preserve prior stacking

## Independent review

- Confirmed DatePicker `popperProps.style` stacking regression — fixed by restoring `popperClassName="!z-22"` with rationale.
- G1 / G3 listener lifecycle judged clean.

## Test plan

- `bun run type-check`
- `bun test:web` (1794/1794)
- `bun test:e2e` (21/21)
- `bun run lint`
- Manual browser smoke on http://localhost:9080/week

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f4fa83e2-a2f2-420d-a869-a0ff474b8eeb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f4fa83e2-a2f2-420d-a869-a0ff474b8eeb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

