### PR TITLE
refactor(web): fold clsx into classnames

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -142,7 +142,6 @@
         "@tiptap/starter-kit": "^3.29.2",
         "bson": "^7.2.0",
         "classnames": "^2.3.1",
-        "clsx": "^1.2.1",
         "dexie": "^4.2.1",
         "dompurify": "^3.4.13",
         "fast-deep-equal": "^3.1.3",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -20,7 +20,6 @@
     "@tiptap/starter-kit": "^3.29.2",
     "bson": "^7.2.0",
     "classnames": "^2.3.1",
-    "clsx": "^1.2.1",
     "dexie": "^4.2.1",
     "dompurify": "^3.4.13",
     "fast-deep-equal": "^3.1.3",

--- a/packages/web/src/components/AuthModal/components/AuthButton.tsx
+++ b/packages/web/src/components/AuthModal/components/AuthButton.tsx
@@ -1,4 +1,4 @@
-import clsx from "clsx";
+import classNames from "classnames";
 import { type ButtonHTMLAttributes, type FC } from "react";
 
 interface AuthButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
@@ -30,7 +30,7 @@ export const AuthButton: FC<AuthButtonProps> = ({
   return (
     <button
       disabled={isDisabled}
-      className={clsx(
+      className={classNames(
         "rounded-3xl text-sm transition-all duration-150",
         "focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-transparent",
         isDisabled ? "cursor-not-allowed" : "cursor-pointer",

--- a/packages/web/src/components/AuthModal/components/AuthInput.tsx
+++ b/packages/web/src/components/AuthModal/components/AuthInput.tsx
@@ -1,4 +1,4 @@
-import clsx from "clsx";
+import classNames from "classnames";
 import { forwardRef, type InputHTMLAttributes, useId } from "react";
 
 interface AuthInputProps
@@ -40,7 +40,7 @@ export const AuthInput = forwardRef<HTMLInputElement, AuthInputProps>(
         <input
           ref={ref}
           id={inputId}
-          className={clsx(
+          className={classNames(
             "border-border border-b bg-transparent py-2 text-base transition-colors",
             "text-text placeholder:text-text-subtle",
             "focus:border-accent focus:outline-none",

--- a/packages/web/src/components/AuthModal/components/GoogleButton.tsx
+++ b/packages/web/src/components/AuthModal/components/GoogleButton.tsx
@@ -1,4 +1,4 @@
-import clsx from "clsx";
+import classNames from "classnames";
 import type React from "react";
 
 /**
@@ -50,7 +50,7 @@ export const GoogleButton = ({
       onClick={onClick}
       disabled={disabled}
       aria-label={label}
-      className={clsx(
+      className={classNames(
         "inline-flex h-10 items-center justify-center gap-2.5 whitespace-nowrap rounded-full border border-[#1f1f1f] bg-[#fff] px-3 font-medium text-[#1f1f1f] text-sm transition-[background-color,box-shadow,transform] duration-200",
         disabled
           ? "cursor-not-allowed opacity-60"

--- a/packages/web/src/components/OverlayPanel/OverlayPanel.tsx
+++ b/packages/web/src/components/OverlayPanel/OverlayPanel.tsx
@@ -1,4 +1,4 @@
-import clsx from "clsx";
+import classNames from "classnames";
 import {
   type ButtonHTMLAttributes,
   type ReactNode,
@@ -94,14 +94,14 @@ export const OverlayPanel = ({
     };
   }, [restoreFocus, role, skipFocusRestoreRef]);
 
-  const backdropClasses = clsx(
+  const backdropClasses = classNames(
     "fixed inset-0 flex items-center justify-center bg-background/85 backdrop-blur-sm",
     variant === "modal" &&
       "transition-opacity duration-400 ease-out data-closing:opacity-0 motion-reduce:transition-none",
     backdropClassName,
   );
 
-  const panelClasses = clsx(
+  const panelClasses = classNames(
     "flex flex-col",
     align === "start" ? "items-start" : "items-center",
     variant === "modal" && [
@@ -113,11 +113,13 @@ export const OverlayPanel = ({
       "max-w-sm gap-3 rounded-lg border border-border bg-surface/90 px-6 py-5 shadow-lg",
   );
 
-  const titleClasses = clsx(
+  const titleClasses = classNames(
     "m-0 line-clamp-2 w-full min-w-0 font-semibold text-lg text-text",
   );
 
-  const messageClasses = clsx("m-0 whitespace-pre-line text-base text-text");
+  const messageClasses = classNames(
+    "m-0 whitespace-pre-line text-base text-text",
+  );
 
   const handleBackdropClick = (e: React.MouseEvent) => {
     if (onDismiss && e.target === e.currentTarget) {
@@ -207,7 +209,7 @@ export const OverlayPanelActions = ({
   align = "end",
 }: OverlayPanelActionsProps) => (
   <div
-    className={clsx(
+    className={classNames(
       "flex w-full gap-3",
       align === "start" ? "justify-start" : "justify-end",
     )}
@@ -229,7 +231,7 @@ export const OverlayPanelActionButton = ({
   ...buttonProps
 }: OverlayPanelActionButtonProps) => (
   <button
-    className={clsx(
+    className={classNames(
       "h-11 rounded px-4 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-surface-panel disabled:pointer-events-none disabled:opacity-50",
       variant === "primary" &&
         "bg-accent text-on-accent transition hover:brightness-110",


### PR DESCRIPTION
## Summary
- Replace the four remaining `clsx` call sites with `classnames`
- Remove the direct `clsx` dependency from `@compass/web` (transitive use via `react-toastify` remains)

## Test plan
- [x] `bun lint` (warnings only, pre-existing)
- [x] `bun test:web packages/web/src/components/OverlayPanel/OverlayPanel.test.tsx`
- [ ] CI green