### PR TITLE
fix(web): trap focus in welcome and release-notes dialogs

### DIFF
--- a/packages/web/src/components/OverlayPanel/OverlayPanel.test.tsx
+++ b/packages/web/src/components/OverlayPanel/OverlayPanel.test.tsx
@@ -80,4 +80,29 @@ describe("OverlayPanel", () => {
     await user.tab({ shift: true });
     expect(last).toHaveFocus();
   });
+
+  it("skips focus restore when skipFocusRestoreRef is set", () => {
+    const skipFocusRestoreRef = { current: false };
+    const { rerender } = render(<button type="button">Outside</button>);
+    const outside = screen.getByRole("button", { name: "Outside" });
+    outside.focus();
+
+    rerender(
+      <>
+        <button type="button">Outside</button>
+        <OverlayPanel
+          title="Confirm"
+          onDismiss={() => {}}
+          skipFocusRestoreRef={skipFocusRestoreRef}
+        >
+          <button type="button">Inside</button>
+        </OverlayPanel>
+      </>,
+    );
+    expect(screen.getByRole("button", { name: "Inside" })).toHaveFocus();
+
+    skipFocusRestoreRef.current = true;
+    rerender(<button type="button">Outside</button>);
+    expect(outside).not.toHaveFocus();
+  });
 });

--- a/packages/web/src/components/OverlayPanel/OverlayPanel.test.tsx
+++ b/packages/web/src/components/OverlayPanel/OverlayPanel.test.tsx
@@ -1,5 +1,6 @@
 import "@testing-library/jest-dom";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { OverlayPanel } from "@web/components/OverlayPanel/OverlayPanel";
 import { describe, expect, it } from "bun:test";
 
@@ -40,5 +41,43 @@ describe("OverlayPanel", () => {
     expect(document.body.dataset.appLocked).toBe("true");
     unmount();
     expect(document.body.dataset.appLocked).toBeUndefined();
+  });
+
+  it("names untitled dialogs via ariaLabel", () => {
+    render(
+      <OverlayPanel ariaLabel="Welcome guide" onDismiss={() => {}}>
+        <button type="button">Close</button>
+      </OverlayPanel>,
+    );
+
+    expect(
+      screen.getByRole("dialog", { name: "Welcome guide" }),
+    ).toBeInTheDocument();
+  });
+
+  it("traps Tab within the dialog", async () => {
+    const user = userEvent.setup();
+    render(
+      <>
+        <button type="button">Outside</button>
+        <OverlayPanel title="Confirm" onDismiss={() => {}}>
+          <button type="button">First</button>
+          <button type="button">Last</button>
+        </OverlayPanel>
+      </>,
+    );
+
+    const first = screen.getByRole("button", { name: "First" });
+    const last = screen.getByRole("button", { name: "Last" });
+    expect(first).toHaveFocus();
+
+    await user.tab();
+    expect(last).toHaveFocus();
+
+    await user.tab();
+    expect(first).toHaveFocus();
+
+    await user.tab({ shift: true });
+    expect(last).toHaveFocus();
   });
 });

