### PR TITLE
fix(sync): keep google instances when apply-all discards overrides

### DIFF
--- a/packages/sync/src/domain/occurrence-projection.test.ts
+++ b/packages/sync/src/domain/occurrence-projection.test.ts
@@ -2,6 +2,7 @@ import { faker } from "@faker-js/faker";
 import { type EventSchedule } from "@core/types/event.contracts";
 import { type SyncEventRecurrence } from "@core/types/sync/event.contracts";
 import {
+  occurrenceScheduleAfterSeriesEdit,
   type ProjectionHorizon,
   projectOccurrences,
   truncateRulesBefore,
@@ -501,6 +502,44 @@ describe("projectOccurrences", () => {
         "2026-07-06T15:00:00.000Z",
         "2026-07-13T15:00:00.000Z",
       ]);
+    });
+  });
+
+  describe("occurrenceScheduleAfterSeriesEdit", () => {
+    it("keeps the recurrence instant when the master time is unchanged", () => {
+      const master = timed(
+        "2026-07-14T09:00:00-06:00",
+        "2026-07-14T10:00:00-06:00",
+      );
+      expect(
+        occurrenceScheduleAfterSeriesEdit(
+          master,
+          master,
+          "2026-07-21T09:00:00-06:00" as never,
+        ),
+      ).toEqual(
+        timed("2026-07-21T09:00:00-06:00", "2026-07-21T10:00:00-06:00"),
+      );
+    });
+
+    it("applies the master start delta to the recurrence instant", () => {
+      const previous = timed(
+        "2026-07-14T09:00:00-06:00",
+        "2026-07-14T10:00:00-06:00",
+      );
+      const next = timed(
+        "2026-07-14T10:00:00-06:00",
+        "2026-07-14T11:00:00-06:00",
+      );
+      expect(
+        occurrenceScheduleAfterSeriesEdit(
+          previous,
+          next,
+          "2026-07-21T09:00:00-06:00" as never,
+        ),
+      ).toEqual(
+        timed("2026-07-21T10:00:00-06:00", "2026-07-21T11:00:00-06:00"),
+      );
     });
   });
 });

--- a/packages/sync/src/domain/occurrence-projection.ts
+++ b/packages/sync/src/domain/occurrence-projection.ts
@@ -304,6 +304,22 @@ export function occurrenceScheduleAt(
   return shiftSchedule(masterSchedule, new Date(recurrenceId));
 }
 
+// Schedule for a former override after an edit-all. Applies the master's start
+// delta so a series time change moves every instance, then materializes at that
+// aligned instant with the new master's duration/zone. A content-only edit
+// (delta zero) matches occurrenceScheduleAt(next, recurrenceId).
+export function occurrenceScheduleAfterSeriesEdit(
+  previousMasterSchedule: EventSchedule,
+  nextMasterSchedule: EventSchedule,
+  recurrenceId: DateTime,
+): EventSchedule {
+  const deltaMs =
+    scheduleStartAt(nextMasterSchedule).getTime() -
+    scheduleStartAt(previousMasterSchedule).getTime();
+  const alignedStart = new Date(new Date(recurrenceId).getTime() + deltaMs);
+  return shiftSchedule(nextMasterSchedule, alignedStart);
+}
+
 // Builds one occurrence's schedule from the master's, at the given original
 // start instant, preserving duration and (for timed) the zone.
 function shiftSchedule(

--- a/packages/sync/src/domain/provider-command.service.db.test.ts
+++ b/packages/sync/src/domain/provider-command.service.db.test.ts
@@ -504,6 +504,8 @@ class FakeUpdateWriter implements ProviderEventWriter {
     providerVersion: "etag-2",
   };
   patchError?: unknown;
+  // Fail only instance patches (edit-all override align), not the master patch.
+  instancePatchError?: unknown;
   deleteError?: unknown;
   fetchCalls: ProviderFetchInput[] = [];
   patchCalls: ProviderPatchInput[] = [];
@@ -513,6 +515,9 @@ class FakeUpdateWriter implements ProviderEventWriter {
   }
   async patchEvent(input: ProviderPatchInput): Promise<ProviderWriteResult> {
     this.patchCalls.push(input);
+    if (input.recurrence.kind === "instance" && this.instancePatchError) {
+      throw this.instancePatchError;
+    }
     if (this.patchError) throw this.patchError;
     return this.patchResult;
   }
@@ -524,6 +529,9 @@ class FakeUpdateWriter implements ProviderEventWriter {
     this.fetchCalls.push(input);
     if (this.fetchError) throw this.fetchError;
     return this.fetched;
+  }
+  fetchInstanceAt(): Promise<ProviderEvent | null> {
+    throw new Error("unused");
   }
 }
 
