### PR TITLE
fix(web): humanize google sync status copy

### DIFF
--- a/docs/frontend/frontend-runtime-flow.md
+++ b/docs/frontend/frontend-runtime-flow.md
@@ -345,13 +345,15 @@ control. The command palette deliberately does not show Google status or actions
 CTA (prefer Sync connection vocabulary when a summary is present):
 
 - `HEALTHY` / connection `healthy` → “Calendar connected” (no CTA)
-- `ATTENTION` / connection `delayed` → “Calendar updates are taking longer than usual. We'll keep trying.” and **Refresh calendar**
+- connection `catchingUp` (after a short quiet window) → “Syncing in the background…”
+- `ATTENTION` / connection `delayed` → “Calendar updates are taking longer than usual…” / “Calendar updates are delayed” and **Refresh calendar**
 - `IMPORTING` / early connection work → “Adding your calendar…” (no CTA)
 - `RECONNECT_REQUIRED` → “Calendar needs reconnecting” and **Reconnect Google Calendar**
 - `NOT_CONNECTED` → **Connect Google Calendar**
 - `checking` → no status line
 
-User-facing copy avoids internal terms such as “repair” and “catching up.”
+User-facing copy talks about the calendar and updates, not the Sync service or
+internal states such as “repair” and “catching up.”
 
 Important constraint:
 

--- a/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.util.test.ts
+++ b/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.util.test.ts
@@ -121,14 +121,14 @@ describe("getGoogleSyncStatus", () => {
       ),
     ).toEqual({
       variant: "syncing",
-      text: "Sync is catching up. Last updated 15 minutes ago. This usually clears on its own.",
+      text: "Syncing in the background… Last updated 15 minutes ago. This usually finishes on its own.",
     });
   });
 
   it("returns warning copy for ATTENTION without a connection summary", () => {
     expect(getGoogleSyncStatus("ATTENTION")).toEqual({
       variant: "warning",
-      text: "Sync is stuck. Refresh your calendars, or reconnect if this continues.",
+      text: "Calendar updates are taking longer than usual. Try Refresh, or reconnect if this continues.",
     });
   });
 
@@ -173,7 +173,7 @@ describe("getGoogleSyncStatus", () => {
       ),
     ).toEqual({
       variant: "warning",
-      text: "Sync is stuck. Last updated 15 minutes ago. Refresh your calendars, or reconnect if this continues.",
+      text: "Calendar updates are taking longer than usual. Last updated 15 minutes ago. Try Refresh, or reconnect if this continues.",
     });
   });
 
@@ -194,7 +194,7 @@ describe("getGoogleSyncStatus", () => {
       ),
     ).toEqual({
       variant: "warning",
-      text: "Sync hit an error. Last updated 15 minutes ago. Refresh your calendars, or reconnect if this continues.",
+      text: "Couldn't update your calendar. Last updated 15 minutes ago. Try Refresh, or reconnect if this continues.",
     });
   });
 
@@ -216,7 +216,7 @@ describe("getGoogleSyncStatus", () => {
       ),
     ).toEqual({
       variant: "error",
-      text: "Sync is stuck. Last updated 15 minutes ago. Reconnect your calendar, or email tyler@switchback.tech for help.",
+      text: "We couldn't update your calendar. Last updated 15 minutes ago. Reconnect, or email tyler@switchback.tech for help.",
     });
   });
 });
@@ -261,11 +261,11 @@ describe("getSidebarSyncStatus", () => {
       }),
     ).toEqual({
       variant: "syncing",
-      text: "Sync is catching up",
+      text: "Syncing in the background…",
     });
   });
 
