### PR TITLE
fix(web): lock app shortcuts while OverlayPanel is open

### DIFF
--- a/packages/web/src/components/MobileGate/MobileGate.test.tsx
+++ b/packages/web/src/components/MobileGate/MobileGate.test.tsx
@@ -90,4 +90,12 @@ describe("MobileGate", () => {
       expect(heading).toHaveTextContent("Open Compass on a computer");
     });
   });
+
+  it("locks app shortcuts while mounted", () => {
+    const { unmount } = render(<MobileGate />);
+
+    expect(document.body.dataset.appLocked).toBe("true");
+    unmount();
+    expect(document.body.dataset.appLocked).toBeUndefined();
+  });
 });

--- a/packages/web/src/components/MobileGate/MobileGate.tsx
+++ b/packages/web/src/components/MobileGate/MobileGate.tsx
@@ -1,11 +1,13 @@
 import type React from "react";
 import { useEffect, useRef, useState } from "react";
+import { useAppLockReason } from "@web/shortcuts/app-lock";
 
 const WAITLIST_URL = "https://tylerdane.kit.com/compass-mobile";
 
 export const MobileGate: React.FC = () => {
   const [copied, setCopied] = useState(false);
   const copiedResetTimeoutRef = useRef<number | null>(null);
+  useAppLockReason("mobileGate", true);
 
   useEffect(() => {
     return () => {

--- a/packages/web/src/components/OverlayPanel/OverlayPanel.test.tsx
+++ b/packages/web/src/components/OverlayPanel/OverlayPanel.test.tsx
@@ -1,0 +1,44 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import { OverlayPanel } from "@web/components/OverlayPanel/OverlayPanel";
+import { describe, expect, it } from "bun:test";
+
+describe("OverlayPanel", () => {
+  it("locks app shortcuts while mounted and clears on unmount", () => {
+    const { unmount } = render(
+      <OverlayPanel title="Confirm" onDismiss={() => {}} />,
+    );
+
+    expect(document.body.dataset.appLocked).toBe("true");
+    unmount();
+    expect(document.body.dataset.appLocked).toBeUndefined();
+  });
+
+  it("keeps the app locked when multiple panels are stacked", () => {
+    const { unmount: unmountFirst } = render(
+      <OverlayPanel title="First" onDismiss={() => {}} />,
+    );
+    const { unmount: unmountSecond } = render(
+      <OverlayPanel title="Second" onDismiss={() => {}} />,
+    );
+
+    expect(document.body.dataset.appLocked).toBe("true");
+
+    unmountFirst();
+    expect(document.body.dataset.appLocked).toBe("true");
+    expect(screen.getByRole("dialog", { name: "Second" })).toBeInTheDocument();
+
+    unmountSecond();
+    expect(document.body.dataset.appLocked).toBeUndefined();
+  });
+
+  it("locks status panels too", () => {
+    const { unmount } = render(
+      <OverlayPanel role="status" variant="status" message="Working…" />,
+    );
+
+    expect(document.body.dataset.appLocked).toBe("true");
+    unmount();
+    expect(document.body.dataset.appLocked).toBeUndefined();
+  });
+});

--- a/packages/web/src/components/OverlayPanel/OverlayPanel.tsx
+++ b/packages/web/src/components/OverlayPanel/OverlayPanel.tsx
@@ -7,6 +7,7 @@ import {
   useRef,
 } from "react";
 import { Z_INDEX_MODAL } from "@web/common/constants/web.constants";
+import { useAppLockReason } from "@web/shortcuts/app-lock";
 
 const FOCUSABLE_SELECTOR =
   'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
@@ -50,8 +51,11 @@ export const OverlayPanel = ({
   widthClassName = "w-[400px]",
 }: Props) => {
   const panelRef = useRef<HTMLDivElement>(null);
-  const titleId = useId();
-  const messageId = useId();
+  const baseId = useId();
+  const titleId = `${baseId}-title`;
+  const messageId = `${baseId}-message`;
+  // Unique per instance: app-lock reasons are a Set, not refcounted.
+  useAppLockReason(`overlayPanel:${baseId}`, true);
 
   useEffect(() => {
     if (role !== "dialog") return;


### PR DESCRIPTION
## Summary
- Hold an app-lock reason inside `OverlayPanel` (per-instance via `useId`) so Logout, Delete Account, Feedback, and other panel dialogs block global shortcuts while mounted
- Lock `MobileGate` the same way while the full-page gate is shown
- Cover mount/unmount, stacked panels, and status panels with unit tests

## Test plan
- [x] `bun run type-check`
- [x] `bun test:web` (1813/1813)
- [x] Focused OverlayPanel / MobileGate / dialog / app-lock tests
- [x] `bun test:e2e` (21/21)
- [x] `bun run lint` (pre-existing warnings only)
- [x] Manual smoke: About dialog sets `data-app-locked`, `j` does not navigate, dismiss clears lock