### PR TITLE
fix(web): place all-day events on the correct day in Day View

### DIFF
--- a/packages/web/src/events/queries/day.event.query.test.ts
+++ b/packages/web/src/events/queries/day.event.query.test.ts
@@ -1,0 +1,81 @@
+import { EventScheduleSchema } from "@core/types/event.contracts";
+import dayjs, { type Dayjs } from "@core/util/date/dayjs";
+import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
+import { toUTCOffset } from "@web/common/utils/datetime/web.date.util";
+import { type EventRepository } from "@web/events/repositories/event.repository.types";
+import { fetchDayEvents } from "./day.event.query";
+import { describe, expect, it, mock } from "bun:test";
+
+/** Same shape as dayEventQueryRange, without importing the hook module. */
+const dayRange = (date: Dayjs) => ({
+  startDate: toUTCOffset(date.startOf("day")),
+  endDate: toUTCOffset(date.add(1, "day").startOf("day")),
+});
+
+const mondayAllDay = createMockEvent({
+  content: { kind: "details", title: "AW-0-#", description: "" },
+  schedule: EventScheduleSchema.parse({
+    kind: "allDay",
+    start: "2026-08-10",
+    end: "2026-08-11",
+  }),
+});
+
+describe("fetchDayEvents remote Sync startAt skew", () => {
+  it("pads the Sync request and keeps Monday all-day only on Monday (Denver)", async () => {
+    const list = mock(async () => [mondayAllDay]);
+    const repository = { list } as unknown as EventRepository;
+
+    const sunday = dayjs.tz("2026-08-09 12:00", "America/Denver");
+    const monday = dayjs.tz("2026-08-10 12:00", "America/Denver");
+    const sundayRange = dayRange(sunday);
+    const mondayRange = dayRange(monday);
+
+    const sundayResult = await fetchDayEvents(
+      sundayRange,
+      repository,
+      "remote",
+    );
+    expect(list).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "range",
+        start: toUTCOffset(dayjs(sundayRange.startDate).subtract(1, "day")),
+        end: toUTCOffset(dayjs(sundayRange.endDate).add(1, "day")),
+      }),
+    );
+    expect(sundayResult.ids).toEqual([]);
+
+    list.mockClear();
+    const mondayResult = await fetchDayEvents(
+      mondayRange,
+      repository,
+      "remote",
+    );
+    expect(list).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "range",
+        start: toUTCOffset(dayjs(mondayRange.startDate).subtract(1, "day")),
+        end: toUTCOffset(dayjs(mondayRange.endDate).add(1, "day")),
+      }),
+    );
+    expect(mondayResult.ids).toEqual([mondayAllDay.id]);
+    expect(mondayResult.entities[mondayAllDay.id]?.content).toMatchObject({
+      title: "AW-0-#",
+    });
+  });
+
+  it("does not pad or call the repository for an empty calendarIds list", async () => {
+    const list = mock(async () => [mondayAllDay]);
+    const repository = { list } as unknown as EventRepository;
+    const monday = dayjs.tz("2026-08-10 12:00", "America/Denver");
+
+    const result = await fetchDayEvents(
+      { ...dayRange(monday), calendarIds: [] },
+      repository,
+      "remote",
+    );
+
+    expect(list).not.toHaveBeenCalled();
+    expect(result.ids).toEqual([]);
+  });
+});

--- a/packages/web/src/events/queries/day.event.query.ts
+++ b/packages/web/src/events/queries/day.event.query.ts
@@ -1,9 +1,11 @@
 import { type CalendarId } from "@core/types/domain-primitives";
 import { EventListQuerySchema } from "@core/types/event-command.contracts";
+import dayjs from "@core/util/date/dayjs";
+import { toUTCOffset } from "@web/common/utils/datetime/web.date.util";
 import { type EventRepositorySource } from "@web/events/repositories/event.repository.factory";
 import { type EventRepository } from "@web/events/repositories/event.repository.types";
 import { fetchLocalEventsRange } from "./event.query.local";
