### PR TITLE
refactor(web): replace Escape DOM probe with floating-layer registry

### DIFF
--- a/packages/web/src/__tests__/setup/test-lifecycle.ts
+++ b/packages/web/src/__tests__/setup/test-lifecycle.ts
@@ -26,6 +26,9 @@ const { cleanup, configure } = await import("@testing-library/react");
 const { resetAllStores } = await import("../utils/state/reset-stores");
 const { BaseApi } = await import("@web/api/base/base.api");
 const { clearAppLockReasons } = await import("@web/shortcuts/app-lock");
+const { clearFloatingLayerReasons } = await import(
+  "@web/shortcuts/floating-layer"
+);
 
 configure({ asyncUtilTimeout: 5000 });
 
@@ -35,6 +38,7 @@ function resetDocument() {
   document.body.removeAttribute("class");
   document.body.removeAttribute("data-app-locked");
   clearAppLockReasons();
+  clearFloatingLayerReasons();
   document.documentElement.removeAttribute("style");
   for (const style of document.head.querySelectorAll("style")) {
     if (

--- a/packages/web/src/common/utils/form/form.util.test.ts
+++ b/packages/web/src/common/utils/form/form.util.test.ts
@@ -1,104 +1,13 @@
-import {
-  ID_CONTEXT_MENU_ITEMS,
-  ID_EVENT_FORM,
-} from "../../constants/web.constants";
+import { ID_EVENT_FORM } from "../../constants/web.constants";
 import {
   isComboboxInteraction,
-  isContextMenuOpen,
   isEditableKeyboardTarget,
   isEventFormKeyboardTarget,
-  isFloatingLayerOpen,
   shouldDeferEnterToTarget,
 } from "./form.util";
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  mock,
-  spyOn,
-} from "bun:test";
-
-const mockGetElementById = mock();
+import { describe, expect, it } from "bun:test";
 
 describe("form.util", () => {
-  let getElementByIdSpy: ReturnType<typeof spyOn>;
-
-  beforeEach(() => {
-    mockGetElementById.mockClear();
-    getElementByIdSpy = spyOn(document, "getElementById").mockImplementation(
-      mockGetElementById as typeof document.getElementById,
-    );
-  });
-
-  afterEach(() => {
-    getElementByIdSpy.mockRestore();
-  });
-
-  describe("isContextMenuOpen", () => {
-    it("should return true when context menu is open", () => {
-      // Mock getElementById to return an element
-      const mockElement = { id: ID_CONTEXT_MENU_ITEMS };
-      mockGetElementById.mockReturnValue(mockElement);
-
-      const result = isContextMenuOpen();
-
-      expect(result).toBe(true);
-      expect(mockGetElementById).toHaveBeenCalledWith(ID_CONTEXT_MENU_ITEMS);
-    });
-
-    it("should return false when context menu is not open", () => {
-      // Mock getElementById to return null
-      mockGetElementById.mockReturnValue(null);
-
-      const result = isContextMenuOpen();
-
-      expect(result).toBe(false);
-      expect(mockGetElementById).toHaveBeenCalledWith(ID_CONTEXT_MENU_ITEMS);
-    });
-
-    it("should return false when context menu element is undefined", () => {
-      // Mock getElementById to return undefined
-      mockGetElementById.mockReturnValue(undefined);
-
-      const result = isContextMenuOpen();
-
-      expect(result).toBe(false);
-      expect(mockGetElementById).toHaveBeenCalledWith(ID_CONTEXT_MENU_ITEMS);
-    });
-
-    it("should return false when context menu element is empty string", () => {
-      // Mock getElementById to return empty string (falsy value)
-      mockGetElementById.mockReturnValue("");
-
-      const result = isContextMenuOpen();
-
-      expect(result).toBe(false);
-      expect(mockGetElementById).toHaveBeenCalledWith(ID_CONTEXT_MENU_ITEMS);
-    });
-
-    it("should return false when context menu element is 0", () => {
-      // Mock getElementById to return 0 (falsy value)
-      mockGetElementById.mockReturnValue(0);
-
-      const result = isContextMenuOpen();
-
-      expect(result).toBe(false);
-      expect(mockGetElementById).toHaveBeenCalledWith(ID_CONTEXT_MENU_ITEMS);
-    });
-
-    it("should return true for any truthy element", () => {
-      // Mock getElementById to return a truthy value
-      mockGetElementById.mockReturnValue("truthy-string");
-
-      const result = isContextMenuOpen();
-
-      expect(result).toBe(true);
-      expect(mockGetElementById).toHaveBeenCalledWith(ID_CONTEXT_MENU_ITEMS);
-    });
-  });
-
   describe("isComboboxInteraction", () => {
     const createEvent = (element: HTMLElement | null) =>
       ({ target: element }) as unknown as KeyboardEvent;
@@ -223,35 +132,6 @@ describe("form.util", () => {
       document.body.appendChild(button);
 
       expect(isEventFormKeyboardTarget(createEvent(button))).toBe(false);
-    });
-  });
-
-  describe("isFloatingLayerOpen", () => {
-    afterEach(() => {
-      document.body.replaceChildren();
-    });
-
-    it("ignores inert dialogs that stay mounted while closed", () => {
-      const dialog = document.createElement("div");
-      dialog.setAttribute("role", "dialog");
-      dialog.inert = true;
-      Object.defineProperty(dialog, "getClientRects", {
-        value: () => [new DOMRect(0, 0, 100, 100)],
-      });
-      document.body.appendChild(dialog);
-
-      expect(isFloatingLayerOpen()).toBe(false);
-    });
-
-    it("treats a visible non-inert dialog as open", () => {
-      const dialog = document.createElement("div");
-      dialog.setAttribute("role", "dialog");
-      Object.defineProperty(dialog, "getClientRects", {
-        value: () => [new DOMRect(0, 0, 100, 100)],
-      });
-      document.body.appendChild(dialog);
-
-      expect(isFloatingLayerOpen()).toBe(true);
     });
   });
 });

--- a/packages/web/src/common/utils/form/form.util.ts
+++ b/packages/web/src/common/utils/form/form.util.ts
@@ -1,31 +1,4 @@
-import {
-  ID_CONTEXT_MENU_ITEMS,
-  ID_EVENT_FORM,
-} from "../../constants/web.constants";
-
-export const isContextMenuOpen = () => {
-  const contextMenuItems = document.getElementById(ID_CONTEXT_MENU_ITEMS);
-  return !!contextMenuItems;
-};
-
-// A nested floating layer (actions menu, time picker, recurrence selects,
-// confirmation dialogs) handles its own Escape; another Escape consumer
-// acting at the same time would fight it. Carve-outs for layers that stay
-// mounted while inactive: `aria-hidden` / `inert` overlays (ShortcutsOverlay
-// uses `inert` when closed), and the sidebar's inline month picker, whose
-// react-datepicker month grid is a permanently-visible role="listbox".
-export const isFloatingLayerOpen = () =>
-  Array.from(
-    document.querySelectorAll(
-      '[role="menu"], [role="listbox"], [role="dialog"]',
-    ),
-  ).some((element) => {
-    if (element.getAttribute("aria-hidden") === "true") return false;
-    if (element instanceof HTMLElement && element.inert) return false;
-    if (element.getClientRects().length === 0) return false;
-    if (element.closest('[data-testid="Month picker"]')) return false;
-    return true;
-  });
+import { ID_EVENT_FORM } from "../../constants/web.constants";
 
 const EVENT_FORM_SELECTOR = `form[name="${ID_EVENT_FORM}"]`;
 

--- a/packages/web/src/common/utils/toast/useEscapeToDismissToast.test.tsx
+++ b/packages/web/src/common/utils/toast/useEscapeToDismissToast.test.tsx
@@ -2,7 +2,6 @@ import { HotkeyManager } from "@tanstack/react-hotkeys";
 import { renderHook } from "@testing-library/react";
 import { createTestToastPort } from "@web/__tests__/helpers/web-test-seams";
 import { pressKey } from "@web/__tests__/utils/keyboard.test.util";
-import { ID_CONTEXT_MENU_ITEMS } from "@web/common/constants/web.constants";
 import {
   registerToastPort,
   resetToastPort,
@@ -13,7 +12,11 @@ import {
   timedGridSchedule,
 } from "@web/events/grid-event-draft.adapter";
 import { draftActions } from "@web/events/stores/draft.store";
-import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
+import {
+  clearFloatingLayerReasons,
+  setFloatingLayerReason,
+} from "@web/shortcuts/floating-layer";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 
 describe("useEscapeToDismissToast", () => {
   let mocks: ReturnType<typeof createTestToastPort>["mocks"];
@@ -21,6 +24,7 @@ describe("useEscapeToDismissToast", () => {
   beforeEach(() => {
     HotkeyManager.resetInstance();
     document.body.removeAttribute("data-app-locked");
+    clearFloatingLayerReasons();
 
     const testPort = createTestToastPort();
     mocks = testPort.mocks;
@@ -31,6 +35,7 @@ describe("useEscapeToDismissToast", () => {
     resetToastPort();
     document.body.innerHTML = "";
     draftActions.discard();
+    clearFloatingLayerReasons();
   });
 
   it("dismisses the visible toast on Escape", () => {
@@ -40,17 +45,6 @@ describe("useEscapeToDismissToast", () => {
 
     expect(mocks.dismiss).toHaveBeenCalledTimes(1);
     expect(mocks.dismiss).toHaveBeenCalledWith();
-  });
-
-  it("does not dismiss while a context menu is open", () => {
-    const contextMenu = document.createElement("div");
-    contextMenu.id = ID_CONTEXT_MENU_ITEMS;
-    document.body.appendChild(contextMenu);
-
-    renderHook(() => useEscapeToDismissToast());
-    pressKey("Escape");
-
-    expect(mocks.dismiss).not.toHaveBeenCalled();
   });
 
   it("does not dismiss while the event form is open", () => {
@@ -71,21 +65,24 @@ describe("useEscapeToDismissToast", () => {
     expect(mocks.dismiss).not.toHaveBeenCalled();
   });
 
-  it("does not dismiss while a floating layer (dialog) is open", () => {
-    const dialog = document.createElement("div");
-    dialog.setAttribute("role", "dialog");
-    document.body.appendChild(dialog);
-    // jsdom has no layout engine, so a plain element always reports zero
-    // client rects; stub it to look on-screen, matching a real dialog.
-    const rectsSpy = spyOn(dialog, "getClientRects").mockReturnValue([
-      {} as DOMRect,
-    ] as unknown as DOMRectList);
+  it("does not dismiss while a floating layer is open", () => {
+    setFloatingLayerReason("test-layer", true);
 
     renderHook(() => useEscapeToDismissToast());
     pressKey("Escape");
 
     expect(mocks.dismiss).not.toHaveBeenCalled();
-    rectsSpy.mockRestore();
+  });
+
+  it("does not dismiss while the context-menu floating layer is registered", () => {
+    // Mirrors ContextMenu's useFloatingLayer("contextMenu", …) reason so a
+    // broken/missing wire-up would fail this stand-down check.
+    setFloatingLayerReason("contextMenu", true);
+
+    renderHook(() => useEscapeToDismissToast());
+    pressKey("Escape");
+
+    expect(mocks.dismiss).not.toHaveBeenCalled();
   });
 
   it("does not dismiss while the app is locked (a modal is open)", () => {

--- a/packages/web/src/common/utils/toast/useEscapeToDismissToast.ts
+++ b/packages/web/src/common/utils/toast/useEscapeToDismissToast.ts
@@ -1,15 +1,12 @@
-import {
-  isContextMenuOpen,
-  isFloatingLayerOpen,
-} from "@web/common/utils/form/form.util";
 import { getToast } from "@web/common/utils/toast/toast.port";
 import { isEventFormOpen } from "@web/events/stores/draft.store";
+import { isFloatingLayerOpen } from "@web/shortcuts/floating-layer";
 import { useAppShortcut } from "@web/shortcuts/useAppShortcut";
 
 /**
  * Escape clears the visible toast so a notice never has to be waited out.
  * Lowest-priority Escape consumer by design: modals are excluded for free by
- * the app lock (no `ignoreAppLock` here), and the probes below stand this
+ * the app lock (no `ignoreAppLock` here), and the checks below stand this
  * handler down while the form or a floating layer owns Escape.
  *
  * Wart: `dismiss()` clears what is on screen but not react-toastify's waiting
@@ -20,7 +17,6 @@ export const useEscapeToDismissToast = () => {
   useAppShortcut(
     "Escape",
     () => {
-      if (isContextMenuOpen()) return;
       if (isEventFormOpen()) return;
       if (isFloatingLayerOpen()) return;
 

--- a/packages/web/src/components/ContextMenu/ContextMenu.tsx
+++ b/packages/web/src/components/ContextMenu/ContextMenu.tsx
@@ -7,6 +7,7 @@ import {
 } from "@floating-ui/react";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { type GridEvent } from "@web/common/types/web.event.types";
+import { useFloatingLayer } from "@web/shortcuts/floating-layer";
 import {
   ContextMenuItems,
   type ContextMenuItemsActions,
@@ -54,6 +55,7 @@ export const ContextMenu = React.forwardRef<HTMLUListElement, ContextMenuProps>(
     // the pending timeout before it ever fired. `hasEvent` only flips when the
     // menu opens or closes.
     const hasEvent = !!event;
+    useFloatingLayer("contextMenu", hasEvent);
     useEffect(() => {
       if (!hasEvent) return;
       // Seat focus on the first item, deferred and retried for a short window.

--- a/packages/web/src/components/ContextMenu/ContextMenuItems.tsx
+++ b/packages/web/src/components/ContextMenu/ContextMenuItems.tsx
@@ -112,7 +112,8 @@ export function ContextMenuItemsView({
 
   return (
     // role="none" keeps the menu -> menuitem ownership valid across this
-    // container (the id is also how isContextMenuOpen() detects the menu).
+    // container. Escape ownership is registered via useFloatingLayer on
+    // ContextMenu; the id remains a stable test/DOM anchor.
     <div id={ID_CONTEXT_MENU_ITEMS} role="none">
       {menuActions.map((item, index) => {
         const select = () => {

--- a/packages/web/src/components/DatePicker/DatePicker.tsx
+++ b/packages/web/src/components/DatePicker/DatePicker.tsx
@@ -1,5 +1,6 @@
 import classNames from "classnames";
 import type React from "react";
+import { useId } from "react";
 import * as ReactDatePickerModule from "react-datepicker";
 import { type ReactDatePickerProps } from "react-datepicker";
 import dayjs from "@core/util/date/dayjs";
@@ -11,6 +12,7 @@ import { MonthNavButton } from "@web/components/DatePicker/MonthNavButton";
 import { ChevronLeftIcon } from "@web/components/Icons/ChevronLeftIcon";
 import { ChevronRightIcon } from "@web/components/Icons/ChevronRightIcon";
 import { selectTheme, useThemeStore } from "@web/settings/theme/theme.store";
+import { useFloatingLayer } from "@web/shortcuts/floating-layer";
 import { Focusable, INPUT_RESET_CLASSNAME } from "../Focusable/Focusable";
 import { CircleIcon } from "../Icons/CircleIcon";
 import { TooltipWrapper } from "../Tooltip/TooltipWrapper";
@@ -59,6 +61,10 @@ export const DatePicker: React.FC<Props> = (datePickerProps) => {
     withTodayButton = true,
     ...props
   } = datePickerProps;
+  const layerId = useId();
+  // Sidebar month grid stays mounted and visible; only transient grid popovers
+  // own Escape (same carve-out the old DOM probe encoded via Month picker).
+  useFloatingLayer(`datePicker:${layerId}`, view === "grid" && isOpen);
   const isDarkTheme = useThemeStore(selectTheme) === "dark-abyss";
   const resolvedBgColor =
     bgColor ?? (isDarkTheme ? colors.background : lightColors.background);

--- a/packages/web/src/components/SelectView/SelectView.tsx
+++ b/packages/web/src/components/SelectView/SelectView.tsx
@@ -13,6 +13,7 @@ import { useRef, useState } from "react";
 import { ROOT_ROUTES } from "@web/common/constants/routes";
 import { Z_INDEX_FLOATING_MENU } from "@web/common/constants/web.constants";
 import { ShortcutKeys } from "@web/components/Shortcuts/ShortcutKeys";
+import { useFloatingLayer } from "@web/shortcuts/floating-layer";
 import {
   LIFE_SHORTCUT,
   VIEW_SHORTCUTS,
@@ -30,6 +31,7 @@ export const SelectView = ({ label, onToday }: SelectViewProps) => {
   const location = useLocation();
   const navigate = useNavigate();
   const listRef = useRef<Array<HTMLElement | null>>([]);
+  useFloatingLayer("viewSelect", isOpen);
 
   const getCurrentView = (): "Day" | "Week" | "Life" => {
     const pathname = location.pathname;

--- a/packages/web/src/components/Sidebar/ShortcutsOverlay/ShortcutsOverlay.tsx
+++ b/packages/web/src/components/Sidebar/ShortcutsOverlay/ShortcutsOverlay.tsx
@@ -51,8 +51,8 @@ export function ShortcutsOverlay({ sections, viewLabel }: Props) {
   // keeping the slide animation. (Conditional unmount is the other F3
   // option, but it exposed unrelated sidebar contrast debt to axe that
   // the old covering dialog had been papering over — tracked separately.)
-  // isFloatingLayerOpen ignores inert dialogs so Escape can still close the
-  // event form while this overlay stays mounted closed.
+  // App-lock is held only while open, so a closed-but-mounted overlay does
+  // not block form/toast Escape.
   useEffect(() => {
     const overlay = overlayRef.current;
     if (overlay) {

--- a/packages/web/src/shortcuts/floating-layer.test.ts
+++ b/packages/web/src/shortcuts/floating-layer.test.ts
@@ -1,0 +1,50 @@
+import { act, renderHook } from "@testing-library/react";
+import {
+  clearFloatingLayerReasons,
+  isFloatingLayerOpen,
+  setFloatingLayerReason,
+  useFloatingLayer,
+} from "@web/shortcuts/floating-layer";
+import { afterEach, describe, expect, it } from "bun:test";
+
+afterEach(() => {
+  clearFloatingLayerReasons();
+});
+
+describe("floating-layer", () => {
+  it("tracks named reasons without clearing siblings", () => {
+    expect(isFloatingLayerOpen()).toBe(false);
+
+    setFloatingLayerReason("a", true);
+    expect(isFloatingLayerOpen()).toBe(true);
+
+    setFloatingLayerReason("b", true);
+    setFloatingLayerReason("a", false);
+    expect(isFloatingLayerOpen()).toBe(true);
+
+    setFloatingLayerReason("b", false);
+    expect(isFloatingLayerOpen()).toBe(false);
+  });
+
+  it("useFloatingLayer syncs with open and cleans up on unmount", () => {
+    const { rerender, unmount } = renderHook(
+      ({ open }) => useFloatingLayer("hook", open),
+      { initialProps: { open: true } },
+    );
+
+    expect(isFloatingLayerOpen()).toBe(true);
+
+    act(() => {
+      rerender({ open: false });
+    });
+    expect(isFloatingLayerOpen()).toBe(false);
+
+    act(() => {
+      rerender({ open: true });
+    });
+    expect(isFloatingLayerOpen()).toBe(true);
+
+    unmount();
+    expect(isFloatingLayerOpen()).toBe(false);
+  });
+});

--- a/packages/web/src/shortcuts/floating-layer.ts
+++ b/packages/web/src/shortcuts/floating-layer.ts
@@ -1,0 +1,32 @@
+import { useEffect } from "react";
+
+const openLayers = new Set<string>();
+
+/**
+ * Named floating-layer reasons so nested Escape owners (menus, listboxes,
+ * date pickers) can open/close independently without DOM visibility probes.
+ * Modeled on `app-lock.ts`; Escape consumers stand down while any reason is set.
+ */
+export function setFloatingLayerReason(reason: string, open: boolean) {
+  if (open) {
+    openLayers.add(reason);
+  } else {
+    openLayers.delete(reason);
+  }
+}
+
+/** Clears every reason — used by tests between cases. */
+export function clearFloatingLayerReasons() {
+  openLayers.clear();
+}
+
+export function isFloatingLayerOpen() {
+  return openLayers.size > 0;
+}
+
+export function useFloatingLayer(reason: string, open: boolean) {
+  useEffect(() => {
+    setFloatingLayerReason(reason, open);
+    return () => setFloatingLayerReason(reason, false);
+  }, [open, reason]);
+}

--- a/packages/web/src/views/Forms/ActionsMenu/ActionsMenu.tsx
+++ b/packages/web/src/views/Forms/ActionsMenu/ActionsMenu.tsx
@@ -26,6 +26,7 @@ import {
   Z_INDEX_FLOATING_MENU,
 } from "@web/common/constants/web.constants";
 import IconButton from "@web/components/IconButton/IconButton";
+import { useFloatingLayer } from "@web/shortcuts/floating-layer";
 
 interface MenuContextValue {
   getItemProps: (
@@ -55,6 +56,7 @@ export const ActionsMenu: React.FC<ActionsMenuProps> = ({ children, id }) => {
 
   const menuId = id || ID_EVENT_FORM_ACTION_MENU;
   const triggerId = `${menuId}-trigger`;
+  useFloatingLayer(`actionsMenu:${menuId}`, open);
 
   const { refs, context } = useFloating({
     open,

--- a/packages/web/src/views/Forms/EventForm/CalendarSelect/CalendarSelect.tsx
+++ b/packages/web/src/views/Forms/EventForm/CalendarSelect/CalendarSelect.tsx
@@ -7,7 +7,7 @@ import {
   useRole,
 } from "@floating-ui/react";
 import classNames from "classnames";
-import { useRef, useState } from "react";
+import { useId, useRef, useState } from "react";
 import { type Calendar } from "@core/types/calendar.contracts";
 import { type CalendarId } from "@core/types/domain-primitives";
 import { useCalendarsQuery } from "@web/calendars/calendar.query";
@@ -21,6 +21,7 @@ import {
   useDefaultTargetCalendar,
 } from "@web/calendars/useDefaultTargetCalendar";
 import { Z_INDEX_FLOATING_MENU } from "@web/common/constants/web.constants";
+import { useFloatingLayer } from "@web/shortcuts/floating-layer";
 
 interface CalendarSelectProps {
   value: CalendarId | null;
@@ -74,6 +75,8 @@ export const CalendarSelect = ({
   const [isOpen, setIsOpen] = useState(false);
   const [activeIndex, setActiveIndex] = useState<number | null>(null);
   const listRef = useRef<Array<HTMLElement | null>>([]);
+  const layerId = useId();
+  useFloatingLayer(`calendarSelect:${layerId}`, isOpen);
 
   const selectedCalendar =
     writableCalendars.find((calendar) => calendar.id === value) ?? null;

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/TimePicker.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/TimePicker.tsx
@@ -1,10 +1,11 @@
 import type React from "react";
-import { useRef } from "react";
+import { useId, useRef } from "react";
 import { type CSSObjectWithLabel, type Props as RSProps } from "react-select";
 import CreatableSelect from "react-select/creatable";
 import { type SelectOption } from "@web/common/types/component.types";
 import { type TimeOption } from "@web/common/types/util.types";
 import { parseUserTime } from "@web/common/utils/datetime/web.date.util";
+import { useFloatingLayer } from "@web/shortcuts/floating-layer";
 
 export interface Props extends Omit<RSProps, "onChange" | "value"> {
   isMenuOpen: boolean;
@@ -43,6 +44,8 @@ export const TimePicker = ({
 }: Props) => {
   const TIMEPICKER = "timepicker";
   const containerRef = useRef<HTMLDivElement>(null);
+  const layerId = useId();
+  useFloatingLayer(`timePicker:${layerId}`, isMenuOpen);
   let scrollTimer: number;
 
   return (

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/components/FreqSelect.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/components/FreqSelect.tsx
@@ -1,7 +1,8 @@
-import { useMemo } from "react";
+import { useId, useMemo, useState } from "react";
 import ReactSelect from "react-select";
 import { colors } from "@web/common/styles/colors";
 import { theme } from "@web/common/styles/theme";
+import { useFloatingLayer } from "@web/shortcuts/floating-layer";
 import {
   FREQUENCY_MAP,
   FREQUENCY_OPTIONS,
@@ -21,6 +22,9 @@ export const FreqSelect = ({
 }: FreqSelectProps) => {
   const options = useMemo(() => FREQUENCY_OPTIONS(plural ? "s" : ""), [plural]);
   const fontSize = theme.text.size.m;
+  const layerId = useId();
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  useFloatingLayer(`freqSelect:${layerId}`, isMenuOpen);
 
   const label = useMemo(
     () => `${FREQUENCY_MAP[value]}${plural ? "s" : ""}`,
@@ -32,6 +36,8 @@ export const FreqSelect = ({
       options={options}
       classNamePrefix="freq-select"
       value={{ label, value }}
+      onMenuOpen={() => setIsMenuOpen(true)}
+      onMenuClose={() => setIsMenuOpen(false)}
       onChange={(option) =>
         option && option.value !== undefined && onFreqSelect(option.value)
       }

--- a/packages/web/src/views/Forms/hooks/useEscapeToCloseForm.test.tsx
+++ b/packages/web/src/views/Forms/hooks/useEscapeToCloseForm.test.tsx
@@ -1,0 +1,54 @@
+import { HotkeyManager } from "@tanstack/react-hotkeys";
+import { renderHook } from "@testing-library/react";
+import { pressKey } from "@web/__tests__/utils/keyboard.test.util";
+import {
+  clearFloatingLayerReasons,
+  setFloatingLayerReason,
+} from "@web/shortcuts/floating-layer";
+import { useEscapeToCloseForm } from "@web/views/Forms/hooks/useEscapeToCloseForm";
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+
+describe("useEscapeToCloseForm", () => {
+  beforeEach(() => {
+    HotkeyManager.resetInstance();
+    document.body.removeAttribute("data-app-locked");
+    clearFloatingLayerReasons();
+  });
+
+  afterEach(() => {
+    clearFloatingLayerReasons();
+  });
+
+  it("closes the form on Escape when no floating layer is open", () => {
+    const onClose = mock(() => {});
+    renderHook(() => useEscapeToCloseForm(onClose));
+
+    pressKey("Escape");
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("stands down while a floating layer owns Escape", () => {
+    const onClose = mock(() => {});
+    setFloatingLayerReason("actionsMenu:test", true);
+    renderHook(() => useEscapeToCloseForm(onClose));
+
+    pressKey("Escape");
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("closes after the floating layer clears", () => {
+    const onClose = mock(() => {});
+    setFloatingLayerReason("actionsMenu:test", true);
+    renderHook(() => useEscapeToCloseForm(onClose));
+
+    pressKey("Escape");
+    expect(onClose).not.toHaveBeenCalled();
+
+    setFloatingLayerReason("actionsMenu:test", false);
+    pressKey("Escape");
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/web/src/views/Forms/hooks/useEscapeToCloseForm.ts
+++ b/packages/web/src/views/Forms/hooks/useEscapeToCloseForm.ts
@@ -1,16 +1,14 @@
 import { useState } from "react";
-import {
-  isContextMenuOpen,
-  isFloatingLayerOpen,
-} from "@web/common/utils/form/form.util";
 import { selectGridDraft, useDraftStore } from "@web/events/stores/draft.store";
+import { isFloatingLayerOpen } from "@web/shortcuts/floating-layer";
 import { useAppShortcut } from "@web/shortcuts/useAppShortcut";
 import { shouldConfirmDiscardUnsavedChanges } from "@web/views/Forms/hooks/shouldConfirmDiscardUnsavedChanges";
 
 /**
  * Escape closes the event-details form. Dirty edits of a persisted event
  * confirm first; create drafts and unchanged edits discard immediately.
- * Nested floating layers (menus, dialogs) win Escape via isFloatingLayerOpen.
+ * Nested floating layers (menus, listboxes, date pickers) register via
+ * `useFloatingLayer` so Escape closes them first.
  */
 export const useEscapeToCloseForm = (onClose: () => void) => {
   const [isConfirmOpen, setIsConfirmOpen] = useState(false);
@@ -18,7 +16,6 @@ export const useEscapeToCloseForm = (onClose: () => void) => {
   useAppShortcut(
     "Escape",
     (keyboardEvent) => {
-      if (isContextMenuOpen()) return;
       if (isFloatingLayerOpen()) return;
 
       keyboardEvent.preventDefault();


### PR DESCRIPTION
## Summary
- Replace the Escape DOM visibility probe (`role=menu|listbox|dialog` + `getClientRects` + Month picker carve-out) with a named floating-layer registry modeled on app-lock.
- Wire `useFloatingLayer` into Escape-owning nested layers (actions menu, calendar/view selects, time/freq selects, grid date pickers, context menu) so form/toast Escape stands down without DOM coupling.
- Sidebar MonthPicker stays out of the registry (`view="sidebar"`), preserving Escape-to-close-form while the inline month grid is visible.

## Simplicity
- Mirror of the existing `app-lock` Set/hook pattern; deleted `isContextMenuOpen` Escape probe and the role/`getClientRects` scanner rather than layering a second mechanism.

## Automated validation
- Browser (`http://localhost:9083/week`): create timed event → open actions menu → Escape closes menu, form stays → Escape closes form with Month picker still visible → reopen → calendar listbox Escape closes listbox, form stays.
- Unit/e2e commands below.

## Independent review
- Fresh code-reviewer pass: no Escape ordering / MonthPicker false-positive / cleanup bugs at ≥80 confidence.
- Important test gaps fixed before merge: `useEscapeToCloseForm` floating-layer stand-down tests + toast coverage for the `contextMenu` reason.

## Test plan
- `bun test:web` (1828 pass before final regression file; focused Escape tests 8/8 after)
- `bun test:web packages/web/src/views/Forms/hooks/useEscapeToCloseForm.test.tsx packages/web/src/common/utils/toast/useEscapeToDismissToast.test.tsx`
- `bun test:e2e` (21/21)
- `bun lint` (pre-existing warnings only)