### PR TITLE
fix(web): clean up grid mouse-down listeners on unmount

### DIFF
--- a/packages/web/src/views/Week/hooks/grid/useGridEventMouseDown.test.tsx
+++ b/packages/web/src/views/Week/hooks/grid/useGridEventMouseDown.test.tsx
@@ -1,0 +1,69 @@
+import { act, renderHook } from "@testing-library/react";
+import { type MouseEvent as ReactMouseEvent } from "react";
+import { type GridEvent } from "@web/common/types/web.event.types";
+import { INTERACTION_HOLD_DELAY_MS } from "@web/interaction/interaction.constants";
+import { useGridEventMouseDown } from "@web/views/Week/hooks/grid/useGridEventMouseDown";
+import { describe, expect, it, mock } from "bun:test";
+
+const gridEvent = { _id: "event-1" } as GridEvent;
+
+const pressEvent = (target: HTMLElement) =>
+  ({
+    stopPropagation: () => {},
+    currentTarget: target,
+    clientX: 10,
+    clientY: 20,
+  }) as unknown as ReactMouseEvent;
+
+describe("useGridEventMouseDown", () => {
+  it("removes document listeners and cancels the hold timer on unmount", () => {
+    const onClick = mock(() => {});
+    const onDrag = mock(() => {});
+    const { result, unmount } = renderHook(() =>
+      useGridEventMouseDown(onClick, onDrag, INTERACTION_HOLD_DELAY_MS),
+    );
+
+    const target = document.createElement("div");
+    document.body.appendChild(target);
+
+    act(() => {
+      result.current.onMouseDown(pressEvent(target), gridEvent);
+    });
+
+    unmount();
+
+    act(() => {
+      document.dispatchEvent(
+        new MouseEvent("mousemove", { clientX: 100, clientY: 100 }),
+      );
+      document.dispatchEvent(new MouseEvent("mouseup"));
+    });
+
+    expect(onClick).not.toHaveBeenCalled();
+    expect(onDrag).not.toHaveBeenCalled();
+    target.remove();
+  });
+
+  it("still clicks on a quick press and release", () => {
+    const onClick = mock(() => {});
+    const onDrag = mock(() => {});
+    const { result } = renderHook(() =>
+      useGridEventMouseDown(onClick, onDrag, INTERACTION_HOLD_DELAY_MS),
+    );
+
+    const target = document.createElement("div");
+    document.body.appendChild(target);
+
+    act(() => {
+      result.current.onMouseDown(pressEvent(target), gridEvent);
+    });
+
+    act(() => {
+      document.dispatchEvent(new MouseEvent("mouseup"));
+    });
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(onDrag).not.toHaveBeenCalled();
+    target.remove();
+  });
+});

--- a/packages/web/src/views/Week/hooks/grid/useGridEventMouseDown.ts
+++ b/packages/web/src/views/Week/hooks/grid/useGridEventMouseDown.ts
@@ -1,4 +1,4 @@
-import { type MouseEvent as ReactMouseEvent, useRef } from "react";
+import { type MouseEvent as ReactMouseEvent, useEffect, useRef } from "react";
 import { type PartialMouseEvent } from "@web/common/types/util.types";
 import { type GridEvent } from "@web/common/types/web.event.types";
 import { isEventFormOpen } from "@web/events/stores/draft.store";
@@ -11,6 +11,10 @@ import { hasExceededInteractionMoveThreshold } from "@web/interaction/interactio
 type HandleDragHandlers = {
   onMouseMove: (e: MouseEvent) => void;
   onMouseUp: () => void;
+};
+
+type ActivePress = {
+  cleanup: () => void;
 };
 
 /**
@@ -31,6 +35,14 @@ export const useGridEventMouseDown = (
   const timeoutId = useRef<NodeJS.Timeout | null>(null);
   const mouseMoved = useRef<boolean>(false);
   const targetRef = useRef<EventTarget | null>(null);
+  const activePressRef = useRef<ActivePress | null>(null);
+
+  useEffect(() => {
+    return () => {
+      activePressRef.current?.cleanup();
+      activePressRef.current = null;
+    };
+  }, []);
 
   const cleanup = (
     onMouseMove: (e: MouseEvent) => void,
@@ -38,9 +50,11 @@ export const useGridEventMouseDown = (
   ) => {
     if (timeoutId.current) {
       clearTimeout(timeoutId.current);
+      timeoutId.current = null;
     }
     document.removeEventListener("mousemove", onMouseMove);
     document.removeEventListener("mouseup", onMouseUp);
+    activePressRef.current = null;
   };
 
   const handleDrag = (
@@ -67,6 +81,8 @@ export const useGridEventMouseDown = (
 
   const onMouseDown = (e: ReactMouseEvent, event: GridEvent) => {
     e.stopPropagation();
+    activePressRef.current?.cleanup();
+
     targetRef.current = e.currentTarget;
     const initialX = e.clientX;
     const initialY = e.clientY;
@@ -83,6 +99,7 @@ export const useGridEventMouseDown = (
         mouseMoved.current = true;
         if (timeoutId.current) {
           clearTimeout(timeoutId.current);
+          timeoutId.current = null;
         }
         onDrag(event, {
           clientX: moveEvent.clientX,
@@ -96,6 +113,7 @@ export const useGridEventMouseDown = (
     const onMouseUp = () => {
       if (!mouseMoved.current && timeoutId.current) {
         clearTimeout(timeoutId.current);
+        timeoutId.current = null;
         onClick(event);
       }
       cleanup(onMouseMove, onMouseUp);
@@ -116,6 +134,9 @@ export const useGridEventMouseDown = (
 
     document.addEventListener("mousemove", onMouseMove);
     document.addEventListener("mouseup", onMouseUp);
+    activePressRef.current = {
+      cleanup: () => cleanup(onMouseMove, onMouseUp),
+    };
   };
 
   return { onMouseDown };


### PR DESCRIPTION
## Summary
- `useGridEventMouseDown` now cancels its hold timer and removes document `mousemove`/`mouseup` listeners on unmount (and before starting a new press), matching `useTimedDraftCreation`'s gesture cancel pattern.
- Adds focused regression coverage for unmount mid-press and quick click.

## Simplicity
- Smallest hygiene fix for the confirmed leak. Parked for follow-up: consolidating Week draft-drag's three window `mousemove` listeners into a shared pointer source, and extracting `ScrollableRegion` for the shared biome ignore (needs careful ref forwarding on TimedGrid).

## Automated validation
- Browser: page load smoke on localhost:9083/week (welcome/gate limited further manual drag); drag paths covered by e2e.
- Commands below.

## Independent review
- Fresh code-reviewer pass: no ≥80 findings on remaining leaks, double-cleanup races, or click/drag regressions.

## Test plan
- `bun test:web packages/web/src/views/Week/hooks/grid/useGridEventMouseDown.test.tsx` (2/2)
- `bun test:web` (1845/1845)
- `bun test:e2e` (21/21)
- `bun lint` (pre-existing warnings only)