@@ -1790,13 +1798,25 @@ describe("executeProviderSeriesUpdate", () => {
     );
 
     expect(result.outcome.state).toBe("confirmed");
-    // Provider cancel only for the content override — not the kept tombstone.
-    expect(writer.deleteCalls).toHaveLength(1);
-    expect(writer.deleteCalls[0]).toMatchObject({
+    // Align the content override at the provider (do not cancel it); leave the
+    // kept tombstone untouched.
+    expect(writer.deleteCalls).toHaveLength(0);
+    const overridePatch = writer.patchCalls.find(
+      (call) => call.providerEventId === "g-inst-override",
+    );
+    expect(overridePatch).toMatchObject({
       providerEventId: "g-inst-override",
       expectedVersion: null,
       invitation: "all",
       calendarId: calendar.providerCalendarId,
+      recurrence: { kind: "instance" },
+      content: expect.objectContaining({ title: "New" }),
+      schedule: {
+        kind: "timed",
+        start: "2026-07-21T09:00:00-06:00",
+        end: "2026-07-21T10:00:00-06:00",
+        timeZone: "America/Denver",
+      },
     });
     // The override is gone; the cancelled tombstone survives the edit.
     expect(
@@ -1823,7 +1843,7 @@ describe("executeProviderSeriesUpdate", () => {
     ]);
   });
 
-  it("leaves the override local when provider cancel is transient", async () => {
+  it("leaves the override local when provider override align is transient", async () => {
     const { tenantId, principalId, calendar, master } = await seedMaster();
     const override = await putException(master, {
       providerEventId: "g-inst-override",
@@ -1837,7 +1857,10 @@ describe("executeProviderSeriesUpdate", () => {
     });
     const writer = new FakeUpdateWriter();
     writer.fetched = providerSeries("Old", "etag-1", weekly4);
-    writer.deleteError = new ProviderWriteError("transient", "rate limited");
+    writer.instancePatchError = new ProviderWriteError(
+      "transient",
+      "rate limited",
+    );
 
     const result = await executeProviderSeriesUpdate(
       deps(writer),
@@ -1848,7 +1871,12 @@ describe("executeProviderSeriesUpdate", () => {
     );
 
     expect(result.outcome.state).toBe("pending");
-    expect(writer.deleteCalls).toHaveLength(1);
+    expect(writer.deleteCalls).toHaveLength(0);
+    expect(
+      writer.patchCalls.some(
+        (call) => call.providerEventId === "g-inst-override",
+      ),
+    ).toBe(true);
     expect(
       await events.findById(tenantId, principalId, override._id),
     ).not.toBeNull();

--- a/packages/sync/src/domain/provider-command.service.db.test.ts
+++ b/packages/sync/src/domain/provider-command.service.db.test.ts
@@ -528,7 +528,15 @@ class FakeUpdateWriter implements ProviderEventWriter {
   async fetchEvent(input: ProviderFetchInput): Promise<ProviderEvent | null> {
     this.fetchCalls.push(input);
     if (this.fetchError) throw this.fetchError;
-    return this.fetched;
+    // Master replay uses `fetched`; unknown ids (e.g. discarded overrides)
+    // resolve as absent so align can exercise delete's 404-OK path.
+    if (
+      this.fetched &&
+      input.providerEventId === this.fetched.providerEventId
+    ) {
+      return this.fetched;
+    }
+    return null;
   }
   fetchInstanceAt(): Promise<ProviderEvent | null> {
     throw new Error("unused");
@@ -1516,7 +1524,11 @@ describe("executeProviderSeriesUpdate", () => {
   // An edit-all update command for the seeded master.
   const editAllCommand = async (
     master: EventRecord,
-    edit: { title: string; recurrence: RecurrenceEdit },
+    edit: {
+      title: string;
+      recurrence: RecurrenceEdit;
+      schedule?: typeof schedule;
+    },
   ) =>
     (
       await commands.submit({
@@ -1528,7 +1540,7 @@ describe("executeProviderSeriesUpdate", () => {
           kind: "update",
           invitation: "all",
           content: content(edit.title),
-          schedule,
+          schedule: edit.schedule ?? schedule,
           recurrence: edit.recurrence,
           scope: "all",
           recurrenceId: null,
@@ -1880,6 +1892,90 @@ describe("executeProviderSeriesUpdate", () => {
     expect(
       await events.findById(tenantId, principalId, override._id),
     ).not.toBeNull();
+  });
+
+  it("aligns discarded overrides to a series time change", async () => {
+    const { calendar, master } = await seedMaster();
+    await putException(master, {
+      providerEventId: "g-inst-override",
+      recurrenceId: "2026-07-21T09:00:00-06:00",
+      cancelled: false,
+      title: "Moved",
+    });
+    const movedSchedule = {
+      kind: "timed" as const,
+      start: "2026-07-14T10:00:00-06:00",
+      end: "2026-07-14T11:00:00-06:00",
+      timeZone: "America/Denver",
+    };
+    const command = await editAllCommand(master, {
+      title: "New",
+      recurrence: { kind: "preserve" },
+      schedule: movedSchedule,
+    });
+    const writer = new FakeUpdateWriter();
+    writer.fetched = providerSeries("Old", "etag-1", weekly4);
+
+    const result = await executeProviderSeriesUpdate(
+      deps(writer),
+      command,
+      master,
+      calendar,
+      now,
+    );
+
+    expect(result.outcome.state).toBe("confirmed");
+    const overridePatch = writer.patchCalls.find(
+      (call) => call.providerEventId === "g-inst-override",
+    );
+    expect(overridePatch?.schedule).toEqual({
+      kind: "timed",
+      start: "2026-07-21T10:00:00-06:00",
+      end: "2026-07-21T11:00:00-06:00",
+      timeZone: "America/Denver",
+    });
+  });
+
+  it("continues edit-all when the override is already gone at the provider", async () => {
+    const { tenantId, principalId, calendar, master } = await seedMaster();
+    const override = await putException(master, {
+      providerEventId: "g-inst-override",
+      recurrenceId: "2026-07-21T09:00:00-06:00",
+      cancelled: false,
+      title: "Moved",
+    });
+    const command = await editAllCommand(master, {
+      title: "New",
+      recurrence: { kind: "preserve" },
+    });
+    const writer = new FakeUpdateWriter();
+    writer.fetched = providerSeries("Old", "etag-1", weekly4);
+    writer.instancePatchError = new ProviderWriteError(
+      "permanentProviderError",
+      "Google rejected the write",
+    );
+
+    const result = await executeProviderSeriesUpdate(
+      deps(writer),
+      command,
+      master,
+      calendar,
+      now,
+    );
+
+    expect(result.outcome.state).toBe("confirmed");
+    expect(
+      writer.fetchCalls.some(
+        (call) => call.providerEventId === "g-inst-override",
+      ),
+    ).toBe(true);
+    expect(
+      await events.findById(tenantId, principalId, override._id),
+    ).toBeNull();
+    const starts = (await masterOccurrences(master._id)).map((o) =>
+      (o["startAt"] as Date).toISOString(),
+    );
+    expect(starts).toContain("2026-07-21T15:00:00.000Z");
   });
 
   it("converts a series to a single event, dropping every exception", async () => {

--- a/packages/sync/src/domain/provider-command.service.ts
+++ b/packages/sync/src/domain/provider-command.service.ts
@@ -545,18 +545,21 @@ export async function executeProviderSeriesUpdate(
 // from the reprojected master so a deleted occurrence is not resurrected. A
 // conversion to a single event drops every exception.
 //
-// Overrides are cancelled at the provider, then deleted locally BEFORE the
-// master is replaced — the same crash-safety ordering the cloud path uses.
-// Google does not drop instance overrides when the master is patched, so a
-// later pull would otherwise resurrect them. Cancel-before-local-delete keeps
-// retries idempotent (provider delete is 404-OK). A convert-to-single edit
-// changes the master's recurrence kind, and a retry that read the converted
-// single master would take the single-event path, which never cleans
-// exceptions; clearing first closes that hole. Gating the kept/discarded
-// split on the command's immutable recurrence intent keeps a retry
-// classifying identically. A false from replaceExisting means the master
-// vanished mid-flight, so leave the command pending rather than confirm a
-// gone series.
+// Content/time overrides are aligned at the provider (patched to the edited
+// series), then deleted locally BEFORE the master is replaced — the same
+// crash-safety ordering the cloud path uses. Google does not drop instance
+// overrides when the master is patched, so a later pull would otherwise
+// resurrect stale override fields. Patching (not deleting) keeps the
+// occurrence confirmed: Google's events.delete on an instance cancels that
+// date, and a later pull would tombstone it out of the series. A
+// convert-to-single edit still deletes discarded exceptions at the provider
+// (they are no longer series members). Clearing locals first also closes the
+// convert-to-single retry hole: a retry that read the converted single master
+// would take the single-event path, which never cleans exceptions. Gating the
+// kept/discarded split on the command's immutable recurrence intent keeps a
+// retry classifying identically. A false from replaceExisting means the
+// master vanished mid-flight, so leave the command pending rather than
+// confirm a gone series.
 async function commitProviderSeriesUpdate(
   deps: ProviderMutationDeps,
   command: CommandRecord,
@@ -585,18 +588,36 @@ async function commitProviderSeriesUpdate(
     ? exceptions
     : exceptions.filter((exception) => !isCancelledException(exception));
 
-  // Cancel discarded overrides at Google first, then clear local copies.
-  // Kept cancelled tombstones are not touched at the provider.
+  // Align or remove discarded overrides at Google first, then clear local
+  // copies. Kept cancelled tombstones are not touched at the provider.
   for (const exception of discarded) {
     if (exception.providerEventId) {
       try {
-        await deps.writer.deleteEvent({
-          accessToken: provider.accessToken,
-          calendarId: provider.calendarId,
-          providerEventId: exception.providerEventId,
-          expectedVersion: null,
-          invitation: input.invitation,
-        });
+        if (convertsToSingle) {
+          await deps.writer.deleteEvent({
+            accessToken: provider.accessToken,
+            calendarId: provider.calendarId,
+            providerEventId: exception.providerEventId,
+            expectedVersion: null,
+            invitation: input.invitation,
+          });
+        } else {
+          // Revert the override into the edited series without cancelling the
+          // occurrence. Delete would mark the instance cancelled at Google.
+          await deps.writer.patchEvent({
+            accessToken: provider.accessToken,
+            calendarId: provider.calendarId,
+            providerEventId: exception.providerEventId,
+            expectedVersion: null,
+            content,
+            schedule: occurrenceScheduleAt(
+              input.schedule,
+              exceptionInstant(exception),
+            ),
+            recurrence: { kind: "instance" },
+            invitation: input.invitation,
+          });
+        }
       } catch (error) {
         if (error instanceof ProviderWriteError) {
           if (error.reason === "transient") return command;
@@ -670,13 +691,12 @@ async function commitProviderSeriesUpdate(
 // use (series-exception.ts), so a provider-linked and a cloud-only
 // series converge to the same on-disk shape.
 //
-// Known deferred gap, matching the documented one in
-// commitProviderSeriesUpdate above: un-cancelling a provider instance (a
-// scope-"this" edit of an instance the provider already reports as
-// cancelled) is not implemented — it fails with permanentProviderError
-// rather than silently no-op'ing. Restoring a cancelled Google instance to
-// "confirmed" is a distinct provider operation this slice does not need for
-// the common edit/delete-a-live-instance path.
+// Known deferred gap: un-cancelling a provider instance (a scope-"this" edit
+// of an instance the provider already reports as cancelled) is not
+// implemented — it fails with permanentProviderError rather than silently
+// no-op'ing. Restoring a cancelled Google instance to "confirmed" is a
+// distinct provider operation this slice does not need for the common
+// edit/delete-a-live-instance path.
 // ---------------------------------------------------------------------------
 
 // Apply a Compass-initiated scope-"this" edit to one occurrence of a

--- a/packages/sync/src/domain/provider-command.service.ts
+++ b/packages/sync/src/domain/provider-command.service.ts
@@ -19,6 +19,7 @@ import {
   omitNullColor,
 } from "@sync/domain/merge-update-content";
 import {
+  occurrenceScheduleAfterSeriesEdit,
   occurrenceScheduleAt,
   scheduleStartAt,
   stripRuleBounds,
@@ -188,6 +189,54 @@ async function failCommand(
     await deps.custody.discardRevoked(connectionId);
   }
   return failed ?? command;
+}
+
+// After a failed override-align patch, continue when the instance is already
+// gone (matching deleteEvent's 404-OK). Return a command to stop on; null means
+// local cleanup may proceed. The master write may already have landed, so a
+// hard fail on a missing override would leave Google mutated and Compass not.
+async function resolveFailedOverrideAlign(
+  deps: ProviderMutationDeps,
+  command: CommandRecord,
+  provider: {
+    accessToken: string;
+    calendarId: string;
+    connectionId: ConnectionId;
+  },
+  providerEventId: string,
+  patchError: ProviderWriteError,
+): Promise<CommandRecord | null> {
+  if (patchError.reason === "transient") return command;
+  if (patchError.reason !== "permanentProviderError") {
+    return failCommand(deps, command, patchError.reason, provider.connectionId);
+  }
+  try {
+    const read = await deps.writer.fetchEvent({
+      accessToken: provider.accessToken,
+      calendarId: provider.calendarId,
+      providerEventId: providerEventId as ProviderEventId,
+    });
+    if (read?.kind === "event") {
+      return failCommand(
+        deps,
+        command,
+        patchError.reason,
+        provider.connectionId,
+      );
+    }
+    return null;
+  } catch (fetchError) {
+    if (fetchError instanceof ProviderWriteError) {
+      if (fetchError.reason === "transient") return command;
+      return failCommand(
+        deps,
+        command,
+        fetchError.reason,
+        provider.connectionId,
+      );
+    }
+    throw fetchError;
+  }
 }
 
 // Build the canonical event for a provider-linked create: same shape as a cloud
@@ -610,7 +659,8 @@ async function commitProviderSeriesUpdate(
             providerEventId: exception.providerEventId,
             expectedVersion: null,
             content,
-            schedule: occurrenceScheduleAt(
+            schedule: occurrenceScheduleAfterSeriesEdit(
+              master.schedule,
               input.schedule,
               exceptionInstant(exception),
             ),
@@ -619,7 +669,8 @@ async function commitProviderSeriesUpdate(
           });
         }
       } catch (error) {
-        if (error instanceof ProviderWriteError) {
+        if (!(error instanceof ProviderWriteError)) throw error;
+        if (convertsToSingle) {
           if (error.reason === "transient") return command;
           return failCommand(
             deps,
@@ -628,7 +679,14 @@ async function commitProviderSeriesUpdate(
             provider.connectionId,
           );
         }
-        throw error;
+        const stop = await resolveFailedOverrideAlign(
+          deps,
+          command,
+          provider,
+          exception.providerEventId,
+          error,
+        );
+        if (stop) return stop;
       }
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Renaming a recurring Google-linked instance and choosing **All** could make that instance disappear after sync. Edit-all discarded overrides with `deleteEvent`, which Google treats as cancelling the occurrence; the next pull imported the cancellation as a tombstone.

Edit-all now **patches** discarded content/time overrides to match the updated series (keeping them confirmed), and only uses `deleteEvent` when converting a series to a single event. Cancelled tombstones stay untouched.

Follow-up hardening from independent review:
- Missing overrides are treated like delete’s former 404-OK so Apply All can finish after the master write.
- Override schedules apply the series start delta so a time change does not leave Google instances at the old clock time.

## Simplicity

Kept the change in `commitProviderSeriesUpdate` plus a small `resolveFailedOverrideAlign` helper and `occurrenceScheduleAfterSeriesEdit` for the schedule delta. No new provider APIs or un-cancel path.

## Automated validation

- `bun test:sync -- packages/sync/src/domain/provider-command.service.db.test.ts packages/sync/src/domain/occurrence-projection.test.ts` — 82 pass
- `bun run lint` — exit 0 (pre-existing warnings only; none in touched files)

## Independent review

Fresh read-only review of the branch diff:
1. **Fixed:** missing override `permanentProviderError` after master patch — now continues when fetch shows absent/cancelled.
2. **Fixed:** override align ignored series time delta — now uses `occurrenceScheduleAfterSeriesEdit`.
3. Residual risk: a live override that permanently fails for a non-absence reason still fails the command after the master provider write has landed (pre-existing ordering with delete as well).

## Test plan

- `bun test:sync -- packages/sync/src/domain/provider-command.service.db.test.ts packages/sync/src/domain/occurrence-projection.test.ts`
- `bun run lint`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1254e542-7fd7-4b6e-aa51-f68821e6801f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1254e542-7fd7-4b6e-aa51-f68821e6801f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

