### PR TITLE
refactor(web): share dismiss transitions and reduced-motion checks

### DIFF
--- a/packages/web/src/common/constants/motion.constants.ts
+++ b/packages/web/src/common/constants/motion.constants.ts
@@ -1,0 +1,9 @@
+/**
+ * JS dismiss timers that must match the Tailwind duration classes on the
+ * animated surfaces. Keep these next to each other so a duration change
+ * updates both the class and the unmount delay.
+ */
+/** Modal/dialog dismiss fade+scale — `duration-400`. */
+export const MODAL_DISMISS_MS = 400;
+/** Up-next banner dismiss fade — `duration-300`. */
+export const BANNER_DISMISS_MS = 300;

--- a/packages/web/src/common/constants/motion.constants.ts
+++ b/packages/web/src/common/constants/motion.constants.ts
@@ -1,9 +1,3 @@
-/**
- * JS dismiss timers that must match the Tailwind duration classes on the
- * animated surfaces. Keep these next to each other so a duration change
- * updates both the class and the unmount delay.
- */
-/** Modal/dialog dismiss fade+scale — `duration-400`. */
+/** JS unmount delays paired with Tailwind `duration-*` on the same surface. */
 export const MODAL_DISMISS_MS = 400;
-/** Up-next banner dismiss fade — `duration-300`. */
 export const BANNER_DISMISS_MS = 300;

--- a/packages/web/src/common/hooks/prefersReducedMotion.ts
+++ b/packages/web/src/common/hooks/prefersReducedMotion.ts
@@ -1,0 +1,13 @@
+import { useMediaQuery } from "@web/common/hooks/useMediaQuery";
+
+export const PREFERS_REDUCED_MOTION_QUERY = "(prefers-reduced-motion: reduce)";
+
+/** One-shot read for event handlers and layout effects. */
+export function prefersReducedMotion(): boolean {
+  return window.matchMedia?.(PREFERS_REDUCED_MOTION_QUERY).matches ?? false;
+}
+
+/** Reactive subscription for render-time consumers. */
+export function usePrefersReducedMotion(): boolean {
+  return useMediaQuery(PREFERS_REDUCED_MOTION_QUERY);
+}

--- a/packages/web/src/common/hooks/prefersReducedMotion.ts
+++ b/packages/web/src/common/hooks/prefersReducedMotion.ts
@@ -1,6 +1,6 @@
 import { useMediaQuery } from "@web/common/hooks/useMediaQuery";
 
