### PR TITLE
refactor(web): close EventForm via queueMicrotask

### DIFF
--- a/packages/web/src/views/Forms/EventForm/EventForm.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.tsx
@@ -406,9 +406,9 @@ export const EventForm: React.FC<GridEventFormProps> = memo(
     };
 
     const onClose = useCallback(() => {
-      setTimeout(() => {
-        _onClose();
-      }, 1);
+      // Defer past the current event turn so menu/Escape handlers finish
+      // before the form unmounts — without an arbitrary delay.
+      queueMicrotask(_onClose);
     }, [_onClose]);
 
     const onDeleteEvent = useCallback(() => {


### PR DESCRIPTION
## Summary
- Replace EventForm’s `setTimeout(_onClose, 1)` with `queueMicrotask(_onClose)`
- Still defers unmount past the current Escape/menu turn; drops the arbitrary delay

## Test plan
- [x] `bun test:web` (1846)
- [x] `bun test:e2e` (21)
- [x] Independent review clean
- [x] `bun lint` (warnings only)
- [ ] CI green + staging deploy watch