-  it("shows Sync is stuck for delayed workOverdue", () => {
+  it("shows Calendar updates are delayed for delayed workOverdue", () => {
     expect(
       getSidebarSyncStatus({
         connection: {
@@ -283,11 +283,11 @@ describe("getSidebarSyncStatus", () => {
       }),
     ).toEqual({
       variant: "warning",
-      text: "Sync is stuck",
+      text: "Calendar updates are delayed",
     });
   });
 
-  it("shows Sync is catching up while a Refresh is in flight on delayed", () => {
+  it("shows Syncing in the background while a Refresh is in flight on delayed", () => {
     expect(
       getSidebarSyncStatus({
         connection: {
@@ -306,11 +306,11 @@ describe("getSidebarSyncStatus", () => {
       }),
     ).toEqual({
       variant: "syncing",
-      text: "Sync is catching up",
+      text: "Syncing in the background…",
     });
   });
 
-  it("shows Sync hit an error for delayed providerErrors", () => {
+  it("shows Couldn't update your calendar for delayed providerErrors", () => {
     expect(
       getSidebarSyncStatus({
         connection: {
@@ -328,7 +328,7 @@ describe("getSidebarSyncStatus", () => {
       }),
     ).toEqual({
       variant: "warning",
-      text: "Sync hit an error",
+      text: "Couldn't update your calendar",
     });
   });
 

--- a/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.util.ts
+++ b/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.util.ts
@@ -96,12 +96,12 @@ const lastUpdatedSuffix = (
 
 const stuckReconnectStatus = (lastBit: string): SyncStatus => ({
   variant: "error",
-  text: `Sync is stuck.${lastBit} Reconnect your calendar, or email ${SUPPORT_EMAIL} for help.`,
+  text: `We couldn't update your calendar.${lastBit} Reconnect, or email ${SUPPORT_EMAIL} for help.`,
 });
 
 const catchingUpDetailStatus = (lastBit: string): SyncStatus => ({
   variant: "syncing",
-  text: `Sync is catching up.${lastBit} This usually clears on its own.`,
+  text: `Syncing in the background…${lastBit} This usually finishes on its own.`,
 });
 
 export type GoogleConnectionHandlers = {
@@ -169,12 +169,12 @@ const delayedSettingsStatus = (
   if (connection.stateReason === "providerErrors") {
     return {
       variant: "warning",
-      text: `Sync hit an error.${lastBit} Refresh your calendars, or reconnect if this continues.`,
+      text: `Couldn't update your calendar.${lastBit} Try Refresh, or reconnect if this continues.`,
     };
   }
   return {
     variant: "warning",
-    text: `Sync is stuck.${lastBit} Refresh your calendars, or reconnect if this continues.`,
+    text: `Calendar updates are taking longer than usual.${lastBit} Try Refresh, or reconnect if this continues.`,
   };
 };
 
@@ -255,7 +255,7 @@ export const getGoogleSyncStatus = (
       }
       return {
         variant: "warning",
-        text: "Sync is stuck. Refresh your calendars, or reconnect if this continues.",
+        text: "Calendar updates are taking longer than usual. Try Refresh, or reconnect if this continues.",
       };
     case "RECONNECT_REQUIRED":
       return { variant: "error", text: "Calendar needs reconnecting" };
@@ -300,16 +300,16 @@ export const getSidebarSyncStatus = ({
     refreshGaveUp &&
     (state === "ATTENTION" || connection?.state === "delayed")
   ) {
-    return { variant: "error", text: "Sync is stuck" };
+    return { variant: "error", text: "Calendar updates are delayed" };
   }
 
-  // Align with the Catching up… CTA while we wait for delayed to clear —
-  // otherwise the bar keeps saying "Sync is stuck" beside a hopeful button.
+  // Align with the Syncing… status while we wait for delayed to clear —
+  // otherwise the bar keeps saying updates are delayed beside a hopeful button.
   if (
     refreshInFlight &&
     (state === "ATTENTION" || connection?.state === "delayed")
   ) {
-    return { variant: "syncing", text: "Sync is catching up" };
+    return { variant: "syncing", text: "Syncing in the background…" };
   }
 
   if (connection) {
@@ -320,7 +320,7 @@ export const getSidebarSyncStatus = ({
         }
         const ageMs = syncedAgeMs(connection.lastSyncedAt, nowMs);
         if (ageMs !== null && ageMs >= CATCHING_UP_NOTICE_AFTER_MS) {
-          return { variant: "syncing", text: "Sync is catching up" };
+          return { variant: "syncing", text: "Syncing in the background…" };
         }
         return null;
       }
@@ -329,8 +329,8 @@ export const getSidebarSyncStatus = ({
           variant: "warning",
           text:
             connection.stateReason === "providerErrors"
-              ? "Sync hit an error"
-              : "Sync is stuck",
+              ? "Couldn't update your calendar"
+              : "Calendar updates are delayed",
         };
       case "actionRequired":
       case "disconnected":

--- a/packages/web/src/common/utils/toast/google-delayed.toast.tsx
+++ b/packages/web/src/common/utils/toast/google-delayed.toast.tsx
@@ -25,10 +25,12 @@ export const GoogleDelayedToast = ({ toastId }: GoogleDelayedToastProps) => {
 
   return (
     <div className="flex w-full flex-col gap-2">
-      <p className="font-medium text-sm text-text">Calendar sync is delayed</p>
+      <p className="font-medium text-sm text-text">
+        Calendar updates are delayed
+      </p>
       <p className="text-sm text-text">
-        Calendar sync is taking longer than expected. Refresh to try again, or
-        reconnect if this continues.
+        Updates are taking longer than expected. Try Refresh, or reconnect if
+        this continues.
       </p>
       <button
         className="w-full rounded bg-accent-secondary px-3 py-2 font-medium text-on-accent text-sm transition-colors hover:bg-accent-secondary-hover"

--- a/packages/web/src/components/Feedback/FeedbackDialog.test.tsx
+++ b/packages/web/src/components/Feedback/FeedbackDialog.test.tsx
@@ -73,7 +73,7 @@ describe("FeedbackDialog", () => {
         <>
           <button
             type="button"
-            aria-label="Open command palette, calendar syncing"
+            aria-label="Open command palette, syncing in the background"
           />
           {open ? (
             <FeedbackDialog
@@ -98,7 +98,7 @@ describe("FeedbackDialog", () => {
     await waitFor(() =>
       expect(
         screen.getByRole("button", {
-          name: "Open command palette, calendar syncing",
+          name: "Open command palette, syncing in the background",
         }),
       ).toHaveFocus(),
     );

--- a/packages/web/src/components/Sidebar/SidebarActions/SidebarActions.test.tsx
+++ b/packages/web/src/components/Sidebar/SidebarActions/SidebarActions.test.tsx
@@ -44,7 +44,7 @@ describe("SidebarActions", () => {
 
     expect(
       screen.getByRole("button", {
-        name: "Open command palette, calendar syncing",
+        name: "Open command palette, syncing in the background",
       }),
     ).toBeInTheDocument();
   });

--- a/packages/web/src/components/Sidebar/SidebarActions/SidebarActions.tsx
+++ b/packages/web/src/components/Sidebar/SidebarActions/SidebarActions.tsx
@@ -61,7 +61,7 @@ export const SidebarActions = () => {
           <button
             aria-label={
               isCalendarSyncing
-                ? "Open command palette, calendar syncing"
+                ? "Open command palette, syncing in the background"
                 : "Open command palette"
             }
             className="flex size-9 items-center justify-center rounded-default text-text-muted transition hover:bg-surface-panel hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"

--- a/packages/web/src/components/Sidebar/SidebarStatusBar.test.tsx
+++ b/packages/web/src/components/Sidebar/SidebarStatusBar.test.tsx
@@ -127,7 +127,7 @@ describe("SidebarStatusBar", () => {
     expect(screen.queryByText("Adding your calendar…")).toBeNull();
   });
 
-  it("shows Sync is catching up when catch-up is more than two minutes behind", () => {
+  it("shows Syncing in the background when catch-up is more than two minutes behind", () => {
     googleState = "IMPORTING";
     connection = createMockConnection("ahab@pequod.com", {
       state: "catchingUp",
@@ -139,14 +139,16 @@ describe("SidebarStatusBar", () => {
 
     render(<SidebarStatusBar />, { wrapper });
 
-    expect(screen.getByRole("status")).toHaveTextContent("Sync is catching up");
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Syncing in the background…",
+    );
     expect(screen.getByRole("button")).toHaveAttribute(
       "title",
-      "Sync is catching up",
+      "Syncing in the background…",
     );
   });
 
-  it("shows Sync is stuck for delayed workOverdue", () => {
+  it("shows Calendar updates are delayed for delayed workOverdue", () => {
     googleState = "ATTENTION";
     connection = createMockConnection("ahab@pequod.com", {
       state: "delayed",
@@ -159,7 +161,9 @@ describe("SidebarStatusBar", () => {
 
     render(<SidebarStatusBar />, { wrapper });
 
-    expect(screen.getByRole("status")).toHaveTextContent("Sync is stuck");
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Calendar updates are delayed",
+    );
   });
 
   it("opens Settings when the status bar is activated", async () => {
@@ -176,7 +180,7 @@ describe("SidebarStatusBar", () => {
     render(<SidebarStatusBar />, { wrapper });
     await user.click(
       screen.getByRole("button", {
-        name: "Sync is stuck. Open account settings",
+        name: "Calendar updates are delayed. Open account settings",
       }),
     );
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Replace Sync-service jargon in Google calendar status lines, the delayed toast, and the command-palette a11y label with calendar-focused copy users can understand (for example “Syncing in the background…” instead of “Sync is catching up”).

## Simplicity

Copy-only change in the existing status/toast helpers. No new abstractions or control-flow changes.

## Automated validation

Pending focused web tests and lint after the initial push.

## Independent review

Pending after validation.

## Test plan

- `bun test` on the touched web status/toast/sidebar tests
- `bun run lint`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f066fd35-c8d5-4363-a064-33b69bbb58ca?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f066fd35-c8d5-4363-a064-33b69bbb58ca&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

