### PR TITLE
fix(sync): show Google all-day events west of UTC

### DIFF
--- a/packages/sync/src/domain/occurrence-projection.ts
+++ b/packages/sync/src/domain/occurrence-projection.ts
@@ -383,7 +383,8 @@ export function isFollowingSplitAtSeriesStart(
 // exclusive, so midnight UTC of it is the exclusive end. A zero-duration timed
 // schedule (start == end, e.g. a reminder) yields startAt === endAt: it never
 // satisfies an overlap query, which is correct — it occupies no busy time —
-// but it still surfaces via the startAt-only range query used by grid reads.
+// but grid reads still surface it via the start-in-range branch of
+// listByCalendarRange.
 export function scheduleEndAt(schedule: EventSchedule): Date {
   if (schedule.kind === "timed") return new Date(schedule.end);
   return new Date(`${schedule.end}T00:00:00.000Z`);

--- a/packages/sync/src/storage/repositories/event-occurrence.repository.db.test.ts
+++ b/packages/sync/src/storage/repositories/event-occurrence.repository.db.test.ts
@@ -359,6 +359,120 @@ describe("EventOccurrenceRepository", () => {
       expect(repaired).toHaveLength(1);
       expect(repaired[0]?.occurrenceKey).toBe(`${cal}:repair`);
     });
+
+    it("includes all-day UTC-midnight starts for America/Denver local-midnight windows", async () => {
+      // All-day startAt is UTC midnight of the civil date. A Denver day view
+      // sends local midnight (06:00Z), so startAt-only misses the row while a
+      // same-day timed event still matches.
+      const tenant = objectId() as OccurrenceInput["tenantId"];
+      const principal = objectId() as OccurrenceInput["principalId"];
+      const cal = objectId() as OccurrenceInput["calendarId"];
+      const allDayEventId = objectId() as OccurrenceInput["eventId"];
+      const timedEventId = objectId() as OccurrenceInput["eventId"];
+      const zeroDurationEventId = objectId() as OccurrenceInput["eventId"];
+      const priorAllDayEventId = objectId() as OccurrenceInput["eventId"];
+
+      await repo.replaceForEvents([
+        {
+          eventId: allDayEventId,
+          generation: 0,
+          occurrences: [
+            occurrence({
+              tenantId: tenant,
+              principalId: principal,
+              eventId: allDayEventId,
+              occurrenceKey: `${cal}:allday`,
+              calendarId: cal,
+              title: "from gcal",
+              schedule: {
+                kind: "allDay",
+                start: "2026-08-06",
+                end: "2026-08-07",
+              },
+              startAt: new Date("2026-08-06T00:00:00.000Z"),
+              endAt: new Date("2026-08-07T00:00:00.000Z"),
+            }),
+          ],
+        },
+        {
+          eventId: timedEventId,
+          generation: 0,
+          occurrences: [
+            occurrence({
+              tenantId: tenant,
+              principalId: principal,
+              eventId: timedEventId,
+              occurrenceKey: `${cal}:timed`,
+              calendarId: cal,
+              title: "live sync???",
+              schedule: {
+                kind: "timed",
+                start: "2026-08-06T11:30:00-06:00",
+                end: "2026-08-06T13:00:00-06:00",
+                timeZone: "America/Denver",
+              },
+              startAt: new Date("2026-08-06T11:30:00-06:00"),
+              endAt: new Date("2026-08-06T13:00:00-06:00"),
+            }),
+          ],
+        },
+        {
+          eventId: zeroDurationEventId,
+          generation: 0,
+          occurrences: [
+            occurrence({
+              tenantId: tenant,
+              principalId: principal,
+              eventId: zeroDurationEventId,
+              occurrenceKey: `${cal}:zero`,
+              calendarId: cal,
+              title: "reminder",
+              busy: false,
+              schedule: {
+                kind: "timed",
+                start: "2026-08-06T15:00:00-06:00",
+                end: "2026-08-06T15:00:00-06:00",
+                timeZone: "America/Denver",
+              },
+              startAt: new Date("2026-08-06T15:00:00-06:00"),
+              endAt: new Date("2026-08-06T15:00:00-06:00"),
+            }),
+          ],
+        },
+        {
+          eventId: priorAllDayEventId,
+          generation: 0,
+          occurrences: [
+            occurrence({
+              tenantId: tenant,
+              principalId: principal,
+              eventId: priorAllDayEventId,
+              occurrenceKey: `${cal}:prior`,
+              calendarId: cal,
+              title: "yesterday",
+              schedule: {
+                kind: "allDay",
+                start: "2026-08-05",
+                end: "2026-08-06",
+              },
+              startAt: new Date("2026-08-05T00:00:00.000Z"),
+              endAt: new Date("2026-08-06T00:00:00.000Z"),
+            }),
+          ],
+        },
+      ]);
+
+      const page = await repo.listByCalendarRange({
+        tenantId: tenant,
+        principalId: principal,
+        calendars: [{ calendarId: cal, generation: 0 }],
+        start: new Date("2026-08-06T00:00:00-06:00"),
+        end: new Date("2026-08-07T00:00:00-06:00"),
+        limit: 100,
+      });
+      const keys = page.map((o) => o.occurrenceKey).sort();
+      expect(keys).toEqual([`${cal}:allday`, `${cal}:timed`, `${cal}:zero`]);
+    });
   });
 
   describe("listBusyOverlapping", () => {

--- a/packages/sync/src/storage/repositories/event-occurrence.repository.ts
+++ b/packages/sync/src/storage/repositories/event-occurrence.repository.ts
@@ -13,8 +13,9 @@ import {
 
 export type OccurrenceInput = Omit<EventOccurrenceRecord, "_id">;
 
-// Longest occurrence start we still consider when answering a busy window.
-// Keeps calendar_gen_start range-bounded; see listBusyOverlapping.
+// Longest occurrence start we still consider when answering a busy or grid
+// overlap window. Keeps calendar_gen_start range-bounded; see
+// listBusyOverlapping and listByCalendarRange.
 export const BUSY_MAX_LOOKBACK_MS = 366 * 24 * 60 * 60 * 1000;
 
 export interface OccurrenceRangeCursor {
@@ -34,7 +35,9 @@ export interface OccurrenceRangeQuery {
   tenantId: TenantId;
   principalId: PrincipalId;
   calendars: readonly CalendarGeneration[];
-  // Half-open [start, end) over the normalized start instant.
+  // Half-open display window [start, end). An occurrence matches when it
+  // starts inside the window, or when it started earlier (within lookback)
+  // and its [startAt, endAt) interval still overlaps the window.
   start: Date;
   end: Date;
   limit: number;
@@ -182,6 +185,12 @@ export class EventOccurrenceRepository {
     return result.deletedCount;
   }
 
+  // Grid/display occurrences for [start, end). Matches start-in-range rows
+  // (including zero-duration timed reminders) and earlier-starting rows whose
+  // [startAt, endAt) still overlaps the window — so all-day events whose
+  // startAt is UTC midnight still appear for west-of-UTC local-midnight
+  // queries. startAt is lower-bounded by (windowStart - BUSY_MAX_LOOKBACK_MS)
+  // so the calendar_gen_start index stays range-bounded, same as busy reads.
   async listByCalendarRange(
     query: OccurrenceRangeQuery,
   ): Promise<EventOccurrenceRecord[]> {
@@ -196,7 +205,16 @@ export class EventOccurrenceRepository {
         generation: c.generation,
       })),
     };
-    const inRange = { startAt: { $gte: query.start, $lt: query.end } };
+    const startAtFloor = new Date(query.start.getTime() - BUSY_MAX_LOOKBACK_MS);
+    const inRange = {
+      $or: [
+        { startAt: { $gte: query.start, $lt: query.end } },
+        {
+          startAt: { $gte: startAtFloor, $lt: query.start },
+          endAt: { $gt: query.start },
+        },
+      ],
+    };
 
     // Composite keyset over the (startAt, _id) sort: a later instant, or the
     // same instant with a greater _id. startAt is a top-level Date and _id a

--- a/packages/web/src/events/queries/event.query.normalize.test.ts
+++ b/packages/web/src/events/queries/event.query.normalize.test.ts
@@ -1,0 +1,37 @@
+import { EventScheduleSchema } from "@core/types/event.contracts";
+import dayjs from "@core/util/date/dayjs";
+import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
+import { eventMatchesRange } from "@web/events/queries/event.query.normalize";
+import { WEEK_DAY_COUNT } from "@web/views/Week/util/week-window.util";
+import { describe, expect, it } from "bun:test";
+
+const DATE_FORMAT = dayjs.DateFormat.YEAR_MONTH_DAY_FORMAT;
+
+const lastDayAllDay = () =>
+  createMockEvent({
+    schedule: EventScheduleSchema.parse({
+      kind: "allDay",
+      start: "2026-08-12",
+      end: "2026-08-13",
+    }),
+  });
+
+describe("eventMatchesRange", () => {
+  it("includes a last-day all-day event when the range end is next midnight", () => {
+    const start = dayjs("2026-08-06", DATE_FORMAT).startOf("day");
+    const end = start.add(WEEK_DAY_COUNT, "day").startOf("day");
+
+    expect(
+      eventMatchesRange(lastDayAllDay(), start.format(), end.format()),
+    ).toBe(true);
+  });
+
+  it("excludes a last-day all-day event when the range end is endOf(day)", () => {
+    const start = dayjs("2026-08-06", DATE_FORMAT).startOf("day");
+    const end = start.add(WEEK_DAY_COUNT - 1, "day").endOf("day");
+
+    expect(
+      eventMatchesRange(lastDayAllDay(), start.format(), end.format()),
+    ).toBe(false);
+  });
+});

--- a/packages/web/src/views/Week/hooks/useWeek.test.tsx
+++ b/packages/web/src/views/Week/hooks/useWeek.test.tsx
@@ -244,4 +244,18 @@ describe("useWeek", () => {
       queryEndAtSeven,
     );
   });
+
+  it("uses exclusive next local midnight as the fetch window end", () => {
+    mockParams.dateString = "2026-08-06";
+    const today = dayjs("2026-08-07", DATE_FORMAT);
+    const { result } = renderHook(() => useWeek(today));
+
+    expect(result.current.query.startOfView.format(DATE_FORMAT)).toBe(
+      "2026-08-06",
+    );
+    // WEEK_DAY_COUNT days from the anchor → exclusive end is the following midnight.
+    expect(result.current.query.endOfView.format()).toBe(
+      dayjs("2026-08-13", DATE_FORMAT).startOf("day").format(),
+    );
+  });
 });

