### PR TITLE
refactor(web): show db-init toast after paint

### DIFF
--- a/packages/web/src/common/utils/app-init.util.test.ts
+++ b/packages/web/src/common/utils/app-init.util.test.ts
@@ -19,32 +19,39 @@ describe("app-init.util", () => {
   const mockInitializeStorage = mock();
   const { port, mocks } = createTestToastPort();
 
-  const timeoutId = {} as ReturnType<typeof setTimeout>;
-  let setTimeoutSpy: ReturnType<typeof spyOn>;
-  let timeoutCallback: (() => void) | undefined;
+  let rafCallbacks: FrameRequestCallback[];
+  let rafSpy: ReturnType<typeof spyOn>;
 
   beforeEach(() => {
     mockInitializeStorage.mockClear();
     mocks.error.mockClear();
     mocks.toast.mockClear();
     registerToastPort(port);
-    timeoutCallback = undefined;
-    setTimeoutSpy = spyOn(globalThis, "setTimeout").mockImplementation(((
-      callback: TimerHandler,
+    rafCallbacks = [];
+    rafSpy = spyOn(globalThis, "requestAnimationFrame").mockImplementation(((
+      callback: FrameRequestCallback,
     ) => {
-      if (typeof callback === "function") {
-        timeoutCallback = () => callback();
-      }
-      return timeoutId;
-    }) as unknown as typeof setTimeout);
+      rafCallbacks.push(callback);
+      return rafCallbacks.length;
+    }) as typeof requestAnimationFrame);
   });
 
   afterEach(() => {
-    setTimeoutSpy.mockRestore();
+    rafSpy.mockRestore();
   });
 
-  const runToastTimeout = () => {
-    timeoutCallback?.();
+  /** Flush both rAF frames used by `showDbInitErrorToast`. */
+  const runToastAfterPaint = () => {
+    const first = [...rafCallbacks];
+    rafCallbacks = [];
+    for (const callback of first) {
+      callback(0);
+    }
+    const second = [...rafCallbacks];
+    rafCallbacks = [];
+    for (const callback of second) {
+      callback(0);
+    }
   };
 
   describe("initializeDatabaseWithErrorHandling", () => {
@@ -95,14 +102,14 @@ describe("app-init.util", () => {
   });
 
   describe("showDbInitErrorToast", () => {
-    it("should show error toast with correct message after timeout", () => {
+    it("should show error toast with correct message after paint", () => {
       const dbError = new DatabaseInitError("Storage quota exceeded");
 
       showDbInitErrorToast(dbError);
 
       expect(mocks.error).not.toHaveBeenCalled();
 
-      runToastTimeout();
+      runToastAfterPaint();
 
       expect(mocks.error).toHaveBeenCalledWith(
         "Compass can't use offline storage right now: Storage quota exceeded. Your changes won't be saved on this device.",
@@ -117,7 +124,7 @@ describe("app-init.util", () => {
       const dbError = new DatabaseInitError("Database version mismatch");
 
       showDbInitErrorToast(dbError);
-      runToastTimeout();
+      runToastAfterPaint();
 
       expect(mocks.error).toHaveBeenCalledWith(
         expect.stringContaining("Database version mismatch"),
@@ -129,7 +136,7 @@ describe("app-init.util", () => {
       const dbError = new DatabaseInitError("Test error");
 
       showDbInitErrorToast(dbError);
-      runToastTimeout();
+      runToastAfterPaint();
 
       expect(mocks.error).toHaveBeenCalledWith(
         expect.any(String),
@@ -153,7 +160,7 @@ describe("app-init.util", () => {
 
       if (dbInitError) {
         showDbInitErrorToast(dbInitError);
-        runToastTimeout();
+        runToastAfterPaint();
 
         expect(mocks.error).toHaveBeenCalledWith(
           "Compass can't use offline storage right now: Failed to initialize IndexedDB after 3 attempts. Your changes won't be saved on this device.",
@@ -174,7 +181,7 @@ describe("app-init.util", () => {
 
       expect(dbInitError).toBeNull();
 
-      runToastTimeout();
+      runToastAfterPaint();
       expect(mocks.error).not.toHaveBeenCalled();
     });
   });

--- a/packages/web/src/common/utils/app-init.util.ts
+++ b/packages/web/src/common/utils/app-init.util.ts
@@ -33,9 +33,12 @@ export async function initializeDatabaseWithErrorHandling(
   return { dbInitError };
 }
 
-/** Defer toast until after render so the toast container is mounted. */
+/**
+ * Defer toast until after the next paint so ToastContainer from `root.render`
+ * has mounted. Double rAF waits for commit + paint without an arbitrary delay.
+ */
 export function showDbInitErrorToast(dbInitError: DatabaseInitError): void {
-  setTimeout(() => {
+  const show = () => {
     getToast().error(
       `Compass can't use offline storage right now: ${dbInitError.message}. Your changes won't be saved on this device.`,
       {
@@ -43,5 +46,9 @@ export function showDbInitErrorToast(dbInitError: DatabaseInitError): void {
         position: "bottom-right",
       },
     );
-  }, 100);
+  };
+
+  requestAnimationFrame(() => {
+    requestAnimationFrame(show);
+  });
 }


### PR DESCRIPTION
## Summary
- Replace the 100ms `setTimeout` in `showDbInitErrorToast` with double `requestAnimationFrame`
- Keeps toast deferred until after `root.render` commit/paint without a magic delay

## Test plan
- [x] `bun test:web packages/web/src/common/utils/app-init.util.test.ts`
- [x] `bun lint` (warnings only, pre-existing)
- [ ] CI green