### PR TITLE
refactor(web): stamp registry ids on read-only event cards

### DIFF
--- a/e2e/calendars/calendar-experience.spec.ts
+++ b/e2e/calendars/calendar-experience.spec.ts
@@ -446,14 +446,19 @@ test("a read-only event blocks a drag attempt", async ({ page }) => {
   await card.scrollIntoViewIfNeeded();
 
   // isEventReadOnly (useCalendarLookup.ts) fails OPEN as writable until the
-  // authenticated calendars query resolves, so the card can briefly render
-  // interactive right after setupCalendarExperiencePage returns (its own
-  // wait only confirms the sidebar reflects the refetch, not this card's
-  // next render). Wait for the read-only gate's actual DOM signal - the
-  // absence of the interaction-registry id attribute
-  // (WEEK_INTERACTION_EVENT_ID_ATTRIBUTE in weekEventRegistry.ts) - before
-  // dragging, so the drag itself isn't racing that same settling window.
-  await expect(card).not.toHaveAttribute("data-week-interaction-event-id");
+  // authenticated calendars query resolves, so the card can briefly register
+  // for drag/resize right after setupCalendarExperiencePage returns (its
+  // own wait only confirms the sidebar reflects the refetch, not this
+  // card's next render). Id attrs now stamp even for read-only cards; wait
+  // for the calendar-name accessible suffix instead - that only appears
+  // once the multi-calendar lookup that drives isReadOnly has settled.
+  await expect(card).toHaveAttribute(
+    "data-week-interaction-event-id",
+    EVENT_B_ID,
+  );
+  await expect(card).toHaveAccessibleName(
+    new RegExp(`${EVENT_B_TITLE}.*${CALENDAR_B_NAME} calendar`),
+  );
 
   const box = await card.boundingBox();
   if (!box) {
@@ -462,7 +467,7 @@ test("a read-only event blocks a drag attempt", async ({ page }) => {
   const cx = box.x + box.width / 2;
   const cy = box.y + box.height / 2;
 
-  // A read-only card has no interaction-registry entry (packet 08 step 8),
+  // A read-only card has no drag/resize registry entry (packet 08 step 8),
   // so this never becomes a real move - no mutation fires and the card
   // stays exactly where it was.
   await page.mouse.move(cx, cy);

--- a/e2e/timed/move-event-reduced-days.spec.ts
+++ b/e2e/timed/move-event-reduced-days.spec.ts
@@ -35,7 +35,7 @@ test("aligns the mid-drag visual and drops on the hovered day at a reduced day c
   expect(dayDates).toHaveLength(columns.length);
 
   const savedEvent = page
-    .locator('#timedEvents [role="button"][data-event-id]')
+    .locator('#timedEvents [role="button"][data-week-interaction-event-id]')
     .filter({ hasText: title });
   const eventBox = await savedEvent.boundingBox();
   if (!eventBox) {

--- a/packages/web/src/common/constants/web.constants.ts
+++ b/packages/web/src/common/constants/web.constants.ts
@@ -11,7 +11,6 @@ export const ID_MAIN = "mainSection";
 export const ID_DATEPICKER_SIDEBAR = "sidebarDatePicker";
 export const ID_SIDEBAR = "sidebar";
 export const ID_EVENT_FORM_ACTION_MENU = "event-action-menu";
-export const DATA_EVENT_ELEMENT_ID = "data-event-id";
 export const DATA_TIMED_GRID_ROW = "data-calendar-timed-grid-row";
 export const ID_CONTEXT_MENU_ITEMS = "context-menu-items";
 

--- a/packages/web/src/common/utils/event/event.util.test.ts
+++ b/packages/web/src/common/utils/event/event.util.test.ts
@@ -4,7 +4,6 @@ import { createMockStandaloneEvent } from "@core/util/test/ccal.event.factory";
 import { createTestToastPort } from "@web/__tests__/helpers/web-test-seams";
 import { type ApiError, type ApiResponse } from "@web/api/api.types";
 import { GENERIC_ERROR_TOAST_ID } from "@web/common/constants/toast.constants";
-import { DATA_EVENT_ELEMENT_ID } from "@web/common/constants/web.constants";
 import { type GridEvent } from "@web/common/types/web.event.types";
 import {
   addId,
@@ -12,6 +11,7 @@ import {
   refocusEventElement,
 } from "@web/common/utils/event/event.util";
 import { registerToastPort } from "@web/common/utils/toast/toast.port";
+import { WEEK_INTERACTION_EVENT_ID_ATTRIBUTE } from "@web/views/Week/interaction/registry/week-event.registry";
 import {
   afterEach,
   beforeEach,
@@ -213,7 +213,7 @@ describe("refocusEventElement", () => {
 
   const addEventElement = () => {
     const element = document.createElement("div");
-    element.setAttribute(DATA_EVENT_ELEMENT_ID, EVENT_ID);
+    element.setAttribute(WEEK_INTERACTION_EVENT_ID_ATTRIBUTE, EVENT_ID);
     element.tabIndex = 0;
     document.body.appendChild(element);
     return element;

--- a/packages/web/src/common/utils/event/event.util.ts
+++ b/packages/web/src/common/utils/event/event.util.ts
@@ -13,7 +13,6 @@ import { isBackendUnavailableError } from "@web/api/util/backend-unavailable-err
 import { getUserId } from "@web/auth/compass/session/session.util";
 import { getPosthogClient } from "@web/auth/posthog/posthog.bootstrap";
 import { GENERIC_ERROR_TOAST_ID } from "@web/common/constants/toast.constants";
-import { DATA_EVENT_ELEMENT_ID } from "@web/common/constants/web.constants";
 import { type PartialMouseEvent } from "@web/common/types/util.types";
 import {
   Categories_Event,
@@ -22,6 +21,10 @@ import {
 } from "@web/common/types/web.event.types";
 import { createObjectIdString } from "@web/common/utils/id/object-id.util";
 import { showErrorToast } from "@web/common/utils/toast/error-toast.util";
+import {
+  calendarEventIdValueSelector,
+  readCalendarEventIdFromElement,
+} from "@web/grid/interaction/view-event-registry";
 
 export const gridEventDefaultPosition: GridEvent["position"] = {
   isOverlapping: false,
@@ -117,17 +120,15 @@ export const getEventDragOffset = (
   };
 };
 
-export const getCalendarEventIdFromElement = (element: HTMLElement) => {
-  const eventElement = element.closest(`[${DATA_EVENT_ELEMENT_ID}]`);
-  return eventElement ? eventElement.getAttribute(DATA_EVENT_ELEMENT_ID) : null;
-};
+export const getCalendarEventIdFromElement = (element: HTMLElement) =>
+  readCalendarEventIdFromElement(element);
 
 /**
  * Refocuses an event's element after React replaces it. Retries across
  * animation frames until the new element appears, then focuses it.
  */
 export const refocusEventElement = (eventId: string) => {
-  const selector = `[${DATA_EVENT_ELEMENT_ID}="${eventId}"]`;
+  const selector = calendarEventIdValueSelector(eventId);
   const staleElement = document.querySelector(selector);
   let attemptsLeft = 30;
 

--- a/packages/web/src/components/ContextMenu/GridContextMenuWrapper.tsx
+++ b/packages/web/src/components/ContextMenu/GridContextMenuWrapper.tsx
@@ -49,10 +49,10 @@ export const ContextMenuWrapper = ({
   });
 
   const getDraftForEvent = (eventId: string): GridEventDraft | null => {
-    // The id comes from the DOM (`data-event-id`), which can legitimately
-    // disagree with the react-query cache: an in-progress grid draft renders
-    // with `draft.clientId`/its edited source id (never cached), so match it
-    // directly rather than looking it up.
+    // The id comes from the DOM (view-registry interaction id attrs), which
+    // can legitimately disagree with the react-query cache: an in-progress
+    // grid draft renders with `draft.clientId`/its edited source id (never
+    // cached), so match it directly rather than looking it up.
     if (gridDraft && getGridDraftId(gridDraft) === eventId) {
       return gridDraft;
     }

--- a/packages/web/src/components/ContextMenu/contextMenuLayering.test.tsx
+++ b/packages/web/src/components/ContextMenu/contextMenuLayering.test.tsx
@@ -8,16 +8,15 @@ import {
 import { toNormalizedEventQueryData } from "@web/__tests__/utils/event-query-test-data";
 import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
 import { createCompassQueryClient } from "@web/api/query-client";
-import {
-  DATA_EVENT_ELEMENT_ID,
-  Z_INDEX_FLOATING_MENU,
-} from "@web/common/constants/web.constants";
+import { Z_INDEX_FLOATING_MENU } from "@web/common/constants/web.constants";
 import { type GridEvent } from "@web/common/types/web.event.types";
 import { gridEventDefaultPosition } from "@web/common/utils/event/event.util";
 import { ContextMenuWrapper } from "@web/components/ContextMenu/GridContextMenuWrapper";
 import { eventQueryKeys } from "@web/events/queries/event.query.keys";
 import { draftActions } from "@web/events/stores/draft.store";
 import { useDayCalendarContextMenu } from "@web/views/Day/components/Calendar/DayCalendarContextMenu";
+import { DAY_INTERACTION_EVENT_ID_ATTRIBUTE } from "@web/views/Day/interaction/registry/day-event.registry";
+import { WEEK_INTERACTION_EVENT_ID_ATTRIBUTE } from "@web/views/Week/interaction/registry/week-event.registry";
 import { afterEach, describe, expect, it } from "bun:test";
 import "@testing-library/jest-dom";
 
@@ -82,7 +81,9 @@ describe("context menu layering", () => {
       <ContextMenuWrapper id={WRAPPER_ID}>
         {/* Stands in for an event card: the wrapper reads the id off the
             right-clicked element. */}
-        <div {...{ [DATA_EVENT_ELEMENT_ID]: event.id }}>Stacked event</div>
+        <div {...{ [WEEK_INTERACTION_EVENT_ID_ATTRIBUTE]: event.id }}>
+          Stacked event
+        </div>
       </ContextMenuWrapper>,
       { queryClient: seedCacheEntry() },
     );
@@ -99,7 +100,9 @@ describe("context menu layering", () => {
   it("ignores a right-click on an event that isn't in the cache", () => {
     render(
       <ContextMenuWrapper id={WRAPPER_ID}>
-        <div {...{ [DATA_EVENT_ELEMENT_ID]: "not-in-cache" }}>Orphan event</div>
+        <div {...{ [WEEK_INTERACTION_EVENT_ID_ATTRIBUTE]: "not-in-cache" }}>
+          Orphan event
+        </div>
       </ContextMenuWrapper>,
       { queryClient: createCompassQueryClient() },
     );
@@ -124,7 +127,9 @@ describe("context menu layering", () => {
       return (
         // biome-ignore lint/a11y/noStaticElementInteractions: stands in for the day grid, which forwards right-clicks from its cards.
         <div id={WRAPPER_ID} onContextMenu={handleContextMenu}>
-          <div {...{ [DATA_EVENT_ELEMENT_ID]: event.id }}>Stacked event</div>
+          <div {...{ [DAY_INTERACTION_EVENT_ID_ATTRIBUTE]: event.id }}>
+            Stacked event
+          </div>
           {contextMenu}
         </div>
       );

--- a/packages/web/src/events/mutations/useUndoRedo.ts
+++ b/packages/web/src/events/mutations/useUndoRedo.ts
@@ -3,7 +3,6 @@ import { useCallback } from "react";
 import { type EventId } from "@core/types/domain-primitives";
 import { type Event } from "@core/types/event.contracts";
 import { UNDO_DECLINED_TOAST_ID } from "@web/common/constants/toast.constants";
-import { DATA_EVENT_ELEMENT_ID } from "@web/common/constants/web.constants";
 import {
   showRestoredToast,
   showRestoreFailedToast,
@@ -34,6 +33,7 @@ import {
   undoHistoryActions,
   useUndoHistoryStore,
 } from "@web/events/stores/undo.store";
+import { calendarEventIdValueSelector } from "@web/grid/interaction/view-event-registry";
 
 const isCreateEntry = (
   entry: UndoHistoryEntry,
@@ -58,7 +58,7 @@ const refocusAfterReplay = (eventId: string) => {
   let attempts = 0;
   const tryFocus = () => {
     const element = document.querySelector<HTMLElement>(
-      `[${DATA_EVENT_ELEMENT_ID}="${eventId}"]`,
+      calendarEventIdValueSelector(eventId),
     );
     if (element) {
       element.focus();

--- a/packages/web/src/grid/components/AllDayEventCard.tsx
+++ b/packages/web/src/grid/components/AllDayEventCard.tsx
@@ -9,10 +9,7 @@ import {
 import dayjs from "@core/util/date/dayjs";
 import { isRecurringEvent } from "@core/util/event/event.util";
 import { type CalendarCardIdentity } from "@web/calendars/useCalendarLookup";
-import {
-  DATA_EVENT_ELEMENT_ID,
-  ZIndex,
-} from "@web/common/constants/web.constants";
+import { ZIndex } from "@web/common/constants/web.constants";
 import { brighten, darken, isDark } from "@web/common/styles/color.utils";
 import { theme } from "@web/common/styles/theme";
 import { useEventPalette } from "@web/common/styles/theme.util";
@@ -121,7 +118,6 @@ const AllDayEventCardBase = (
   return (
     // biome-ignore lint/a11y/useSemanticElements: All-day events are draggable/resizable blocks, not native buttons.
     <div
-      {...{ [DATA_EVENT_ELEMENT_ID]: event._id }}
       {...interactionAttributes}
       aria-label={accessibleLabel}
       ref={ref}

--- a/packages/web/src/grid/components/EventCard.test.tsx
+++ b/packages/web/src/grid/components/EventCard.test.tsx
@@ -66,7 +66,6 @@ describe("EventCard", () => {
       name: "Timed event: Planning block, 9 - 10 AM",
     });
     expect(card).not.toHaveAttribute("aria-disabled");
-    expect(card).toHaveAttribute("data-event-id", "event-1");
     expect(card).toHaveAttribute("data-week-interaction-event-id", "event-1");
     expect(screen.getByText("Planning block")).toBeInTheDocument();
 
@@ -359,7 +358,7 @@ describe("EventCard", () => {
       name: "All-day event: Conference",
     });
     expect(card).not.toHaveAttribute("aria-disabled");
-    expect(card).toHaveAttribute("data-event-id", "event-1");
+    expect(card).toHaveAttribute("data-week-interaction-event-id", "event-2");
     expect(card).toHaveAttribute("data-week-interaction-event-type", "all-day");
     expect(screen.getByText("Conference")).toBeInTheDocument();
 

--- a/packages/web/src/grid/components/TimedEventCard.tsx
+++ b/packages/web/src/grid/components/TimedEventCard.tsx
@@ -10,10 +10,7 @@ import {
 import dayjs from "@core/util/date/dayjs";
 import { isRecurringEvent } from "@core/util/event/event.util";
 import { type CalendarCardIdentity } from "@web/calendars/useCalendarLookup";
-import {
-  DATA_EVENT_ELEMENT_ID,
-  ZIndex,
-} from "@web/common/constants/web.constants";
+import { ZIndex } from "@web/common/constants/web.constants";
 import { brighten, darken, isDark } from "@web/common/styles/color.utils";
 import { theme } from "@web/common/styles/theme";
 import { useEventPalette } from "@web/common/styles/theme.util";
@@ -248,7 +245,6 @@ const TimedEventCardBase = (
   return (
     // biome-ignore lint/a11y/useSemanticElements: Grid events are draggable/resizable blocks, not native buttons.
     <div
-      {...{ [DATA_EVENT_ELEMENT_ID]: event._id }}
       {...interactionAttributes}
       aria-label={accessibleLabel}
       ref={ref}

--- a/packages/web/src/grid/interaction/view-event-registry.test.ts
+++ b/packages/web/src/grid/interaction/view-event-registry.test.ts
@@ -1,8 +1,31 @@
-import { createViewInteractionRegistry } from "./view-event-registry";
+import {
+  calendarEventIdElementSelector,
+  calendarEventIdValueSelector,
+  createViewInteractionRegistry,
+  readCalendarEventIdFromElement,
+} from "./view-event-registry";
 import { afterEach, describe, expect, it } from "bun:test";
 
 afterEach(() => {
   document.body.innerHTML = "";
+});
+
+describe("calendar event id DOM helpers", () => {
+  it("reads a day or week interaction id from an element or its ancestor", () => {
+    const weekCard = document.createElement("div");
+    weekCard.setAttribute("data-week-interaction-event-id", "week-event");
+    const child = document.createElement("span");
+    weekCard.append(child);
+    document.body.append(weekCard);
+
+    expect(readCalendarEventIdFromElement(child)).toBe("week-event");
+    expect(calendarEventIdElementSelector()).toContain(
+      "data-day-interaction-event-id",
+    );
+    expect(calendarEventIdValueSelector("week-event")).toContain(
+      '[data-week-interaction-event-id="week-event"]',
+    );
+  });
 });
 
 describe("createViewInteractionRegistry", () => {

--- a/packages/web/src/grid/interaction/view-event-registry.ts
+++ b/packages/web/src/grid/interaction/view-event-registry.ts
@@ -30,6 +30,43 @@ export const viewInteractionAttributeNames = (viewName: string) => ({
 });
 
 /**
+ * Day and Week are sibling routes and never co-mounted, so a DOM query can
+ * safely accept either view's id attribute. Used by context menus, undo
+ * focus-restore, and other callers that need an event id without knowing
+ * which view rendered the card.
+ */
+export const CALENDAR_VIEW_INTERACTION_ID_ATTRIBUTES = [
+  viewInteractionAttributeNames("day").idAttribute,
+  viewInteractionAttributeNames("week").idAttribute,
+] as const;
+
+export const calendarEventIdElementSelector = () =>
+  CALENDAR_VIEW_INTERACTION_ID_ATTRIBUTES.map((attr) => `[${attr}]`).join(", ");
+
+export const calendarEventIdValueSelector = (eventId: string) =>
+  CALENDAR_VIEW_INTERACTION_ID_ATTRIBUTES.map(
+    (attr) => `[${attr}="${eventId}"]`,
+  ).join(", ");
+
+export const readCalendarEventIdFromElement = (
+  element: HTMLElement,
+): string | null => {
+  const eventElement = element.closest(calendarEventIdElementSelector());
+  if (!eventElement) {
+    return null;
+  }
+
+  for (const attr of CALENDAR_VIEW_INTERACTION_ID_ATTRIBUTES) {
+    const eventId = eventElement.getAttribute(attr);
+    if (eventId) {
+      return eventId;
+    }
+  }
+
+  return null;
+};
+
+/**
  * One interaction registry per calendar view (Day, Week), namespaced by
  * `data-${viewName}-interaction-event-*` attributes so a view only ever
  * resolves its own DOM nodes. Day and Week previously hand-rolled identical

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarEventCards.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarEventCards.tsx
@@ -52,28 +52,29 @@ export const DayAllDayCalendarEvent = ({
   onOpenEvent,
   visibleDates,
 }: DayEventCardProps) => {
-  // Read-only events never register as an interaction target below, so the
-  // drag/resize engine can't find them - blocked before any optimistic
-  // state change reaches the store (packet 08 step 8).
-  const isRegistered = Boolean(event._id) && !isPlaceholder && !isReadOnly;
+  // Stamp view-registry id attrs for any saved card (including read-only) so
+  // context menus / focus restore can resolve an id. Drag/resize stays gated
+  // separately: registry registration + hover targeting require !isReadOnly.
+  const hasEventIdentity = Boolean(event._id) && !isPlaceholder;
+  const isRegisteredForDragResize = hasEventIdentity && !isReadOnly;
   const registrationRef = useDayEventRegistrationRef({
     eventId: event._id,
     eventType: "all-day",
-    isEnabled: isRegistered,
+    isEnabled: isRegisteredForDragResize,
   });
   const interactionAttributes = useMemo(
     () =>
-      isRegistered
+      hasEventIdentity
         ? getDayInteractionTargetAttributes({
             eventId: event._id,
             eventType: "all-day",
           })
         : undefined,
-    [event._id, isRegistered],
+    [event._id, hasEventIdentity],
   );
-  // Being unregistered above also means the interaction engine's own click
-  // resolution never fires, so a read-only card would otherwise stop being
-  // clickable - events must stay inspectable even when they can't be
+  // Unregistered for drag/resize also means the interaction engine's own
+  // click resolution never fires, so a read-only card would otherwise stop
+  // being clickable - events must stay inspectable even when they can't be
   // mutated. Wiring the click straight to the same "open" action the
   // keyboard path uses bypasses the engine entirely for this card.
   const onEventMouseDown = isReadOnly
@@ -97,7 +98,7 @@ export const DayAllDayCalendarEvent = ({
       onEventKeyDown={onOpenEvent}
       onEventMouseDown={onEventMouseDown}
       onMouseEnter={(mouseEvent) => {
-        if (!isRegistered) return;
+        if (!isRegisteredForDragResize) return;
 
         setHoveredDayGridEventTarget(mouseEvent.currentTarget);
       }}
@@ -127,30 +128,31 @@ export const DayTimedCalendarEvent = ({
   onOpenEvent,
   visibleDates,
 }: DayTimedEventCardProps) => {
-  // Read-only events never register as an interaction target below, so the
-  // drag/resize engine can't find them - blocked before any optimistic
-  // state change reaches the store (packet 08 step 8).
-  const isRegistered = Boolean(event._id) && !isPlaceholder && !isReadOnly;
+  // Stamp view-registry id attrs for any saved card (including read-only) so
+  // context menus / focus restore can resolve an id. Drag/resize stays gated
+  // separately: registry registration + hover targeting require !isReadOnly.
+  const hasEventIdentity = Boolean(event._id) && !isPlaceholder;
+  const isRegisteredForDragResize = hasEventIdentity && !isReadOnly;
   const isDeck = Boolean(deckLayout);
   const [isFocused, setIsFocused] = useState(false);
   const registrationRef = useDayEventRegistrationRef({
     eventId: event._id,
     eventType: "timed",
-    isEnabled: isRegistered,
+    isEnabled: isRegisteredForDragResize,
   });
   const interactionAttributes = useMemo(
     () =>
-      isRegistered
+      hasEventIdentity
         ? getDayInteractionTargetAttributes({
             eventId: event._id,
             eventType: "timed",
           })
         : undefined,
-    [event._id, isRegistered],
+    [event._id, hasEventIdentity],
   );
-  // Being unregistered above also means the interaction engine's own click
-  // resolution never fires, so a read-only card would otherwise stop being
-  // clickable - events must stay inspectable even when they can't be
+  // Unregistered for drag/resize also means the interaction engine's own
+  // click resolution never fires, so a read-only card would otherwise stop
+  // being clickable - events must stay inspectable even when they can't be
   // mutated. Wiring the click straight to the same "open" action the
   // keyboard path uses bypasses the engine entirely for this card.
   const onEventMouseDown = isReadOnly
@@ -192,7 +194,7 @@ export const DayTimedCalendarEvent = ({
       onEventMouseDown={onEventMouseDown}
       onFocus={isDeck ? () => setIsFocused(true) : undefined}
       onMouseEnter={(mouseEvent) => {
-        if (!isRegistered) return;
+        if (!isRegisteredForDragResize) return;
 
         setHoveredDayGridEventTarget(mouseEvent.currentTarget);
       }}

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarEventCards.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarEventCards.tsx
@@ -52,11 +52,13 @@ export const DayAllDayCalendarEvent = ({
   onOpenEvent,
   visibleDates,
 }: DayEventCardProps) => {
-  // Stamp view-registry id attrs for any saved card (including read-only) so
-  // context menus / focus restore can resolve an id. Drag/resize stays gated
-  // separately: registry registration + hover targeting require !isReadOnly.
-  const hasEventIdentity = Boolean(event._id) && !isPlaceholder;
-  const isRegisteredForDragResize = hasEventIdentity && !isReadOnly;
+  // Stamp view-registry id attrs whenever the card has an id (saved, draft,
+  // or read-only) so context menus / focus restore can resolve it.
+  // Drag/resize stays gated: registry registration + hover require a saved,
+  // non-read-only card.
+  const hasEventIdentity = Boolean(event._id);
+  const isRegisteredForDragResize =
+    hasEventIdentity && !isPlaceholder && !isReadOnly;
   const registrationRef = useDayEventRegistrationRef({
     eventId: event._id,
     eventType: "all-day",
@@ -128,11 +130,13 @@ export const DayTimedCalendarEvent = ({
   onOpenEvent,
   visibleDates,
 }: DayTimedEventCardProps) => {
-  // Stamp view-registry id attrs for any saved card (including read-only) so
-  // context menus / focus restore can resolve an id. Drag/resize stays gated
-  // separately: registry registration + hover targeting require !isReadOnly.
-  const hasEventIdentity = Boolean(event._id) && !isPlaceholder;
-  const isRegisteredForDragResize = hasEventIdentity && !isReadOnly;
+  // Stamp view-registry id attrs whenever the card has an id (saved, draft,
+  // or read-only) so context menus / focus restore can resolve it.
+  // Drag/resize stays gated: registry registration + hover require a saved,
+  // non-read-only card.
+  const hasEventIdentity = Boolean(event._id);
+  const isRegisteredForDragResize =
+    hasEventIdentity && !isPlaceholder && !isReadOnly;
   const isDeck = Boolean(deckLayout);
   const [isFocused, setIsFocused] = useState(false);
   const registrationRef = useDayEventRegistrationRef({

--- a/packages/web/src/views/Week/components/Draft/grid/GridDraft.tsx
+++ b/packages/web/src/views/Week/components/Draft/grid/GridDraft.tsx
@@ -22,6 +22,7 @@ import { AllDayEventMemo } from "@web/views/Week/components/Grid/AllDayRow/AllDa
 import { useGridEventMouseDown } from "@web/views/Week/hooks/grid/useGridEventMouseDown";
 import { type Measurements_Grid } from "@web/views/Week/hooks/grid/useGridLayout";
 import { type WeekProps } from "@web/views/Week/hooks/useWeek";
+import { getWeekInteractionTargetAttributes } from "@web/views/Week/interaction/registry/week-event.registry";
 
 interface Props {
   activeAllDayDraftEvent?: GridEventEntity | null;
@@ -93,6 +94,14 @@ export const GridDraft: FC<Props> = ({
     ? (activeAllDayDraftEvent ?? draftToAllDayRowGridEvent(draft))
     : draftAsGridEvent;
 
+  const draftEventType = rendersInAllDayRow ? "all-day" : "timed";
+  const draftInteractionAttributes = draftAsGridEvent._id
+    ? getWeekInteractionTargetAttributes({
+        eventId: draftAsGridEvent._id,
+        eventType: draftEventType,
+      })
+    : undefined;
+
   return (
     <>
       {/* Read-only previews of the other recurrence occurrences in view. They
@@ -102,6 +111,14 @@ export const GridDraft: FC<Props> = ({
         <GridEvent
           displayMode="draft"
           event={preview}
+          interactionAttributes={
+            preview._id
+              ? getWeekInteractionTargetAttributes({
+                  eventId: preview._id,
+                  eventType: "timed",
+                })
+              : undefined
+          }
           key={`draft-preview-${preview.startDate}`}
           measurements={measurements}
           weekProps={weekProps}
@@ -111,6 +128,7 @@ export const GridDraft: FC<Props> = ({
       {rendersInAllDayRow ? (
         <AllDayEventMemo
           event={allDayDraftEvent}
+          interactionAttributes={draftInteractionAttributes}
           isPlaceholder={false}
           key={`draft-${draftAsGridEvent._id}`}
           measurements={measurements}
@@ -133,6 +151,7 @@ export const GridDraft: FC<Props> = ({
           deckLayout={deckLayout}
           displayMode="draft"
           event={draftAsGridEvent}
+          interactionAttributes={draftInteractionAttributes}
           key={`draft-${draftAsGridEvent._id}`}
           measurements={measurements}
           motionMode={motionMode}

--- a/packages/web/src/views/Week/components/Grid/AllDayRow/AllDayEvents.tsx
+++ b/packages/web/src/views/Week/components/Grid/AllDayRow/AllDayEvents.tsx
@@ -147,8 +147,9 @@ const AllDayEventItem = ({
   // Stamp view-registry id attrs for any saved card (including read-only) so
   // context menus / focus restore can resolve an id. Drag/resize stays gated
   // separately via registry registration.
-  const hasEventIdentity = Boolean(event._id) && !isPlaceholder;
-  const isRegisteredForDragResize = hasEventIdentity && !isReadOnly;
+  const hasEventIdentity = Boolean(event._id);
+  const isRegisteredForDragResize =
+    hasEventIdentity && !isPlaceholder && !isReadOnly;
   const registrationRef = useWeekEventRegistrationRef({
     eventId: event._id,
     eventType: "all-day",

--- a/packages/web/src/views/Week/components/Grid/AllDayRow/AllDayEvents.tsx
+++ b/packages/web/src/views/Week/components/Grid/AllDayRow/AllDayEvents.tsx
@@ -144,30 +144,30 @@ const AllDayEventItem = ({
   onOpenReadOnlyDetails,
   weekDays,
 }: AllDayEventItemProps) => {
-  // Read-only events never register as an interaction target below, so the
-  // drag/resize engine can't find them - blocked before any optimistic
-  // state change reaches the store (packet 08 step 8).
-  const isRegisteredForWeekInteraction =
-    Boolean(event._id) && !isPlaceholder && !isReadOnly;
+  // Stamp view-registry id attrs for any saved card (including read-only) so
+  // context menus / focus restore can resolve an id. Drag/resize stays gated
+  // separately via registry registration.
+  const hasEventIdentity = Boolean(event._id) && !isPlaceholder;
+  const isRegisteredForDragResize = hasEventIdentity && !isReadOnly;
   const registrationRef = useWeekEventRegistrationRef({
     eventId: event._id,
     eventType: "all-day",
-    isEnabled: isRegisteredForWeekInteraction,
+    isEnabled: isRegisteredForDragResize,
   });
 
   const interactionAttributes = useMemo(
     () =>
-      isRegisteredForWeekInteraction
+      hasEventIdentity
         ? getWeekInteractionTargetAttributes({
             eventId: event._id,
             eventType: "all-day",
           })
         : undefined,
-    [event._id, isRegisteredForWeekInteraction],
+    [event._id, hasEventIdentity],
   );
-  // Being unregistered above also means the interaction engine's own click
-  // resolution never fires, so a read-only card would otherwise stop being
-  // clickable - events must stay inspectable even when they can't be
+  // Unregistered for drag/resize also means the interaction engine's own
+  // click resolution never fires, so a read-only card would otherwise stop
+  // being clickable - events must stay inspectable even when they can't be
   // mutated. Wiring the click straight to an "open" action bypasses the
   // engine entirely for this card.
   const onMouseDown = isReadOnly

--- a/packages/web/src/views/Week/components/Grid/MainGrid/MainGridEvents.tsx
+++ b/packages/web/src/views/Week/components/Grid/MainGrid/MainGridEvents.tsx
@@ -167,31 +167,30 @@ const MainGridEventItem = ({
   onOpenReadOnlyDetails,
   weekProps,
 }: MainGridEventItemProps) => {
-  // Read-only events never register as an interaction target below, so the
-  // drag/resize engine can't find them - blocked before any optimistic
-  // state change reaches the store (packet 08 step 8). A placeholder is
-  // already mid-drag by its own (necessarily writable) owner, so it's
-  // exempted the same way it always was.
-  const isRegisteredForWeekInteraction =
-    Boolean(event._id) && !isPlaceholder && !isReadOnly;
+  // Stamp view-registry id attrs for any saved card (including read-only) so
+  // context menus / focus restore can resolve an id. Drag/resize stays gated
+  // separately via registry registration. A placeholder is already mid-drag
+  // by its own (necessarily writable) owner, so it stays unstamped.
+  const hasEventIdentity = Boolean(event._id) && !isPlaceholder;
+  const isRegisteredForDragResize = hasEventIdentity && !isReadOnly;
   const registrationRef = useWeekEventRegistrationRef({
     eventId: event._id,
     eventType: "timed",
-    isEnabled: isRegisteredForWeekInteraction,
+    isEnabled: isRegisteredForDragResize,
   });
   const interactionAttributes = useMemo(
     () =>
-      isRegisteredForWeekInteraction
+      hasEventIdentity
         ? getWeekInteractionTargetAttributes({
             eventId: event._id,
             eventType: "timed",
           })
         : undefined,
-    [event._id, isRegisteredForWeekInteraction],
+    [event._id, hasEventIdentity],
   );
-  // Being unregistered above also means the interaction engine's own click
-  // resolution never fires, so a read-only card would otherwise stop being
-  // clickable - events must stay inspectable even when they can't be
+  // Unregistered for drag/resize also means the interaction engine's own
+  // click resolution never fires, so a read-only card would otherwise stop
+  // being clickable - events must stay inspectable even when they can't be
   // mutated. Wiring the click straight to an "open" action bypasses the
   // engine entirely for this card, so it never becomes a drag/resize target
   // no matter how the pointer moves.

--- a/packages/web/src/views/Week/components/Grid/MainGrid/MainGridEvents.tsx
+++ b/packages/web/src/views/Week/components/Grid/MainGrid/MainGridEvents.tsx
@@ -167,12 +167,13 @@ const MainGridEventItem = ({
   onOpenReadOnlyDetails,
   weekProps,
 }: MainGridEventItemProps) => {
-  // Stamp view-registry id attrs for any saved card (including read-only) so
-  // context menus / focus restore can resolve an id. Drag/resize stays gated
-  // separately via registry registration. A placeholder is already mid-drag
-  // by its own (necessarily writable) owner, so it stays unstamped.
-  const hasEventIdentity = Boolean(event._id) && !isPlaceholder;
-  const isRegisteredForDragResize = hasEventIdentity && !isReadOnly;
+  // Stamp view-registry id attrs whenever the card has an id (saved, draft
+  // placeholder, or read-only) so context menus / focus restore can resolve
+  // it. Drag/resize stays gated via registry registration on saved writable
+  // cards only.
+  const hasEventIdentity = Boolean(event._id);
+  const isRegisteredForDragResize =
+    hasEventIdentity && !isPlaceholder && !isReadOnly;
   const registrationRef = useWeekEventRegistrationRef({
     eventId: event._id,
     eventType: "timed",

--- a/packages/web/src/views/Week/components/Grid/MainGrid/eventReadOnlyInteraction.test.tsx
+++ b/packages/web/src/views/Week/components/Grid/MainGrid/eventReadOnlyInteraction.test.tsx
@@ -33,15 +33,11 @@ import { MainGridEvents } from "./MainGridEvents";
 import { afterEach, describe, expect, it, mock } from "bun:test";
 
 // packet 08 step 8: an event on a read-only (unwritable) calendar, or with
-// busy content, must never attach interaction attributes / registry
-// registration - that's the concrete mechanism that stops the drag/resize
-// engine from ever treating it as a target, blocked before any optimistic
-// state change. The resize-handle/interaction-attribute DOM is unlabeled
-// (aria-hidden), so this asserts the "props seam" at the list-component
-// level instead: the interaction-registry id attribute the engine keys off
-// of (WEEK_INTERACTION_EVENT_ID_ATTRIBUTE), mirroring how MainGrid.test.tsx
-// already asserts the writable case ("keeps pending saved events fully
-// interactive").
+// busy content, must never enter the drag/resize registry - that's the
+// concrete mechanism that stops the engine from treating it as a target,
+// blocked before any optimistic state change. Id-bearing view-registry
+// attributes still stamp so context menus / focus restore can resolve the
+// card; registration (`weekEventRegistry.resolve`) is the gate.
 
 let seededEvents: Event[] = [];
 let seededCalendars: Calendar[] = [];
@@ -202,15 +198,17 @@ const renderAllDayEvents = () =>
   );
 
 describe("Week grid read-only interaction gate", () => {
-  it("does not register a read-only-calendar timed event as an interaction target", () => {
+  it("stamps id attrs on a read-only timed event without registering it for drag/resize", () => {
     const readOnlyCalendar = makeCalendar();
     seededCalendars = [readOnlyCalendar];
-    seededEvents = [createTimedEvent(readOnlyCalendar.id)];
+    const event = createTimedEvent(readOnlyCalendar.id);
+    seededEvents = [event];
 
     renderMainGridEvents();
 
     const card = screen.getByRole("button", { name: /shared meeting/i });
-    expect(card).not.toHaveAttribute(WEEK_INTERACTION_EVENT_ID_ATTRIBUTE);
+    expect(card).toHaveAttribute(WEEK_INTERACTION_EVENT_ID_ATTRIBUTE, event.id);
+    expect(weekEventRegistry.resolve(event.id, "timed")).toBeNull();
   });
 
   it("keeps registering a writable-calendar timed event as an interaction target", () => {
@@ -228,19 +226,22 @@ describe("Week grid read-only interaction gate", () => {
 
     const card = screen.getByRole("button", { name: /my focus block/i });
     expect(card).toHaveAttribute(WEEK_INTERACTION_EVENT_ID_ATTRIBUTE, event.id);
+    expect(weekEventRegistry.resolve(event.id, "timed")).toBe(card);
   });
 
-  it("does not register a read-only-calendar all-day event as an interaction target", () => {
+  it("stamps id attrs on a read-only all-day event without registering it for drag/resize", () => {
     const readOnlyCalendar = makeCalendar();
     seededCalendars = [readOnlyCalendar];
-    seededEvents = [createAllDayEvent(readOnlyCalendar.id)];
+    const event = createAllDayEvent(readOnlyCalendar.id);
+    seededEvents = [event];
 
     renderAllDayEvents();
 
     const card = screen.getByRole("button", {
       name: /all-day event: team holiday/i,
     });
-    expect(card).not.toHaveAttribute(WEEK_INTERACTION_EVENT_ID_ATTRIBUTE);
+    expect(card).toHaveAttribute(WEEK_INTERACTION_EVENT_ID_ATTRIBUTE, event.id);
+    expect(weekEventRegistry.resolve(event.id, "all-day")).toBeNull();
   });
 
   it("still opens a read-only all-day event for inspection on click", () => {
@@ -354,13 +355,15 @@ describe("Week grid read-only interaction gate", () => {
       capabilities: getCalendarCapabilities("owner"),
     });
     seededCalendars = [writableCalendar];
-    seededEvents = [
-      createTimedEvent(writableCalendar.id, { content: { kind: "busy" } }),
-    ];
+    const event = createTimedEvent(writableCalendar.id, {
+      content: { kind: "busy" },
+    });
+    seededEvents = [event];
 
     renderMainGridEvents();
 
     const card = screen.getByRole("button", { name: /timed event: busy/i });
-    expect(card).not.toHaveAttribute(WEEK_INTERACTION_EVENT_ID_ATTRIBUTE);
+    expect(card).toHaveAttribute(WEEK_INTERACTION_EVENT_ID_ATTRIBUTE, event.id);
+    expect(weekEventRegistry.resolve(event.id, "timed")).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- Stamp Day/Week view-registry id attrs on saved read-only cards (and drafts) so context menus / focus restore keep working
- Keep drag/resize gated via registry `isEnabled` + mouse handlers (`!isReadOnly`, non-placeholder)
- Remove `DATA_EVENT_ELEMENT_ID` / `data-event-id` from event cards and resolve ids through the registry attrs

## Test plan
- [x] Focused unit tests + read-only interaction tests
- [x] `bun test:web`
- [x] `bun test:e2e` (incl. read-only context menu / drag)
- [x] Independent review finding fixed (draft id stamping)
- [ ] CI + staging deploy watch