### PR TITLE
refactor(web): starting-style palette reveal and shared edge threshold

### DIFF
--- a/packages/web/src/common/hooks/prefersReducedMotion.ts
+++ b/packages/web/src/common/hooks/prefersReducedMotion.ts
@@ -1,13 +1,6 @@
-import { useMediaQuery } from "@web/common/hooks/useMediaQuery";
-
 const PREFERS_REDUCED_MOTION_QUERY = "(prefers-reduced-motion: reduce)";
 
 /** One-shot read for event handlers and layout effects. */
 export function prefersReducedMotion(): boolean {
   return window.matchMedia?.(PREFERS_REDUCED_MOTION_QUERY).matches ?? false;
-}
-
-/** Reactive subscription for render-time consumers. */
-export function usePrefersReducedMotion(): boolean {
-  return useMediaQuery(PREFERS_REDUCED_MOTION_QUERY);
 }

--- a/packages/web/src/components/CommandPalette/CommandPalette.tsx
+++ b/packages/web/src/components/CommandPalette/CommandPalette.tsx
@@ -9,9 +9,8 @@ import {
 } from "@floating-ui/react";
 import { ArrowCounterClockwiseIcon } from "@phosphor-icons/react";
 import { useNavigate } from "@tanstack/react-router";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { Z_INDEX_MODAL } from "@web/common/constants/web.constants";
-import { usePrefersReducedMotion } from "@web/common/hooks/prefersReducedMotion";
 import { eventCommandPaletteItems } from "@web/components/CommandPalette/event.cmd.constants";
 import { HighlightedLabel } from "@web/components/CommandPalette/HighlightedLabel";
 import { useAuthCmdItems } from "@web/components/CommandPalette/hooks/useAuthCmdItems";