--- a/packages/web/src/components/OverlayPanel/OverlayPanel.tsx
+++ b/packages/web/src/components/OverlayPanel/OverlayPanel.tsx
@@ -17,6 +17,8 @@ interface Props {
   icon?: ReactNode;
   /** Main title text */
   title?: string;
+  /** Accessible name when the panel has no visible title */
+  ariaLabel?: string;
   /** Optional content rendered on the same row as the title (e.g. a switch link) */
   titleAction?: ReactNode;
   /** Description/message text */
@@ -35,11 +37,16 @@ interface Props {
   variant?: "modal" | "status";
   /** Tailwind width class for the modal variant (default: "w-[400px]") */
   widthClassName?: string;
+  /** Extra classes for the backdrop (e.g. overflow for tall dialogs) */
+  backdropClassName?: string;
+  /** When true, applies dismiss-transition `data-closing` styles before unmount */
+  closing?: boolean;
 }
 
 export const OverlayPanel = ({
   icon,
   title,
+  ariaLabel,
   titleAction,
   message,
   children,
@@ -49,6 +56,8 @@ export const OverlayPanel = ({
   align = "center",
   variant = "modal",
   widthClassName = "w-[400px]",
+  backdropClassName,
+  closing = false,
 }: Props) => {
   const panelRef = useRef<HTMLDivElement>(null);
   const baseId = useId();
@@ -73,6 +82,9 @@ export const OverlayPanel = ({
 
   const backdropClasses = clsx(
     "fixed inset-0 flex items-center justify-center bg-background/85 backdrop-blur-sm",
+    variant === "modal" &&
+      "transition-opacity duration-400 ease-out data-closing:opacity-0 motion-reduce:transition-none",
+    backdropClassName,
   );
 
   const panelClasses = clsx(
@@ -81,6 +93,7 @@ export const OverlayPanel = ({
     variant === "modal" && [
       widthClassName,
       "max-w-[90vw] gap-6 rounded-xl bg-surface-panel p-8 shadow-[0_20px_25px_-5px_rgba(0,0,0,0.1),0_10px_10px_-5px_rgba(0,0,0,0.04)]",
+      "transition-transform duration-400 ease-out data-closing:scale-105 motion-reduce:transition-none",
     ],
     variant === "status" &&
       "max-w-sm gap-3 rounded-lg border border-border bg-surface/90 px-6 py-5 shadow-lg",
@@ -126,6 +139,7 @@ export const OverlayPanel = ({
     // biome-ignore lint/a11y/noStaticElementInteractions: The backdrop catches outside clicks and Escape to dismiss the panel.
     <div
       className={backdropClasses}
+      data-closing={closing || undefined}
       onClick={handleBackdropClick}
       onKeyDown={handleKeyDown}
       role="presentation"
@@ -136,9 +150,11 @@ export const OverlayPanel = ({
       <div
         ref={panelRef}
         className={panelClasses}
+        data-closing={closing || undefined}
         role={role}
         tabIndex={role === "dialog" ? -1 : undefined}
         aria-modal={role === "dialog" ? true : undefined}
+        aria-label={!title ? ariaLabel : undefined}
         aria-labelledby={title ? titleId : undefined}
         aria-describedby={message ? messageId : undefined}
         aria-live={role === "status" ? "polite" : undefined}

--- a/packages/web/src/components/OverlayPanel/OverlayPanel.tsx
+++ b/packages/web/src/components/OverlayPanel/OverlayPanel.tsx
@@ -2,6 +2,7 @@ import clsx from "clsx";
 import {
   type ButtonHTMLAttributes,
   type ReactNode,
+  type RefObject,
   useEffect,
   useId,
   useRef,
@@ -32,6 +33,11 @@ interface Props {
   onDismiss?: () => void;
   /** Overrides the element that receives focus when the dialog closes. */
   restoreFocus?: () => void;
+  /**
+   * When `.current` is true at unmount, skip focus restore — for dialog-to-dialog
+   * handoffs where the next dialog will seat focus itself.
+   */
+  skipFocusRestoreRef?: RefObject<boolean>;
   /** ARIA role for the panel (default: "dialog") */
   role?: "dialog" | "status" | "alert";
   /** Cross-axis alignment of the title/message/children (default: "center") */
@@ -55,6 +61,7 @@ export const OverlayPanel = ({
   children,
   onDismiss,
   restoreFocus,
+  skipFocusRestoreRef,
   role = "dialog",
   align = "center",
   variant = "modal",
@@ -77,11 +84,13 @@ export const OverlayPanel = ({
     const [firstFocusable] = getFocusableElements(panel);
     (firstFocusable ?? panel).focus();
     return () => {
+      // Read at unmount so callers can suppress restore for dialog handoffs.
+      if (skipFocusRestoreRef?.current) return;
       // Let the Escape key's global handlers finish before restoring focus.
       if (restoreFocus) setTimeout(restoreFocus);
       else previouslyFocused?.focus?.();
     };
-  }, [restoreFocus, role]);
+  }, [restoreFocus, role, skipFocusRestoreRef]);
 
   const backdropClasses = clsx(
     "fixed inset-0 flex items-center justify-center bg-background/85 backdrop-blur-sm",

--- a/packages/web/src/components/OverlayPanel/OverlayPanel.tsx
+++ b/packages/web/src/components/OverlayPanel/OverlayPanel.tsx
@@ -12,6 +12,9 @@ import { useAppLockReason } from "@web/shortcuts/app-lock";
 const FOCUSABLE_SELECTOR =
   'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
 
+const getFocusableElements = (root: HTMLElement) =>
+  Array.from(root.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR));
+
 interface Props {
   /** Icon or element displayed at the top of the panel */
   icon?: ReactNode;
@@ -71,7 +74,7 @@ export const OverlayPanel = ({
     const panel = panelRef.current;
     if (!panel) return;
     const previouslyFocused = document.activeElement as HTMLElement | null;
-    const firstFocusable = panel.querySelector<HTMLElement>(FOCUSABLE_SELECTOR);
+    const [firstFocusable] = getFocusableElements(panel);
     (firstFocusable ?? panel).focus();
     return () => {
       // Let the Escape key's global handlers finish before restoring focus.
@@ -118,20 +121,17 @@ export const OverlayPanel = ({
       onDismiss();
       return;
     }
-    if (e.key === "Tab" && panelRef.current) {
-      const focusables = Array.from(
-        panelRef.current.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
-      );
-      if (focusables.length === 0) return;
-      const first = focusables[0];
-      const last = focusables[focusables.length - 1];
-      if (e.shiftKey && document.activeElement === first) {
-        e.preventDefault();
-        last.focus();
-      } else if (!e.shiftKey && document.activeElement === last) {
-        e.preventDefault();
-        first.focus();
-      }
+    if (e.key !== "Tab" || !panelRef.current) return;
+    const focusables = getFocusableElements(panelRef.current);
+    if (focusables.length === 0) return;
+    const first = focusables[0];
+    const last = focusables[focusables.length - 1];
+    if (e.shiftKey && document.activeElement === first) {
+      e.preventDefault();
+      last.focus();
+    } else if (!e.shiftKey && document.activeElement === last) {
+      e.preventDefault();
+      first.focus();
     }
   };
 

--- a/packages/web/src/components/ReleaseNotesPrompt/ReleaseNotesPrompt.tsx
+++ b/packages/web/src/components/ReleaseNotesPrompt/ReleaseNotesPrompt.tsx
@@ -1,17 +1,11 @@
-import {
-  type KeyboardEvent,
-  type MouseEvent,
-  useCallback,
-  useState,
-} from "react";
+import { useState } from "react";
 import { UserApi } from "@web/api/user.api";
 import { MODAL_DISMISS_MS } from "@web/common/constants/motion.constants";
-import { Z_INDEX_MODAL } from "@web/common/constants/web.constants";
 import { useDismissTransition } from "@web/common/hooks/useDismissTransition";
 import { showErrorToast } from "@web/common/utils/toast/error-toast.util";
+import { OverlayPanel } from "@web/components/OverlayPanel/OverlayPanel";
 import { releaseNotesPromptActions } from "@web/components/ReleaseNotesPrompt/release-notes-prompt.store";
 import { PixelPirate } from "@web/components/WelcomeModal/PixelPirate";
-import { useAppLockReason } from "@web/shortcuts/app-lock";
 
 type PromptState =
   | "asking"
@@ -23,14 +17,6 @@ type PromptState =
 export function ReleaseNotesPrompt() {
   const [state, setState] = useState<PromptState>("asking");
   const { closing, beginDismiss } = useDismissTransition(MODAL_DISMISS_MS);
-  useAppLockReason("releaseNotes", true);
-
-  // RootShell mounts this only while the store flag is open, so each open is a
-  // fresh mount (state starts at "asking", no reset effect needed). A callback
-  // ref focuses the backdrop on mount so Escape works without a click first.
-  const focusOnMount = useCallback((node: HTMLDivElement | null) => {
-    node?.focus();
-  }, []);
 
   const dismiss = () => {
     beginDismiss(() => releaseNotesPromptActions.close());
@@ -69,33 +55,16 @@ export function ReleaseNotesPrompt() {
     }
   };
 
-  const handleBackdropClick = (event: MouseEvent<HTMLDivElement>) => {
-    if (event.target === event.currentTarget) decline();
-  };
-
-  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
-    if (event.key === "Escape") decline();
-  };
-
   return (
-    // biome-ignore lint/a11y/noStaticElementInteractions: The backdrop catches outside clicks and Escape to dismiss the modal.
-    <div
-      className="fixed inset-0 flex items-center justify-center bg-background/85 p-8 backdrop-blur-sm transition-opacity duration-400 ease-out data-closing:opacity-0 motion-reduce:transition-none"
-      data-closing={closing || undefined}
-      onClick={handleBackdropClick}
-      onKeyDown={handleKeyDown}
-      ref={focusOnMount}
-      role="presentation"
-      style={{ zIndex: Z_INDEX_MODAL }}
-      tabIndex={-1}
+    <OverlayPanel
+      align="start"
+      ariaLabel="Release notes subscription"
+      backdropClassName="p-8"
+      closing={closing}
+      onDismiss={decline}
+      widthClassName="w-120"
     >
-      <div
-        role="dialog"
-        aria-modal
-        aria-label="Release notes subscription"
-        data-closing={closing || undefined}
-        className="flex w-120 max-w-[90vw] flex-col gap-6 rounded-xl bg-surface-panel p-8 shadow-[0_20px_25px_-5px_rgba(0,0,0,0.1),0_10px_10px_-5px_rgba(0,0,0,0.04)] transition-transform duration-400 ease-out data-closing:scale-105 motion-reduce:transition-none"
-      >
+      <div className="flex w-full flex-col gap-6">
         <PixelPirate className="h-14 w-14" />
         {state === "asking" ? (
           <>
@@ -158,6 +127,6 @@ export function ReleaseNotesPrompt() {
           </div>
         )}
       </div>
-    </div>
+    </OverlayPanel>
   );
 }

--- a/packages/web/src/components/WelcomeModal/WelcomeGuideModal.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeGuideModal.tsx
@@ -1,55 +1,27 @@
-import { type KeyboardEvent, type MouseEvent, useCallback } from "react";
 import { MODAL_DISMISS_MS } from "@web/common/constants/motion.constants";
-import { Z_INDEX_MODAL } from "@web/common/constants/web.constants";
 import { useDismissTransition } from "@web/common/hooks/useDismissTransition";
-import { useAppLockReason } from "@web/shortcuts/app-lock";
+import { OverlayPanel } from "@web/components/OverlayPanel/OverlayPanel";
 import { PixelPirate } from "./PixelPirate";
 import { WelcomeGuideBody } from "./WelcomeGuideBody";
 import { welcomeGuideActions } from "./welcome.guide.store";
 
 export function WelcomeGuideModal() {
   const { closing, beginDismiss } = useDismissTransition(MODAL_DISMISS_MS);
-  useAppLockReason("welcomeGuide", true);
-
-  const focusOnMount = useCallback((node: HTMLDivElement | null) => {
-    node?.focus();
-  }, []);
 
   const dismiss = () => {
     beginDismiss(() => welcomeGuideActions.close());
   };
 
-  const handleBackdropClick = (event: MouseEvent<HTMLDivElement>) => {
-    if (event.target === event.currentTarget) {
-      dismiss();
-    }
-  };
-
-  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
-    if (event.key === "Escape") {
-      dismiss();
-    }
-  };
-
   return (
-    // biome-ignore lint/a11y/noStaticElementInteractions: The backdrop catches outside clicks and Escape to dismiss the welcome guide.
-    <div
-      className="fixed inset-0 flex items-center justify-center overflow-y-auto bg-background/85 py-8 backdrop-blur-sm transition-opacity duration-400 ease-out data-closing:opacity-0 motion-reduce:transition-none"
-      data-closing={closing || undefined}
-      onClick={handleBackdropClick}
-      onKeyDown={handleKeyDown}
-      ref={focusOnMount}
-      role="presentation"
-      style={{ zIndex: Z_INDEX_MODAL }}
-      tabIndex={-1}
+    <OverlayPanel
+      align="start"
+      ariaLabel="Welcome to Compass Calendar"
+      backdropClassName="overflow-y-auto py-8"
+      closing={closing}
+      onDismiss={dismiss}
+      widthClassName="w-120"
     >
-      <div
-        role="dialog"
-        aria-modal
-        aria-label="Welcome to Compass Calendar"
-        data-closing={closing || undefined}
-        className="flex w-120 max-w-[90vw] flex-col gap-6 rounded-xl bg-surface-panel p-8 shadow-[0_20px_25px_-5px_rgba(0,0,0,0.1),0_10px_10px_-5px_rgba(0,0,0,0.04)] transition-transform duration-400 ease-out data-closing:scale-105 motion-reduce:transition-none"
-      >
+      <div className="flex w-full flex-col gap-6">
         <PixelPirate className="h-14 w-14 shrink-0" />
         <WelcomeGuideBody />
 
@@ -63,6 +35,6 @@ export function WelcomeGuideModal() {
           </button>
         </div>
       </div>
-    </div>
+    </OverlayPanel>
   );
 }

--- a/packages/web/src/components/WelcomeModal/WelcomeModal.test.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeModal.test.tsx
@@ -158,20 +158,12 @@ describe("WelcomeModal", () => {
       </>,
     );
 
-    const dialog = screen.getByRole("dialog", {
-      name: "Welcome to Compass Calendar",
-    });
     const signUp = screen.getByRole("button", { name: "Sign up" });
     expect(signUp).toHaveFocus();
 
-    const focusables = Array.from(
-      dialog.querySelectorAll<HTMLElement>(
-        'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])',
-      ),
-    );
-    const last = focusables[focusables.length - 1];
-    last.focus();
-    expect(last).toHaveFocus();
+    const terms = screen.getByRole("link", { name: "Terms" });
+    terms.focus();
+    expect(terms).toHaveFocus();
 
     await user.tab();
     expect(signUp).toHaveFocus();

--- a/packages/web/src/components/WelcomeModal/WelcomeModal.test.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeModal.test.tsx
@@ -96,6 +96,38 @@ describe("WelcomeModal", () => {
     ).toBeNull();
   });
 
+  it("does not restore underlay focus when handing off to auth", async () => {
+    const user = userEvent.setup();
+
+    const { rerender } = render(
+      <button type="button">Outside calendar</button>,
+    );
+    const outside = screen.getByRole("button", { name: "Outside calendar" });
+    outside.focus();
+
+    rerender(
+      <>
+        <button type="button">Outside calendar</button>
+        <WelcomeModal />
+      </>,
+    );
+    expect(screen.getByRole("button", { name: "Sign up" })).toHaveFocus();
+
+    await user.click(screen.getByRole("button", { name: "Log in" }));
+    authModalState.isOpen = true;
+    rerender(
+      <>
+        <button type="button">Outside calendar</button>
+        <WelcomeModal />
+      </>,
+    );
+
+    expect(
+      screen.queryByRole("dialog", { name: "Welcome to Compass Calendar" }),
+    ).toBeNull();
+    expect(outside).not.toHaveFocus();
+  });
+
   it("reappears when the auth modal closes (e.g. via the browser back button)", async () => {
     const user = userEvent.setup();
 

--- a/packages/web/src/components/WelcomeModal/WelcomeModal.test.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeModal.test.tsx
@@ -147,4 +147,36 @@ describe("WelcomeModal", () => {
     expect(answer).toHaveAttribute("aria-hidden", "true");
     expect(answer).toHaveAttribute("data-state", "closed");
   });
+
+  it("focuses the first control and keeps Tab inside the dialog", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <>
+        <button type="button">Outside calendar</button>
+        <WelcomeModal />
+      </>,
+    );
+
+    const dialog = screen.getByRole("dialog", {
+      name: "Welcome to Compass Calendar",
+    });
+    const signUp = screen.getByRole("button", { name: "Sign up" });
+    expect(signUp).toHaveFocus();
+
+    const focusables = Array.from(
+      dialog.querySelectorAll<HTMLElement>(
+        'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])',
+      ),
+    );
+    const last = focusables[focusables.length - 1];
+    last.focus();
+    expect(last).toHaveFocus();
+
+    await user.tab();
+    expect(signUp).toHaveFocus();
+    expect(
+      screen.getByRole("button", { name: "Outside calendar" }),
+    ).not.toHaveFocus();
+  });
 });

--- a/packages/web/src/components/WelcomeModal/WelcomeModal.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeModal.tsx
@@ -3,22 +3,14 @@ import {
   LinkedinLogoIcon,
   XLogoIcon,
 } from "@phosphor-icons/react";
-import {
-  type KeyboardEvent,
-  type MouseEvent,
-  useContext,
-  useEffect,
-  useRef,
-  useState,
-} from "react";
+import { useContext, useEffect, useRef, useState } from "react";
 import { SessionContext } from "@web/auth/compass/session/session.context";
 import { track } from "@web/auth/posthog/track";
 import { MODAL_DISMISS_MS } from "@web/common/constants/motion.constants";
 import { SOCIAL_LINKS } from "@web/common/constants/social.constants";
-import { Z_INDEX_MODAL } from "@web/common/constants/web.constants";
 import { useDismissTransition } from "@web/common/hooks/useDismissTransition";
 import { useAuthModal } from "@web/components/AuthModal/hooks/useAuthModal";
-import { useAppLockReason } from "@web/shortcuts/app-lock";
+import { OverlayPanel } from "@web/components/OverlayPanel/OverlayPanel";
 import { maybeShowCmdPaletteHint } from "./cmd-palette-hint.util";
 import { PixelPirate } from "./PixelPirate";
 import { WelcomeGuideBody } from "./WelcomeGuideBody";
@@ -37,22 +29,17 @@ export function WelcomeModal() {
     () => !authenticated && !hasSeenWelcome(),
   );
   const { closing, beginDismiss } = useDismissTransition(MODAL_DISMISS_MS);
-  const backdropRef = useRef<HTMLDivElement>(null);
 
   // The auth modal's openness lives in the URL (?auth=), so the welcome
   // screen simply hides while it is open and reappears when the browser
   // back button (or Escape) removes the param again.
   const visible = isOpen && !isAuthModalOpen && !authenticated;
-  useAppLockReason("welcomeModal", visible);
 
   const shownRef = useRef(false);
   useEffect(() => {
-    if (visible) {
-      backdropRef.current?.focus();
-      if (!shownRef.current) {
-        shownRef.current = true;
-        track("welcome_modal_shown");
-      }
+    if (visible && !shownRef.current) {
+      shownRef.current = true;
+      track("welcome_modal_shown");
     }
   }, [visible]);
 
@@ -83,37 +70,16 @@ export function WelcomeModal() {
     openModal("signUp");
   };
 
-  const handleBackdropClick = (event: MouseEvent<HTMLDivElement>) => {
-    if (event.target === event.currentTarget) {
-      dismiss();
-    }
-  };
-
-  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
-    if (event.key === "Escape") {
-      dismiss();
-    }
-  };
-
   return (
-    // biome-ignore lint/a11y/noStaticElementInteractions: The backdrop catches outside clicks and Escape to dismiss the welcome modal.
-    <div
-      className="fixed inset-0 flex items-center justify-center overflow-y-auto bg-background/85 py-8 backdrop-blur-sm transition-opacity duration-400 ease-out data-closing:opacity-0 motion-reduce:transition-none"
-      data-closing={closing || undefined}
-      onClick={handleBackdropClick}
-      onKeyDown={handleKeyDown}
-      ref={backdropRef}
-      role="presentation"
-      style={{ zIndex: Z_INDEX_MODAL }}
-      tabIndex={-1}
+    <OverlayPanel
+      align="start"
+      ariaLabel="Welcome to Compass Calendar"
+      backdropClassName="overflow-y-auto py-8"
+      closing={closing}
+      onDismiss={() => dismiss()}
+      widthClassName="w-120"
     >
-      <div
-        role="dialog"
-        aria-modal
-        aria-label="Welcome to Compass Calendar"
-        data-closing={closing || undefined}
-        className="flex w-120 max-w-[90vw] flex-col gap-6 rounded-xl bg-surface-panel p-8 shadow-[0_20px_25px_-5px_rgba(0,0,0,0.1),0_10px_10px_-5px_rgba(0,0,0,0.04)] transition-transform duration-400 ease-out data-closing:scale-105 motion-reduce:transition-none"
-      >
+      <div className="flex w-full flex-col gap-6">
         {/* Top row: pirate top-left, auth pills top-right */}
         <div className="flex items-center justify-between">
           <div className="group relative flex items-center">
@@ -198,6 +164,6 @@ export function WelcomeModal() {
           </div>
         </div>
       </div>
-    </div>
+    </OverlayPanel>
   );
 }

--- a/packages/web/src/components/WelcomeModal/WelcomeModal.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeModal.tsx
@@ -29,6 +29,9 @@ export function WelcomeModal() {
     () => !authenticated && !hasSeenWelcome(),
   );
   const { closing, beginDismiss } = useDismissTransition(MODAL_DISMISS_MS);
+  // Suppress OverlayPanel's unmount restore when handing off to Auth — Auth
+  // seats its own focus; restoring the underlay first causes a focus flash.
+  const skipFocusRestoreRef = useRef(false);
 
   // The auth modal's openness lives in the URL (?auth=), so the welcome
   // screen simply hides while it is open and reappears when the browser
@@ -37,9 +40,12 @@ export function WelcomeModal() {
 
   const shownRef = useRef(false);
   useEffect(() => {
-    if (visible && !shownRef.current) {
-      shownRef.current = true;
-      track("welcome_modal_shown");
+    if (visible) {
+      skipFocusRestoreRef.current = false;
+      if (!shownRef.current) {
+        shownRef.current = true;
+        track("welcome_modal_shown");
+      }
     }
   }, [visible]);
 
@@ -55,19 +61,15 @@ export function WelcomeModal() {
     beginDismiss(() => setIsOpen(false));
   };
 
-  const handleLogIn = () => {
+  const handOffToAuth = (cta: "log_in" | "sign_up") => {
+    skipFocusRestoreRef.current = true;
     markWelcomeSeen();
     maybeShowCmdPaletteHint();
-    track("welcome_modal_dismissed", { cta: "log_in" });
-    openModal("login");
-  };
-
-  const handleSignUp = () => {
-    markWelcomeSeen();
-    maybeShowCmdPaletteHint();
-    track("welcome_modal_dismissed", { cta: "sign_up" });
-    track("signup_started", { source: "welcome_modal" });
-    openModal("signUp");
+    track("welcome_modal_dismissed", { cta });
+    if (cta === "sign_up") {
+      track("signup_started", { source: "welcome_modal" });
+    }
+    openModal(cta === "log_in" ? "login" : "signUp");
   };
 
   return (
@@ -77,6 +79,7 @@ export function WelcomeModal() {
       backdropClassName="overflow-y-auto py-8"
       closing={closing}
       onDismiss={dismiss}
+      skipFocusRestoreRef={skipFocusRestoreRef}
       widthClassName="w-120"
     >
       <div className="flex w-full flex-col gap-6">
@@ -97,14 +100,14 @@ export function WelcomeModal() {
           <div className="flex shrink-0 items-center gap-2">
             <button
               type="button"
-              onClick={handleSignUp}
+              onClick={() => handOffToAuth("sign_up")}
               className="rounded-3xl bg-accent px-4 py-1.5 text-on-accent text-xs transition-all hover:brightness-110"
             >
               Sign up
             </button>
             <button
               type="button"
-              onClick={handleLogIn}
+              onClick={() => handOffToAuth("log_in")}
               className="rounded-3xl bg-[#c2c6cc] px-4 py-1.5 text-[#1f1f1f] text-xs transition-all hover:bg-[#d1d5da]"
             >
               Log in

--- a/packages/web/src/components/WelcomeModal/WelcomeModal.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeModal.tsx
@@ -76,7 +76,7 @@ export function WelcomeModal() {
       ariaLabel="Welcome to Compass Calendar"
       backdropClassName="overflow-y-auto py-8"
       closing={closing}
-      onDismiss={() => dismiss()}
+      onDismiss={dismiss}
       widthClassName="w-120"
     >
       <div className="flex w-full flex-col gap-6">


### PR DESCRIPTION
## Summary

- Route `WelcomeModal`, `WelcomeGuideModal`, and `ReleaseNotesPrompt` through `OverlayPanel` so Tab can no longer escape into the calendar behind those `aria-modal` dialogs.
- Extend `OverlayPanel` with `ariaLabel`, `backdropClassName`, `closing` (dismiss-transition styles), and `skipFocusRestoreRef` for the Welcome → Auth handoff (avoids flashing underlay focus before Auth seats).

## Simplicity

- Reused the existing OverlayPanel focus trap instead of adding FloatingFocusManager shells or a third trap implementation.
- Folded Log in / Sign up into one `handOffToAuth` helper; simplify pass DRY'd focusable queries in OverlayPanel.

## Automated validation

- `bun run type-check` — clean
- Focused OverlayPanel + WelcomeModal tests — 12/12
- Overlay-adjacent suites (About/Auth/Settings/Logout/Delete/Feedback) — 96/96
- `bun test:web` — 1831/1831
- `bun lint` — clean of new issues (pre-existing warnings only)
- Manual browser smoke at http://localhost:9083 (anon, cleared localStorage): Welcome opens with Sign up focused; Tab from Terms wraps to Sign up; Start Now dismisses and clears `data-app-locked`

## Independent review

Fresh diff-first review found one Important issue: Welcome → Auth unmount ran OverlayPanel's default focus restore. Fixed via `skipFocusRestoreRef` + regression tests in a follow-up commit. No remaining confirmed findings.

## Test plan

- `bun run type-check`
- `bun test:web`
- `bun lint`
- Browser: clear welcome storage → confirm Tab trap + dismiss unlock