--- a/packages/web/src/views/Week/hooks/useWeek.ts
+++ b/packages/web/src/views/Week/hooks/useWeek.ts
@@ -54,8 +54,10 @@ export const useWeek = (
   );
   // Fetch window is always WEEK_DAY_COUNT days from the anchor so resize-driven
   // column changes reuse the same cache entry; display still clips to weekDays.
+  // Exclusive next local midnight (not endOf("day")) so all-day membership via
+  // eventMatchesRange's date-slice exclusive end includes the last fetched day.
   const queryEnd = useMemo(
-    () => start.add(WEEK_DAY_COUNT - 1, "day").endOf("day"),
+    () => start.add(WEEK_DAY_COUNT, "day").startOf("day"),
     [start],
   );
 
@@ -92,15 +94,13 @@ export const useWeek = (
     {
       startDate: toUTCOffset(previousStart),
       endDate: toUTCOffset(
-        previousStart.add(WEEK_DAY_COUNT - 1, "day").endOf("day"),
+        previousStart.add(WEEK_DAY_COUNT, "day").startOf("day"),
       ),
       calendarIds: weekQuery.calendarIds,
     },
     {
       startDate: toUTCOffset(nextStart),
-      endDate: toUTCOffset(
-        nextStart.add(WEEK_DAY_COUNT - 1, "day").endOf("day"),
-      ),
+      endDate: toUTCOffset(nextStart.add(WEEK_DAY_COUNT, "day").startOf("day")),
       calendarIds: weekQuery.calendarIds,
     },
     weekQuery.isSuccess,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Google all-day events were imported successfully but missing in the Compass grid for users west of UTC. Sync stored all-day `startAt` as UTC midnight while the web queried local midnight, and `listByCalendarRange` only matched start-in-range — so the first day of a day/week window dropped all-days while timed events still showed and sync health stayed green.

This changes grid reads to start-in-range **or** lookback overlap via `endAt` (same bound as busy reads), preserving zero-duration timed reminders, and aligns week fetch/prefetch ends with exclusive next local midnight so last-day all-days match on the local/cache path.

## Simplicity

Minimal read-path change: one Mongo `$or` branch in the existing range query, plus week exclusive-end bounds already used by day view. No schema, index, or import changes. Simplify pass found nothing further to reduce without hurting clarity.

## Automated validation

- `bun run test:sync -- packages/sync/src/storage/repositories/event-occurrence.repository.db.test.ts` — pass (America/Denver all-day + zero-duration timed + prior-day exclusion)
- `bun run test:web -- packages/web/src/events/queries/event.query.normalize.test.ts packages/web/src/views/Week/hooks/useWeek.test.tsx` — pass
- Equivalent scenario: Sync DB test reproduces the west-of-UTC local-midnight window that dropped Google all-days while timed peers remained
- `bun run lint` — warnings only (pre-existing)
- `bun run type-check` — pass

## Independent review

Fresh read-only review of `main...HEAD`: **approve**, no confirmed findings. Residual non-blocking notes only (lookback front-loading long multi-day rows; civil-date vs UTC-instant overlap still refined client-side).

## Test plan

- `bun run test:sync -- packages/sync/src/storage/repositories/event-occurrence.repository.db.test.ts`
- `bun run test:web -- packages/web/src/events/queries/event.query.normalize.test.ts packages/web/src/views/Week/hooks/useWeek.test.tsx`
- `bun run lint`
- `bun run type-check`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c42ea171-1194-46a1-b764-5ed9d3a5707b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c42ea171-1194-46a1-b764-5ed9d3a5707b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