@@ -68,23 +67,13 @@ const CommandPaletteContent = ({
   const [activeIndex, setActiveIndex] = useState<number | null>(0);
   const listRef = useRef<Array<HTMLElement | null>>([]);
 
-  // Entrance-only fade/scale — no exit animation. Close is driven by the
-  // external `isCmdPaletteOpen` store (shortcuts + tests flip it
-  // synchronously), and this component unmounts the instant it flips false;
-  // animating that would need a delayed-unmount state machine to handle
-  // "reopened while still closing." Not worth it for a UI pattern where an
-  // instant close is normal — dismissal isn't a decision the user watches,
-  // unlike a confirmation modal.
-  const [visible, setVisible] = useState(false);
-  const reduceMotion = usePrefersReducedMotion();
-  useEffect(() => {
-    if (reduceMotion) {
-      setVisible(true);
-      return;
-    }
-    const raf = requestAnimationFrame(() => setVisible(true));
-    return () => cancelAnimationFrame(raf);
-  }, [reduceMotion]);
+  // Entrance-only fade/scale via `@starting-style` / `starting:` — no exit
+  // animation. Close is driven by the external `isCmdPaletteOpen` store
+  // (shortcuts + tests flip it synchronously), and this component unmounts
+  // the instant it flips false; animating that would need a delayed-unmount
+  // state machine to handle "reopened while still closing." Not worth it for
+  // a UI pattern where an instant close is normal — dismissal isn't a
+  // decision the user watches, unlike a confirmation modal.
 
   // Focus the search input the moment it mounts (commit phase, like the
   // autoFocus attribute — but without tripping the a11y lint). Stable identity
@@ -145,9 +134,7 @@ const CommandPaletteContent = ({
     <FloatingPortal>
       <FloatingOverlay
         lockScroll
-        className={`flex justify-center bg-background/85 backdrop-blur-sm transition-opacity duration-200 ease-out motion-reduce:transition-none ${
-          visible ? "opacity-100" : "opacity-0"
-        }`}
+        className="flex justify-center bg-background/85 backdrop-blur-sm opacity-100 starting:opacity-0 transition-opacity duration-200 ease-out motion-reduce:transition-none"
         style={{ zIndex: Z_INDEX_MODAL }}
       >
         {/* No FloatingFocusManager: virtual list navigation keeps real focus in
@@ -155,9 +142,7 @@ const CommandPaletteContent = ({
             input on open via the focusInputOnMount callback ref above. */}
         <div
           ref={refs.setFloating}
-          className={`mt-[15vh] h-fit w-[640px] max-w-[90vw] overflow-hidden rounded-xl border border-border bg-surface shadow-[0_16px_48px_var(--color-shadow-default)] transition-[opacity,transform] duration-200 ease-out motion-reduce:transition-none ${
-            visible ? "scale-100 opacity-100" : "scale-95 opacity-0"
-          }`}
+          className="mt-[15vh] h-fit w-[640px] max-w-[90vw] overflow-hidden rounded-xl border border-border bg-surface shadow-[0_16px_48px_var(--color-shadow-default)] scale-100 opacity-100 starting:scale-95 starting:opacity-0 transition-[opacity,transform] duration-200 ease-out motion-reduce:transition-none"
         >
           <input
             {...getReferenceProps({

--- a/packages/web/src/interaction/interaction.constants.ts
+++ b/packages/web/src/interaction/interaction.constants.ts
@@ -6,8 +6,12 @@
  * `TIMED_DRAFT_CREATE_MOVE_THRESHOLD_PX` (4) is intentionally tighter: on empty
  * grid it distinguishes a click-to-create from a drag-to-resize-duration. Do
  * not unify these values; they measure different products of the gesture.
+ *
+ * `INTERACTION_EDGE_THRESHOLD_PX` is the shared proximity band for Day/Week
+ * smart-scroll and Week edge-navigation — same distance, different axes.
  */
 export const INTERACTION_HOLD_DELAY_MS = 750;
 export const INTERACTION_MOVE_THRESHOLD_PX = 25;
 export const INTERACTION_COMMIT_TEARDOWN_DEADLINE_MS = 250;
+export const INTERACTION_EDGE_THRESHOLD_PX = 50;
 export const TIMED_DRAFT_CREATE_MOVE_THRESHOLD_PX = 4;

--- a/packages/web/src/views/Day/interaction/adapter/geometry/day-layout.cache.ts
+++ b/packages/web/src/views/Day/interaction/adapter/geometry/day-layout.cache.ts
@@ -14,15 +14,13 @@ import {
   type GridLayoutCache,
   type GridLayoutCacheSources,
 } from "@web/grid/interaction/layout.cache";
+import { INTERACTION_EDGE_THRESHOLD_PX } from "@web/interaction/interaction.constants";
 import {
   type DayAllDayDragTarget,
   type DayAllDayResizeTarget,
   type DayInteractionTarget,
   type DayTimedDragTarget,
 } from "../day-interaction.adapter.types";
-
-/** Day timed smart-scroll edge threshold (Week uses edge-nav threshold instead). */
-const DAY_SMART_SCROLL_EDGE_THRESHOLD_PX = 50;
 
 export type DayLayoutCache = GridLayoutCache;
 export type DayLayoutCacheSources = GridLayoutCacheSources;
@@ -33,7 +31,7 @@ export const buildDayTimedLayoutCache = (
 ) =>
   buildTimedGridLayoutCache({
     ...sources,
-    edgeThresholdPx: DAY_SMART_SCROLL_EDGE_THRESHOLD_PX,
+    edgeThresholdPx: INTERACTION_EDGE_THRESHOLD_PX,
     mainGridElementId: ID_GRID_MAIN,
     smartScroll: {
       bottomInsetPx: SMART_SCROLL_BOTTOM_INSET_PX,

--- a/packages/web/src/views/Week/hooks/grid/useDragEventSmartScroll.ts
+++ b/packages/web/src/views/Week/hooks/grid/useDragEventSmartScroll.ts
@@ -1,8 +1,8 @@
 import { type MutableRefObject, useEffect, useRef, useState } from "react";
+import { INTERACTION_EDGE_THRESHOLD_PX } from "@web/interaction/interaction.constants";
 import { useDraftDragMotion } from "@web/views/Week/components/Draft/context/useDraftDragMotion";
 
 const SCROLL_SPEED = 10;
-const EDGE_THRESHOLD = 50;
 
 export const useDragEventSmartScroll = (
   mainGridRef: MutableRefObject<HTMLElement | null>,
@@ -48,9 +48,9 @@ export const useDragEventSmartScroll = (
       const isAtBottom =
         container.scrollTop + container.clientHeight >= container.scrollHeight;
 
-      if (y < top + EDGE_THRESHOLD && !isAtTop) {
+      if (y < top + INTERACTION_EDGE_THRESHOLD_PX && !isAtTop) {
         scrollAmount = -SCROLL_SPEED;
-      } else if (y > bottom - EDGE_THRESHOLD && !isAtBottom) {
+      } else if (y > bottom - INTERACTION_EDGE_THRESHOLD_PX && !isAtBottom) {
         scrollAmount = SCROLL_SPEED;
       }
 

--- a/packages/web/src/views/Week/interaction/adapter/edge-navigation.ts
+++ b/packages/web/src/views/Week/interaction/adapter/edge-navigation.ts
@@ -1,3 +1,4 @@
+import { INTERACTION_EDGE_THRESHOLD_PX } from "@web/interaction/interaction.constants";
 import { type WeekInteractionEdgeNavigationState } from "../state/edge-navigation.state";
 
 export type WeekEdgeNavigationSide = "next" | "prev";
@@ -31,7 +32,7 @@ export interface WeekEdgeNavigationController {
 }
 
 export const WEEK_EDGE_NAVIGATION_DWELL_MS = 500;
-export const WEEK_EDGE_NAVIGATION_THRESHOLD_PX = 50;
+export const WEEK_EDGE_NAVIGATION_THRESHOLD_PX = INTERACTION_EDGE_THRESHOLD_PX;
 
 const idleDraggingState: WeekInteractionEdgeNavigationState = {
   currentEdge: null,


### PR DESCRIPTION
## Summary
- Command palette entrance now uses CSS `@starting-style` / `starting:` (same pattern as UpNextBanner), dropping the rAF + `visible` state machine
- Fold the three identical 50px edge-proximity constants (Day smart-scroll, Week draft smart-scroll, Week edge-nav) into `INTERACTION_EDGE_THRESHOLD_PX`

## Test plan
- [x] `bun test:web` CommandPalette + smart-scroll + week timed-drag edge-nav tests
- [x] `bun run lint` (pre-existing warnings only)
- [ ] CI unit + e2e
- [ ] Optional: open palette with `Cmd/Ctrl+K` and confirm fade/scale still plays when motion is allowed