### PR TITLE
feat(web): show live day and up-next context in the tab title

### DIFF
--- a/packages/web/src/components/DocumentTitle/DocumentTitle.tsx
+++ b/packages/web/src/components/DocumentTitle/DocumentTitle.tsx
@@ -1,0 +1,7 @@
+import { useDocumentTitle } from "./useDocumentTitle";
+
+/** Headless mount for the live browser tab title. */
+export function DocumentTitle() {
+  useDocumentTitle();
+  return null;
+}

--- a/packages/web/src/components/DocumentTitle/formatDocumentTitle.test.ts
+++ b/packages/web/src/components/DocumentTitle/formatDocumentTitle.test.ts
@@ -1,0 +1,115 @@
+import dayjs from "@core/util/date/dayjs";
+import {
+  DOCUMENT_TITLE_BRAND,
+  formatDocumentTitle,
+  formatViewTitleLabel,
+} from "./formatDocumentTitle";
+import { describe, expect, it } from "bun:test";
+
+const now = dayjs("2026-08-06T15:00:00.000Z");
+
+describe("formatDocumentTitle", () => {
+  it("shows a countdown for an upcoming event", () => {
+    expect(
+      formatDocumentTitle({
+        now,
+        event: {
+          title: "Standup",
+          start: now.add(12, "minute"),
+          end: now.add(42, "minute"),
+        },
+        isCurrentEvent: false,
+        viewLabel: "Wed Aug 6",
+      }),
+    ).toBe(`In 12m: Standup - ${DOCUMENT_TITLE_BRAND}`);
+  });
+
+  it("shows Now for an ongoing event", () => {
+    expect(
+      formatDocumentTitle({
+        now,
+        event: {
+          title: "Standup",
+          start: now.subtract(5, "minute"),
+          end: now.add(25, "minute"),
+        },
+        isCurrentEvent: true,
+        viewLabel: "Wed Aug 6",
+      }),
+    ).toBe(`Now: Standup - ${DOCUMENT_TITLE_BRAND}`);
+  });
+
+  it("rolls upcoming events up to hours", () => {
+    expect(
+      formatDocumentTitle({
+        now,
+        event: {
+          title: "Demo",
+          start: now.add(120, "minute"),
+          end: now.add(150, "minute"),
+        },
+        isCurrentEvent: false,
+        viewLabel: "Wed Aug 6",
+      }),
+    ).toBe(`In 2h: Demo - ${DOCUMENT_TITLE_BRAND}`);
+  });
+
+  it("falls back to the view label when idle", () => {
+    expect(
+      formatDocumentTitle({
+        now,
+        event: null,
+        isCurrentEvent: false,
+        viewLabel: "Wed Aug 6",
+      }),
+    ).toBe(`Wed Aug 6 - ${DOCUMENT_TITLE_BRAND}`);
+  });
+
+  it("uses a placeholder when the event title is blank", () => {
+    expect(
+      formatDocumentTitle({
+        now,
+        event: {
+          title: "  ",
+          start: now.add(5, "minute"),
+          end: now.add(35, "minute"),
+        },
+        isCurrentEvent: false,
+        viewLabel: "Wed Aug 6",
+      }),
+    ).toBe(`In 5m: Event - ${DOCUMENT_TITLE_BRAND}`);
+  });
+});
+
+describe("formatViewTitleLabel", () => {
+  it("formats the day in view", () => {
+    expect(
+      formatViewTitleLabel({
+        pathname: "/day/2026-08-06",
+        dayDateString: "2026-08-06",
+        weekStart: "2026-08-02T00:00:00.000Z",
+        weekEnd: "2026-08-08T23:59:59.999Z",
+      }),
+    ).toBe("Thu Aug 6");
+  });
+
+  it("formats a week range", () => {
+    expect(
+      formatViewTitleLabel({
+        pathname: "/week/2026-08-02",
+        weekStart: "2026-08-02T00:00:00.000Z",
+        weekEnd: "2026-08-08T23:59:59.999Z",
+      }),
+    ).toBe("Aug 2 - 8");
+  });
+
+  it("labels the life view", () => {
+    expect(
+      formatViewTitleLabel({
+        pathname: "/life",
+        weekStart: "2026-08-02T00:00:00.000Z",
+        weekEnd: "2026-08-08T23:59:59.999Z",
+      }),
+    ).toBe("Life");
+  });
+});

