### PR TITLE
fix(web): dismiss shortcuts overlay through app shortcuts

### DIFF
--- a/packages/web/src/components/Sidebar/ShortcutsOverlay/ShortcutsOverlay.test.tsx
+++ b/packages/web/src/components/Sidebar/ShortcutsOverlay/ShortcutsOverlay.test.tsx
@@ -50,9 +50,9 @@ describe("ShortcutsOverlay", () => {
       wrapper,
     });
 
-    const overlay = screen.getByRole("dialog", { name: "Keyboard shortcuts" });
-
-    expect(overlay.firstElementChild?.className).toContain("translate-x-0");
+    expect(
+      screen.getByRole("dialog", { name: "Keyboard shortcuts" }),
+    ).toBeInTheDocument();
     expect(screen.getByText("Shortcuts")).toBeInTheDocument();
     expect(
       screen.getByText("Keyboard shortcuts for Day view"),

--- a/packages/web/src/components/Sidebar/ShortcutsOverlay/ShortcutsOverlay.test.tsx
+++ b/packages/web/src/components/Sidebar/ShortcutsOverlay/ShortcutsOverlay.test.tsx
@@ -50,9 +50,10 @@ describe("ShortcutsOverlay", () => {
       wrapper,
     });
 
-    expect(
-      screen.getByRole("dialog", { name: "Keyboard shortcuts" }),
-    ).toBeInTheDocument();
+    const overlay = screen.getByRole("dialog", { name: "Keyboard shortcuts" });
+
+    expect(overlay.firstElementChild?.className).toContain("translate-x-0");
+    expect(overlay.inert).toBe(false);
     expect(screen.getByText("Shortcuts")).toBeInTheDocument();
     expect(
       screen.getByText("Keyboard shortcuts for Day view"),
@@ -128,12 +129,16 @@ describe("ShortcutsOverlay", () => {
     });
   });
 
-  it("does not render when closed", () => {
+  it("is inert and off-screen when closed", () => {
     render(<ShortcutsOverlay sections={sections} />, { wrapper });
 
-    expect(
-      screen.queryByRole("dialog", { name: "Keyboard shortcuts" }),
-    ).toBeNull();
-    expect(screen.queryByText("Shortcuts")).not.toBeInTheDocument();
+    // jsdom still exposes inert dialogs to role queries; assert the inert
+    // flag and off-screen transform that browsers use to hide it.
+    const overlay = screen.getByRole("dialog", {
+      hidden: true,
+      name: "Keyboard shortcuts",
+    });
+    expect(overlay.inert).toBe(true);
+    expect(overlay.firstElementChild?.className).toContain("-translate-x-full");
   });
 });

--- a/packages/web/src/components/Sidebar/ShortcutsOverlay/ShortcutsOverlay.test.tsx
+++ b/packages/web/src/components/Sidebar/ShortcutsOverlay/ShortcutsOverlay.test.tsx
@@ -1,10 +1,14 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { HotkeyManager, HotkeysProvider } from "@tanstack/react-hotkeys";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { type PropsWithChildren } from "react";
+import { pressKey } from "@web/__tests__/utils/keyboard.test.util";
 import {
   selectIsShortcutsOpen,
   useViewStore,
   viewActions,
 } from "@web/events/stores/view.store";
-import { describe, expect, it } from "bun:test";
+import { beforeEach, describe, expect, it } from "bun:test";
 import "@testing-library/jest-dom";
 import { ShortcutsOverlay } from "./ShortcutsOverlay";
 
@@ -27,12 +31,24 @@ const sections = [
   },
 ];
 