-export const PREFERS_REDUCED_MOTION_QUERY = "(prefers-reduced-motion: reduce)";
+const PREFERS_REDUCED_MOTION_QUERY = "(prefers-reduced-motion: reduce)";
 
 /** One-shot read for event handlers and layout effects. */
 export function prefersReducedMotion(): boolean {

--- a/packages/web/src/common/hooks/useDismissTransition.test.ts
+++ b/packages/web/src/common/hooks/useDismissTransition.test.ts
@@ -1,0 +1,118 @@
+import { act, renderHook } from "@testing-library/react";
+import { useDismissTransition } from "@web/common/hooks/useDismissTransition";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  mock,
+  spyOn,
+} from "bun:test";
+
+describe("useDismissTransition", () => {
+  let timeoutCallback: (() => void) | undefined;
+  let setTimeoutSpy: ReturnType<typeof spyOn>;
+  let clearTimeoutSpy: ReturnType<typeof spyOn>;
+  const originalMatchMedia = window.matchMedia;
+
+  beforeEach(() => {
+    timeoutCallback = undefined;
+    setTimeoutSpy = spyOn(globalThis, "setTimeout").mockImplementation(((
+      callback: TimerHandler,
+    ) => {
+      if (typeof callback === "function") {
+        timeoutCallback = () => callback();
+      }
+      return 1 as unknown as ReturnType<typeof setTimeout>;
+    }) as unknown as typeof setTimeout);
+    clearTimeoutSpy = spyOn(globalThis, "clearTimeout").mockImplementation(
+      () => {},
+    );
+    window.matchMedia = mock((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: mock(),
+      removeListener: mock(),
+      addEventListener: mock(),
+      removeEventListener: mock(),
+      dispatchEvent: mock(() => false),
+    })) as typeof window.matchMedia;
+  });
+
+  afterEach(() => {
+    setTimeoutSpy.mockRestore();
+    clearTimeoutSpy.mockRestore();
+    window.matchMedia = originalMatchMedia;
+  });
+
+  it("sets closing and calls onComplete after the duration", () => {
+    const onComplete = mock(() => {});
+    const { result } = renderHook(() => useDismissTransition(300));
+
+    expect(result.current.closing).toBe(false);
+
+    act(() => {
+      expect(result.current.beginDismiss(onComplete)).toBe(true);
+    });
+
+    expect(result.current.closing).toBe(true);
+    expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 300);
+    expect(onComplete).not.toHaveBeenCalled();
+
+    act(() => {
+      timeoutCallback?.();
+    });
+
+    expect(onComplete).toHaveBeenCalledTimes(1);
+    expect(result.current.closing).toBe(false);
+  });
+
+  it("skips the delay when reduced motion is preferred", () => {
+    window.matchMedia = mock((query: string) => ({
+      matches: query.includes("prefers-reduced-motion"),
+      media: query,
+      onchange: null,
+      addListener: mock(),
+      removeListener: mock(),
+      addEventListener: mock(),
+      removeEventListener: mock(),
+      dispatchEvent: mock(() => false),
+    })) as typeof window.matchMedia;
+
+    const onComplete = mock(() => {});
+    const { result } = renderHook(() => useDismissTransition(400));
+
+    act(() => {
+      result.current.beginDismiss(onComplete);
+    });
+
+    expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 0);
+  });
+
+  it("ignores a second beginDismiss while already closing", () => {
+    const first = mock(() => {});
+    const second = mock(() => {});
+    const { result } = renderHook(() => useDismissTransition(300));
+
+    act(() => {
+      expect(result.current.beginDismiss(first)).toBe(true);
+      expect(result.current.beginDismiss(second)).toBe(false);
+    });
+
+    expect(setTimeoutSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears the pending timer on unmount", () => {
+    const { result, unmount } = renderHook(() => useDismissTransition(300));
+
+    act(() => {
+      result.current.beginDismiss(() => {});
+    });
+
+    unmount();
+
+    expect(clearTimeoutSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/web/src/common/hooks/useDismissTransition.test.ts
+++ b/packages/web/src/common/hooks/useDismissTransition.test.ts
@@ -16,6 +16,21 @@ describe("useDismissTransition", () => {
   let clearTimeoutSpy: ReturnType<typeof spyOn>;
   const originalMatchMedia = window.matchMedia;
 
+  const installMatchMediaMock = (
+    matches: boolean | ((query: string) => boolean) = false,
+  ) => {
+    window.matchMedia = mock((query: string) => ({
+      matches: typeof matches === "function" ? matches(query) : matches,
+      media: query,
+      onchange: null,
+      addListener: mock(),
+      removeListener: mock(),
+      addEventListener: mock(),
+      removeEventListener: mock(),
+      dispatchEvent: mock(() => false),
+    })) as typeof window.matchMedia;
+  };
+
   beforeEach(() => {
     timeoutCallback = undefined;
     setTimeoutSpy = spyOn(globalThis, "setTimeout").mockImplementation(((
@@ -29,16 +44,7 @@ describe("useDismissTransition", () => {
     clearTimeoutSpy = spyOn(globalThis, "clearTimeout").mockImplementation(
       () => {},
     );
-    window.matchMedia = mock((query: string) => ({
-      matches: false,
-      media: query,
-      onchange: null,
-      addListener: mock(),
-      removeListener: mock(),
-      addEventListener: mock(),
-      removeEventListener: mock(),
-      dispatchEvent: mock(() => false),
-    })) as typeof window.matchMedia;
+    installMatchMediaMock();
   });
 
   afterEach(() => {
@@ -70,16 +76,7 @@ describe("useDismissTransition", () => {
   });
 
   it("skips the delay when reduced motion is preferred", () => {
-    window.matchMedia = mock((query: string) => ({
-      matches: query.includes("prefers-reduced-motion"),
-      media: query,
-      onchange: null,
-      addListener: mock(),
-      removeListener: mock(),
-      addEventListener: mock(),
-      removeEventListener: mock(),
-      dispatchEvent: mock(() => false),
-    })) as typeof window.matchMedia;
+    installMatchMediaMock((query) => query.includes("prefers-reduced-motion"));
 
     const onComplete = mock(() => {});
     const { result } = renderHook(() => useDismissTransition(400));

--- a/packages/web/src/common/hooks/useDismissTransition.ts
+++ b/packages/web/src/common/hooks/useDismissTransition.ts
@@ -1,0 +1,39 @@
+import { useEffect, useRef, useState } from "react";
+import { prefersReducedMotion } from "@web/common/hooks/prefersReducedMotion";
+
+/**
+ * Shared dismiss state machine: flip `closing` for a CSS exit transition,
+ * then call `onComplete` after `durationMs` (or immediately when the user
+ * prefers reduced motion). Clears the timer on unmount.
+ */
+export function useDismissTransition(durationMs: number) {
+  const [closing, setClosing] = useState(false);
+  const closingRef = useRef(false);
+  const timerRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current !== null) {
+        window.clearTimeout(timerRef.current);
+      }
+    };
+  }, []);
+
+  const beginDismiss = (onComplete: () => void): boolean => {
+    if (closingRef.current) return false;
+    closingRef.current = true;
+    setClosing(true);
+    const delay = prefersReducedMotion() ? 0 : durationMs;
+    timerRef.current = window.setTimeout(() => {
+      timerRef.current = null;
+      // Clear closing before onComplete so stay-mounted surfaces (UpNextBanner)
+      // can dismiss a later event, and so both updates batch in one render.
+      closingRef.current = false;
+      setClosing(false);
+      onComplete();
+    }, delay);
+    return true;
+  };
+
+  return { closing, beginDismiss };
+}

--- a/packages/web/src/common/hooks/useMediaQuery.test.ts
+++ b/packages/web/src/common/hooks/useMediaQuery.test.ts
@@ -1,0 +1,53 @@
+import { act, renderHook } from "@testing-library/react";
+import { useMediaQuery } from "@web/common/hooks/useMediaQuery";
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+
+describe("useMediaQuery", () => {
+  const originalMatchMedia = window.matchMedia;
+  let listeners: Array<(event: MediaQueryListEvent) => void>;
+  let currentMatches: boolean;
+
+  beforeEach(() => {
+    listeners = [];
+    currentMatches = true;
+    window.matchMedia = mock((query: string) => ({
+      get matches() {
+        return currentMatches;
+      },
+      media: query,
+      onchange: null,
+      addListener: mock(),
+      removeListener: mock(),
+      addEventListener: mock(
+        (_type: string, listener: (event: MediaQueryListEvent) => void) => {
+          listeners.push(listener);
+        },
+      ),
+      removeEventListener: mock(
+        (_type: string, listener: (event: MediaQueryListEvent) => void) => {
+          listeners = listeners.filter((entry) => entry !== listener);
+        },
+      ),
+      dispatchEvent: mock(() => false),
+    })) as typeof window.matchMedia;
+  });
+
+  afterEach(() => {
+    window.matchMedia = originalMatchMedia;
+  });
+
+  it("returns the initial match and updates on change", () => {
+    const { result } = renderHook(() => useMediaQuery("(min-width: 800px)"));
+
+    expect(result.current).toBe(true);
+
+    act(() => {
+      currentMatches = false;
+      for (const listener of listeners) {
+        listener({ matches: false } as MediaQueryListEvent);
+      }
+    });
+
+    expect(result.current).toBe(false);
+  });
+});

--- a/packages/web/src/common/hooks/useMediaQuery.ts
+++ b/packages/web/src/common/hooks/useMediaQuery.ts
@@ -1,25 +1,25 @@
-import { useLayoutEffect, useState } from "react";
+import { useCallback, useSyncExternalStore } from "react";
 
 /**
  * Subscribes to a CSS media query and returns whether it currently matches.
  * Updates on `change` so breakpoint / preference flips re-render consumers.
  */
 export function useMediaQuery(query: string): boolean {
-  const [matches, setMatches] = useState(
-    () => window.matchMedia?.(query).matches ?? false,
+  const subscribe = useCallback(
+    (onStoreChange: () => void) => {
+      const mediaQuery = window.matchMedia?.(query);
+      if (!mediaQuery) return () => {};
+
+      mediaQuery.addEventListener("change", onStoreChange);
+      return () => mediaQuery.removeEventListener("change", onStoreChange);
+    },
+    [query],
   );
 
-  useLayoutEffect(() => {
-    const mediaQuery = window.matchMedia?.(query);
-    if (!mediaQuery) return;
+  const getSnapshot = useCallback(
+    () => window.matchMedia?.(query).matches ?? false,
+    [query],
+  );
 
-    const onChange = (event: MediaQueryListEvent) => {
-      setMatches(event.matches);
-    };
-    setMatches(mediaQuery.matches);
-    mediaQuery.addEventListener("change", onChange);
-    return () => mediaQuery.removeEventListener("change", onChange);
-  }, [query]);
-
-  return matches;
+  return useSyncExternalStore(subscribe, getSnapshot);
 }

--- a/packages/web/src/common/hooks/useMediaQuery.ts
+++ b/packages/web/src/common/hooks/useMediaQuery.ts
@@ -1,0 +1,25 @@
+import { useLayoutEffect, useState } from "react";
+
+/**
+ * Subscribes to a CSS media query and returns whether it currently matches.
+ * Updates on `change` so breakpoint / preference flips re-render consumers.
+ */
+export function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState(
+    () => window.matchMedia?.(query).matches ?? false,
+  );
+
+  useLayoutEffect(() => {
+    const mediaQuery = window.matchMedia?.(query);
+    if (!mediaQuery) return;
+
+    const onChange = (event: MediaQueryListEvent) => {
+      setMatches(event.matches);
+    };
+    setMatches(mediaQuery.matches);
+    mediaQuery.addEventListener("change", onChange);
+    return () => mediaQuery.removeEventListener("change", onChange);
+  }, [query]);
+
+  return matches;
+}

--- a/packages/web/src/components/AuthenticatedLayout/responsive.constants.ts
+++ b/packages/web/src/components/AuthenticatedLayout/responsive.constants.ts
@@ -1,2 +1,4 @@
 // Tailwind xl breakpoint; the sidebar auto-collapses below this width.
 export const SIDEBAR_AUTO_COLLAPSE_BREAKPOINT = 1280;
+
+export const SIDEBAR_MIN_WIDTH_MEDIA_QUERY = `(min-width: ${SIDEBAR_AUTO_COLLAPSE_BREAKPOINT}px)`;

--- a/packages/web/src/components/AuthenticatedLayout/useResponsiveLayout.test.ts
+++ b/packages/web/src/components/AuthenticatedLayout/useResponsiveLayout.test.ts
@@ -9,10 +9,13 @@ import { useResponsiveLayout } from "./useResponsiveLayout";
 import { afterEach, describe, expect, it, mock } from "bun:test";
 
 // Helper to create a mock matchMedia list for a single query
-const createMediaQueryMock = (matches: boolean) => {
+const createMediaQueryMock = (initialMatches: boolean) => {
   const listeners: Array<(e: MediaQueryListEvent) => void> = [];
+  let matches = initialMatches;
   return {
-    matches,
+    get matches() {
+      return matches;
+    },
     media: "",
     onchange: null,
     addListener: mock(),
@@ -30,6 +33,7 @@ const createMediaQueryMock = (matches: boolean) => {
     ),
     dispatchEvent: mock(),
     _triggerChange: (newMatches: boolean) => {
+      matches = newMatches;
       listeners.forEach((listener) => {
         listener({ matches: newMatches } as MediaQueryListEvent);
       });

--- a/packages/web/src/components/AuthenticatedLayout/useResponsiveLayout.ts
+++ b/packages/web/src/components/AuthenticatedLayout/useResponsiveLayout.ts
@@ -1,4 +1,5 @@
 import { useLayoutEffect } from "react";
+import { useMediaQuery } from "@web/common/hooks/useMediaQuery";
 import { SIDEBAR_AUTO_COLLAPSE_BREAKPOINT } from "@web/components/AuthenticatedLayout/responsive.constants";
 import {
   selectSidebarPreference,
@@ -15,26 +16,13 @@ import {
  * (AuthenticatedLayout) so overrides survive view switches.
  */
 export function useResponsiveLayout() {
+  const isWideEnough = useMediaQuery(
+    `(min-width: ${SIDEBAR_AUTO_COLLAPSE_BREAKPOINT}px)`,
+  );
+
   useLayoutEffect(() => {
-    const panelQueries = [
-      {
-        query: window.matchMedia(
-          `(min-width: ${SIDEBAR_AUTO_COLLAPSE_BREAKPOINT}px)`,
-        ),
-        setOpen: (matches: boolean) =>
-          viewActions.syncSidebarOpen(
-            matches && selectSidebarPreference(useViewStore.getState()),
-          ),
-      },
-    ];
-
-    const cleanups = panelQueries.map(({ query, setOpen }) => {
-      setOpen(query.matches);
-      const onChange = (e: MediaQueryListEvent) => setOpen(e.matches);
-      query.addEventListener("change", onChange);
-      return () => query.removeEventListener("change", onChange);
-    });
-
-    return () => cleanups.forEach((cleanup) => cleanup());
-  }, []);
+    viewActions.syncSidebarOpen(
+      isWideEnough && selectSidebarPreference(useViewStore.getState()),
+    );
+  }, [isWideEnough]);
 }

--- a/packages/web/src/components/AuthenticatedLayout/useResponsiveLayout.ts
+++ b/packages/web/src/components/AuthenticatedLayout/useResponsiveLayout.ts
@@ -1,6 +1,6 @@
 import { useLayoutEffect } from "react";
 import { useMediaQuery } from "@web/common/hooks/useMediaQuery";
-import { SIDEBAR_AUTO_COLLAPSE_BREAKPOINT } from "@web/components/AuthenticatedLayout/responsive.constants";
+import { SIDEBAR_MIN_WIDTH_MEDIA_QUERY } from "@web/components/AuthenticatedLayout/responsive.constants";
 import {
   selectSidebarPreference,
   useViewStore,
@@ -16,9 +16,7 @@ import {
  * (AuthenticatedLayout) so overrides survive view switches.
  */
 export function useResponsiveLayout() {
-  const isWideEnough = useMediaQuery(
-    `(min-width: ${SIDEBAR_AUTO_COLLAPSE_BREAKPOINT}px)`,
-  );
+  const isWideEnough = useMediaQuery(SIDEBAR_MIN_WIDTH_MEDIA_QUERY);
 
   useLayoutEffect(() => {
     viewActions.syncSidebarOpen(

--- a/packages/web/src/components/CommandPalette/CommandPalette.tsx
+++ b/packages/web/src/components/CommandPalette/CommandPalette.tsx
@@ -11,6 +11,7 @@ import { ArrowCounterClockwiseIcon } from "@phosphor-icons/react";
 import { useNavigate } from "@tanstack/react-router";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Z_INDEX_MODAL } from "@web/common/constants/web.constants";
+import { usePrefersReducedMotion } from "@web/common/hooks/prefersReducedMotion";
 import { eventCommandPaletteItems } from "@web/components/CommandPalette/event.cmd.constants";
 import { HighlightedLabel } from "@web/components/CommandPalette/HighlightedLabel";
 import { useAuthCmdItems } from "@web/components/CommandPalette/hooks/useAuthCmdItems";
@@ -75,16 +76,15 @@ const CommandPaletteContent = ({
   // instant close is normal — dismissal isn't a decision the user watches,
   // unlike a confirmation modal.
   const [visible, setVisible] = useState(false);
+  const reduceMotion = usePrefersReducedMotion();
   useEffect(() => {
-    const reduceMotion =
-      window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
     if (reduceMotion) {
       setVisible(true);
       return;
     }
     const raf = requestAnimationFrame(() => setVisible(true));
     return () => cancelAnimationFrame(raf);
-  }, []);
+  }, [reduceMotion]);
 
   // Focus the search input the moment it mounts (commit phase, like the
   // autoFocus attribute — but without tripping the a11y lint). Stable identity

--- a/packages/web/src/components/ReleaseNotesPrompt/ReleaseNotesPrompt.tsx
+++ b/packages/web/src/components/ReleaseNotesPrompt/ReleaseNotesPrompt.tsx
@@ -5,7 +5,9 @@ import {
   useState,
 } from "react";
 import { UserApi } from "@web/api/user.api";
+import { MODAL_DISMISS_MS } from "@web/common/constants/motion.constants";
 import { Z_INDEX_MODAL } from "@web/common/constants/web.constants";
+import { useDismissTransition } from "@web/common/hooks/useDismissTransition";
 import { showErrorToast } from "@web/common/utils/toast/error-toast.util";
 import { releaseNotesPromptActions } from "@web/components/ReleaseNotesPrompt/release-notes-prompt.store";
 import { PixelPirate } from "@web/components/WelcomeModal/PixelPirate";
@@ -20,7 +22,7 @@ type PromptState =
 
 export function ReleaseNotesPrompt() {
   const [state, setState] = useState<PromptState>("asking");
-  const [closing, setClosing] = useState(false);
+  const { closing, beginDismiss } = useDismissTransition(MODAL_DISMISS_MS);
   useAppLockReason("releaseNotes", true);
 
   // RootShell mounts this only while the store flag is open, so each open is a
@@ -31,14 +33,7 @@ export function ReleaseNotesPrompt() {
   }, []);
 
   const dismiss = () => {
-    if (closing) return;
-    setClosing(true);
-    const reducedMotion =
-      window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
-    window.setTimeout(
-      () => releaseNotesPromptActions.close(),
-      reducedMotion ? 0 : 400,
-    );
+    beginDismiss(() => releaseNotesPromptActions.close());
   };
 
   const decline = () => {

--- a/packages/web/src/components/Sidebar/UpNextCard/UpNextBanner.tsx
+++ b/packages/web/src/components/Sidebar/UpNextCard/UpNextBanner.tsx
@@ -1,6 +1,8 @@
 import { type FC, useState } from "react";
 import dayjs from "@core/util/date/dayjs";
+import { BANNER_DISMISS_MS } from "@web/common/constants/motion.constants";
 import { Z_INDEX_FLOATING_MENU } from "@web/common/constants/web.constants";
+import { useDismissTransition } from "@web/common/hooks/useDismissTransition";
 import { ShortcutHint } from "@web/components/Shortcuts/ShortcutHint";
 import { useAppShortcutUp } from "@web/shortcuts/useAppShortcut";
 import { formatEventStatus } from "./UpNextCard";
@@ -13,13 +15,11 @@ const MINUTES_BEFORE_START = 2;
  * start, mirroring Vimcal. N opens the event's details; when the event has a
  * meeting link, the primary action switches to V for "Join" instead.
  */
-const DISMISS_ANIMATION_MS = 200;
-
 export const UpNextBanner: FC = () => {
   const { now, openEventDetails, upNext, conferenceUrl, isCurrentEvent } =
     useUpNextEvent();
   const [dismissedId, setDismissedId] = useState<string | undefined>(undefined);
-  const [isClosing, setIsClosing] = useState(false);
+  const { closing, beginDismiss } = useDismissTransition(BANNER_DISMISS_MS);
 
   const isWithinWindow =
     Boolean(upNext) &&
@@ -34,17 +34,7 @@ export const UpNextBanner: FC = () => {
   // Keeps the banner mounted for one fade-out beat instead of yanking it
   // instantly, matching ReleaseNotesPrompt's dismiss pattern.
   const dismiss = () => {
-    if (isClosing) return;
-    setIsClosing(true);
-    const reducedMotion =
-      window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
-    window.setTimeout(
-      () => {
-        setDismissedId(upNext?._id);
-        setIsClosing(false);
-      },
-      reducedMotion ? 0 : DISMISS_ANIMATION_MS,
-    );
+    beginDismiss(() => setDismissedId(upNext?._id));
   };
 
   useAppShortcutUp("N", () => openEventDetails("keyboardEdit"));
@@ -72,7 +62,7 @@ export const UpNextBanner: FC = () => {
     <div
       aria-atomic="true"
       className="fixed bottom-6 left-1/2 flex w-72 -translate-x-1/2 starting:translate-y-2 items-center gap-3 rounded-lg border border-border bg-surface-panel/80 px-3 py-2 text-sm text-text starting:opacity-0 shadow-xl backdrop-blur-md transition-all duration-300 ease-out data-closing:opacity-0 motion-reduce:transition-none"
-      data-closing={isClosing || undefined}
+      data-closing={closing || undefined}
       role="status"
       style={{ zIndex: Z_INDEX_FLOATING_MENU }}
     >

--- a/packages/web/src/components/Sidebar/hooks/useIsNarrowSidebarLayout.ts
+++ b/packages/web/src/components/Sidebar/hooks/useIsNarrowSidebarLayout.ts
@@ -1,5 +1,5 @@
 import { useMediaQuery } from "@web/common/hooks/useMediaQuery";
-import { SIDEBAR_AUTO_COLLAPSE_BREAKPOINT } from "@web/components/AuthenticatedLayout/responsive.constants";
+import { SIDEBAR_MIN_WIDTH_MEDIA_QUERY } from "@web/components/AuthenticatedLayout/responsive.constants";
 
 /**
  * True when the viewport is below the sidebar auto-collapse breakpoint.
@@ -8,8 +8,6 @@ import { SIDEBAR_AUTO_COLLAPSE_BREAKPOINT } from "@web/components/AuthenticatedL
  * control.
  */
 export function useIsNarrowSidebarLayout() {
-  const isWideEnough = useMediaQuery(
-    `(min-width: ${SIDEBAR_AUTO_COLLAPSE_BREAKPOINT}px)`,
-  );
+  const isWideEnough = useMediaQuery(SIDEBAR_MIN_WIDTH_MEDIA_QUERY);
   return !isWideEnough;
 }

--- a/packages/web/src/components/Sidebar/hooks/useIsNarrowSidebarLayout.ts
+++ b/packages/web/src/components/Sidebar/hooks/useIsNarrowSidebarLayout.ts
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useState } from "react";
+import { useMediaQuery } from "@web/common/hooks/useMediaQuery";
 import { SIDEBAR_AUTO_COLLAPSE_BREAKPOINT } from "@web/components/AuthenticatedLayout/responsive.constants";
 
 /**
@@ -8,21 +8,8 @@ import { SIDEBAR_AUTO_COLLAPSE_BREAKPOINT } from "@web/components/AuthenticatedL
  * control.
  */
 export function useIsNarrowSidebarLayout() {
-  const [isNarrow, setIsNarrow] = useState(
-    () =>
-      !window.matchMedia(`(min-width: ${SIDEBAR_AUTO_COLLAPSE_BREAKPOINT}px)`)
-        .matches,
+  const isWideEnough = useMediaQuery(
+    `(min-width: ${SIDEBAR_AUTO_COLLAPSE_BREAKPOINT}px)`,
   );
-
-  useLayoutEffect(() => {
-    const query = window.matchMedia(
-      `(min-width: ${SIDEBAR_AUTO_COLLAPSE_BREAKPOINT}px)`,
-    );
-    const onChange = () => setIsNarrow(!query.matches);
-    onChange();
-    query.addEventListener("change", onChange);
-    return () => query.removeEventListener("change", onChange);
-  }, []);
-
-  return isNarrow;
+  return !isWideEnough;
 }

--- a/packages/web/src/components/WelcomeModal/WelcomeGuideModal.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeGuideModal.tsx
@@ -1,17 +1,14 @@
-import {
-  type KeyboardEvent,
-  type MouseEvent,
-  useCallback,
-  useState,
-} from "react";
+import { type KeyboardEvent, type MouseEvent, useCallback } from "react";
+import { MODAL_DISMISS_MS } from "@web/common/constants/motion.constants";
 import { Z_INDEX_MODAL } from "@web/common/constants/web.constants";
+import { useDismissTransition } from "@web/common/hooks/useDismissTransition";
 import { useAppLockReason } from "@web/shortcuts/app-lock";
 import { PixelPirate } from "./PixelPirate";
 import { WelcomeGuideBody } from "./WelcomeGuideBody";
 import { welcomeGuideActions } from "./welcome.guide.store";
 
 export function WelcomeGuideModal() {
-  const [closing, setClosing] = useState(false);
+  const { closing, beginDismiss } = useDismissTransition(MODAL_DISMISS_MS);
   useAppLockReason("welcomeGuide", true);
 
   const focusOnMount = useCallback((node: HTMLDivElement | null) => {
@@ -19,14 +16,7 @@ export function WelcomeGuideModal() {
   }, []);
 
   const dismiss = () => {
-    if (closing) return;
-    setClosing(true);
-    const reduceMotion =
-      window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
-    window.setTimeout(
-      () => welcomeGuideActions.close(),
-      reduceMotion ? 0 : 400,
-    );
+    beginDismiss(() => welcomeGuideActions.close());
   };
 
   const handleBackdropClick = (event: MouseEvent<HTMLDivElement>) => {

--- a/packages/web/src/components/WelcomeModal/WelcomeModal.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeModal.tsx
@@ -13,8 +13,10 @@ import {
 } from "react";
 import { SessionContext } from "@web/auth/compass/session/session.context";
 import { track } from "@web/auth/posthog/track";
+import { MODAL_DISMISS_MS } from "@web/common/constants/motion.constants";
 import { SOCIAL_LINKS } from "@web/common/constants/social.constants";
 import { Z_INDEX_MODAL } from "@web/common/constants/web.constants";
+import { useDismissTransition } from "@web/common/hooks/useDismissTransition";
 import { useAuthModal } from "@web/components/AuthModal/hooks/useAuthModal";
 import { useAppLockReason } from "@web/shortcuts/app-lock";
 import { maybeShowCmdPaletteHint } from "./cmd-palette-hint.util";
@@ -34,7 +36,7 @@ export function WelcomeModal() {
   const [isOpen, setIsOpen] = useState(
     () => !authenticated && !hasSeenWelcome(),
   );
-  const [closing, setClosing] = useState(false);
+  const { closing, beginDismiss } = useDismissTransition(MODAL_DISMISS_MS);
   const backdropRef = useRef<HTMLDivElement>(null);
 
   // The auth modal's openness lives in the URL (?auth=), so the welcome
@@ -63,10 +65,7 @@ export function WelcomeModal() {
     markWelcomeSeen();
     maybeShowCmdPaletteHint();
     track("welcome_modal_dismissed", { cta });
-    setClosing(true);
-    const reduceMotion =
-      window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
-    window.setTimeout(() => setIsOpen(false), reduceMotion ? 0 : 400);
+    beginDismiss(() => setIsOpen(false));
   };
 
   const handleLogIn = () => {

--- a/packages/web/src/views/Week/hooks/useDayShiftTransition.ts
+++ b/packages/web/src/views/Week/hooks/useDayShiftTransition.ts
@@ -1,5 +1,6 @@
 import { type RefObject, useLayoutEffect, useRef } from "react";
 import { type Dayjs } from "@core/util/date/dayjs";
+import { prefersReducedMotion } from "@web/common/hooks/prefersReducedMotion";
 import { type WeekNavigationSource } from "@web/views/Week/hooks/useWeek";
 
 const TRANSITION_DURATION_MS = 180;
@@ -20,7 +21,7 @@ export const useDayShiftTransition = (
       !track ||
       navigationSource !== "day-shift" ||
       previousStart.isSame(startOfView, "day") ||
-      window.matchMedia?.("(prefers-reduced-motion: reduce)").matches
+      prefersReducedMotion()
     ) {
       return;
     }


### PR DESCRIPTION
## Summary

- Extract `useDismissTransition` for the shared overlay/banner dismiss state machine (`WelcomeModal`, `WelcomeGuideModal`, `ReleaseNotesPrompt`, `UpNextBanner`).
- Fix UpNextBanner's dismiss timer (200ms → 300ms) so it matches its `duration-300` fade.
- Centralize `prefers-reduced-motion` and breakpoint media queries via `useMediaQuery` / `prefersReducedMotion` / `usePrefersReducedMotion`.

## Simplicity

- Follow-up commit switched `useMediaQuery` to `useSyncExternalStore`, shared the sidebar min-width query constant, and trimmed dismiss-transition test scaffolding.
- Reveal-animation standardization (`@starting-style` for CommandPalette) left out to keep this PR dismiss/timer-scoped.

## Automated validation

- Local browser smoke at http://localhost:9083: cleared welcome storage → welcome dialog shown → Start Now dismissed it (unmounted after fade). Cmd+K palette open/close still works. Console only showed pre-existing backend-connection noise in this worktree.
- Focused + full `bun test:web` green (1825/1825).

## Independent review

- Fresh read-only review of the full branch diff: no confirmed findings.

## Test plan

- `bun run type-check`
- `bun test:web` (full package suite)
- `bun run lint` (pre-existing warnings only)
- Manual smoke: welcome dismiss + command palette open/close on localhost:9083