--- a/packages/web/src/components/DocumentTitle/formatDocumentTitle.ts
+++ b/packages/web/src/components/DocumentTitle/formatDocumentTitle.ts
@@ -1,0 +1,85 @@
+import dayjs, { type Dayjs } from "@core/util/date/dayjs";
+import { ROOT_ROUTES } from "@web/common/constants/routes";
+
+export const DOCUMENT_TITLE_BRAND = "Compass";
+export const DEFAULT_DOCUMENT_TITLE = "Compass Calendar";
+
+const DATE_FORMAT = dayjs.DateFormat.YEAR_MONTH_DAY_FORMAT;
+
+export type DocumentTitleEvent = {
+  title: string;
+  start: Dayjs;
+  end: Dayjs;
+};
+
+export type FormatDocumentTitleArgs = {
+  now: Dayjs;
+  event: DocumentTitleEvent | null;
+  isCurrentEvent: boolean;
+  viewLabel: string;
+};
+
+/** Compact tab title. Lead with the useful part; tabs truncate early. */
+export function formatDocumentTitle({
+  now,
+  event,
+  isCurrentEvent,
+  viewLabel,
+}: FormatDocumentTitleArgs): string {
+  if (event) {
+    const eventTitle = event.title.trim() || "Event";
+    if (isCurrentEvent) {
+      return `Now: ${eventTitle} - ${DOCUMENT_TITLE_BRAND}`;
+    }
+
+    const minutes = Math.round(event.start.diff(now, "minute", true));
+    if (minutes <= 0) {
+      return `Now: ${eventTitle} - ${DOCUMENT_TITLE_BRAND}`;
+    }
+    if (minutes < 60) {
+      return `In ${minutes}m: ${eventTitle} - ${DOCUMENT_TITLE_BRAND}`;
+    }
+    const hours = Math.round(minutes / 60);
+    return `In ${hours}h: ${eventTitle} - ${DOCUMENT_TITLE_BRAND}`;
+  }
+
+  return `${viewLabel} - ${DOCUMENT_TITLE_BRAND}`;
+}
+
+export type FormatViewTitleLabelArgs = {
+  pathname: string;
+  dayDateString?: string;
+  weekStart: string;
+  weekEnd: string;
+};
+
+/** Idle tab label for the current Day / Week / Life context (no brand suffix). */
+export function formatViewTitleLabel({
+  pathname,
+  dayDateString,
+  weekStart,
+  weekEnd,
+}: FormatViewTitleLabelArgs): string {
+  if (
+    pathname === ROOT_ROUTES.LIFE ||
+    pathname.startsWith(`${ROOT_ROUTES.LIFE}/`)
+  ) {
+    return "Life";
+  }
+
+  if (
+    pathname === ROOT_ROUTES.DAY ||
+    pathname.startsWith(`${ROOT_ROUTES.DAY}/`)
+  ) {
+    const date = dayDateString ? dayjs(dayDateString, DATE_FORMAT) : dayjs();
+    return date.format("ddd MMM D");
+  }
+
+  const start = dayjs(weekStart);
+  const end = dayjs(weekEnd);
+  if (start.isSame(end, "day")) {
+    return start.format("ddd MMM D");
+  }
+  const endFormat = start.month() === end.month() ? "D" : "MMM D";
+  return `${start.format("MMM D")} - ${end.format(endFormat)}`;
+}

