### PR TITLE
feat(web): confirm before discarding dirty event edits on escape

### DIFF
--- a/packages/web/src/common/utils/form/form.util.test.ts
+++ b/packages/web/src/common/utils/form/form.util.test.ts
@@ -7,6 +7,7 @@ import {
   isContextMenuOpen,
   isEditableKeyboardTarget,
   isEventFormKeyboardTarget,
+  isFloatingLayerOpen,
   shouldDeferEnterToTarget,
 } from "./form.util";
 import {
@@ -222,6 +223,35 @@ describe("form.util", () => {
       document.body.appendChild(button);
 
       expect(isEventFormKeyboardTarget(createEvent(button))).toBe(false);
+    });
+  });
+
+  describe("isFloatingLayerOpen", () => {
+    afterEach(() => {
+      document.body.replaceChildren();
+    });
+
+    it("ignores inert dialogs that stay mounted while closed", () => {
+      const dialog = document.createElement("div");
+      dialog.setAttribute("role", "dialog");
+      dialog.inert = true;
+      Object.defineProperty(dialog, "getClientRects", {
+        value: () => [new DOMRect(0, 0, 100, 100)],
+      });
+      document.body.appendChild(dialog);
+
+      expect(isFloatingLayerOpen()).toBe(false);
+    });
+
+    it("treats a visible non-inert dialog as open", () => {
+      const dialog = document.createElement("div");
+      dialog.setAttribute("role", "dialog");
+      Object.defineProperty(dialog, "getClientRects", {
+        value: () => [new DOMRect(0, 0, 100, 100)],
+      });
+      document.body.appendChild(dialog);
+
+      expect(isFloatingLayerOpen()).toBe(true);
     });
   });
 });

--- a/packages/web/src/common/utils/form/form.util.ts
+++ b/packages/web/src/common/utils/form/form.util.ts
@@ -10,22 +10,22 @@ export const isContextMenuOpen = () => {
 
 // A nested floating layer (actions menu, time picker, recurrence selects,
 // confirmation dialogs) handles its own Escape; another Escape consumer
-// acting at the same time would fight it. Two carve-outs for layers that are
-// always present rather than transiently floating: overlays that stay
-// mounted while hidden (the keyboard-shortcuts dialog — display:none in
-// Day's tree, aria-hidden in Week's), and the sidebar's inline month picker,
-// whose react-datepicker month grid is a permanently-visible role="listbox".
+// acting at the same time would fight it. Carve-outs for layers that stay
+// mounted while inactive: `aria-hidden` / `inert` overlays (ShortcutsOverlay
+// uses `inert` when closed), and the sidebar's inline month picker, whose
+// react-datepicker month grid is a permanently-visible role="listbox".
 export const isFloatingLayerOpen = () =>
   Array.from(
     document.querySelectorAll(
       '[role="menu"], [role="listbox"], [role="dialog"]',
     ),
-  ).some(
-    (element) =>
-      element.getAttribute("aria-hidden") !== "true" &&
-      element.getClientRects().length > 0 &&
-      !element.closest('[data-testid="Month picker"]'),
-  );
+  ).some((element) => {
+    if (element.getAttribute("aria-hidden") === "true") return false;
+    if (element instanceof HTMLElement && element.inert) return false;
+    if (element.getClientRects().length === 0) return false;
+    if (element.closest('[data-testid="Month picker"]')) return false;
+    return true;
+  });
 
 const EVENT_FORM_SELECTOR = `form[name="${ID_EVENT_FORM}"]`;
 

