### PR TITLE
fix(web): restore sidebar form contrast for muted text and timepickers

### DIFF
--- a/packages/web/src/common/styles/colors.ts
+++ b/packages/web/src/common/styles/colors.ts
@@ -14,7 +14,7 @@ export const colors = {
   borderStrong: "#4E6374",
 
   text: "#C6D0D9",
-  textMuted: "#7E8A95",
+  textMuted: "#88939D",
   textSubtle: "#4E5A66",
 
   accent: "#7CC6E4",

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -24,10 +24,11 @@
   --border-strong: #4e6374;
 
   /* Text — cool tinted. text-muted must clear 4.5:1 against --background,
-     --surface, and --surface-raised (menu items sit on the latter) — the
-     lightest of the three is the binding case. */
+     --surface, --surface-raised (menu items), and the FormCard composite
+     (7% --surface-overlay on sidebar --surface-panel, ~#232a32) — that
+     overlay blend is the binding case. */
   --text: #c6d0d9;
-  --text-muted: #7e8a95;
+  --text-muted: #88939d;
   --text-subtle: #4e5a66;
 
   /* Accents — muted, close in weight */

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/TimePicker.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/TimePicker.tsx
@@ -1,6 +1,6 @@
 import type React from "react";
 import { useRef } from "react";
-import { type Props as RSProps } from "react-select";
+import { type CSSObjectWithLabel, type Props as RSProps } from "react-select";
 import CreatableSelect from "react-select/creatable";
 import { type SelectOption } from "@web/common/types/component.types";
 import { type TimeOption } from "@web/common/types/util.types";
@@ -14,6 +14,23 @@ export interface Props extends Omit<RSProps, "onChange" | "value"> {
   setIsMenuOpen: React.Dispatch<React.SetStateAction<boolean>>;
   value: SelectOption<string>;
 }
+
+// react-select's default neutral80 is hsl(0,0%,20%) / #333. Class-based CSS
+// in .c-time-picker loses to emotion style objects for these roles — same
+// recipe as FreqSelect.
+const themeColor =
+  (cssVar: string) =>
+  (base: CSSObjectWithLabel): CSSObjectWithLabel => ({
+    ...base,
+    color: cssVar,
+  });
+
+const timePickerTextStyles = {
+  singleValue: themeColor("var(--text)"),
+  input: themeColor("var(--text)"),
+  option: themeColor("var(--text)"),
+  placeholder: themeColor("var(--text-muted)"),
+};
 
 export const TimePicker = ({
   isMenuOpen,
@@ -34,6 +51,7 @@ export const TimePicker = ({
         {...props}
         className={selectClassName}
         classNamePrefix={TIMEPICKER}
+        styles={timePickerTextStyles}
         value={value}
         maxMenuHeight={4 * 41}
         blurInputOnSelect


### PR DESCRIPTION
## Summary
- Lighten dark `--text-muted` so FormCard muted labels clear WCAG AA on the sidebar overlay composite (~4.11 → ~4.63).
- Override TimePicker react-select text colors so values/options/input no longer use the library default `#333`.

## Test plan
- [x] `bun run type-check`
- [x] `bun test:web` (1833/1833) + focused theme/TimePicker tests after simplify
- [x] `bun lint` (pre-existing warnings only)
- [x] Simplify pass + independent code review (no findings)
- [x] Manual browser smoke on localhost:9083: open timed event form; All day? muted contrast ~4.63:1 on FormCard; timepicker single-value/options/input use `--text` (not `#333`)