--- a/packages/web/src/components/DocumentTitle/useDocumentTitle.test.tsx
+++ b/packages/web/src/components/DocumentTitle/useDocumentTitle.test.tsx
@@ -1,0 +1,140 @@
+import { renderHook } from "@testing-library/react";
+import dayjs from "@core/util/date/dayjs";
+import { initialViewState, useViewStore } from "@web/events/stores/view.store";
+import {
+  DEFAULT_DOCUMENT_TITLE,
+  DOCUMENT_TITLE_BRAND,
+} from "./formatDocumentTitle";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  mock,
+} from "bun:test";
+
+const now = dayjs("2026-08-06T15:00:00.000Z");
+
+const upNextState = {
+  now,
+  upNext: undefined as
+    | {
+        _id: string;
+        title: string;
+        startDate: string;
+        endDate: string;
+      }
+    | undefined,
+  isCurrentEvent: false,
+  openEventDetails: () => {},
+  conferenceUrl: undefined as string | undefined,
+};
+
+// Bun's mock.module is process-wide; flag off in afterAll so later files get
+// the real hook back (same pattern as CommandPalette.test.tsx).
+const actualUpNext = {
+  ...(await import("@web/components/Sidebar/UpNextCard/useUpNextEvent")),
+};
+let isUpNextMocked = true;
+mock.module("@web/components/Sidebar/UpNextCard/useUpNextEvent", () => ({
+  useUpNextEvent: () =>
+    isUpNextMocked
+      ? upNextState
+      : // biome-ignore lint/correctness/useHookAtTopLevel: mock.module factory, not a component
+        actualUpNext.useUpNextEvent(),
+}));
+
+const actualTanstackRouter = { ...(await import("@tanstack/react-router")) };
+const locationState = { pathname: "/week/2026-08-02" };
+const dayParamsState: { dateString?: string } = {};
+let isRouterMocked = true;
+
+mock.module("@tanstack/react-router", () => ({
+  ...actualTanstackRouter,
+  useLocation: (...args: unknown[]) =>
+    isRouterMocked
+      ? locationState
+      : (actualTanstackRouter.useLocation as (...a: unknown[]) => unknown)(
+          ...args,
+        ),
+  useParams: (...args: unknown[]) =>
+    isRouterMocked
+      ? dayParamsState
+      : (actualTanstackRouter.useParams as (...a: unknown[]) => unknown)(
+          ...args,
+        ),
+}));
+
+const { useDocumentTitle } = await import("./useDocumentTitle");
+
+afterAll(() => {
+  isUpNextMocked = false;
+  isRouterMocked = false;
+});
+
+describe("useDocumentTitle", () => {
+  beforeEach(() => {
+    document.title = DEFAULT_DOCUMENT_TITLE;
+    upNextState.now = now;
+    upNextState.upNext = undefined;
+    upNextState.isCurrentEvent = false;
+    locationState.pathname = "/week/2026-08-02";
+    dayParamsState.dateString = undefined;
+    useViewStore.setState(
+      {
+        ...initialViewState,
+        dates: {
+          start: "2026-08-02T00:00:00.000Z",
+          end: "2026-08-08T23:59:59.999Z",
+        },
+      },
+      true,
+    );
+  });
+
+  afterEach(() => {
+    document.title = DEFAULT_DOCUMENT_TITLE;
+  });
+
+  it("sets an idle week title on mount", () => {
+    renderHook(() => useDocumentTitle());
+
+    expect(document.title).toBe(`Aug 2 - 8 - ${DOCUMENT_TITLE_BRAND}`);
+  });
+
+  it("prefers an upcoming event countdown", () => {
+    upNextState.upNext = {
+      _id: "aaaaaaaaaaaaaaaaaaaaaaaa",
+      title: "Standup",
+      startDate: now.add(12, "minute").format(),
+      endDate: now.add(42, "minute").format(),
+    };
+
+    renderHook(() => useDocumentTitle());
+
+    expect(document.title).toBe(`In 12m: Standup - ${DOCUMENT_TITLE_BRAND}`);
+  });
+
+  it("restores the default title on unmount", () => {
+    const { unmount } = renderHook(() => useDocumentTitle());
+
+    expect(document.title).not.toBe(DEFAULT_DOCUMENT_TITLE);
+
+    unmount();
+
+    expect(document.title).toBe(DEFAULT_DOCUMENT_TITLE);
+  });
+
+  it("uses the day route date for the idle title", () => {
+    locationState.pathname = "/day/2026-08-06";
+    dayParamsState.dateString = "2026-08-06";
+
+    renderHook(() => useDocumentTitle());
+
+    expect(document.title).toBe(
+      `${dayjs("2026-08-06", dayjs.DateFormat.YEAR_MONTH_DAY_FORMAT).format("ddd MMM D")} - ${DOCUMENT_TITLE_BRAND}`,
+    );
+  });
+});