-import { normalizeEventList } from "./event.query.normalize";
+import { eventMatchesRange, normalizeEventList } from "./event.query.normalize";
 import { type NormalizedEventQueryData } from "./event.query.types";
 
 type FetchEventsRangePayload = {
@@ -13,11 +15,23 @@ type FetchEventsRangePayload = {
 };
 
 /**
+ * Sync indexes all-day occurrences at UTC midnight of their date-only start.
+ * A local-midnight day/week window west of UTC therefore misses today's
+ * all-day startAt and can include tomorrow's. Pad the remote request by one
+ * calendar day on each side so those rows are candidates, then keep only
+ * events that pass {@link eventMatchesRange} against the original bounds
+ * (date-slice overlap for all-day — same rule as IndexedDB / optimistic
+ * cache membership). Cache keys stay on the unpadded window.
+ */
+const paddedRemoteRange = (startDate: string, endDate: string) => ({
+  start: toUTCOffset(dayjs(startDate).subtract(1, "day")),
+  end: toUTCOffset(dayjs(endDate).add(1, "day")),
+});
+
+/**
  * Pure async range-events read for day and week queries. No dispatching.
- * Calls the repository with a "range" EventListQuery and normalizes the
- * result. The backend range read does its own exact [start, end) overlap
- * filtering (event.repository.ts listRange) — no client-side date-window
- * adjustment or re-filter needed.
+ * Remote (Sync) reads pad the request window and re-filter with
+ * {@link eventMatchesRange}; local IndexedDB already applies that rule.
  *
  * An empty `calendarIds` array means every calendar is hidden: skip the
  * network and return []. `undefined` keeps the legacy "all calendars" read
@@ -40,15 +54,20 @@ export async function fetchDayEvents(
     return normalizeEventList([]);
   }
 
+  const { start, end } = paddedRemoteRange(payload.startDate, payload.endDate);
   const query = EventListQuerySchema.parse({
     kind: "range",
-    start: payload.startDate,
-    end: payload.endDate,
+    start,
+    end,
     ...(payload.calendarIds !== undefined && payload.calendarIds.length > 0
       ? { calendarIds: payload.calendarIds }
       : {}),
   });
 
   const events = await repository.list(query);
-  return normalizeEventList(events);
+  return normalizeEventList(
+    events.filter((event) =>
+      eventMatchesRange(event, payload.startDate, payload.endDate),
+    ),
+  );
 }

--- a/packages/web/src/views/Day/components/Calendar/dayAllDayRows.util.test.ts
+++ b/packages/web/src/views/Day/components/Calendar/dayAllDayRows.util.test.ts
@@ -1,5 +1,9 @@
+import dayjs from "@core/util/date/dayjs";
 import { type GridEvent } from "@web/common/types/web.event.types";
-import { assignDayAllDayEventRows } from "./dayAllDayRows.util";
+import {
+  assignDayAllDayEventRows,
+  isAllDayEventOnDay,
+} from "./dayAllDayRows.util";
 import { describe, expect, it } from "bun:test";
 
 const allDay = (
@@ -16,6 +20,41 @@ const allDay = (
     title: id,
     ...overrides,
   }) as GridEvent;
+
+describe("isAllDayEventOnDay", () => {
+  const mondayAllDay = allDay("aw", "cal", {
+    startDate: "2026-08-10",
+    endDate: "2026-08-11",
+  });
+  const multiDay = allDay("span", "cal", {
+    startDate: "2026-08-09",
+    endDate: "2026-08-11",
+  });
+
+  it("shows a Monday all-day event on Monday and not Sunday", () => {
+    expect(
+      isAllDayEventOnDay(mondayAllDay, dayjs("2026-08-10T12:00:00-06:00")),
+    ).toBe(true);
+    expect(
+      isAllDayEventOnDay(mondayAllDay, dayjs("2026-08-09T12:00:00-06:00")),
+    ).toBe(false);
+  });
+
+  it("keeps a multi-day all-day event on every day it spans", () => {
+    expect(isAllDayEventOnDay(multiDay, dayjs("2026-08-09"))).toBe(true);
+    expect(isAllDayEventOnDay(multiDay, dayjs("2026-08-10"))).toBe(true);
+    expect(isAllDayEventOnDay(multiDay, dayjs("2026-08-11"))).toBe(false);
+  });
+
+  it("uses date prefixes when start/end are UTC midnight instants", () => {
+    const utcShaped = allDay("utc", "cal", {
+      startDate: "2026-08-10T00:00:00.000Z",
+      endDate: "2026-08-11T00:00:00.000Z",
+    });
+    expect(isAllDayEventOnDay(utcShaped, dayjs("2026-08-10"))).toBe(true);
+    expect(isAllDayEventOnDay(utcShaped, dayjs("2026-08-09"))).toBe(false);
+  });
+});
 
 describe("assignDayAllDayEventRows", () => {
   it("returns one row when there are no all-day events", () => {

--- a/packages/web/src/views/Day/components/Calendar/dayAllDayRows.util.ts
+++ b/packages/web/src/views/Day/components/Calendar/dayAllDayRows.util.ts
@@ -1,4 +1,26 @@
+import { YEAR_MONTH_DAY_FORMAT } from "@core/constants/date.constants";
+import { type Dayjs } from "@core/util/date/dayjs";
 import { type GridEvent } from "@web/common/types/web.event.types";
+
+/**
+ * Whether an all-day (or all-day-row) event's exclusive date span covers
+ * `date`. Uses calendar-date prefixes so Sync UTC-midnight datetime shapes
+ * and date-only schedules agree with {@link eventMatchesRange} / week
+ * {@link isAllDayEventInVisibleDays}.
+ */
+export const isAllDayEventOnDay = (
+  event: Pick<GridEvent, "startDate" | "endDate">,
+  date: Dayjs,
+): boolean => {
+  const dayStart = date.startOf("day").format(YEAR_MONTH_DAY_FORMAT);
+  const dayEnd = date
+    .startOf("day")
+    .add(1, "day")
+    .format(YEAR_MONTH_DAY_FORMAT);
+  const eventStart = event.startDate.slice(0, 10);
+  const eventEnd = event.endDate.slice(0, 10);
+  return eventStart < dayEnd && eventEnd > dayStart;
+};
 
 /**
  * Day view columns are calendars on the same date. Week-style row assignment

--- a/packages/web/src/views/Day/components/Calendar/useDayCalendarColumns.ts
+++ b/packages/web/src/views/Day/components/Calendar/useDayCalendarColumns.ts
@@ -3,6 +3,7 @@ import { YEAR_MONTH_DAY_FORMAT } from "@core/constants/date.constants";
 import { type Dayjs } from "@core/util/date/dayjs";
 import { useCalendarsQuery } from "@web/calendars/calendar.query";
 import { type GridEvent } from "@web/common/types/web.event.types";
+import { isAllDayEventOnDay } from "./dayAllDayRows.util";
 import { getDayViewCalendars } from "./dayCalendarColumns.util";
 
 export const useDayCalendarColumns = ({
@@ -56,10 +57,16 @@ export const useDayCalendarColumns = ({
     [calendarColumnIndexById, calendarIds],
   );
   // Day all-day row stacking (including drafts) is owned by DayCalendarGrid so
-  // strip height and chips stay in sync.
+  // strip height and chips stay in sync. Also drop chips whose date span
+  // does not cover dateInView (week has the same second pass) so a Sync
+  // startAt skew cannot paint tomorrow's all-day event on today.
   const displayedAllDayEvents = useMemo(
-    () => allDayEvents.filter(isDisplayedEvent),
-    [allDayEvents, isDisplayedEvent],
+    () =>
+      allDayEvents.filter(
+        (event) =>
+          isDisplayedEvent(event) && isAllDayEventOnDay(event, dateInView),
+      ),
+    [allDayEvents, dateInView, isDisplayedEvent],
   );
   const displayedTimedEvents = useMemo(
     () => timedEvents.filter(isDisplayedEvent),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

All-day events from Sync were one day off in Day View west of UTC (e.g. `AW-0-#` on Sunday in Day View but Monday in Week View). Sync stores all-day `startAt` as UTC midnight while Day View queries local midnight and painted every returned chip without a date-span check.

## Changes

- **Remote range reads** (`fetchDayEvents` / week): pad the Sync request by ±1 calendar day, then keep only events that pass `eventMatchesRange` against the original bounds (same date-slice rule as IndexedDB).
- **Day View guard**: filter `displayedAllDayEvents` with `isAllDayEventOnDay` so chips only render when their exclusive date span covers `dateInView`.

## Test plan

- [x] `bun test packages/web/src/events/queries/day.event.query.test.ts packages/web/src/views/Day/components/Calendar/dayAllDayRows.util.test.ts`
- [ ] On staging (west of UTC): open Day View for the day before an all-day Google event — it should not appear; open the event’s day — it should appear; Week View still places it on the correct day.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b3e6c8be-80a1-4ef8-a57c-116133645694?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b3e6c8be-80a1-4ef8-a57c-116133645694&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

