### PR TITLE
refactor(web): restore OverlayPanel focus without setTimeout

### DIFF
--- a/packages/web/src/components/OverlayPanel/OverlayPanel.test.tsx
+++ b/packages/web/src/components/OverlayPanel/OverlayPanel.test.tsx
@@ -105,4 +105,27 @@ describe("OverlayPanel", () => {
     rerender(<button type="button">Outside</button>);
     expect(outside).not.toHaveFocus();
   });
+
+  it("restores focus synchronously via restoreFocus on unmount", () => {
+    const outside = document.createElement("button");
+    outside.type = "button";
+    outside.textContent = "Outside";
+    document.body.appendChild(outside);
+    outside.focus();
+
+    const { unmount } = render(
+      <OverlayPanel
+        title="Confirm"
+        onDismiss={() => {}}
+        restoreFocus={() => outside.focus()}
+      >
+        <button type="button">Inside</button>
+      </OverlayPanel>,
+    );
+    expect(screen.getByRole("button", { name: "Inside" })).toHaveFocus();
+
+    unmount();
+    expect(outside).toHaveFocus();
+    outside.remove();
+  });
 });

--- a/packages/web/src/components/OverlayPanel/OverlayPanel.tsx
+++ b/packages/web/src/components/OverlayPanel/OverlayPanel.tsx
@@ -86,8 +86,10 @@ export const OverlayPanel = ({
     return () => {
       // Read at unmount so callers can suppress restore for dialog handoffs.
       if (skipFocusRestoreRef?.current) return;
-      // Let the Escape key's global handlers finish before restoring focus.
-      if (restoreFocus) setTimeout(restoreFocus);
+      // Sync restore is safe: app-lock is still held during this cleanup
+      // (registered before this effect), so document Escape consumers that
+      // respect the lock stand down. OverlayPanel also stopPropagates Escape.
+      if (restoreFocus) restoreFocus();
       else previouslyFocused?.focus?.();
     };
   }, [restoreFocus, role, skipFocusRestoreRef]);


### PR DESCRIPTION
## Summary
- Remove the `setTimeout` around `OverlayPanel` `restoreFocus` on unmount; restore synchronously like the default `previouslyFocused` path.
- Safe because app-lock is still held during this cleanup (registered before the focus effect) and Escape is stopPropagated on the panel.

## Simplicity
- Ordering fix instead of a delay. Other E6 timers (EventForm, TimePicker, app-init) left untouched — Brief says only when touching that file.

## Automated validation
- FeedbackDialog Escape restore tests still pass with sync restore.
- Commands below.

## Independent review
- Fresh code-reviewer pass: no ≥80 findings on Escape/toast/form focus races.

## Test plan
- `bun test:web` OverlayPanel + Feedback/Logout/Delete/Discard dialogs (24/24)
- `bun test:web` (1846/1846)
- `bun test:e2e` (21/21)
- `bun lint` (pre-existing warnings only)