--- a/packages/web/src/common/utils/parse/dirty.parser.ts
+++ b/packages/web/src/common/utils/parse/dirty.parser.ts
@@ -132,6 +132,7 @@ export class DirtyParser {
     if (values.title !== orig.title) return true;
     if (values.description !== orig.description) return true;
     if (values.location !== orig.location) return true;
+    if (values.color !== orig.color) return true;
     if (values.calendarId !== orig.calendarId) return true;
     if (values.schedule.kind !== orig.schedule.kind) return true;
     if (values.schedule.start.getTime() !== orig.schedule.start.getTime()) {

--- a/packages/web/src/components/Sidebar/EventDetails/SidebarEventDetails.test.tsx
+++ b/packages/web/src/components/Sidebar/EventDetails/SidebarEventDetails.test.tsx
@@ -83,6 +83,89 @@ describe("SidebarEventDetails", () => {
     );
   });
 
+  it("closes an unchanged existing event on Escape without prompting", async () => {
+    const existingEvent = createMockEvent({
+      id: EventIdSchema.parse(EXISTING_EVENT_ID),
+      content: {
+        kind: "details",
+        title: "Existing Event",
+        description: "",
+      },
+      schedule: EventScheduleSchema.parse({
+        kind: "timed",
+        start: "2026-05-20T14:00:00.000Z",
+        end: "2026-05-20T15:00:00.000Z",
+        timeZone: "UTC",
+      }),
+    });
+    const draft = editGridEventDraft(existingEvent);
+    if (!draft) throw new Error("expected an edit draft");
+    draftActions.startGridDraft({ activity: "keyboardEdit", draft });
+    draftActions.setFormOpen(true);
+
+    render(<SidebarEventDetails />);
+
+    const titleField = await screen.findByPlaceholderText("Title");
+    fireEvent.keyDown(titleField, { key: "Escape" });
+
+    await waitFor(() =>
+      expect(useDraftStore.getState().status?.isFormOpen).toBe(false),
+    );
+    expect(
+      screen.queryByRole("dialog", { name: "Discard unsaved changes?" }),
+    ).toBeNull();
+  });
+
+  it("prompts before discarding a dirty existing event on Escape", async () => {
+    const existingEvent = createMockEvent({
+      id: EventIdSchema.parse(EXISTING_EVENT_ID),
+      content: {
+        kind: "details",
+        title: "Existing Event",
+        description: "",
+      },
+      schedule: EventScheduleSchema.parse({
+        kind: "timed",
+        start: "2026-05-20T14:00:00.000Z",
+        end: "2026-05-20T15:00:00.000Z",
+        timeZone: "UTC",
+      }),
+    });
+    const draft = editGridEventDraft(existingEvent);
+    if (!draft) throw new Error("expected an edit draft");
+    draft.values.title = "Changed title";
+    draftActions.startGridDraft({ activity: "keyboardEdit", draft });
+    draftActions.setFormOpen(true);
+
+    render(<SidebarEventDetails />);
+
+    const titleField = await screen.findByDisplayValue("Changed title");
+    fireEvent.keyDown(titleField, { key: "Escape" });
+
+    expect(
+      await screen.findByRole("dialog", { name: "Discard unsaved changes?" }),
+    ).toBeInTheDocument();
+    expect(useDraftStore.getState().status?.isFormOpen).toBe(true);
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("dialog", { name: "Discard unsaved changes?" }),
+      ).toBeNull(),
+    );
+    expect(useDraftStore.getState().status?.isFormOpen).toBe(true);
+
+    fireEvent.keyDown(titleField, { key: "Escape" });
+    expect(
+      await screen.findByRole("dialog", { name: "Discard unsaved changes?" }),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Discard" }));
+    await waitFor(() =>
+      expect(useDraftStore.getState().status?.isFormOpen).toBe(false),
+    );
+  });
+
   it("deletes an already-saved event on Delete instead of just closing the form", async () => {
     const existingEvent = createMockEvent({
       id: EventIdSchema.parse(EXISTING_EVENT_ID),

--- a/packages/web/src/components/Sidebar/ShortcutsOverlay/ShortcutsOverlay.tsx
+++ b/packages/web/src/components/Sidebar/ShortcutsOverlay/ShortcutsOverlay.tsx
@@ -51,6 +51,8 @@ export function ShortcutsOverlay({ sections, viewLabel }: Props) {
   // keeping the slide animation. (Conditional unmount is the other F3
   // option, but it exposed unrelated sidebar contrast debt to axe that
   // the old covering dialog had been papering over — tracked separately.)
+  // isFloatingLayerOpen ignores inert dialogs so Escape can still close the
+  // event form while this overlay stays mounted closed.
   useEffect(() => {
     const overlay = overlayRef.current;
     if (overlay) {

--- a/packages/web/src/views/Forms/EventForm/DiscardUnsavedChangesDialog.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/DiscardUnsavedChangesDialog.test.tsx
@@ -1,0 +1,62 @@
+import userEvent from "@testing-library/user-event";
+import { render, screen } from "@web/__tests__/__mocks__/mock.render";
+import { DiscardUnsavedChangesDialog } from "@web/views/Forms/EventForm/DiscardUnsavedChangesDialog";
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+
+const onDiscard = mock();
+const onCancel = mock();
+
+beforeEach(() => {
+  onDiscard.mockClear();
+  onCancel.mockClear();
+});
+
+const renderDialog = (isOpen: boolean) =>
+  render(
+    <DiscardUnsavedChangesDialog
+      isOpen={isOpen}
+      onCancel={onCancel}
+      onDiscard={onDiscard}
+    />,
+  );
+
+describe("DiscardUnsavedChangesDialog", () => {
+  it("renders nothing when closed", () => {
+    renderDialog(false);
+
+    expect(
+      screen.queryByRole("dialog", { name: "Discard unsaved changes?" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows the title and action buttons when open", () => {
+    renderDialog(true);
+
+    expect(
+      screen.getByRole("dialog", { name: "Discard unsaved changes?" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Discard" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Close" })).toBeInTheDocument();
+  });
+
+  it("discards and cancels via the action buttons", async () => {
+    const user = userEvent.setup();
+    renderDialog(true);
+
+    await user.click(screen.getByRole("button", { name: "Discard" }));
+    expect(onDiscard).toHaveBeenCalledTimes(1);
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels via the close button", async () => {
+    const user = userEvent.setup();
+    renderDialog(true);
+
+    await user.click(screen.getByRole("button", { name: "Close" }));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(onDiscard).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/views/Forms/EventForm/DiscardUnsavedChangesDialog.tsx
+++ b/packages/web/src/views/Forms/EventForm/DiscardUnsavedChangesDialog.tsx
@@ -1,0 +1,48 @@
+import { XIcon } from "@phosphor-icons/react";
+import {
+  OverlayPanel,
+  OverlayPanelActionButton,
+  OverlayPanelActions,
+} from "@web/components/OverlayPanel/OverlayPanel";
+
+export type DiscardUnsavedChangesDialogProps = {
+  isOpen: boolean;
+  onCancel: () => void;
+  onDiscard: () => void;
+};
+
+export function DiscardUnsavedChangesDialog({
+  isOpen,
+  onCancel,
+  onDiscard,
+}: DiscardUnsavedChangesDialogProps) {
+  if (!isOpen) return null;
+
+  return (
+    <OverlayPanel
+      title="Discard unsaved changes?"
+      titleAction={
+        <button
+          type="button"
+          aria-label="Close"
+          onClick={onCancel}
+          className="flex h-8 w-8 shrink-0 items-center justify-center rounded text-text-muted transition-colors hover:bg-surface-overlay hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-surface-panel"
+        >
+          <XIcon aria-hidden="true" size={16} />
+        </button>
+      }
+      onDismiss={onCancel}
+      align="start"
+      variant="modal"
+    >
+      <OverlayPanelActions align="end">
+        <OverlayPanelActionButton onClick={onCancel}>
+          Cancel
+        </OverlayPanelActionButton>
+        <OverlayPanelActionButton variant="primary" onClick={onDiscard}>
+          Discard
+        </OverlayPanelActionButton>
+      </OverlayPanelActions>
+    </OverlayPanel>
+  );
+}

--- a/packages/web/src/views/Forms/EventForm/EventForm.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.tsx
@@ -659,11 +659,8 @@ export const EventForm: React.FC<GridEventFormProps> = memo(
       EVENT_FORM_PLAIN_HOTKEY_OPTIONS,
     );
 
-    const {
-      isConfirmOpen: isDiscardConfirmOpen,
-      onCancelConfirm: onCancelDiscardConfirm,
-      onDiscardConfirm,
-    } = useEscapeToCloseForm(onClose);
+    const { isConfirmOpen, onCancelConfirm, onDiscardConfirm } =
+      useEscapeToCloseForm(onClose);
 
     const titleErrorField = fieldErrors?.["content.title"]
       ? "content.title"
@@ -903,8 +900,8 @@ export const EventForm: React.FC<GridEventFormProps> = memo(
           )}
         </EventFormShell>
         <DiscardUnsavedChangesDialog
-          isOpen={isDiscardConfirmOpen}
-          onCancel={onCancelDiscardConfirm}
+          isOpen={isConfirmOpen}
+          onCancel={onCancelConfirm}
           onDiscard={onDiscardConfirm}
         />
       </>

--- a/packages/web/src/views/Forms/EventForm/EventForm.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.tsx
@@ -52,6 +52,7 @@ import { CalendarSelect } from "@web/views/Forms/EventForm/CalendarSelect/Calend
 import { DateControlsSection } from "@web/views/Forms/EventForm/DateControlsSection/DateControlsSection/DateControlsSection";
 import { getFormDates } from "@web/views/Forms/EventForm/DateControlsSection/DateTimeSection/form.datetime.util";
 import { RecurrenceSection } from "@web/views/Forms/EventForm/DateControlsSection/RecurrenceSection/RecurrenceSection";
+import { DiscardUnsavedChangesDialog } from "@web/views/Forms/EventForm/DiscardUnsavedChangesDialog";
 import { EventActionMenu } from "@web/views/Forms/EventForm/EventActionMenu";
 import { EventColorPicker } from "@web/views/Forms/EventForm/EventColorPicker/EventColorPicker";
 import { EventDetailsSection } from "@web/views/Forms/EventForm/EventDetailsSection";
@@ -658,7 +659,11 @@ export const EventForm: React.FC<GridEventFormProps> = memo(
       EVENT_FORM_PLAIN_HOTKEY_OPTIONS,
     );
 
-    useEscapeToCloseForm(onClose);
+    const {
+      isConfirmOpen: isDiscardConfirmOpen,
+      onCancelConfirm: onCancelDiscardConfirm,
+      onDiscardConfirm,
+    } = useEscapeToCloseForm(onClose);
 
     const titleErrorField = fieldErrors?.["content.title"]
       ? "content.title"
@@ -705,194 +710,204 @@ export const EventForm: React.FC<GridEventFormProps> = memo(
     }, [fieldErrors]);
 
     return (
-      <EventFormShell
-        {...props}
-        name={ID_EVENT_FORM}
-        onMouseUp={() => {
-          if (isStartDatePickerOpen) {
-            setIsStartDatePickerOpen(false);
-          }
-
-          if (isEndDatePickerOpen) {
-            setIsEndDatePickerOpen(false);
-          }
-        }}
-        onMouseDown={(e) => {
-          e.stopPropagation();
-        }}
-      >
-        {/* Scrollable body; the save footer below stays pinned. */}
-        <div className="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto px-4 pb-4 [scrollbar-gutter:stable]">
-          <TitleActionsRow
-            title={
-              <Focusable
-                id={EVENT_FORM_TITLE_ID}
-                Component="input"
-                className={classNames(
-                  INPUT_RESET_CLASSNAME,
-                  // w-full: an input's intrinsic size-attribute width would
-                  // overflow the sidebar-width form and force horizontal scroll
-                  "w-full bg-transparent font-semibold text-xl",
-                )}
-                autoFocus
-                disabled={isReadOnly}
-                onChange={onChangeTitle}
-                onKeyDown={handleTitleKeyDown}
-                placeholder="Title"
-                aria-label="Title"
-                name="Event Title"
-                aria-invalid={titleError ? true : undefined}
-                aria-describedby={titleErrorDescribedBy}
-                underlineColor={eventColor}
-                value={displayTitle}
-                withUnderline
-              />
+      <>
+        <EventFormShell
+          {...props}
+          name={ID_EVENT_FORM}
+          onMouseUp={() => {
+            if (isStartDatePickerOpen) {
+              setIsStartDatePickerOpen(false);
             }
-            actions={
-              <EventActionMenu
-                isExistingEvent={isExistingEvent}
-                isReadOnly={isReadOnly}
-                onDuplicate={onDuplicateEvent}
-                onDelete={onDeleteEvent}
-              />
+
+            if (isEndDatePickerOpen) {
+              setIsEndDatePickerOpen(false);
             }
-          />
-
-          {/* Same fieldset mechanism as the title above, covering
-              date/recurrence/calendar/description in one wrapper. Its
-              display: contents keeps the cards direct flex items of the
-              gap-3 body. */}
-          <fieldset className="contents" disabled={isReadOnly}>
-            <FormCard>
-              <fieldset
-                id={EVENT_FORM_SCHEDULE_ID}
-                aria-label="Event schedule"
-                aria-invalid={scheduleError ? true : undefined}
-                aria-describedby={scheduleErrorDescribedBy}
-                tabIndex={scheduleError ? -1 : undefined}
-                className={classNames(
-                  "min-w-0 rounded-xs border-0 p-0",
-                  scheduleError && "ring-1 ring-error",
-                )}
-              >
-                <DateControlsSection
-                  dateTimeSectionProps={dateTimeSectionProps}
-                  eventCategory={category}
-                  onToggleAllDay={onToggleAllDay}
-                />
-              </fieldset>
-
-              <fieldset
-                id={EVENT_FORM_RECURRENCE_ID}
-                aria-label="Recurrence"
-                aria-invalid={recurrenceError ? true : undefined}
-                aria-describedby={recurrenceErrorDescribedBy}
-                tabIndex={recurrenceError ? -1 : undefined}
-                className={classNames(
-                  "min-w-0 rounded-xs border-0 p-0",
-                  recurrenceError && "ring-1 ring-error",
-                )}
-              >
-                <RecurrenceSection {...recurrenceSectionProps} />
-              </fieldset>
-            </FormCard>
-
-            <FormCard>
-              {draft.kind === "create" ? (
-                <CalendarSelect
-                  id={EVENT_FORM_CALENDAR_ID}
-                  onChange={onSelectCalendar}
-                  value={draft.values.calendarId}
-                  error={calendarError ?? undefined}
-                  errorId={calendarErrorDescribedBy}
-                />
-              ) : (
-                <p className="text-text-muted text-xs">
-                  Calendar: {originalCalendarName}
-                </p>
-              )}
-              <EventColorPicker
-                value={color}
-                onChange={(next) => patchDraftFields({ color: next })}
-              />
-            </FormCard>
-
-            <FormCard>
-              <div className="flex items-center gap-2">
-                {location ? (
-                  <a
-                    href={mapsUrlForLocation(location)}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    aria-label="Open in Google Maps"
-                    className="shrink-0 text-text-muted hover:text-text"
-                  >
-                    <MapPinIcon size={16} />
-                  </a>
-                ) : (
-                  <MapPinIcon size={16} className="shrink-0 text-text-muted" />
-                )}
+          }}
+          onMouseDown={(e) => {
+            e.stopPropagation();
+          }}
+        >
+          {/* Scrollable body; the save footer below stays pinned. */}
+          <div className="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto px-4 pb-4 [scrollbar-gutter:stable]">
+            <TitleActionsRow
+              title={
                 <Focusable
+                  id={EVENT_FORM_TITLE_ID}
                   Component="input"
                   className={classNames(
                     INPUT_RESET_CLASSNAME,
-                    "w-full bg-transparent text-sm",
+                    // w-full: an input's intrinsic size-attribute width would
+                    // overflow the sidebar-width form and force horizontal scroll
+                    "w-full bg-transparent font-semibold text-xl",
                   )}
+                  autoFocus
                   disabled={isReadOnly}
-                  onChange={onChangeLocation}
-                  onKeyDown={handleIgnoredKeys}
-                  placeholder="Location"
-                  aria-label="Location"
-                  name="Event Location"
-                  value={location}
+                  onChange={onChangeTitle}
+                  onKeyDown={handleTitleKeyDown}
+                  placeholder="Title"
+                  aria-label="Title"
+                  name="Event Title"
+                  aria-invalid={titleError ? true : undefined}
+                  aria-describedby={titleErrorDescribedBy}
+                  underlineColor={eventColor}
+                  value={displayTitle}
+                  withUnderline
                 />
-              </div>
-            </FormCard>
+              }
+              actions={
+                <EventActionMenu
+                  isExistingEvent={isExistingEvent}
+                  isReadOnly={isReadOnly}
+                  onDuplicate={onDuplicateEvent}
+                  onDelete={onDeleteEvent}
+                />
+              }
+            />
 
-            <FormCard>
-              <DescriptionEditor
-                id={EVENT_FORM_DESCRIPTION_ID}
-                resetKey={draft.kind === "edit" ? draft.source.id : "create"}
-                value={description}
-                onChange={(html) => patchDraftFields({ description: html })}
-                editable={!isReadOnly}
-                underlineColor={eventColor}
-                onKeyDown={handleIgnoredKeys}
-              />
-            </FormCard>
-          </fieldset>
+            {/* Same fieldset mechanism as the title above, covering
+              date/recurrence/calendar/description in one wrapper. Its
+              display: contents keeps the cards direct flex items of the
+              gap-3 body. */}
+            <fieldset className="contents" disabled={isReadOnly}>
+              <FormCard>
+                <fieldset
+                  id={EVENT_FORM_SCHEDULE_ID}
+                  aria-label="Event schedule"
+                  aria-invalid={scheduleError ? true : undefined}
+                  aria-describedby={scheduleErrorDescribedBy}
+                  tabIndex={scheduleError ? -1 : undefined}
+                  className={classNames(
+                    "min-w-0 rounded-xs border-0 p-0",
+                    scheduleError && "ring-1 ring-error",
+                  )}
+                >
+                  <DateControlsSection
+                    dateTimeSectionProps={dateTimeSectionProps}
+                    eventCategory={category}
+                    onToggleAllDay={onToggleAllDay}
+                  />
+                </fieldset>
 
-          {/* Outside the fieldset: read-only display, not an editable
+                <fieldset
+                  id={EVENT_FORM_RECURRENCE_ID}
+                  aria-label="Recurrence"
+                  aria-invalid={recurrenceError ? true : undefined}
+                  aria-describedby={recurrenceErrorDescribedBy}
+                  tabIndex={recurrenceError ? -1 : undefined}
+                  className={classNames(
+                    "min-w-0 rounded-xs border-0 p-0",
+                    recurrenceError && "ring-1 ring-error",
+                  )}
+                >
+                  <RecurrenceSection {...recurrenceSectionProps} />
+                </fieldset>
+              </FormCard>
+
+              <FormCard>
+                {draft.kind === "create" ? (
+                  <CalendarSelect
+                    id={EVENT_FORM_CALENDAR_ID}
+                    onChange={onSelectCalendar}
+                    value={draft.values.calendarId}
+                    error={calendarError ?? undefined}
+                    errorId={calendarErrorDescribedBy}
+                  />
+                ) : (
+                  <p className="text-text-muted text-xs">
+                    Calendar: {originalCalendarName}
+                  </p>
+                )}
+                <EventColorPicker
+                  value={color}
+                  onChange={(next) => patchDraftFields({ color: next })}
+                />
+              </FormCard>
+
+              <FormCard>
+                <div className="flex items-center gap-2">
+                  {location ? (
+                    <a
+                      href={mapsUrlForLocation(location)}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      aria-label="Open in Google Maps"
+                      className="shrink-0 text-text-muted hover:text-text"
+                    >
+                      <MapPinIcon size={16} />
+                    </a>
+                  ) : (
+                    <MapPinIcon
+                      size={16}
+                      className="shrink-0 text-text-muted"
+                    />
+                  )}
+                  <Focusable
+                    Component="input"
+                    className={classNames(
+                      INPUT_RESET_CLASSNAME,
+                      "w-full bg-transparent text-sm",
+                    )}
+                    disabled={isReadOnly}
+                    onChange={onChangeLocation}
+                    onKeyDown={handleIgnoredKeys}
+                    placeholder="Location"
+                    aria-label="Location"
+                    name="Event Location"
+                    value={location}
+                  />
+                </div>
+              </FormCard>
+
+              <FormCard>
+                <DescriptionEditor
+                  id={EVENT_FORM_DESCRIPTION_ID}
+                  resetKey={draft.kind === "edit" ? draft.source.id : "create"}
+                  value={description}
+                  onChange={(html) => patchDraftFields({ description: html })}
+                  editable={!isReadOnly}
+                  underlineColor={eventColor}
+                  onKeyDown={handleIgnoredKeys}
+                />
+              </FormCard>
+            </fieldset>
+
+            {/* Outside the fieldset: read-only display, not an editable
               control, so it stays interactive (the "+N more" toggle) even
               when the event itself is read-only. Renders its own card
               styling and returns null when the event has none of this data. */}
-          {sourceDetails && <EventDetailsSection details={sourceDetails} />}
+            {sourceDetails && <EventDetailsSection details={sourceDetails} />}
 
-          {isReadOnly && (
-            <p role="note" className="text-text-muted text-xs">
-              Read-only — you don't have permission to edit this event.
-            </p>
+            {isReadOnly && (
+              <p role="note" className="text-text-muted text-xs">
+                Read-only — you don't have permission to edit this event.
+              </p>
+            )}
+          </div>
+
+          {!isReadOnly && (
+            <>
+              {fieldErrors && Object.keys(fieldErrors).length > 0 ? (
+                <ul
+                  className="flex list-none flex-col gap-1 border-border border-t px-4 pt-3 text-error text-xs"
+                  role="alert"
+                >
+                  {Object.entries(fieldErrors).map(([field, message]) => (
+                    <li key={field} id={eventFormErrorId(field)}>
+                      {message}
+                    </li>
+                  ))}
+                </ul>
+              ) : null}
+              <SaveSection onSubmit={onSubmitForm} />
+            </>
           )}
-        </div>
-
-        {!isReadOnly && (
-          <>
-            {fieldErrors && Object.keys(fieldErrors).length > 0 ? (
-              <ul
-                className="flex list-none flex-col gap-1 border-border border-t px-4 pt-3 text-error text-xs"
-                role="alert"
-              >
-                {Object.entries(fieldErrors).map(([field, message]) => (
-                  <li key={field} id={eventFormErrorId(field)}>
-                    {message}
-                  </li>
-                ))}
-              </ul>
-            ) : null}
-            <SaveSection onSubmit={onSubmitForm} />
-          </>
-        )}
-      </EventFormShell>
+        </EventFormShell>
+        <DiscardUnsavedChangesDialog
+          isOpen={isDiscardConfirmOpen}
+          onCancel={onCancelDiscardConfirm}
+          onDiscard={onDiscardConfirm}
+        />
+      </>
     );
   },
   fastDeepEqual,

--- a/packages/web/src/views/Forms/hooks/shouldConfirmDiscardUnsavedChanges.test.ts
+++ b/packages/web/src/views/Forms/hooks/shouldConfirmDiscardUnsavedChanges.test.ts
@@ -67,4 +67,26 @@ describe("shouldConfirmDiscardUnsavedChanges", () => {
 
     expect(shouldConfirmDiscardUnsavedChanges(draft)).toBe(true);
   });
+
+  it("returns true when only the event color changed", () => {
+    const existingEvent = createMockEvent({
+      id: EventIdSchema.parse("aaaaaaaaaaaaaaaaaaaaaaaa"),
+      content: {
+        kind: "details",
+        title: "Existing Event",
+        description: "",
+      },
+      schedule: EventScheduleSchema.parse({
+        kind: "timed",
+        start: "2026-05-20T14:00:00.000Z",
+        end: "2026-05-20T15:00:00.000Z",
+        timeZone: "UTC",
+      }),
+    });
+    const draft = editGridEventDraft(existingEvent);
+    if (!draft) throw new Error("expected an edit draft");
+    draft.values.color = "coral";
+
+    expect(shouldConfirmDiscardUnsavedChanges(draft)).toBe(true);
+  });
 });

--- a/packages/web/src/views/Forms/hooks/shouldConfirmDiscardUnsavedChanges.test.ts
+++ b/packages/web/src/views/Forms/hooks/shouldConfirmDiscardUnsavedChanges.test.ts
@@ -1,0 +1,70 @@
+import { EventIdSchema } from "@core/types/domain-primitives";
+import { EventScheduleSchema } from "@core/types/event.contracts";
+import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
+import {
+  createGridEventDraft,
+  editGridEventDraft,
+} from "@web/events/grid-event-draft.adapter";
+import { shouldConfirmDiscardUnsavedChanges } from "./shouldConfirmDiscardUnsavedChanges";
+import { describe, expect, it } from "bun:test";
+
+describe("shouldConfirmDiscardUnsavedChanges", () => {
+  it("returns false when there is no draft", () => {
+    expect(shouldConfirmDiscardUnsavedChanges(null)).toBe(false);
+  });
+
+  it("returns false for create drafts", () => {
+    const draft = createGridEventDraft({
+      kind: "timed",
+      start: new Date("2026-05-20T09:00:00.000Z"),
+      end: new Date("2026-05-20T10:00:00.000Z"),
+      timeZone: "UTC",
+    });
+    draft.values.title = "Brand new";
+
+    expect(shouldConfirmDiscardUnsavedChanges(draft)).toBe(false);
+  });
+
+  it("returns false for an unchanged edit draft", () => {
+    const existingEvent = createMockEvent({
+      id: EventIdSchema.parse("aaaaaaaaaaaaaaaaaaaaaaaa"),
+      content: {
+        kind: "details",
+        title: "Existing Event",
+        description: "",
+      },
+      schedule: EventScheduleSchema.parse({
+        kind: "timed",
+        start: "2026-05-20T14:00:00.000Z",
+        end: "2026-05-20T15:00:00.000Z",
+        timeZone: "UTC",
+      }),
+    });
+    const draft = editGridEventDraft(existingEvent);
+    if (!draft) throw new Error("expected an edit draft");
+
+    expect(shouldConfirmDiscardUnsavedChanges(draft)).toBe(false);
+  });
+
+  it("returns true for a dirty edit draft", () => {
+    const existingEvent = createMockEvent({
+      id: EventIdSchema.parse("aaaaaaaaaaaaaaaaaaaaaaaa"),
+      content: {
+        kind: "details",
+        title: "Existing Event",
+        description: "",
+      },
+      schedule: EventScheduleSchema.parse({
+        kind: "timed",
+        start: "2026-05-20T14:00:00.000Z",
+        end: "2026-05-20T15:00:00.000Z",
+        timeZone: "UTC",
+      }),
+    });
+    const draft = editGridEventDraft(existingEvent);
+    if (!draft) throw new Error("expected an edit draft");
+    draft.values.title = "Changed title";
+
+    expect(shouldConfirmDiscardUnsavedChanges(draft)).toBe(true);
+  });
+});

--- a/packages/web/src/views/Forms/hooks/shouldConfirmDiscardUnsavedChanges.ts
+++ b/packages/web/src/views/Forms/hooks/shouldConfirmDiscardUnsavedChanges.ts
@@ -1,0 +1,13 @@
+import { DirtyParser } from "@web/common/utils/parse/dirty.parser";
+import { type GridEventDraft } from "@web/events/event-draft.types";
+
+/**
+ * Escape should confirm before discarding only when the user is editing a
+ * persisted event and the draft differs from that event's pristine edit state.
+ * Create drafts and unchanged edits close immediately.
+ */
+export function shouldConfirmDiscardUnsavedChanges(
+  draft: GridEventDraft | null,
+): boolean {
+  return draft?.kind === "edit" && DirtyParser.isGridDraftDirty(draft);
+}

--- a/packages/web/src/views/Forms/hooks/useEscapeToCloseForm.ts
+++ b/packages/web/src/views/Forms/hooks/useEscapeToCloseForm.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useState } from "react";
 import {
   isContextMenuOpen,
   isFloatingLayerOpen,
@@ -7,30 +7,13 @@ import { selectGridDraft, useDraftStore } from "@web/events/stores/draft.store";
 import { useAppShortcut } from "@web/shortcuts/useAppShortcut";
 import { shouldConfirmDiscardUnsavedChanges } from "@web/views/Forms/hooks/shouldConfirmDiscardUnsavedChanges";
 
-export type EscapeToCloseFormConfirm = {
-  isConfirmOpen: boolean;
-  onCancelConfirm: () => void;
-  onDiscardConfirm: () => void;
-};
-
 /**
  * Escape closes the event-details form. Dirty edits of a persisted event
  * confirm first; create drafts and unchanged edits discard immediately.
  * Nested floating layers (menus, dialogs) win Escape via isFloatingLayerOpen.
  */
-export const useEscapeToCloseForm = (
-  onClose: () => void,
-): EscapeToCloseFormConfirm => {
+export const useEscapeToCloseForm = (onClose: () => void) => {
   const [isConfirmOpen, setIsConfirmOpen] = useState(false);
-
-  const onCancelConfirm = useCallback(() => {
-    setIsConfirmOpen(false);
-  }, []);
-
-  const onDiscardConfirm = useCallback(() => {
-    setIsConfirmOpen(false);
-    onClose();
-  }, [onClose]);
 
   useAppShortcut(
     "Escape",
@@ -51,5 +34,12 @@ export const useEscapeToCloseForm = (
     { ignoreInputs: false },
   );
 
-  return { isConfirmOpen, onCancelConfirm, onDiscardConfirm };
+  return {
+    isConfirmOpen,
+    onCancelConfirm: () => setIsConfirmOpen(false),
+    onDiscardConfirm: () => {
+      setIsConfirmOpen(false);
+      onClose();
+    },
+  };
 };

--- a/packages/web/src/views/Forms/hooks/useEscapeToCloseForm.ts
+++ b/packages/web/src/views/Forms/hooks/useEscapeToCloseForm.ts
@@ -1,15 +1,37 @@
+import { useCallback, useState } from "react";
 import {
   isContextMenuOpen,
   isFloatingLayerOpen,
 } from "@web/common/utils/form/form.util";
+import { selectGridDraft, useDraftStore } from "@web/events/stores/draft.store";
 import { useAppShortcut } from "@web/shortcuts/useAppShortcut";
+import { shouldConfirmDiscardUnsavedChanges } from "@web/views/Forms/hooks/shouldConfirmDiscardUnsavedChanges";
+
+export type EscapeToCloseFormConfirm = {
+  isConfirmOpen: boolean;
+  onCancelConfirm: () => void;
+  onDiscardConfirm: () => void;
+};
 
 /**
- * Escape closes the event-details form. The floating forms used to get this
- * from floating-ui's `useDismiss`; the docked sidebar panel binds it
- * explicitly.
+ * Escape closes the event-details form. Dirty edits of a persisted event
+ * confirm first; create drafts and unchanged edits discard immediately.
+ * Nested floating layers (menus, dialogs) win Escape via isFloatingLayerOpen.
  */
-export const useEscapeToCloseForm = (onClose: () => void) => {
+export const useEscapeToCloseForm = (
+  onClose: () => void,
+): EscapeToCloseFormConfirm => {
+  const [isConfirmOpen, setIsConfirmOpen] = useState(false);
+
+  const onCancelConfirm = useCallback(() => {
+    setIsConfirmOpen(false);
+  }, []);
+
+  const onDiscardConfirm = useCallback(() => {
+    setIsConfirmOpen(false);
+    onClose();
+  }, [onClose]);
+
   useAppShortcut(
     "Escape",
     (keyboardEvent) => {
@@ -17,8 +39,17 @@ export const useEscapeToCloseForm = (onClose: () => void) => {
       if (isFloatingLayerOpen()) return;
 
       keyboardEvent.preventDefault();
+
+      const draft = selectGridDraft(useDraftStore.getState());
+      if (shouldConfirmDiscardUnsavedChanges(draft)) {
+        setIsConfirmOpen(true);
+        return;
+      }
+
       onClose();
     },
     { ignoreInputs: false },
   );
+
+  return { isConfirmOpen, onCancelConfirm, onDiscardConfirm };
 };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Escape on the shared event form now discards create drafts and unchanged edits immediately, and prompts with a "Discard unsaved changes?" dialog when a persisted event has dirty edits. The gate lives in `useEscapeToCloseForm` + `DirtyParser.isGridDraftDirty`, so week and day both get the behavior through `SidebarEventDetails` / `EventForm` without view-specific duplication.

Also fixed a pre-existing Escape blocker: closed `ShortcutsOverlay` stays mounted as `role="dialog"` with `inert`, and `isFloatingLayerOpen` now ignores inert dialogs so form Escape can run. Color-only edits are treated as dirty for the confirm gate.

Save/duplicate/nav close paths remain force-discard (Escape-scoped).

![Discard unsaved changes dialog](https://cursor.com/artifacts/c/art-d350489d-7b73-423b-9682-150d2b4bbca4)

## Simplicity

Reused `OverlayPanel` and the existing grid-draft dirty check. Simplify pass dropped unused `useCallback`/exported confirm type and kept `useState` for dialog visibility (Cancel must close the dialog without discarding).

## Automated validation

Browser at `http://localhost:9080` (anonymous):

1. Create draft + Escape → closes immediately, no dialog — pass
2. Clean saved event + Escape → closes immediately, no dialog — pass
3. Dirty saved event + Escape → dialog; Cancel keeps form; Discard closes — pass
4. Day view dirty + Escape → same dialog — pass

## Independent review

Fresh reviewer found color-only edits bypassing dirty confirm — fixed in `isGridDraftDirty` with a regression test. No remaining confirmed findings.

## Test plan

- `bun test:web` on helper, dialog, SidebarEventDetails, form.util, dirty.parser tests
- `bun lint`
- Browser Escape scenarios above (week + day)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2cd34e25-5403-4f7a-8d59-f795e5ed491c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2cd34e25-5403-4f7a-8d59-f795e5ed491c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