+function wrapper({ children }: PropsWithChildren) {
+  return <HotkeysProvider>{children}</HotkeysProvider>;
+}
+
 describe("ShortcutsOverlay", () => {
+  beforeEach(() => {
+    HotkeyManager.resetInstance();
+    document.body.removeAttribute("data-app-locked");
+    viewActions.setSidebarOpen(false);
+  });
+
   it("renders shortcut sections over the sidebar", () => {
     viewActions.setSidebarOpen(true);
     viewActions.toggleShortcuts();
 
-    render(<ShortcutsOverlay sections={sections} viewLabel="Day" />);
+    render(<ShortcutsOverlay sections={sections} viewLabel="Day" />, {
+      wrapper,
+    });
 
     const overlay = screen.getByRole("dialog", { name: "Keyboard shortcuts" });
 
@@ -46,30 +62,78 @@ describe("ShortcutsOverlay", () => {
     expect(screen.queryByText("Empty")).not.toBeInTheDocument();
   });
 
-  it("closes when closed with Escape", () => {
+  it("closes when Escape is pressed", async () => {
     viewActions.setSidebarOpen(true);
     viewActions.toggleShortcuts();
 
-    render(<ShortcutsOverlay sections={sections} />);
+    render(<ShortcutsOverlay sections={sections} />, { wrapper });
 
-    fireEvent.keyDown(document, { key: "Escape" });
+    act(() => {
+      pressKey("Escape");
+    });
 
-    expect(selectIsShortcutsOpen(useViewStore.getState())).toBe(false);
+    await waitFor(() => {
+      expect(selectIsShortcutsOpen(useViewStore.getState())).toBe(false);
+    });
+  });
+
+  it("clears the search query before closing on Escape", async () => {
+    const user = userEvent.setup();
+    viewActions.setSidebarOpen(true);
+    viewActions.toggleShortcuts();
+
+    render(<ShortcutsOverlay sections={sections} />, { wrapper });
+
+    await user.type(
+      screen.getByPlaceholderText("Search shortcuts..."),
+      "previous",
+    );
+    expect(screen.getByText("Previous day")).toBeInTheDocument();
+    expect(screen.queryByText("Next day")).not.toBeInTheDocument();
+
+    act(() => {
+      pressKey("Escape");
+    });
+
+    await waitFor(() => {
+      expect(selectIsShortcutsOpen(useViewStore.getState())).toBe(true);
+      expect(screen.getByPlaceholderText("Search shortcuts...")).toHaveValue(
+        "",
+      );
+      expect(screen.getByText("Next day")).toBeInTheDocument();
+    });
+
+    act(() => {
+      pressKey("Escape");
+    });
+
+    await waitFor(() => {
+      expect(selectIsShortcutsOpen(useViewStore.getState())).toBe(false);
+    });
+  });
+
+  it("dismisses with Escape while the app is locked", async () => {
+    document.body.dataset.appLocked = "true";
+    viewActions.setSidebarOpen(true);
+    viewActions.toggleShortcuts();
+
+    render(<ShortcutsOverlay sections={sections} />, { wrapper });
+
+    act(() => {
+      pressKey("Escape");
+    });
+
+    await waitFor(() => {
+      expect(selectIsShortcutsOpen(useViewStore.getState())).toBe(false);
+    });
   });
 
   it("does not render when closed", () => {
-    render(<ShortcutsOverlay sections={sections} />);
+    render(<ShortcutsOverlay sections={sections} />, { wrapper });
 
     expect(
       screen.queryByRole("dialog", { name: "Keyboard shortcuts" }),
     ).toBeNull();
-    const overlay = screen.getByLabelText("Keyboard shortcuts", {
-      selector: "div",
-    });
-    expect(overlay.className).toContain("pointer-events-none");
-    expect(overlay.firstElementChild?.className).toContain("-translate-x-full");
-    expect(
-      screen.getByRole("button", { hidden: true, name: "Close shortcuts" }),
-    ).toHaveProperty("tabIndex", -1);
+    expect(screen.queryByText("Shortcuts")).not.toBeInTheDocument();
   });
 });

--- a/packages/web/src/components/Sidebar/ShortcutsOverlay/ShortcutsOverlay.tsx
+++ b/packages/web/src/components/Sidebar/ShortcutsOverlay/ShortcutsOverlay.tsx
@@ -1,5 +1,6 @@
 import { XIcon } from "@phosphor-icons/react";
-import { useCallback, useEffect, useState } from "react";
+import classNames from "classnames";
+import { useEffect, useRef, useState } from "react";
 import { ZIndex } from "@web/common/constants/web.constants";
 import { ShortcutSection } from "@web/components/Shortcuts/ShortcutOverlay/ShortcutSection";
 import {
@@ -23,6 +24,8 @@ const matchesSearch = (normalizedQuery: string, text: string): boolean =>
 export function ShortcutsOverlay({ sections, viewLabel }: Props) {
   const isOpen = useViewStore(selectIsShortcutsOpen);
   const [searchQuery, setSearchQuery] = useState("");
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const searchInputRef = useRef<HTMLInputElement>(null);
 
   // App-lock is held by useSidebarShortcuts; ignoreAppLock keeps Escape able
   // to clear search / dismiss while that lock is active. ignoreInputs: false
@@ -43,22 +46,29 @@ export function ShortcutsOverlay({ sections, viewLabel }: Props) {
     },
   );
 
-  // toggleShortcuts / sidebar actions can close without this component's
-  // handlers, so reset search whenever the overlay leaves the open state.
+  // Prefer `inert` over permanently mounting an `aria-hidden` dialog: inert
+  // removes the subtree from the a11y tree and blocks interaction while
+  // keeping the slide animation. (Conditional unmount is the other F3
+  // option, but it exposed unrelated sidebar contrast debt to axe that
+  // the old covering dialog had been papering over — tracked separately.)
   useEffect(() => {
-    if (!isOpen) {
-      setSearchQuery("");
+    const overlay = overlayRef.current;
+    if (overlay) {
+      overlay.inert = !isOpen;
     }
   }, [isOpen]);
 
-  // Focus on mount (commit phase). Prefer a stable callback ref over autoFocus
-  // (biome noAutofocus) or useEffect focus (unreliable in jsdom).
-  const focusInputOnMount = useCallback((node: HTMLInputElement | null) => {
-    node?.focus();
-  }, []);
+  useEffect(() => {
+    if (!isOpen) {
+      setSearchQuery("");
+      return;
+    }
+
+    setTimeout(() => searchInputRef.current?.focus(), 0);
+  }, [isOpen]);
 
   const hasSections = sections.some((section) => section.shortcuts.length > 0);
-  if (!hasSections || !isOpen) return null;
+  if (!hasSections) return null;
 
   const normalizedQuery = normalizeSearch(searchQuery);
   const visibleSections = sections
@@ -81,12 +91,22 @@ export function ShortcutsOverlay({ sections, viewLabel }: Props) {
 
   return (
     <div
+      ref={overlayRef}
       aria-label="Keyboard shortcuts"
-      className="absolute inset-0 overflow-hidden"
+      className={classNames(
+        "absolute inset-0 overflow-hidden",
+        !isOpen && "pointer-events-none",
+      )}
       role="dialog"
       style={{ zIndex: ZIndex.MAX }}
     >
-      <div className="flex h-full starting:-translate-x-full flex-col bg-surface/95 px-4 pt-8 pb-5 text-text-muted shadow-2xl backdrop-blur-md transition-transform duration-200 ease-out motion-reduce:transition-none">
+      <div
+        className={classNames(
+          "flex h-full flex-col bg-surface/95 px-4 pt-8 pb-5 text-text-muted shadow-2xl backdrop-blur-md",
+          "transition-transform duration-200 ease-out motion-reduce:transition-none",
+          isOpen ? "translate-x-0" : "-translate-x-full",
+        )}
+      >
         <div className="mb-5 flex items-center justify-between">
           <div className="flex-1">
             <div className="font-medium text-text text-xl">Shortcuts</div>
@@ -104,7 +124,7 @@ export function ShortcutsOverlay({ sections, viewLabel }: Props) {
         </div>
 
         <input
-          ref={focusInputOnMount}
+          ref={searchInputRef}
           type="text"
           placeholder="Search shortcuts..."
           value={searchQuery}

--- a/packages/web/src/components/Sidebar/ShortcutsOverlay/ShortcutsOverlay.tsx
+++ b/packages/web/src/components/Sidebar/ShortcutsOverlay/ShortcutsOverlay.tsx
@@ -1,5 +1,5 @@
 import { XIcon } from "@phosphor-icons/react";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { ZIndex } from "@web/common/constants/web.constants";
 import { ShortcutSection } from "@web/components/Shortcuts/ShortcutOverlay/ShortcutSection";
 import {
@@ -17,16 +17,12 @@ interface Props {
 
 const normalizeSearch = (text: string): string => text.toLowerCase().trim();
 
-const matchesSearch = (searchTerm: string, text: string): boolean => {
-  const normalized = normalizeSearch(text);
-  const query = normalizeSearch(searchTerm);
-  return normalized.includes(query);
-};
+const matchesSearch = (normalizedQuery: string, text: string): boolean =>
+  normalizeSearch(text).includes(normalizedQuery);
 
 export function ShortcutsOverlay({ sections, viewLabel }: Props) {
   const isOpen = useViewStore(selectIsShortcutsOpen);
   const [searchQuery, setSearchQuery] = useState("");
-  const searchInputRef = useRef<HTMLInputElement>(null);
 
   // App-lock is held by useSidebarShortcuts; ignoreAppLock keeps Escape able
   // to clear search / dismiss while that lock is active. ignoreInputs: false
@@ -47,45 +43,41 @@ export function ShortcutsOverlay({ sections, viewLabel }: Props) {
     },
   );
 
+  // toggleShortcuts / sidebar actions can close without this component's
+  // handlers, so reset search whenever the overlay leaves the open state.
   useEffect(() => {
     if (!isOpen) {
       setSearchQuery("");
-      return;
     }
-
-    // Auto-focus search input when overlay opens
-    setTimeout(() => searchInputRef.current?.focus(), 0);
   }, [isOpen]);
 
-  const filteredSections = sections
-    .map((section) => {
-      if (!searchQuery) {
-        return section;
-      }
+  // Focus on mount (commit phase). Prefer a stable callback ref over autoFocus
+  // (biome noAutofocus) or useEffect focus (unreliable in jsdom).
+  const focusInputOnMount = useCallback((node: HTMLInputElement | null) => {
+    node?.focus();
+  }, []);
 
-      const filteredShortcuts = section.shortcuts.filter(
+  const hasSections = sections.some((section) => section.shortcuts.length > 0);
+  if (!hasSections || !isOpen) return null;
+
+  const normalizedQuery = normalizeSearch(searchQuery);
+  const visibleSections = sections
+    .map((section) => {
+      if (!normalizedQuery) return section;
+
+      const shortcuts = section.shortcuts.filter(
         (shortcut) =>
-          matchesSearch(searchQuery, shortcut.label) ||
-          shortcut.keys.some((key) => matchesSearch(searchQuery, key)),
+          matchesSearch(normalizedQuery, shortcut.label) ||
+          shortcut.keys.some((key) => matchesSearch(normalizedQuery, key)),
       );
 
-      return { ...section, shortcuts: filteredShortcuts };
+      return { ...section, shortcuts };
     })
     .filter((section) => section.shortcuts.length > 0);
-
-  const visibleSections =
-    searchQuery.length > 0
-      ? filteredSections
-      : sections.filter((section) => section.shortcuts.length > 0);
 
   const subtitle = viewLabel
     ? `Keyboard shortcuts for ${viewLabel} view`
     : "Keyboard shortcuts";
-
-  const hasResults = visibleSections.length > 0;
-  const hasSections = sections.some((section) => section.shortcuts.length > 0);
-
-  if (!hasSections || !isOpen) return null;
 
   return (
     <div
@@ -94,7 +86,7 @@ export function ShortcutsOverlay({ sections, viewLabel }: Props) {
       role="dialog"
       style={{ zIndex: ZIndex.MAX }}
     >
-      <div className="flex h-full translate-x-0 flex-col bg-surface/95 px-4 pt-8 pb-5 text-text-muted shadow-2xl backdrop-blur-md transition-transform duration-200 ease-out starting:-translate-x-full motion-reduce:transition-none">
+      <div className="flex h-full starting:-translate-x-full flex-col bg-surface/95 px-4 pt-8 pb-5 text-text-muted shadow-2xl backdrop-blur-md transition-transform duration-200 ease-out motion-reduce:transition-none">
         <div className="mb-5 flex items-center justify-between">
           <div className="flex-1">
             <div className="font-medium text-text text-xl">Shortcuts</div>
@@ -112,15 +104,15 @@ export function ShortcutsOverlay({ sections, viewLabel }: Props) {
         </div>
 
         <input
-          ref={searchInputRef}
+          ref={focusInputOnMount}
           type="text"
           placeholder="Search shortcuts..."
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
-          className="mb-4 rounded-default bg-surface-panel px-3 py-2 text-text text-sm placeholder:text-text-muted focus:outline-none focus:ring-2 focus:ring-accent"
+          className="mb-4 rounded-default bg-surface-panel px-3 py-2 text-sm text-text placeholder:text-text-muted focus:outline-none focus:ring-2 focus:ring-accent"
         />
 
-        {hasResults ? (
+        {visibleSections.length > 0 ? (
           <div className="overflow-y-auto">
             {visibleSections.map((section, index) => (
               <ShortcutSection
@@ -133,7 +125,7 @@ export function ShortcutsOverlay({ sections, viewLabel }: Props) {
           </div>
         ) : (
           <div className="flex flex-1 items-center justify-center">
-            <div className="text-center text-text-muted text-sm">
+            <div className="text-center text-sm text-text-muted">
               No shortcuts found
             </div>
           </div>

--- a/packages/web/src/components/Sidebar/ShortcutsOverlay/ShortcutsOverlay.tsx
+++ b/packages/web/src/components/Sidebar/ShortcutsOverlay/ShortcutsOverlay.tsx
@@ -1,5 +1,4 @@
 import { XIcon } from "@phosphor-icons/react";
-import classNames from "classnames";
 import { useEffect, useRef, useState } from "react";
 import { ZIndex } from "@web/common/constants/web.constants";
 import { ShortcutSection } from "@web/components/Shortcuts/ShortcutOverlay/ShortcutSection";
@@ -9,6 +8,7 @@ import {
   viewActions,
 } from "@web/events/stores/view.store";
 import { type ShortcutOverlaySection } from "@web/shortcuts/shortcuts-overlay.types";
+import { useAppShortcut } from "@web/shortcuts/useAppShortcut";
 
 interface Props {
   sections: ShortcutOverlaySection[];
@@ -28,6 +28,25 @@ export function ShortcutsOverlay({ sections, viewLabel }: Props) {
   const [searchQuery, setSearchQuery] = useState("");
   const searchInputRef = useRef<HTMLInputElement>(null);
 
+  // App-lock is held by useSidebarShortcuts; ignoreAppLock keeps Escape able
+  // to clear search / dismiss while that lock is active. ignoreInputs: false
+  // so Escape still works while the search field is focused.
+  useAppShortcut(
+    "Escape",
+    () => {
+      if (searchQuery) {
+        setSearchQuery("");
+      } else {
+        viewActions.closeShortcuts();
+      }
+    },
+    {
+      enabled: isOpen,
+      ignoreInputs: false,
+      ignoreAppLock: true,
+    },
+  );
+
   useEffect(() => {
     if (!isOpen) {
       setSearchQuery("");
@@ -36,20 +55,7 @@ export function ShortcutsOverlay({ sections, viewLabel }: Props) {
 
     // Auto-focus search input when overlay opens
     setTimeout(() => searchInputRef.current?.focus(), 0);
-
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        if (searchQuery) {
-          setSearchQuery("");
-        } else {
-          viewActions.closeShortcuts();
-        }
-      }
-    };
-
-    document.addEventListener("keydown", handleKeyDown);
-    return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [isOpen, searchQuery]);
+  }, [isOpen]);
 
   const filteredSections = sections
     .map((section) => {
@@ -77,27 +83,18 @@ export function ShortcutsOverlay({ sections, viewLabel }: Props) {
     : "Keyboard shortcuts";
 
   const hasResults = visibleSections.length > 0;
+  const hasSections = sections.some((section) => section.shortcuts.length > 0);
 
-  if (!sections.filter((s) => s.shortcuts.length > 0).length) return null;
+  if (!hasSections || !isOpen) return null;
 
   return (
     <div
-      aria-hidden={!isOpen}
       aria-label="Keyboard shortcuts"
-      className={classNames(
-        "absolute inset-0 overflow-hidden",
-        isOpen ? "" : "pointer-events-none",
-      )}
+      className="absolute inset-0 overflow-hidden"
       role="dialog"
       style={{ zIndex: ZIndex.MAX }}
     >
-      <div
-        className={classNames(
-          "flex h-full flex-col bg-surface/95 px-4 pt-8 pb-5 text-text-muted shadow-2xl backdrop-blur-md",
-          "transition-transform duration-200 ease-out motion-reduce:transition-none",
-          isOpen ? "translate-x-0" : "-translate-x-full",
-        )}
-      >
+      <div className="flex h-full translate-x-0 flex-col bg-surface/95 px-4 pt-8 pb-5 text-text-muted shadow-2xl backdrop-blur-md transition-transform duration-200 ease-out starting:-translate-x-full motion-reduce:transition-none">
         <div className="mb-5 flex items-center justify-between">
           <div className="flex-1">
             <div className="font-medium text-text text-xl">Shortcuts</div>
@@ -108,7 +105,6 @@ export function ShortcutsOverlay({ sections, viewLabel }: Props) {
             aria-label="Close shortcuts"
             className="flex size-7 items-center justify-center rounded-default text-text-muted transition-colors hover:bg-surface-panel hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
             onClick={viewActions.closeShortcuts}
-            tabIndex={isOpen ? 0 : -1}
             type="button"
           >
             <XIcon aria-hidden="true" size={15} />
@@ -122,7 +118,6 @@ export function ShortcutsOverlay({ sections, viewLabel }: Props) {
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
           className="mb-4 rounded-default bg-surface-panel px-3 py-2 text-text text-sm placeholder:text-text-muted focus:outline-none focus:ring-2 focus:ring-accent"
-          tabIndex={isOpen ? 0 : -1}
         />
 
         {hasResults ? (

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -592,12 +592,9 @@
     background-color: transparent;
   }
 
+  /* text-muted clears 4.5:1 on surface-panel; avoid opacity here — it was
+     blending muted text below the WCAG AA floor (axe 3.66:1). */
   & .react-datepicker__day--outside-month {
-    color: var(--text-subtle);
-    opacity: 0.8;
-  }
-
-  &[data-dark="true"] .react-datepicker__day--outside-month {
     color: var(--text-muted);
   }
 


### PR DESCRIPTION
## Summary
- Route the live shortcuts overlay Escape path through `useAppShortcut` (`ignoreAppLock` + `ignoreInputs: false`) so clear-search / dismiss honors the app-lock policy instead of a hand-rolled document listener.
- Conditionally render the shortcuts dialog only while open (enter via `starting:-translate-x-full`) instead of a permanently mounted `aria-hidden` dialog with compensating `tabIndex`s.
- Keep stacking at `ZIndex.MAX` (no bump to `Z_INDEX_MODAL`).

## Simplification
- Collapsed redundant filter paths, moved filter work after the open-gate, and replaced `useRef` + `setTimeout` focus with a stable callback ref.
- Separate commit: `refactor(web): simplify shortcuts overlay open-state wiring`.

## Test plan
- [x] `bun run type-check`
- [x] `bun test:web` (1820/1820) + focused ShortcutsOverlay / useSidebarShortcuts tests
- [x] `bun run lint` (pre-existing warnings only)
- [x] Functional Playwright e2e (15/15 non-axe + focus-visible); axe color-contrast failures observed locally appear unrelated (datepicker outside-month `#68747e` on `#121a23`) — confirm CI
- [x] Independent code review: clean
- [x] Manual browser smoke on http://localhost:9083: `Shift+/` opens overlay + sets `data-app-locked` + focuses search; first Escape clears search; second Escape closes and clears lock