### PR TITLE
refactor(web): finish zod v4 imports for leftover modules

### DIFF
--- a/packages/core/src/types/auth.types.ts
+++ b/packages/core/src/types/auth.types.ts
@@ -1,6 +1,6 @@
 import { type Credentials, type TokenPayload } from "google-auth-library";
 import { type User } from "supertokens-node";
-import { z } from "zod";
+import { z } from "zod/v4";
 
 export interface Result_Auth_Compass {
   status: "OK";

--- a/packages/web/src/api/util/api.util.ts
+++ b/packages/web/src/api/util/api.util.ts
@@ -1,4 +1,4 @@
-import { type ZodType } from "zod";
+import { type ZodType } from "zod/v4";
 import { Status } from "@core/errors/status.codes";
 import {
   type GoogleConnectErrorResponse,

--- a/packages/web/src/auth/compass/schemas/auth.schemas.test.ts
+++ b/packages/web/src/auth/compass/schemas/auth.schemas.test.ts
@@ -37,7 +37,7 @@ describe("auth.schemas", () => {
       const result = EmailSchema.safeParse("");
       expect(result.success).toBe(false);
       if (!result.success) {
-        expect(result.error.errors[0].message).toBe("Email is required");
+        expect(result.error.issues[0].message).toBe("Email is required");
       }
     });
 
@@ -45,7 +45,7 @@ describe("auth.schemas", () => {
       const result = EmailSchema.safeParse("not-an-email");
       expect(result.success).toBe(false);
       if (!result.success) {
-        expect(result.error.errors[0].message).toBe(
+        expect(result.error.issues[0].message).toBe(
           "Please enter a valid email address",
         );
       }
@@ -72,7 +72,7 @@ describe("auth.schemas", () => {
       const result = PasswordSchema.safeParse("");
       expect(result.success).toBe(false);
       if (!result.success) {
-        expect(result.error.errors[0].message).toBe("Password is required");
+        expect(result.error.issues[0].message).toBe("Password is required");
       }
     });
 
@@ -80,7 +80,7 @@ describe("auth.schemas", () => {
       const result = PasswordSchema.safeParse("1234567");
       expect(result.success).toBe(false);
       if (!result.success) {
-        expect(result.error.errors[0].message).toBe(
+        expect(result.error.issues[0].message).toBe(
           "Password must be at least 8 characters",
         );
       }
@@ -108,7 +108,7 @@ describe("auth.schemas", () => {
       const result = NameSchema.safeParse("");
       expect(result.success).toBe(false);
       if (!result.success) {
-        expect(result.error.errors[0].message).toBe("Name is required");
+        expect(result.error.issues[0].message).toBe("Name is required");
       }
     });
 

--- a/packages/web/src/auth/compass/schemas/auth.schemas.ts
+++ b/packages/web/src/auth/compass/schemas/auth.schemas.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v4";
 
 /**
  * Email validation schema

--- a/packages/web/src/auth/compass/state/auth.state.util.ts
+++ b/packages/web/src/auth/compass/state/auth.state.util.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v4";
 import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
 import { persistentBrowserStore } from "@web/common/storage/browser-key-value.store";
 import { subscribeToStorageKey } from "@web/common/utils/external-store.util";

--- a/packages/web/src/auth/google/authorization/google-authorization.storage.ts
+++ b/packages/web/src/auth/google/authorization/google-authorization.storage.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v4";
 import { sessionBrowserStore } from "@web/common/storage/browser-key-value.store";
 import {
   GOOGLE_AUTH_INTENT_MAX_AGE_MS,

--- a/packages/web/src/calendars/calendar-visibility.storage.ts
+++ b/packages/web/src/calendars/calendar-visibility.storage.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v4";
 import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
 import { persistentBrowserStore } from "@web/common/storage/browser-key-value.store";
 

--- a/packages/web/src/calendars/collapsed-accounts.storage.ts
+++ b/packages/web/src/calendars/collapsed-accounts.storage.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v4";
 import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
 import { persistentBrowserStore } from "@web/common/storage/browser-key-value.store";
 

--- a/packages/web/src/common/constants/env.constants.ts
+++ b/packages/web/src/common/constants/env.constants.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v4";
 import { isDev } from "@core/util/env.util";
 
 export const getApiBaseUrl = (apiBaseUrl?: string, port?: string): string => {

--- a/packages/web/src/components/AuthModal/hooks/useZodForm.ts
+++ b/packages/web/src/components/AuthModal/hooks/useZodForm.ts
@@ -5,7 +5,7 @@ import {
   useMemo,
   useState,
 } from "react";
-import { type z } from "zod";
+import { type z } from "zod/v4";
 
 /**
  * Extracts field errors from a ZodError as Record<field, firstMessage>
@@ -22,7 +22,7 @@ function getFieldErrors(error: z.ZodError): Record<string, string> {
 
 export interface UseZodFormConfig<TValues extends Record<string, string>> {
   /** Zod schema - output type must match TValues */
-  schema: z.ZodType<TValues, z.ZodTypeDef, unknown>;
+  schema: z.ZodType<TValues, unknown>;
   initialValues: TValues;
   onSubmit: (data: TValues) => void | Promise<void>;
 }

--- a/packages/web/src/components/CommandPalette/recent-commands.storage.ts
+++ b/packages/web/src/components/CommandPalette/recent-commands.storage.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v4";
 import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
 import { persistentBrowserStore } from "@web/common/storage/browser-key-value.store";
 

--- a/packages/web/src/components/Sidebar/SidebarActions/useVersionCheck.ts
+++ b/packages/web/src/components/Sidebar/SidebarActions/useVersionCheck.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { z } from "zod";
+import { z } from "zod/v4";
 import * as envConstants from "@web/common/constants/env.constants";
 import { APP_VERSION } from "@web/common/constants/version.constants";
 import { useVisibleAfterHidden } from "@web/common/hooks/useVisibleAfterHidden";

--- a/packages/web/src/views/Life/life-preferences.storage.ts
+++ b/packages/web/src/views/Life/life-preferences.storage.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v4";
 import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
 import { persistentBrowserStore } from "@web/common/storage/browser-key-value.store";
 import {


### PR DESCRIPTION
## Summary
- Migrate remaining web `zod` imports to `zod/v4`
- Update core `auth.types.ts` so shared schemas share the same ZodType surface
- Adjust `useZodForm` generics and auth schema tests for Zod 4 (`ZodType` / `.issues`)

## Test plan
- [x] `bun type-check`
- [x] AuthModal + auth.schemas tests (67 pass)
- [ ] CI green