### PR TITLE
fix(backend): return 410 for GOOGLE_REVOKED instead of 401

### DIFF
--- a/packages/backend/src/event/controllers/event.controller.test.ts
+++ b/packages/backend/src/event/controllers/event.controller.test.ts
@@ -333,12 +333,12 @@ describe("EventController", () => {
     expect(json).toHaveBeenCalled();
   });
 
-  it("maps authorizationRevoked to 401 GOOGLE_REVOKED (not retryable)", async () => {
+  it("maps authorizationRevoked to 410 GOOGLE_REVOKED (not retryable)", async () => {
     mockSyncCommandFailure("authorizationRevoked");
     const { res, json } = await createViaSync();
 
     expect((res.status as ReturnType<typeof mock>).mock.calls[0]?.[0]).toBe(
-      Status.UNAUTHORIZED,
+      Status.GONE,
     );
     expect(json).toHaveBeenCalledWith({
       code: "GOOGLE_REVOKED",

--- a/packages/backend/src/event/event.error.ts
+++ b/packages/backend/src/event/event.error.ts
@@ -19,7 +19,10 @@ const STATUS_BY_CODE: Record<EventMutationErrorCode, Status> = {
   INVALID_SCHEDULE: Status.BAD_REQUEST,
   INVALID_OCCURRENCE_ID: Status.BAD_REQUEST,
   PROVIDER_FAILURE: 502 as Status,
-  GOOGLE_REVOKED: Status.UNAUTHORIZED,
+  // 410 Gone, not 401: SuperTokens treats every 401 as a Compass session
+  // expiry and retries the request after refresh. Google revocation must not
+  // share that status or event creates loop until maxRetryAttemptsForSessionRefresh.
+  GOOGLE_REVOKED: Status.GONE,
   MAINTENANCE: Status.SERVICE_UNAVAILABLE,
   MOVE_UNSUPPORTED: Status.BAD_REQUEST,
   INVALID_INPUT: Status.BAD_REQUEST,

--- a/packages/web/src/api/base/base.api.test.ts
+++ b/packages/web/src/api/base/base.api.test.ts
@@ -84,8 +84,8 @@ describe("BaseApi backend availability", () => {
           config,
           data: { code: "GOOGLE_REVOKED" },
           headers: new Headers(),
-          status: 401,
-          statusText: "Unauthorized",
+          status: 410,
+          statusText: "Gone",
         },
       });
     };

--- a/packages/web/src/api/util/api.util.ts
+++ b/packages/web/src/api/util/api.util.ts
@@ -142,6 +142,8 @@ export const handleErrorResponse = async (
   }
 
   if (
+    // Prefer 410 Gone (backend). Keep accepting 401 for older deployments;
+    // SuperTokens may already have exhausted session refresh on those.
     (status === Status.GONE || status === Status.UNAUTHORIZED) &&
     // "GOOGLE_REVOKED" here is the HTTP error envelope code the backend sends
     // on this response (independent of the syncStatusChanged SSE code of the


### PR DESCRIPTION
## Summary

- Map `GOOGLE_REVOKED` event-mutation errors to HTTP 410 Gone instead of 401 Unauthorized.
- Stops SuperTokens from treating Google revocation as a Compass session expiry and retrying `POST /api/event` until `maxRetryAttemptsForSessionRefresh`.
- Web already handles 410 for `GOOGLE_REVOKED` (reconnect toast); it still accepts 401 from older deployments.

## Simplicity

Already minimal: one status mapping change plus test/comment updates. No new abstractions.

## Automated validation

- Focused backend: `maps authorizationRevoked to 410 GOOGLE_REVOKED` passes.
- Focused web: BaseApi + `handleErrorResponse` revocation paths pass (410 primary; 401 still accepted).
- Staging root cause confirmed from DevTools: `GOOGLE_REVOKED` body on 401 with SuperTokens session-refresh loop on event create.

## Independent review

[code-reviewer](34e4d182-2d45-45f9-84ad-f437db119d3e): no confirmed actionable findings.

## Test plan

- `bun run test:backend:fast -- packages/backend/src/event/controllers/event.controller.test.ts`
- `bun run test:web -- packages/web/src/api/base/base.api.test.ts packages/web/src/api/util/api.util.test.ts`
- `bun run lint` (exit 0; pre-existing warnings only)