### PR TITLE
refactor(web): extract ScrollableRegion for grid scroll a11y

### DIFF
--- a/packages/web/src/components/ScrollableRegion/ScrollableRegion.tsx
+++ b/packages/web/src/components/ScrollableRegion/ScrollableRegion.tsx
@@ -1,0 +1,23 @@
+import { type ComponentPropsWithoutRef, forwardRef } from "react";
+
+type Props = ComponentPropsWithoutRef<"section">;
+
+/**
+ * Keyboard-focusable scroll container (WCAG 2.1.1 / axe
+ * scrollable-region-focusable). Callers own overflow classes and any
+ * focus-ring overlays.
+ */
+export const ScrollableRegion = forwardRef<HTMLElement, Props>(
+  function ScrollableRegion({ children, ...props }, ref) {
+    return (
+      <section
+        {...props}
+        ref={ref}
+        // biome-ignore lint/a11y/noNoninteractiveTabindex: WCAG 2.1.1 requires a scrollable region to be keyboard-focusable (axe's scrollable-region-focusable rule).
+        tabIndex={0}
+      >
+        {children}
+      </section>
+    );
+  },
+);

--- a/packages/web/src/grid/components/TimedGrid.tsx
+++ b/packages/web/src/grid/components/TimedGrid.tsx
@@ -20,6 +20,7 @@ import {
   getHourLabels,
 } from "@web/common/utils/datetime/web.date.util";
 import { getCurrentPercentOfDay } from "@web/common/utils/grid/grid.util";
+import { ScrollableRegion } from "@web/components/ScrollableRegion/ScrollableRegion";
 import {
   EVENT_WIDTH_MINIMUM,
   GRID_MARGIN_LEFT,
@@ -53,7 +54,7 @@ export const TimedGrid: FC<TimedGridProps> = ({
   );
 
   return (
-    <section
+    <ScrollableRegion
       aria-label="Timed events grid"
       // EventGrid renders the visible focus ring as a sibling overlay so it
       // wraps the all-day row and timed grid together and is not clipped by
@@ -61,8 +62,6 @@ export const TimedGrid: FC<TimedGridProps> = ({
       className="peer c-scroll relative min-h-0 w-full flex-1 overflow-y-auto overflow-x-hidden [--scrollbar-width:0px] focus-visible:outline-none"
       id={timedGridId}
       ref={timedGridRef}
-      // biome-ignore lint/a11y/noNoninteractiveTabindex: WCAG 2.1.1 requires a scrollable region to be keyboard-focusable (axe's scrollable-region-focusable rule); tabIndex={-1} previously made a mouse click the only way in.
-      tabIndex={0}
     >
       <CalendarTimeColumn />
       <div
@@ -122,7 +121,7 @@ export const TimedGrid: FC<TimedGridProps> = ({
       </div>
 
       {eventsLayer}
-    </section>
+    </ScrollableRegion>
   );
 };
 

--- a/packages/web/src/views/Week/components/Grid/WeekGridScrollArea.tsx
+++ b/packages/web/src/views/Week/components/Grid/WeekGridScrollArea.tsx
@@ -1,18 +1,17 @@
 import { type FC, type PropsWithChildren } from "react";
 import { ID_WEEK_GRID_SCROLLER } from "@web/common/constants/web.constants";
+import { ScrollableRegion } from "@web/components/ScrollableRegion/ScrollableRegion";
 
 export const WeekGridScrollArea: FC<PropsWithChildren> = ({ children }) => {
   return (
     <div className="relative min-h-0 w-full flex-1">
-      <section
+      <ScrollableRegion
         className="peer h-full w-full overflow-x-auto overflow-y-hidden [overscroll-behavior-x:contain] [scrollbar-width:none] focus-visible:outline-none [&::-webkit-scrollbar]:hidden [&::-webkit-scrollbar]:h-0 [&::-webkit-scrollbar]:w-0"
         aria-label="Week calendar horizontal scroll area"
         id={ID_WEEK_GRID_SCROLLER}
-        // biome-ignore lint/a11y/noNoninteractiveTabindex: WCAG 2.1.1 requires a scrollable region to be keyboard-focusable (axe's scrollable-region-focusable rule); the focus-visible overlay below is already styled for this, tabIndex={-1} just made it unreachable by Tab.
-        tabIndex={0}
       >
         {children}
-      </section>
+      </ScrollableRegion>
       {/* Rendered as a sibling overlay, not an outline on the section itself, so the ring isn't clipped by the section's own overflow-y-hidden (which cuts off the top edge behind the all-day row). */}
       <div className="pointer-events-none absolute inset-0 hidden outline outline-1 outline-[var(--accent)] peer-focus-visible:block" />
     </div>


### PR DESCRIPTION
## Summary
- Add `ScrollableRegion` with the shared `tabIndex={0}` / WCAG scrollable-region pattern
- Use it from `TimedGrid` (ref-forwarding preserved) and `WeekGridScrollArea`

## Test plan
- [x] `bun test:web packages/web/src/grid/components/TimedGrid.test.tsx`
- [x] `bun type-check`
- [x] `bun lint` (no new issues)
- [ ] CI green