--- a/packages/web/src/components/DocumentTitle/useDocumentTitle.ts
+++ b/packages/web/src/components/DocumentTitle/useDocumentTitle.ts
@@ -1,0 +1,54 @@
+import { useLocation, useParams } from "@tanstack/react-router";
+import { useEffect } from "react";
+import dayjs from "@core/util/date/dayjs";
+import { ROUTE_IDS } from "@web/common/constants/routes";
+import { useUpNextEvent } from "@web/components/Sidebar/UpNextCard/useUpNextEvent";
+import { useViewStore } from "@web/events/stores/view.store";
+import {
+  DEFAULT_DOCUMENT_TITLE,
+  formatDocumentTitle,
+  formatViewTitleLabel,
+} from "./formatDocumentTitle";
+
+/**
+ * Sets `document.title` from Up Next (when present) or the current view date.
+ * Mount once under the authenticated root so it shares the same Up Next query
+ * cache as the banner/card (React Query dedupes; each mount still has its own
+ * minute tick via useUpNextEvent).
+ */
+export function useDocumentTitle() {
+  const { now, upNext, isCurrentEvent } = useUpNextEvent();
+  const { pathname } = useLocation();
+  const dayParams = useParams({
+    from: ROUTE_IDS.DAY_DATE,
+    shouldThrow: false,
+  });
+  const weekDates = useViewStore((state) => state.dates);
+
+  const viewLabel = formatViewTitleLabel({
+    pathname,
+    dayDateString: dayParams?.dateString,
+    weekStart: weekDates.start,
+    weekEnd: weekDates.end,
+  });
+
+  const title = formatDocumentTitle({
+    now,
+    event: upNext
+      ? {
+          title: upNext.title ?? "",
+          start: dayjs(upNext.startDate),
+          end: dayjs(upNext.endDate),
+        }
+      : null,
+    isCurrentEvent,
+    viewLabel,
+  });
+
+  useEffect(() => {
+    document.title = title;
+    return () => {
+      document.title = DEFAULT_DOCUMENT_TITLE;
+    };
+  }, [title]);
+}

--- a/packages/web/src/views/Root.tsx
+++ b/packages/web/src/views/Root.tsx
@@ -5,6 +5,7 @@ import { UserProvider } from "@web/auth/compass/user/context/UserProvider";
 import { isMobileOS } from "@web/common/utils/device/device.util";
 import { AuthenticatedLayout } from "@web/components/AuthenticatedLayout/AuthenticatedLayout";
 import { GlobalShortcutsHost } from "@web/components/CompassProvider/CompassProvider";
+import { DocumentTitle } from "@web/components/DocumentTitle/DocumentTitle";
 import { MobileGate } from "@web/components/MobileGate/MobileGate";
 import { UpNextBanner } from "@web/components/Sidebar/UpNextCard/UpNextBanner";
 import SSEProvider from "@web/sse/provider/SSEProvider";
@@ -31,6 +32,7 @@ export const RootView = () => {
     <UserProvider>
       <SSEProvider>
         <GlobalShortcutsHost />
+        <DocumentTitle />
         <UpNextBanner />
         <AuthenticatedLayout />
       </SSEProvider>


### PR DESCRIPTION
## Summary

Sets the browser tab title from the next/current timed event (`In 12m: Standup - Compass` / `Now: Standup - Compass`) or the current Day/Week/Life date context when idle, so background tabs stay useful at a glance.

## Simplicity

Thin headless mount plus pure formatters. Reuses the existing Up Next event selection and minute tick via `useUpNextEvent`; no favicon/badge or head-management library.

## Automated validation

- Focused DocumentTitle unit/hook tests: countdown, Now, idle Day/Week/Life labels, unmount restore
- `bun run type-check` passed
- `bun run lint` passed (pre-existing warnings only)

## Independent review

Self-reviewed the branch diff: title formats match the proposed copy (hyphen, short lead-in), reads shared Up Next data so deletes/edits clear the countdown, restores the static default on unmount. No confirmed defects.

## Test plan

- `bun packages/scripts/src/testing/test-parallel.ts web -- packages/web/src/components/DocumentTitle`
- `bun run type-check`
- `bun run lint`