### PR TITLE
fix(web): keep google reconnect status congruent

### DIFF
--- a/docs/acceptance/google-sync.md
+++ b/docs/acceptance/google-sync.md
@@ -82,7 +82,7 @@ Use this guide to validate:
 - Google-side calendar add/rename/recolor/hide/delete reconciling into Compass
 - watch repair self-healing after an expired/deleted watch
 - freeBusyReader calendars showing availability without event details
-- revoked access pruning Google data while Compass-local data survives
+- revoked access keeping last-known events read-only while other accounts stay usable
 - status surfaces staying congruent through recovery and action-required paths
 
 Do not use this guide to validate:
@@ -326,8 +326,9 @@ save an event.
 
 ### Expected Results
 
-- As soon as revocation is known, a reconnect toast appears (current copy:
-  “Google Calendar disconnected”, with **Reconnect Google Calendar**).
+- As soon as revocation is known, a reconnect toast appears that **names the
+  affected account** (for example “Google Calendar disconnected
+  (`lance.essert@gmail.com`)”) with **Reconnect Google Calendar**.
 - Sidebar status for the affected account shows reconnect-required copy and a
   **Reconnect Google Calendar** action — not “Calendar connected”, not
   “Syncing in the background…”, and not a calm/healthy state.
@@ -337,8 +338,11 @@ save an event.
 - The user does not need a failed create/edit (`410` / `GOOGLE_REVOKED`) to
   learn that reconnect is required; that failure path is a last resort, not
   the primary signal.
-- Google-origin events are removed from the Compass calendar once revocation
-  is applied; Compass-originated local events remain visible.
+- Last-known Google events for the affected account remain visible as
+  **read-only** (inspectable, not editable/deletable/draggable). Creates
+  cannot target that account’s calendars.
+- If another Google account is still healthy, its events stay writable and
+  syncing continues for that account.
 - The UI does not later flip into a false healthy or “syncing in the
   background” state while the underlying Google access remains revoked.
 
@@ -369,13 +373,15 @@ leave a stale “everything is fine” or stale “please reconnect” message b
 
 - Throughout the wait, toast / sidebar / Settings never contradict each other
   for more than a brief transition: reconnect-required and healthy/syncing
-  must not be shown as simultaneous truths.
+  must not be shown as simultaneous truths for the affected account.
 - A reconnect toast does not linger after the account is healthy again.
 - After a successful reconnect, sidebar and Settings both settle to “Calendar
   connected” (optional “Updated …” timestamp), with no reconnect CTA and no
   disconnected toast.
-- The user is never encouraged to believe CRUD will succeed while Compass
-  still needs OAuth help.
+- Attempting create/edit/delete on the affected account is hard-blocked and
+  steers the user back to reconnect rather than sending a doomed `410`.
+- UpNext / “All clear” is unrelated to sync health and is not required to
+  change for this scenario.
 
 ---
 
@@ -545,14 +551,14 @@ blocks on the grid, with no event content and no way to interact with them.
 
 ---
 
-## Scenario 13: Revoked Access Prunes Google Data While Compass-Local Data Survives
+## Scenario 13: Revoked Access Keeps Read-Only Google Data And Protects Other Accounts
 
 ### UX
 
-Revoking Compass's Google access removes every Google-sourced calendar and
-its events — not just the primary one — while the Compass-local calendar
-and anything created without Google (password-only events)
-is never touched.
+When Google access for an account becomes unusable, Compass keeps that
+account’s last-known events visible as read-only and requires reconnect.
+Compass-local data and any still-healthy Google accounts are never demoted
+or wiped by the broken account’s failure.
 
 ### Steps
 
@@ -561,24 +567,24 @@ is never touched.
    Compass-local calendar.
 2. Connect Google Calendar (see Scenario 1) with multiple calendars
    available — at least one writable calendar and, if possible, a reader or
-   `freeBusyReader` calendar too. Let import complete.
+   `freeBusyReader` calendar too. Let import complete. Prefer a second
+   healthy Google account when available.
 3. Confirm events/availability from every Google calendar are visible,
    alongside your original Compass-local events.
-4. Revoke Compass's access at `myaccount.google.com/permissions` (see
-   Scenario 7).
+4. Revoke Compass's access for one account at
+   `myaccount.google.com/permissions` (see Scenario 7).
 5. Return to Compass and wait for the revocation to be detected.
 
 ### Expected Results
 
-- Every Google-sourced calendar disappears from the sidebar, not just the
-  primary one.
-- All events and availability blocks from every Google calendar are
-  removed.
-- The Compass-local calendar, and the scheduled events you
-  created on it before ever connecting Google, remain exactly as they
-  were — nothing about the account or local data is deleted.
+- The affected account’s calendars remain listed; their events stay visible
+  but are read-only until reconnect.
+- Writes targeting the affected account are hard-blocked with a reconnect
+  path; a healthy sibling account (if present) still accepts CRUD and sync.
+- Compass-local events created before Google was connected remain exactly as
+  they were.
 - The toast and reconnect-prompt behavior matches Scenario 7 (early,
-  congruent, action-required — not discovered first via a failed event write).
+  congruent, named account — not discovered first via a failed event write).
 
 ---
 
@@ -595,18 +601,21 @@ If time is limited, run these checks before shipping Google sync changes:
 7. An ATTENTION state shows warning status copy and a **Refresh calendar** button.
 8. After the refresh completes, status returns to HEALTHY.
 9. Returning to a HEALTHY/ATTENTION tab after 30+ seconds hidden triggers a silent refresh with no failure toast.
-10. Revoking access shows reconnect-required UX early (toast + account status)
-    before any failed event create/edit, and removes Google-origin events.
-11. While reconnect is required, toast / sidebar / Settings tell one story —
-    never “disconnected” beside “Calendar connected” or “Syncing in the
-    background…”.
-12. Re-connecting after revocation triggers a fresh import, repopulates Google
-    events, and clears every reconnect warning together.
+10. Revoking access shows reconnect-required UX early (named-account toast +
+    account status) before any failed event create/edit; last-known events
+    stay visible read-only and writes to that account are hard-blocked.
+11. While reconnect is required, toast / sidebar / Settings tell one story for
+    the affected account — never “disconnected” beside “Calendar connected”
+    or “Syncing in the background…”. A healthy sibling account keeps working.
+12. Re-connecting after revocation triggers a fresh import, restores writes,
+    and clears every reconnect warning together.
 13. Hiding/showing a calendar in the sidebar persists across reload, and the server excludes hidden-calendar events from event reads.
 14. A Google-side calendar add/rename/recolor/hide/delete reconciles into the sidebar without a full reset.
 15. Reopening the app after a watch expires or is deleted repairs it automatically, with no manual action.
 16. A freeBusyReader calendar's busy blocks show no title, details, or event actions.
-17. Revoking access prunes only Google-sourced calendars/events; the Compass-local calendar and its events survive.
+17. Revoking one account keeps its last-known events read-only, hard-blocks
+    its writes, and leaves Compass-local data plus any healthy sibling
+    Google account usable.
 18. A known terminal reconnect-required state does not later flicker into a
     false healthy or background-syncing state while Google access remains
     revoked.

--- a/docs/acceptance/google-sync.md
+++ b/docs/acceptance/google-sync.md
@@ -106,7 +106,10 @@ Do not use this guide to validate:
 
 Helpful notes:
 
-- There is no user-facing "Disconnect Google" button. Revocation only happens when the user removes access in Google's own account settings.
+- Users can disconnect a Google account from Settings → Accounts. Access can
+  also become unusable when the user removes Compass in Google's account
+  settings (`myaccount.google.com/permissions`) or when Google reports
+  expired/revoked credentials.
 - All eligible Google calendars import by default — there's no UI to opt a
   calendar out of import. The sidebar's "Calendars" list controls per-calendar
   *visibility* in Compass instead (Scenario 9); a hidden calendar keeps

--- a/docs/acceptance/google-sync.md
+++ b/docs/acceptance/google-sync.md
@@ -2,6 +2,69 @@
 
 This runbook covers the Google Calendar sync UX in Compass.
 
+## Principles
+
+The goal of sync, auth, and session UX is to keep users focused on creating,
+editing, and deleting events. Status UI exists only to support that goal. Every
+sync/auth surface should answer one of three questions honestly:
+
+1. **Can Compass handle this without the user?** Prefer silent background
+   recovery so the user never has to think about sync.
+2. **Is Compass still working on it, with no user action needed?** Tell the
+   user their data will catch up soon, calmly and consistently.
+3. **Does Compass need the user right now?** Make that unmistakable, give a
+   direct path to help, and do it before the user wastes time on work that
+   cannot be saved.
+
+### Prefer silent background recovery
+
+If Compass can recover without help — token refresh, watch repair, incremental
+catch-up, focus refresh, or similar — it should. Do not ask the user to act,
+and do not elevate a recoverable situation into an error toast or
+reconnect CTA.
+
+### Progress when help is not needed yet
+
+When work is in progress and will likely finish on its own, say so clearly
+(for example “Adding your calendar…” or “Syncing in the background…”). The
+user should understand that data will catch up soon and that no action is
+required. This mode must never be used once Compass already knows recovery
+needs the user.
+
+### Action-required must be unmistakable and early
+
+When Compass cannot reliably recover without the user — especially Google
+OAuth reconnect after access expires or is revoked — every relevant surface
+must say so as soon as that terminal state is known, and must offer a direct
+path to help (Reconnect).
+
+Do not wait for a failed create/edit/delete (for example HTTP `410` with
+`GOOGLE_REVOKED`) to reveal the problem. Prefer steering the user toward
+reconnect before they invest time writing an event that will not save.
+
+### One story across the UI
+
+Toast, sidebar status, Settings / Accounts status, and any other sync or auth
+indicators must tell the same story at the same time.
+
+- If reconnect is required, no surface may claim the calendar is connected,
+  healthy, “all clear,” or merely syncing in the background.
+- If background recovery succeeds, every surface that previously asked for
+  help must update or dismiss — no stale reconnect toast after the connection
+  is healthy again.
+- Contradictory states (toast says disconnected, Settings says connected,
+  sidebar says syncing) are acceptance failures, even if events eventually
+  reappear.
+
+### Durable truth over optimistic flicker
+
+A known terminal reconnect-required failure must not be overridden by
+transient healthy, importing, or catching-up signals. Brief verification
+progress is allowed, but the UI must not bounce the user through states that
+imply the problem resolved when it did not. False recovery followed by a
+later write failure and disappearing events is worse than staying clearly in
+action-required.
+
 ## Scope
 
 Use this guide to validate:
@@ -13,13 +76,14 @@ Use this guide to validate:
 - Google Calendar status displaying as HEALTHY
 - sync needing attention and user triggering a refresh
 - automatic silent refresh on app focus / long tab hide
-- Google access revoked — events removed and reconnect prompt shown
+- Google access revoked — reconnect-required UX shown early and congruently
 - re-connecting Google after revocation
 - per-calendar visibility hide/show and its server-side read filtering
 - Google-side calendar add/rename/recolor/hide/delete reconciling into Compass
 - watch repair self-healing after an expired/deleted watch
 - freeBusyReader calendars showing availability without event details
 - revoked access pruning Google data while Compass-local data survives
+- status surfaces staying congruent through recovery and action-required paths
 
 Do not use this guide to validate:
 
@@ -53,6 +117,9 @@ Helpful notes:
 - The email shimmer animation appears during import and local saves. There is no granular progress bar.
 - Manual refresh failures toast; automatic focus refresh is silent on failure.
 - Successful sync operations do not toast.
+- Reconnect-required messaging is sticky until the requirement clears or the
+  user starts reconnect. When the requirement clears, every surface that
+  showed it must update together.
 
 ---
 
@@ -233,11 +300,15 @@ refresh is silent — a transient failure must not toast.
 
 ---
 
-## Scenario 7: Google Access Revoked — Events Removed And Reconnect Prompt Shown
+## Scenario 7: Google Access Revoked — Reconnect Required Early And Congruently
 
 ### UX
 
-If the user removes Compass's access in Google's account settings, the next time Compass tries to sync it detects the revocation. All Google-origin events are removed from the calendar and the connection status resets to NOT_CONNECTED with a prompt to reconnect.
+If the user removes Compass's access in Google's account settings (or Google
+access otherwise becomes unusable), Compass detects a terminal
+reconnect-required state. The user must see one clear story across the UI and
+a direct reconnect path **before** they discover the problem by failing to
+save an event.
 
 ### Steps
 
@@ -245,13 +316,63 @@ If the user removes Compass's access in Google's account settings, the next time
 2. In a separate browser tab, go to `myaccount.google.com/permissions`.
 3. Find Compass and remove its access.
 4. Return to Compass and wait for the app to detect the revocation (may require triggering a sync action or waiting for the next background sync cycle).
+5. Before creating or editing any event, inspect the bottom-left toast, the
+   sidebar account status, and Settings → Accounts for the affected account.
+6. Attempt to create an event only after confirming the reconnect-required UX
+   is already visible (this step checks that CRUD is not the first signal).
 
 ### Expected Results
 
-- A toast appears: "Google access revoked. Your Google data has been removed."
-- All events that originated from Google (or were imported from Google) are removed from the Compass calendar.
-- Compass-originated events that were pushed to Google remain visible in Compass.
-- The sidebar shows **Connect Google Calendar** again.
+- As soon as revocation is known, a reconnect toast appears (current copy:
+  “Google Calendar disconnected”, with **Reconnect Google Calendar**).
+- Sidebar status for the affected account shows reconnect-required copy and a
+  **Reconnect Google Calendar** action — not “Calendar connected”, not
+  “Syncing in the background…”, and not a calm/healthy state.
+- Settings → Accounts for the affected account matches the sidebar: it does
+  not claim “Calendar connected” / “Updated just now” while reconnect is
+  required.
+- The user does not need a failed create/edit (`410` / `GOOGLE_REVOKED`) to
+  learn that reconnect is required; that failure path is a last resort, not
+  the primary signal.
+- Google-origin events are removed from the Compass calendar once revocation
+  is applied; Compass-originated local events remain visible.
+- The UI does not later flip into a false healthy or “syncing in the
+  background” state while the underlying Google access remains revoked.
+
+---
+
+## Scenario 7b: Status Surfaces Stay Congruent Through False Starts
+
+### UX
+
+While Compass is detecting or applying a reconnect-required state, individual
+surfaces may update at slightly different times, but they must converge quickly
+to one story. Temporary event visibility or background sync attempts must not
+leave a stale “everything is fine” or stale “please reconnect” message behind.
+
+### Steps
+
+1. Start from Scenario 7 after revocation has been detected at least once.
+2. Leave the tab open for at least one background sync / focus-refresh cycle
+   (wait ~30–60 seconds, or hide the tab for 30+ seconds and return).
+3. Open Settings → Accounts and compare it with the sidebar status and any
+   visible toast.
+4. If Google events briefly reappear or the grid goes blank, keep watching the
+   status surfaces rather than interacting with events.
+5. Complete reconnect from the toast or account CTA, then confirm every
+   reconnect warning clears.
+
+### Expected Results
+
+- Throughout the wait, toast / sidebar / Settings never contradict each other
+  for more than a brief transition: reconnect-required and healthy/syncing
+  must not be shown as simultaneous truths.
+- A reconnect toast does not linger after the account is healthy again.
+- After a successful reconnect, sidebar and Settings both settle to “Calendar
+  connected” (optional “Updated …” timestamp), with no reconnect CTA and no
+  disconnected toast.
+- The user is never encouraged to believe CRUD will succeed while Compass
+  still needs OAuth help.
 
 ---
 
@@ -259,12 +380,16 @@ If the user removes Compass's access in Google's account settings, the next time
 
 ### UX
 
-After revocation, the user can reconnect Google using the same flow as the initial connection. A new import runs and Google events repopulate the calendar.
+After revocation, the user can reconnect Google using the same flow as the
+initial connection (sidebar/Settings CTA or the reconnect toast). A new import
+runs and Google events repopulate the calendar. All previously action-required
+surfaces clear together.
 
 ### Steps
 
-1. Complete Scenario 7 so the connection is in the NOT_CONNECTED state.
-2. In the sidebar, select Connect Google Calendar.
+1. Complete Scenario 7 so the connection is in the reconnect-required state.
+2. Choose either the toast **Reconnect Google Calendar** action or the matching
+   sidebar / Settings CTA.
 3. Complete the Google authorization redirect.
 4. Wait for the import to complete.
 
@@ -274,6 +399,8 @@ After revocation, the user can reconnect Google using the same flow as the initi
 - The sidebar shows “Adding your calendar…” with the syncing shimmer during import.
 - Google events repopulate the calendar after import completes.
 - The sidebar status returns to “Calendar connected” (HEALTHY).
+- Settings → Accounts matches the sidebar healthy state.
+- The reconnect toast is dismissed once reconnect is no longer required.
 - Previously revoked-and-removed events reappear if they still exist in Google Calendar.
 
 ---
@@ -447,7 +574,8 @@ is never touched.
 - The Compass-local calendar, and the scheduled events you
   created on it before ever connecting Google, remain exactly as they
   were — nothing about the account or local data is deleted.
-- The toast and reconnect-prompt behavior matches Scenario 7.
+- The toast and reconnect-prompt behavior matches Scenario 7 (early,
+  congruent, action-required — not discovered first via a failed event write).
 
 ---
 
@@ -464,10 +592,18 @@ If time is limited, run these checks before shipping Google sync changes:
 7. An ATTENTION state shows warning status copy and a **Refresh calendar** button.
 8. After the refresh completes, status returns to HEALTHY.
 9. Returning to a HEALTHY/ATTENTION tab after 30+ seconds hidden triggers a silent refresh with no failure toast.
-10. Revoking access in Google's settings removes all Google-origin events from Compass and shows the revocation toast.
-11. Re-connecting after revocation triggers a fresh import and repopulates Google events.
-12. Hiding/showing a calendar in the sidebar persists across reload, and the server excludes hidden-calendar events from event reads.
-13. A Google-side calendar add/rename/recolor/hide/delete reconciles into the sidebar without a full reset.
-14. Reopening the app after a watch expires or is deleted repairs it automatically, with no manual action.
-15. A freeBusyReader calendar's busy blocks show no title, details, or event actions.
-16. Revoking access prunes only Google-sourced calendars/events; the Compass-local calendar and its events survive.
+10. Revoking access shows reconnect-required UX early (toast + account status)
+    before any failed event create/edit, and removes Google-origin events.
+11. While reconnect is required, toast / sidebar / Settings tell one story —
+    never “disconnected” beside “Calendar connected” or “Syncing in the
+    background…”.
+12. Re-connecting after revocation triggers a fresh import, repopulates Google
+    events, and clears every reconnect warning together.
+13. Hiding/showing a calendar in the sidebar persists across reload, and the server excludes hidden-calendar events from event reads.
+14. A Google-side calendar add/rename/recolor/hide/delete reconciles into the sidebar without a full reset.
+15. Reopening the app after a watch expires or is deleted repairs it automatically, with no manual action.
+16. A freeBusyReader calendar's busy blocks show no title, details, or event actions.
+17. Revoking access prunes only Google-sourced calendars/events; the Compass-local calendar and its events survive.
+18. A known terminal reconnect-required state does not later flicker into a
+    false healthy or background-syncing state while Google access remains
+    revoked.

--- a/packages/web/src/api/api.types.ts
+++ b/packages/web/src/api/api.types.ts
@@ -10,6 +10,7 @@ export interface ApiError extends Error {
 }
 
 export interface ApiRequestConfig {
+  body?: unknown;
   headers?: HeadersInit;
   method?: string;
   skipSessionRecovery?: boolean;

--- a/packages/web/src/api/base/base.api.ts
+++ b/packages/web/src/api/base/base.api.ts
@@ -28,6 +28,7 @@ const request = async <T>(
   config: ApiMethodConfig = {},
 ): Promise<ApiResponse<T>> => {
   const requestConfig = {
+    body,
     headers: config.headers,
     method,
     skipSessionRecovery: config.skipSessionRecovery,
@@ -86,7 +87,9 @@ const request = async <T>(
 export const BaseApi = {
   defaults: {
     adapter: undefined as ApiAdapter | undefined,
-    onGoogleRevoked: undefined as (() => void) | undefined,
+    onGoogleRevoked: undefined as
+      | ((context?: { calendarId?: string | null }) => void)
+      | undefined,
     withCredentials: true,
   },
   delete<T>(url: string, config?: ApiMethodConfig) {

--- a/packages/web/src/api/util/api.util.test.ts
+++ b/packages/web/src/api/util/api.util.test.ts
@@ -196,16 +196,19 @@ describe("handleErrorResponse", () => {
     Status.GONE,
   ])("delegates Google revocation for status %s and rethrows the API error", async (status) => {
     const onGoogleRevoked = mock();
-    const error = createApiError({
-      data: { code: "GOOGLE_REVOKED" },
-      status,
-    });
+    const error = createApiError(
+      {
+        data: { code: "GOOGLE_REVOKED" },
+        status,
+      },
+      { body: { calendarId: "cal-123" } },
+    );
 
     await expect(handleErrorResponse(error, { onGoogleRevoked })).rejects.toBe(
       error,
     );
 
-    expect(onGoogleRevoked).toHaveBeenCalledTimes(1);
+    expect(onGoogleRevoked).toHaveBeenCalledWith({ calendarId: "cal-123" });
   });
 
   it("does not delegate unrelated API errors", async () => {

--- a/packages/web/src/api/util/api.util.ts
+++ b/packages/web/src/api/util/api.util.ts
@@ -125,8 +125,17 @@ export const getResponseData = async (response: Response): Promise<unknown> => {
 };
 
 interface ApiErrorResponseDependencies {
-  onGoogleRevoked?: () => void;
+  onGoogleRevoked?: (context?: { calendarId?: string | null }) => void;
 }
+
+const getRequestCalendarId = (body: unknown): string | null | undefined => {
+  if (!body || typeof body !== "object") return undefined;
+  if (!("calendarId" in body)) return undefined;
+  const calendarId = (body as { calendarId?: unknown }).calendarId;
+  return typeof calendarId === "string" || calendarId === null
+    ? calendarId
+    : undefined;
+};
 
 export const handleErrorResponse = async (
   error: ApiError,
@@ -154,7 +163,9 @@ export const handleErrorResponse = async (
       throw new Error("Google revocation handler is not configured");
     }
 
-    onGoogleRevoked();
+    onGoogleRevoked({
+      calendarId: getRequestCalendarId(error.config?.body),
+    });
     throw error;
   }
 

--- a/packages/web/src/auth/compass/user/util/user-metadata.util.ts
+++ b/packages/web/src/auth/compass/user/util/user-metadata.util.ts
@@ -32,18 +32,16 @@ export const applyUserMetadataSideEffects = (metadata: UserMetadata): void => {
     hasGoogleReconnectRequired();
 
   if (needsReconnect) {
-    const primary =
-      findPrimaryGoogleSyncConnectionFromMetadata(metadata) ??
+    const broken =
       connections.find(
         (connection) => connection.connectionState === "RECONNECT_REQUIRED",
-      ) ??
-      connections[0];
+      ) ?? findPrimaryGoogleSyncConnectionFromMetadata(metadata);
 
     if (!hasShownReconnectToastThisLoad) {
       hasShownReconnectToastThisLoad = true;
       showGoogleReconnectToast({
-        connectionId: primary?.id,
-        accountEmail: primary?.accountEmail,
+        connectionId: broken?.id,
+        accountEmail: broken?.accountEmail,
       });
     }
   } else {

--- a/packages/web/src/auth/compass/user/util/user-metadata.util.ts
+++ b/packages/web/src/auth/compass/user/util/user-metadata.util.ts
@@ -1,12 +1,64 @@
 import { Status } from "@core/errors/status.codes";
+import { type UserMetadata } from "@core/types/user.types";
 import { UserApi } from "@web/api/user.api";
-import { userMetadataActions } from "@web/auth/state/user-metadata.store";
+import {
+  hasGoogleReconnectRequired,
+  syncReconnectRequiredFromConnections,
+} from "@web/auth/google/state/google.reconnect.state";
+import {
+  findPrimaryGoogleSyncConnectionFromMetadata,
+  userMetadataActions,
+} from "@web/auth/state/user-metadata.store";
 import { showGoogleDelayedToast } from "@web/common/utils/toast/google-delayed.toast";
-import { showGoogleReconnectToast } from "@web/common/utils/toast/google-reconnect.toast";
+import {
+  dismissGoogleReconnectToast,
+  showGoogleReconnectToast,
+} from "@web/common/utils/toast/google-reconnect.toast";
 
 let refreshUserMetadataRequest: Promise<void> | null = null;
 let hasShownReconnectToastThisLoad = false;
 let hasShownDelayedToastThisLoad = false;
+
+/**
+ * Keep session reconnect overrides and sticky toasts congruent with the latest
+ * metadata payload, whether it arrived from REST refresh or SSE.
+ */
+export const applyUserMetadataSideEffects = (metadata: UserMetadata): void => {
+  const connections = metadata.google?.connections ?? [];
+  syncReconnectRequiredFromConnections(connections);
+
+  const needsReconnect =
+    metadata.google?.connectionState === "RECONNECT_REQUIRED" ||
+    hasGoogleReconnectRequired();
+
+  if (needsReconnect) {
+    const primary =
+      findPrimaryGoogleSyncConnectionFromMetadata(metadata) ??
+      connections.find(
+        (connection) => connection.connectionState === "RECONNECT_REQUIRED",
+      ) ??
+      connections[0];
+
+    if (!hasShownReconnectToastThisLoad) {
+      hasShownReconnectToastThisLoad = true;
+      showGoogleReconnectToast({
+        connectionId: primary?.id,
+        accountEmail: primary?.accountEmail,
+      });
+    }
+  } else {
+    dismissGoogleReconnectToast();
+    hasShownReconnectToastThisLoad = false;
+  }
+
+  if (
+    metadata.google?.connectionState === "ATTENTION" &&
+    !hasShownDelayedToastThisLoad
+  ) {
+    hasShownDelayedToastThisLoad = true;
+    showGoogleDelayedToast();
+  }
+};
 
 export const refreshUserMetadata = async (options?: {
   force?: boolean;
@@ -27,24 +79,7 @@ export const refreshUserMetadata = async (options?: {
   refreshUserMetadataRequest = UserApi.getMetadata()
     .then((metadata) => {
       userMetadataActions.set(metadata);
-
-      // Catches returning users whose Google grant died while they were away:
-      // they get the actionable reconnect toast in addition to the sidebar
-      // action. At most once per page load, so a dismissal isn't nagged by
-      // later refreshes.
-      if (
-        metadata.google?.connectionState === "RECONNECT_REQUIRED" &&
-        !hasShownReconnectToastThisLoad
-      ) {
-        hasShownReconnectToastThisLoad = true;
-        showGoogleReconnectToast();
-      } else if (
-        metadata.google?.connectionState === "ATTENTION" &&
-        !hasShownDelayedToastThisLoad
-      ) {
-        hasShownDelayedToastThisLoad = true;
-        showGoogleDelayedToast();
-      }
+      applyUserMetadataSideEffects(metadata);
     })
     .catch((error) => {
       const status = (error as { response?: { status?: number } })?.response

--- a/packages/web/src/auth/compass/user/util/user-metadata.util.ts
+++ b/packages/web/src/auth/compass/user/util/user-metadata.util.ts
@@ -2,6 +2,7 @@ import { Status } from "@core/errors/status.codes";
 import { type UserMetadata } from "@core/types/user.types";
 import { UserApi } from "@web/api/user.api";
 import {
+  getGoogleReconnectRequiredAccountEmails,
   hasGoogleReconnectRequired,
   syncReconnectRequiredFromConnections,
 } from "@web/auth/google/state/google.reconnect.state";
@@ -11,12 +12,13 @@ import {
 } from "@web/auth/state/user-metadata.store";
 import { showGoogleDelayedToast } from "@web/common/utils/toast/google-delayed.toast";
 import {
+  clearGoogleReconnectToastGate,
   dismissGoogleReconnectToast,
+  hasShownGoogleReconnectToastThisLoad,
   showGoogleReconnectToast,
 } from "@web/common/utils/toast/google-reconnect.toast";
 
 let refreshUserMetadataRequest: Promise<void> | null = null;
-let hasShownReconnectToastThisLoad = false;
 let hasShownDelayedToastThisLoad = false;
 
 /**
@@ -32,13 +34,22 @@ export const applyUserMetadataSideEffects = (metadata: UserMetadata): void => {
     hasGoogleReconnectRequired();
 
   if (needsReconnect) {
+    const stickyEmails = getGoogleReconnectRequiredAccountEmails();
     const broken =
       connections.find(
         (connection) => connection.connectionState === "RECONNECT_REQUIRED",
-      ) ?? findPrimaryGoogleSyncConnectionFromMetadata(metadata);
+      ) ??
+      connections.find((connection) => {
+        const email = connection.accountEmail?.toLowerCase();
+        return Boolean(email && stickyEmails.has(email));
+      }) ??
+      // Only fall back to primary when Sync itself says reconnect is required —
+      // never invent a target from sticky alone pointing at a healthy primary.
+      (metadata.google?.connectionState === "RECONNECT_REQUIRED"
+        ? findPrimaryGoogleSyncConnectionFromMetadata(metadata)
+        : null);
 
-    if (!hasShownReconnectToastThisLoad) {
-      hasShownReconnectToastThisLoad = true;
+    if (!hasShownGoogleReconnectToastThisLoad()) {
       showGoogleReconnectToast({
         connectionId: broken?.id,
         accountEmail: broken?.accountEmail,
@@ -46,7 +57,7 @@ export const applyUserMetadataSideEffects = (metadata: UserMetadata): void => {
     }
   } else {
     dismissGoogleReconnectToast();
-    hasShownReconnectToastThisLoad = false;
+    clearGoogleReconnectToastGate();
   }
 
   if (

--- a/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.ts
+++ b/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.ts
@@ -4,10 +4,6 @@ import { type ConnectionId } from "@core/types/sync/identity.contracts";
 import { type GoogleSyncConnectionSummary } from "@core/types/user.types";
 import { AuthApi } from "@web/api/auth.api";
 import {
-  isAccountReconnectRequired,
-  isConnectionReconnectRequired,
-} from "@web/auth/google/state/google.reconnect.state";
-import {
   noteGoogleSyncRefreshImproved,
   refreshGoogleSync,
   useGoogleSyncRefreshSnapshot,
@@ -27,7 +23,10 @@ import { eventQueryKeys } from "@web/events/queries/event.query.keys";
 import { settingsActions } from "@web/settings/settings.store";
 import { useIsConnectGoogleAvailable } from "../useIsGoogleAvailable/useIsGoogleAvailable";
 import { type UseConnectGoogleResult } from "./useConnectGoogle.types";
-import { getGoogleConnectionConfig } from "./useConnectGoogle.util";
+import {
+  connectionHasReconnectRequired,
+  getGoogleConnectionConfig,
+} from "./useConnectGoogle.util";
 import { useGoogleUiState } from "./useGoogleUiState";
 
 export interface UseConnectGoogleOptions {
@@ -49,14 +48,12 @@ export const useConnectGoogle = (
   );
   const scopedConnection = options?.connection;
   const syncConnection = scopedConnection ?? primaryConnection;
-  const scopedNeedsReconnect =
-    scopedConnection != null &&
-    (scopedConnection.connectionState === "RECONNECT_REQUIRED" ||
-      isConnectionReconnectRequired(scopedConnection.id) ||
-      isAccountReconnectRequired(scopedConnection.accountEmail));
-  const state = scopedNeedsReconnect
-    ? "RECONNECT_REQUIRED"
-    : (scopedConnection?.connectionState ?? aggregateState);
+  // Scope to this connection only — do not inherit a sibling account's
+  // aggregate RECONNECT_REQUIRED into a still-healthy account.
+  const state =
+    scopedConnection != null && connectionHasReconnectRequired(scopedConnection)
+      ? "RECONNECT_REQUIRED"
+      : (scopedConnection?.connectionState ?? aggregateState);
   const queryClient = useQueryClient();
   const [isConnecting, setIsConnecting] = useState(false);
   // Sync guard so rapid re-clicks before React re-renders cannot start a

--- a/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.ts
+++ b/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.ts
@@ -4,6 +4,10 @@ import { type ConnectionId } from "@core/types/sync/identity.contracts";
 import { type GoogleSyncConnectionSummary } from "@core/types/user.types";
 import { AuthApi } from "@web/api/auth.api";
 import {
+  isAccountReconnectRequired,
+  isConnectionReconnectRequired,
+} from "@web/auth/google/state/google.reconnect.state";
+import {
   noteGoogleSyncRefreshImproved,
   refreshGoogleSync,
   useGoogleSyncRefreshSnapshot,
@@ -45,7 +49,14 @@ export const useConnectGoogle = (
   );
   const scopedConnection = options?.connection;
   const syncConnection = scopedConnection ?? primaryConnection;
-  const state = scopedConnection?.connectionState ?? aggregateState;
+  const scopedNeedsReconnect =
+    scopedConnection != null &&
+    (scopedConnection.connectionState === "RECONNECT_REQUIRED" ||
+      isConnectionReconnectRequired(scopedConnection.id) ||
+      isAccountReconnectRequired(scopedConnection.accountEmail));
+  const state = scopedNeedsReconnect
+    ? "RECONNECT_REQUIRED"
+    : (scopedConnection?.connectionState ?? aggregateState);
   const queryClient = useQueryClient();
   const [isConnecting, setIsConnecting] = useState(false);
   // Sync guard so rapid re-clicks before React re-renders cannot start a

--- a/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.util.test.ts
+++ b/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.util.test.ts
@@ -139,6 +139,42 @@ describe("getGoogleSyncStatus", () => {
     });
   });
 
+  it("keeps reconnect-required over a lagging Sync catchingUp/healthy summary", () => {
+    expect(
+      getGoogleSyncStatus(
+        "RECONNECT_REQUIRED",
+        {
+          id: "c1",
+          state: "catchingUp",
+          stateReason: null,
+          lastSyncedAt: "2026-07-24T11:45:00.000Z",
+          lastHealthyAt: "2026-07-24T11:45:00.000Z",
+          accountEmail: "a@example.com",
+          connectionState: "IMPORTING",
+        },
+        nowMs,
+      ),
+    ).toEqual({
+      variant: "error",
+      text: "Calendar needs reconnecting",
+    });
+
+    expect(
+      getGoogleSyncStatus("HEALTHY", {
+        id: "c1",
+        state: "healthy",
+        stateReason: null,
+        lastSyncedAt: "2026-07-24T12:00:00.000Z",
+        lastHealthyAt: "2026-07-24T12:00:00.000Z",
+        accountEmail: "a@example.com",
+        connectionState: "RECONNECT_REQUIRED",
+      }),
+    ).toEqual({
+      variant: "error",
+      text: "Calendar needs reconnecting",
+    });
+  });
+
   it("shows setup copy for a connection that has never been healthy", () => {
     expect(
       getGoogleSyncStatus("IMPORTING", {

--- a/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.util.ts
+++ b/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.util.ts
@@ -1,11 +1,31 @@
 import { ArrowsClockwiseIcon, CloudArrowUpIcon } from "@phosphor-icons/react";
 import { type GoogleSyncConnectionSummary } from "@core/types/user.types";
+import {
+  isAccountReconnectRequired,
+  isConnectionReconnectRequired,
+} from "@web/auth/google/state/google.reconnect.state";
 import { type SyncStatus } from "@web/calendars/sync-status.types";
 import {
   type CommandActionIcon,
   type GoogleUiConfig,
   type GoogleUiState,
 } from "./useConnectGoogle.types";
+
+const RECONNECT_STATUS: SyncStatus = {
+  variant: "error",
+  text: "Calendar needs reconnecting",
+};
+
+/** Product enum, Sync disconnected, or session override after a live 410. */
+export const connectionNeedsReconnect = (
+  state: GoogleUiState,
+  connection?: GoogleSyncConnectionSummary | null,
+): boolean =>
+  state === "RECONNECT_REQUIRED" ||
+  connection?.connectionState === "RECONNECT_REQUIRED" ||
+  connection?.state === "disconnected" ||
+  isConnectionReconnectRequired(connection?.id) ||
+  isAccountReconnectRequired(connection?.accountEmail);
 
 const CONNECT_ICON: CommandActionIcon = CloudArrowUpIcon;
 const REFRESH_ICON: CommandActionIcon = ArrowsClockwiseIcon;
@@ -200,13 +220,18 @@ export type GoogleSyncStatusOptions = {
 };
 
 // Prefer Sync vocabulary when a connection summary is present; fall back to the
-// collapsed product enum for legacy deployments.
+// collapsed product enum for legacy deployments. Reconnect-required always wins
+// over healthy/catchingUp so a stale Sync summary cannot contradict a toast.
 export const getGoogleSyncStatus = (
   state: GoogleUiState,
   connection?: GoogleSyncConnectionSummary | null,
   nowMs: number = Date.now(),
   options: GoogleSyncStatusOptions = {},
 ): SyncStatus => {
+  if (connectionNeedsReconnect(state, connection)) {
+    return RECONNECT_STATUS;
+  }
+
   // A connection summary describes durable provider work. Local metadata
   // loading and a routine incremental pull must not replace a calm, usable
   // calendar with transient "checking" or "syncing" copy.
@@ -258,7 +283,7 @@ export const getGoogleSyncStatus = (
         text: "Calendar updates are taking longer than usual. Try Refresh, or reconnect if this continues.",
       };
     case "RECONNECT_REQUIRED":
-      return { variant: "error", text: "Calendar needs reconnecting" };
+      return RECONNECT_STATUS;
     case "NOT_CONNECTED":
       return null;
   }
@@ -289,11 +314,14 @@ export const getSidebarSyncStatus = ({
   if (isConnecting) {
     return {
       variant: "syncing",
-      text:
-        state === "RECONNECT_REQUIRED"
-          ? "Reconnecting your calendar…"
-          : "Connecting your calendar…",
+      text: connectionNeedsReconnect(state, connection)
+        ? "Reconnecting your calendar…"
+        : "Connecting your calendar…",
     };
+  }
+
+  if (connectionNeedsReconnect(state, connection)) {
+    return RECONNECT_STATUS;
   }
 
   if (
@@ -334,7 +362,7 @@ export const getSidebarSyncStatus = ({
         };
       case "actionRequired":
       case "disconnected":
-        return { variant: "error", text: "Calendar needs reconnecting" };
+        return RECONNECT_STATUS;
       case "connecting":
       case "importing":
         return connection.lastHealthyAt

--- a/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.util.ts
+++ b/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.util.ts
@@ -16,16 +16,21 @@ const RECONNECT_STATUS: SyncStatus = {
   text: "Calendar needs reconnecting",
 };
 
-/** Product enum, Sync disconnected, or session override after a live 410. */
-export const connectionNeedsReconnect = (
-  state: GoogleUiState,
+/** Sync disconnected / product reconnect / session override after a live 410. */
+export const connectionHasReconnectRequired = (
   connection?: GoogleSyncConnectionSummary | null,
 ): boolean =>
-  state === "RECONNECT_REQUIRED" ||
   connection?.connectionState === "RECONNECT_REQUIRED" ||
   connection?.state === "disconnected" ||
   isConnectionReconnectRequired(connection?.id) ||
   isAccountReconnectRequired(connection?.accountEmail);
+
+/** Aggregate UI state or a specific connection needs reconnect. */
+export const connectionNeedsReconnect = (
+  state: GoogleUiState,
+  connection?: GoogleSyncConnectionSummary | null,
+): boolean =>
+  state === "RECONNECT_REQUIRED" || connectionHasReconnectRequired(connection);
 
 const CONNECT_ICON: CommandActionIcon = CloudArrowUpIcon;
 const REFRESH_ICON: CommandActionIcon = ArrowsClockwiseIcon;

--- a/packages/web/src/auth/google/hooks/useConnectGoogle/useGoogleUiState.test.ts
+++ b/packages/web/src/auth/google/hooks/useConnectGoogle/useGoogleUiState.test.ts
@@ -35,6 +35,28 @@ describe("useGoogleUiState", () => {
     expect(result.current).toBe("IMPORTING");
   });
 
+  it("does not let a syncing indicator override reconnect-required", () => {
+    expect(
+      resolveGoogleUiState({
+        connectionState: "RECONNECT_REQUIRED",
+        hasAuthenticated: true,
+        hasReconnectRequired: false,
+        syncIndicator: "syncing",
+        userMetadataStatus: "loaded",
+      }),
+    ).toBe("RECONNECT_REQUIRED");
+
+    expect(
+      resolveGoogleUiState({
+        connectionState: "HEALTHY",
+        hasAuthenticated: true,
+        hasReconnectRequired: true,
+        syncIndicator: "syncing",
+        userMetadataStatus: "loaded",
+      }),
+    ).toBe("RECONNECT_REQUIRED");
+  });
+
   it("reports checking while a returning user's metadata loads", () => {
     expect(
       resolveGoogleUiState({

--- a/packages/web/src/auth/google/hooks/useConnectGoogle/useGoogleUiState.ts
+++ b/packages/web/src/auth/google/hooks/useConnectGoogle/useGoogleUiState.ts
@@ -2,9 +2,8 @@ import { useSyncExternalStore } from "react";
 import { type GoogleConnectionState } from "@core/types/user.types";
 import { hasUserEverAuthenticated } from "@web/auth/compass/state/auth.state.util";
 import {
-  getGoogleReconnectRequiredVersion,
   hasGoogleReconnectRequired,
-  subscribeToGoogleReconnectRequired,
+  useGoogleReconnectRequiredVersion,
 } from "@web/auth/google/state/google.reconnect.state";
 import {
   getGoogleSyncIndicatorOverride,
@@ -58,11 +57,7 @@ export function useGoogleUiState(): GoogleUiState {
     getGoogleSyncIndicatorOverride,
     getGoogleSyncIndicatorOverride,
   );
-  useSyncExternalStore(
-    subscribeToGoogleReconnectRequired,
-    getGoogleReconnectRequiredVersion,
-    getGoogleReconnectRequiredVersion,
-  );
+  useGoogleReconnectRequiredVersion();
 
   // Returning users should not briefly look disconnected while their server
   // metadata is still loading.

--- a/packages/web/src/auth/google/hooks/useConnectGoogle/useGoogleUiState.ts
+++ b/packages/web/src/auth/google/hooks/useConnectGoogle/useGoogleUiState.ts
@@ -2,6 +2,11 @@ import { useSyncExternalStore } from "react";
 import { type GoogleConnectionState } from "@core/types/user.types";
 import { hasUserEverAuthenticated } from "@web/auth/compass/state/auth.state.util";
 import {
+  getGoogleReconnectRequiredVersion,
+  hasGoogleReconnectRequired,
+  subscribeToGoogleReconnectRequired,
+} from "@web/auth/google/state/google.reconnect.state";
+import {
   getGoogleSyncIndicatorOverride,
   subscribeToGoogleSyncUIState,
 } from "@web/auth/google/state/google.sync.state";
@@ -18,14 +23,22 @@ type SyncIndicator = ReturnType<typeof getGoogleSyncIndicatorOverride>;
 export function resolveGoogleUiState({
   connectionState,
   hasAuthenticated,
+  hasReconnectRequired = false,
   syncIndicator,
   userMetadataStatus,
 }: {
   connectionState: GoogleConnectionState;
   hasAuthenticated: boolean;
+  hasReconnectRequired?: boolean;
   syncIndicator: SyncIndicator;
   userMetadataStatus: UserMetadataStatus;
 }): GoogleUiState {
+  // Terminal reconnect-required must not be overwritten by a transient
+  // "syncing" indicator or a lagging healthy metadata snapshot.
+  if (connectionState === "RECONNECT_REQUIRED" || hasReconnectRequired) {
+    return "RECONNECT_REQUIRED";
+  }
+
   if (syncIndicator === "syncing") return "IMPORTING";
 
   if (hasAuthenticated && userMetadataStatus !== "loaded") {
@@ -45,12 +58,18 @@ export function useGoogleUiState(): GoogleUiState {
     getGoogleSyncIndicatorOverride,
     getGoogleSyncIndicatorOverride,
   );
+  useSyncExternalStore(
+    subscribeToGoogleReconnectRequired,
+    getGoogleReconnectRequiredVersion,
+    getGoogleReconnectRequiredVersion,
+  );
 
   // Returning users should not briefly look disconnected while their server
   // metadata is still loading.
   return resolveGoogleUiState({
     connectionState,
     hasAuthenticated: hasUserEverAuthenticated(),
+    hasReconnectRequired: hasGoogleReconnectRequired(),
     syncIndicator,
     userMetadataStatus,
   });

--- a/packages/web/src/auth/google/hooks/useDisconnectGoogleAccount.ts
+++ b/packages/web/src/auth/google/hooks/useDisconnectGoogleAccount.ts
@@ -3,6 +3,7 @@ import { useCallback, useState } from "react";
 import { type Calendar } from "@core/types/calendar.contracts";
 import { AuthApi } from "@web/api/auth.api";
 import { refreshUserMetadata } from "@web/auth/compass/user/util/user-metadata.util";
+import { clearAccountReconnectRequired } from "@web/auth/google/state/google.reconnect.state";
 import { userMetadataActions } from "@web/auth/state/user-metadata.store";
 import { calendarQueryKeys } from "@web/calendars/calendar.query";
 import {
@@ -34,6 +35,7 @@ export function useDisconnectGoogleAccount(): {
       return AuthApi.disconnectGoogleConnection(connectionId)
         .then(async () => {
           // Show success confirmation and dismiss any stale reconnect warning.
+          clearAccountReconnectRequired({ connectionId, accountEmail });
           getToast().dismiss(GOOGLE_REVOKED_TOAST_ID);
           showStatusToast(
             ACCOUNT_DISCONNECTED_TOAST_ID,

--- a/packages/web/src/auth/google/state/google.auth.state.test.ts
+++ b/packages/web/src/auth/google/state/google.auth.state.test.ts
@@ -3,14 +3,22 @@ import {
   isGoogleRevoked,
   markGoogleAsRevoked,
 } from "./google.auth.state";
+import {
+  hasGoogleReconnectRequired,
+  markAccountReconnectRequired,
+  resetGoogleReconnectRequiredForTests,
+} from "./google.reconnect.state";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 
 describe("google-auth-state.util", () => {
   beforeEach(() => {
     clearGoogleRevokedState();
+    resetGoogleReconnectRequiredForTests();
   });
 
   afterEach(() => {
     clearGoogleRevokedState();
+    resetGoogleReconnectRequiredForTests();
   });
 
   describe("markGoogleAsRevoked", () => {
@@ -22,13 +30,19 @@ describe("google-auth-state.util", () => {
   });
 
   describe("clearGoogleRevokedState", () => {
-    it("should clear the in-memory revoked flag", () => {
+    it("should clear the in-memory revoked flag and reconnect overrides", () => {
       markGoogleAsRevoked();
+      markAccountReconnectRequired({
+        connectionId: "conn-1",
+        accountEmail: "a@example.com",
+      });
       expect(isGoogleRevoked()).toBe(true);
+      expect(hasGoogleReconnectRequired()).toBe(true);
 
       clearGoogleRevokedState();
 
       expect(isGoogleRevoked()).toBe(false);
+      expect(hasGoogleReconnectRequired()).toBe(false);
     });
   });
 

--- a/packages/web/src/auth/google/state/google.auth.state.ts
+++ b/packages/web/src/auth/google/state/google.auth.state.ts
@@ -3,40 +3,39 @@
  * Tracks revocation state that doesn't need to persist across page refreshes.
  */
 
+import { clearAllGoogleReconnectRequired } from "./google.reconnect.state";
+
 /**
- * In-memory flag for Google revocation state.
- * This is intentionally NOT persisted to localStorage because:
- * 1. After page refresh, the app will "self-correct" by detecting the 400 error
- * 2. Keeps localStorage cleaner (only persistent auth state)
- * 3. Simpler implementation with acceptable UX trade-off
+ * Legacy in-memory flag for a global Google-revoked session. New reconnect UX
+ * uses per-account overrides in {@link google.reconnect.state}; this flag remains
+ * only for a few anonymous-write helpers and is no longer used to force the
+ * whole app onto LocalEventRepository.
  */
 let isGoogleRevokedInSession = false;
 
 /**
- * Marks that Google access has been revoked.
- * When set, the app will use LocalEventRepository instead of RemoteEventRepository
- * to prevent API errors until user re-authenticates.
+ * Marks that Google access has been revoked in this session.
  *
- * Note: This is stored in-memory only. After page refresh, the app will
- * "self-correct" by detecting a 400 error on the first API call.
+ * Prefer {@link markAccountReconnectRequired} for multi-account reconnect UX.
+ * This global flag must not demote healthy accounts to local storage.
  */
 export function markGoogleAsRevoked(): void {
   isGoogleRevokedInSession = true;
 }
 
 /**
- * Clears the Google revoked state.
+ * Clears the Google revoked state and per-account reconnect overrides.
  * Called when user successfully re-authenticates with Google.
  */
 export function clearGoogleRevokedState(): void {
   isGoogleRevokedInSession = false;
+  clearAllGoogleReconnectRequired();
 }
 
 /**
  * Checks if Google access has been revoked in this session.
- * When true, the app should use LocalEventRepository instead of RemoteEventRepository.
  *
- * @returns true if Google access was revoked in this session
+ * @returns true if the legacy global revoked flag is set
  */
 export function isGoogleRevoked(): boolean {
   return isGoogleRevokedInSession;

--- a/packages/web/src/auth/google/state/google.reconnect.calendar.ts
+++ b/packages/web/src/auth/google/state/google.reconnect.calendar.ts
@@ -1,0 +1,25 @@
+import { type Calendar } from "@core/types/calendar.contracts";
+import {
+  isAccountReconnectRequired,
+  isConnectionReconnectRequired,
+} from "@web/auth/google/state/google.reconnect.state";
+import {
+  selectGoogleSyncConnections,
+  useUserMetadataStore,
+} from "@web/auth/state/user-metadata.store";
+
+/**
+ * True when this calendar's Google account needs reconnect, whether the
+ * session override was keyed by email or by connection id.
+ */
+export function isCalendarReconnectRequired(
+  calendar: Pick<Calendar, "accountEmail"> | null | undefined,
+): boolean {
+  if (!calendar?.accountEmail) return false;
+  if (isAccountReconnectRequired(calendar.accountEmail)) return true;
+
+  const connection = selectGoogleSyncConnections(
+    useUserMetadataStore.getState(),
+  ).find((entry) => entry.accountEmail === calendar.accountEmail);
+  return isConnectionReconnectRequired(connection?.id);
+}

--- a/packages/web/src/auth/google/state/google.reconnect.state.test.ts
+++ b/packages/web/src/auth/google/state/google.reconnect.state.test.ts
@@ -1,0 +1,89 @@
+import {
+  clearAccountReconnectRequired,
+  clearAllGoogleReconnectRequired,
+  getGoogleReconnectRequiredAccountEmails,
+  hasGoogleReconnectRequired,
+  isAccountReconnectRequired,
+  isConnectionReconnectRequired,
+  markAccountReconnectRequired,
+  resetGoogleReconnectRequiredForTests,
+  syncReconnectRequiredFromConnections,
+} from "./google.reconnect.state";
+import { afterEach, describe, expect, it } from "bun:test";
+
+afterEach(() => {
+  resetGoogleReconnectRequiredForTests();
+});
+
+describe("google.reconnect.state", () => {
+  it("marks and queries reconnect-required by connection id and email", () => {
+    markAccountReconnectRequired({
+      connectionId: "conn-1",
+      accountEmail: "Lance@Example.com",
+    });
+
+    expect(isConnectionReconnectRequired("conn-1")).toBe(true);
+    expect(isAccountReconnectRequired("lance@example.com")).toBe(true);
+    expect(hasGoogleReconnectRequired()).toBe(true);
+    expect([...getGoogleReconnectRequiredAccountEmails()]).toEqual([
+      "lance@example.com",
+    ]);
+  });
+
+  it("adds RECONNECT_REQUIRED rows and drops overrides only when the account disappears", () => {
+    markAccountReconnectRequired({
+      connectionId: "stale",
+      accountEmail: "gone@example.com",
+    });
+    markAccountReconnectRequired({
+      connectionId: "lagging",
+      accountEmail: "lag@example.com",
+    });
+
+    syncReconnectRequiredFromConnections([
+      {
+        id: "healthy",
+        accountEmail: "ok@example.com",
+        connectionState: "HEALTHY",
+      },
+      {
+        id: "lagging",
+        accountEmail: "lag@example.com",
+        // Still healthy in metadata after a 410 — must not clear the override.
+        connectionState: "HEALTHY",
+      },
+      {
+        id: "broken",
+        accountEmail: "bad@example.com",
+        connectionState: "RECONNECT_REQUIRED",
+      },
+    ]);
+
+    expect(isConnectionReconnectRequired("stale")).toBe(false);
+    expect(isAccountReconnectRequired("gone@example.com")).toBe(false);
+    expect(isConnectionReconnectRequired("lagging")).toBe(true);
+    expect(isAccountReconnectRequired("lag@example.com")).toBe(true);
+    expect(isConnectionReconnectRequired("broken")).toBe(true);
+    expect(isAccountReconnectRequired("bad@example.com")).toBe(true);
+    expect(isConnectionReconnectRequired("healthy")).toBe(false);
+  });
+
+  it("clearAccountReconnectRequired and clearAll remove overrides", () => {
+    markAccountReconnectRequired({
+      connectionId: "conn-1",
+      accountEmail: "a@example.com",
+    });
+    clearAccountReconnectRequired({
+      connectionId: "conn-1",
+      accountEmail: "a@example.com",
+    });
+    expect(hasGoogleReconnectRequired()).toBe(false);
+
+    markAccountReconnectRequired({
+      connectionId: "conn-2",
+      accountEmail: "b@example.com",
+    });
+    clearAllGoogleReconnectRequired();
+    expect(hasGoogleReconnectRequired()).toBe(false);
+  });
+});

--- a/packages/web/src/auth/google/state/google.reconnect.state.ts
+++ b/packages/web/src/auth/google/state/google.reconnect.state.ts
@@ -1,0 +1,183 @@
+/**
+ * Session-scoped reconnect-required overrides for Google accounts.
+ *
+ * Sync metadata can lag behind a live `410 GOOGLE_REVOKED` (or briefly report
+ * healthy/catchingUp while credentials are already dead). This store keeps a
+ * durable per-account truth so toast, sidebar, Settings, and write gates stay
+ * congruent until metadata catches up or the user reconnects.
+ */
+
+export type GoogleReconnectTarget = {
+  connectionId?: string | null;
+  accountEmail?: string | null;
+};
+
+const reconnectRequiredConnectionIds = new Set<string>();
+const reconnectRequiredAccountEmails = new Set<string>();
+const listeners = new Set<() => void>();
+let version = 0;
+
+const notify = (): void => {
+  version += 1;
+  for (const listener of listeners) {
+    listener();
+  }
+};
+
+const normalizeEmail = (email: string | null | undefined): string | null => {
+  if (!email) return null;
+  const trimmed = email.trim().toLowerCase();
+  return trimmed.length > 0 ? trimmed : null;
+};
+
+export function subscribeToGoogleReconnectRequired(
+  listener: () => void,
+): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+/** Snapshot key for useSyncExternalStore — changes whenever the set mutates. */
+export function getGoogleReconnectRequiredVersion(): number {
+  return version;
+}
+
+export function markAccountReconnectRequired(
+  target: GoogleReconnectTarget,
+): void {
+  const connectionId = target.connectionId?.trim() || null;
+  const accountEmail = normalizeEmail(target.accountEmail);
+  if (!connectionId && !accountEmail) return;
+
+  let changed = false;
+  if (connectionId && !reconnectRequiredConnectionIds.has(connectionId)) {
+    reconnectRequiredConnectionIds.add(connectionId);
+    changed = true;
+  }
+  if (accountEmail && !reconnectRequiredAccountEmails.has(accountEmail)) {
+    reconnectRequiredAccountEmails.add(accountEmail);
+    changed = true;
+  }
+  if (changed) notify();
+}
+
+export function clearAccountReconnectRequired(
+  target: GoogleReconnectTarget,
+): void {
+  const connectionId = target.connectionId?.trim() || null;
+  const accountEmail = normalizeEmail(target.accountEmail);
+  let changed = false;
+  if (connectionId && reconnectRequiredConnectionIds.delete(connectionId)) {
+    changed = true;
+  }
+  if (accountEmail && reconnectRequiredAccountEmails.delete(accountEmail)) {
+    changed = true;
+  }
+  if (changed) notify();
+}
+
+export function clearAllGoogleReconnectRequired(): void {
+  if (
+    reconnectRequiredConnectionIds.size === 0 &&
+    reconnectRequiredAccountEmails.size === 0
+  ) {
+    return;
+  }
+  reconnectRequiredConnectionIds.clear();
+  reconnectRequiredAccountEmails.clear();
+  notify();
+}
+
+/**
+ * Align session overrides with the latest metadata connections:
+ * - add every metadata `RECONNECT_REQUIRED` row
+ * - drop overrides only when the connection/account disappears (disconnect)
+ *
+ * Do **not** clear an override just because metadata still reports healthy /
+ * catchingUp — that lag is exactly why the session override exists after a
+ * live `410 GOOGLE_REVOKED`. Successful reconnect uses a full navigation, which
+ * drops this in-memory state; Disconnect removes the connection row.
+ */
+export function syncReconnectRequiredFromConnections(
+  connections: ReadonlyArray<{
+    id: string;
+    accountEmail: string | null;
+    connectionState: string;
+  }>,
+): void {
+  const presentIds = new Set(connections.map((connection) => connection.id));
+  const presentEmails = new Set(
+    connections
+      .map((connection) => normalizeEmail(connection.accountEmail))
+      .filter((email): email is string => Boolean(email)),
+  );
+  let changed = false;
+
+  for (const connection of connections) {
+    if (connection.connectionState !== "RECONNECT_REQUIRED") continue;
+
+    if (!reconnectRequiredConnectionIds.has(connection.id)) {
+      reconnectRequiredConnectionIds.add(connection.id);
+      changed = true;
+    }
+    const email = normalizeEmail(connection.accountEmail);
+    if (email && !reconnectRequiredAccountEmails.has(email)) {
+      reconnectRequiredAccountEmails.add(email);
+      changed = true;
+    }
+  }
+
+  for (const connectionId of [...reconnectRequiredConnectionIds]) {
+    if (!presentIds.has(connectionId)) {
+      reconnectRequiredConnectionIds.delete(connectionId);
+      changed = true;
+    }
+  }
+
+  for (const email of [...reconnectRequiredAccountEmails]) {
+    if (!presentEmails.has(email)) {
+      reconnectRequiredAccountEmails.delete(email);
+      changed = true;
+    }
+  }
+
+  if (changed) notify();
+}
+
+export function isConnectionReconnectRequired(
+  connectionId: string | null | undefined,
+): boolean {
+  const id = connectionId?.trim();
+  return Boolean(id && reconnectRequiredConnectionIds.has(id));
+}
+
+export function isAccountReconnectRequired(
+  accountEmail: string | null | undefined,
+): boolean {
+  const email = normalizeEmail(accountEmail);
+  return Boolean(email && reconnectRequiredAccountEmails.has(email));
+}
+
+export function hasGoogleReconnectRequired(): boolean {
+  return (
+    reconnectRequiredConnectionIds.size > 0 ||
+    reconnectRequiredAccountEmails.size > 0
+  );
+}
+
+export function getGoogleReconnectRequiredAccountEmails(): ReadonlySet<string> {
+  return reconnectRequiredAccountEmails;
+}
+
+export function getGoogleReconnectRequiredConnectionIds(): ReadonlySet<string> {
+  return reconnectRequiredConnectionIds;
+}
+
+/** Test-only reset. */
+export function resetGoogleReconnectRequiredForTests(): void {
+  reconnectRequiredConnectionIds.clear();
+  reconnectRequiredAccountEmails.clear();
+  version = 0;
+}

--- a/packages/web/src/auth/google/state/google.reconnect.state.ts
+++ b/packages/web/src/auth/google/state/google.reconnect.state.ts
@@ -7,6 +7,8 @@
  * congruent until metadata catches up or the user reconnects.
  */
 
+import { useSyncExternalStore } from "react";
+
 export type GoogleReconnectTarget = {
   connectionId?: string | null;
   accountEmail?: string | null;
@@ -30,6 +32,13 @@ const normalizeEmail = (email: string | null | undefined): string | null => {
   return trimmed.length > 0 ? trimmed : null;
 };
 
+const normalizeTarget = (
+  target: GoogleReconnectTarget,
+): { connectionId: string | null; accountEmail: string | null } => ({
+  connectionId: target.connectionId?.trim() || null,
+  accountEmail: normalizeEmail(target.accountEmail),
+});
+
 export function subscribeToGoogleReconnectRequired(
   listener: () => void,
 ): () => void {
@@ -44,11 +53,23 @@ export function getGoogleReconnectRequiredVersion(): number {
   return version;
 }
 
+/**
+ * Subscribe so the caller re-renders when session reconnect overrides change.
+ * Pair with the imperative getters (`hasGoogleReconnectRequired`,
+ * `isAccountReconnectRequired`, …) read during render.
+ */
+export function useGoogleReconnectRequiredVersion(): number {
+  return useSyncExternalStore(
+    subscribeToGoogleReconnectRequired,
+    getGoogleReconnectRequiredVersion,
+    getGoogleReconnectRequiredVersion,
+  );
+}
+
 export function markAccountReconnectRequired(
   target: GoogleReconnectTarget,
 ): void {
-  const connectionId = target.connectionId?.trim() || null;
-  const accountEmail = normalizeEmail(target.accountEmail);
+  const { connectionId, accountEmail } = normalizeTarget(target);
   if (!connectionId && !accountEmail) return;
 
   let changed = false;
@@ -66,8 +87,7 @@ export function markAccountReconnectRequired(
 export function clearAccountReconnectRequired(
   target: GoogleReconnectTarget,
 ): void {
-  const connectionId = target.connectionId?.trim() || null;
-  const accountEmail = normalizeEmail(target.accountEmail);
+  const { connectionId, accountEmail } = normalizeTarget(target);
   let changed = false;
   if (connectionId && reconnectRequiredConnectionIds.delete(connectionId)) {
     changed = true;
@@ -169,10 +189,6 @@ export function hasGoogleReconnectRequired(): boolean {
 
 export function getGoogleReconnectRequiredAccountEmails(): ReadonlySet<string> {
   return reconnectRequiredAccountEmails;
-}
-
-export function getGoogleReconnectRequiredConnectionIds(): ReadonlySet<string> {
-  return reconnectRequiredConnectionIds;
 }
 
 /** Test-only reset. */

--- a/packages/web/src/auth/google/util/google.auth.util.factory.ts
+++ b/packages/web/src/auth/google/util/google.auth.util.factory.ts
@@ -1,7 +1,9 @@
 import { type toast } from "react-toastify";
 import { Status } from "@core/errors/status.codes";
 import { type ApiError } from "@web/api/api.types";
+import { type GoogleReconnectTarget } from "@web/auth/google/state/google.reconnect.state";
 import { getToastDefaultOptions } from "@web/common/constants/toast.constants";
+
 export interface SyncLocalEventsResult {
   syncedCount: number;
   success: boolean;
@@ -13,17 +15,21 @@ export const LOCAL_EVENTS_SYNC_ERROR_MESSAGE =
 export const LOCAL_EVENTS_SYNC_SESSION_EXPIRED_MESSAGE =
   "You were signed out before Compass could save your events to the cloud. Sign in again to finish. Your changes are still safe on this device.";
 
+export type GoogleRevokedContext = {
+  calendarId?: string | null;
+  connectionId?: string | null;
+  accountEmail?: string | null;
+};
+
 type GoogleAuthUtilDependencies = {
   closeStream: () => void;
-  markGoogleAsRevoked: () => void;
   openStream: () => void;
-  refreshEventRepositorySource: (sessionExists?: boolean) => void;
   refreshUserMetadata: () => void;
-  // B14: drops cached events belonging to a google-provider calendar (by id),
-  // replacing the legacy origin-based prune.
-  removeEventsByGoogleCalendars: () => void;
-  removeEventQueries: () => void;
-  showReconnectToast: () => void;
+  resolveRevokedAccount: (
+    context?: GoogleRevokedContext,
+  ) => GoogleReconnectTarget;
+  markAccountReconnectRequired: (target: GoogleReconnectTarget) => void;
+  showReconnectToast: (target: GoogleReconnectTarget) => void;
   syncLocalEventsToCloud: () => Promise<number>;
   toastError: typeof toast.error;
 };
@@ -33,30 +39,23 @@ const getApiErrorStatus = (error: Error | undefined): number | undefined =>
 
 export function createGoogleAuthUtil({
   closeStream,
-  markGoogleAsRevoked,
   openStream,
-  refreshEventRepositorySource,
   refreshUserMetadata,
-  removeEventsByGoogleCalendars,
-  removeEventQueries,
+  resolveRevokedAccount,
+  markAccountReconnectRequired,
   showReconnectToast,
   syncLocalEventsToCloud,
   toastError,
 }: GoogleAuthUtilDependencies) {
-  const handleGoogleRevoked = () => {
-    showReconnectToast();
+  const handleGoogleRevoked = (context?: GoogleRevokedContext) => {
+    const target = resolveRevokedAccount(context);
+    markAccountReconnectRequired(target);
+    showReconnectToast(target);
 
-    markGoogleAsRevoked();
-    // Source now resolves to "local"; re-key active queries so their next fetch
-    // hits IndexedDB, then drop the stale remote cache entries.
-    refreshEventRepositorySource();
-
-    // The server prunes before notifying, so this refetch lands in
-    // RECONNECT_REQUIRED and the sidebar offers "Reconnect" right away.
+    // Refresh metadata so Sync's actionRequired row can confirm the account,
+    // but keep last-known events and the remote repository so healthy sibling
+    // accounts continue CRUD.
     refreshUserMetadata();
-
-    removeEventsByGoogleCalendars();
-    removeEventQueries();
 
     closeStream();
     openStream();

--- a/packages/web/src/auth/google/util/google.auth.util.factory.ts
+++ b/packages/web/src/auth/google/util/google.auth.util.factory.ts
@@ -27,9 +27,9 @@ type GoogleAuthUtilDependencies = {
   refreshUserMetadata: () => void;
   resolveRevokedAccount: (
     context?: GoogleRevokedContext,
-  ) => GoogleReconnectTarget;
+  ) => GoogleReconnectTarget | null;
   markAccountReconnectRequired: (target: GoogleReconnectTarget) => void;
-  showReconnectToast: (target: GoogleReconnectTarget) => void;
+  showReconnectToast: (target?: GoogleReconnectTarget) => void;
   syncLocalEventsToCloud: () => Promise<number>;
   toastError: typeof toast.error;
 };
@@ -49,12 +49,17 @@ export function createGoogleAuthUtil({
 }: GoogleAuthUtilDependencies) {
   const handleGoogleRevoked = (context?: GoogleRevokedContext) => {
     const target = resolveRevokedAccount(context);
-    markAccountReconnectRequired(target);
-    showReconnectToast(target);
+    if (target) {
+      // Only sticky-mark when we know which account died — inventing a
+      // primary override on multi-account can brick a healthy sibling.
+      markAccountReconnectRequired(target);
+      showReconnectToast(target);
+    }
 
     // Refresh metadata so Sync's actionRequired row can confirm the account,
     // but keep last-known events and the remote repository so healthy sibling
-    // accounts continue CRUD.
+    // accounts continue CRUD. Named toast also lands from metadata side
+    // effects once Sync identifies the broken connection.
     refreshUserMetadata();
 
     closeStream();

--- a/packages/web/src/auth/google/util/google.auth.util.test.ts
+++ b/packages/web/src/auth/google/util/google.auth.util.test.ts
@@ -1,8 +1,10 @@
 import {
-  clearGoogleRevokedState,
-  isGoogleRevoked,
-  markGoogleAsRevoked,
-} from "@web/auth/google/state/google.auth.state";
+  clearAllGoogleReconnectRequired,
+  hasGoogleReconnectRequired,
+  isAccountReconnectRequired,
+  markAccountReconnectRequired,
+  resetGoogleReconnectRequiredForTests,
+} from "@web/auth/google/state/google.reconnect.state";
 import {
   createGoogleAuthUtil,
   LOCAL_EVENTS_SYNC_ERROR_MESSAGE,
@@ -24,18 +26,20 @@ const mockShowReconnectToast = mock();
 const mockRefreshUserMetadata = mock();
 const mockCloseStream = mock();
 const mockOpenStream = mock();
-const mockRefreshEventRepositorySource = mock();
-const mockRemoveEventsByGoogleCalendars = mock();
-const mockRemoveEventQueries = mock();
+const mockMarkAccountReconnectRequired = mock((target) =>
+  markAccountReconnectRequired(target),
+);
+const mockResolveRevokedAccount = mock(() => ({
+  connectionId: "conn-1",
+  accountEmail: "lance@example.com",
+}));
 
 const googleAuthUtil = createGoogleAuthUtil({
   closeStream: mockCloseStream,
-  markGoogleAsRevoked,
   openStream: mockOpenStream,
-  refreshEventRepositorySource: mockRefreshEventRepositorySource,
   refreshUserMetadata: mockRefreshUserMetadata,
-  removeEventsByGoogleCalendars: mockRemoveEventsByGoogleCalendars,
-  removeEventQueries: mockRemoveEventQueries,
+  resolveRevokedAccount: mockResolveRevokedAccount,
+  markAccountReconnectRequired: mockMarkAccountReconnectRequired,
   showReconnectToast: mockShowReconnectToast,
   syncLocalEventsToCloud: mockSyncLocalEventsToCloud,
   toastError: mockToastError,
@@ -52,15 +56,13 @@ describe("google-auth.util", () => {
     mockRefreshUserMetadata.mockClear();
     mockCloseStream.mockClear();
     mockOpenStream.mockClear();
-    mockRefreshEventRepositorySource.mockClear();
-    mockRemoveEventsByGoogleCalendars.mockClear();
-    mockRemoveEventQueries.mockClear();
-
-    clearGoogleRevokedState();
+    mockMarkAccountReconnectRequired.mockClear();
+    mockResolveRevokedAccount.mockClear();
+    resetGoogleReconnectRequiredForTests();
   });
 
   afterEach(() => {
-    clearGoogleRevokedState();
+    clearAllGoogleReconnectRequired();
   });
 
   describe("syncLocalEvents", () => {
@@ -147,24 +149,33 @@ describe("google-auth.util", () => {
   });
 
   describe("handleGoogleRevoked", () => {
-    it("shows the actionable reconnect toast", () => {
-      handleGoogleRevoked();
+    it("marks the affected account, shows a named reconnect toast, and refreshes metadata", () => {
+      handleGoogleRevoked({ calendarId: "cal-1" });
 
-      expect(mockShowReconnectToast).toHaveBeenCalledTimes(1);
-    });
-
-    it("refreshes user metadata (not clears) so the UI lands in RECONNECT_REQUIRED, and drops Google-origin events", () => {
-      handleGoogleRevoked();
-
+      expect(mockResolveRevokedAccount).toHaveBeenCalledWith({
+        calendarId: "cal-1",
+      });
+      expect(mockMarkAccountReconnectRequired).toHaveBeenCalledWith({
+        connectionId: "conn-1",
+        accountEmail: "lance@example.com",
+      });
+      expect(mockShowReconnectToast).toHaveBeenCalledWith({
+        connectionId: "conn-1",
+        accountEmail: "lance@example.com",
+      });
       expect(mockRefreshUserMetadata).toHaveBeenCalledTimes(1);
-      expect(mockRemoveEventsByGoogleCalendars).toHaveBeenCalledTimes(1);
+      expect(isAccountReconnectRequired("lance@example.com")).toBe(true);
+      expect(hasGoogleReconnectRequired()).toBe(true);
     });
 
-    it("re-keys queries to local and removes stale remote cache entries", () => {
+    it("does not prune Google events or flip the app onto local storage", () => {
       handleGoogleRevoked();
 
-      expect(mockRefreshEventRepositorySource).toHaveBeenCalledTimes(1);
-      expect(mockRemoveEventQueries).toHaveBeenCalledTimes(1);
+      // Former side effects were removeEventsByGoogleCalendars /
+      // refreshEventRepositorySource / removeEventQueries / markGoogleAsRevoked.
+      // They are intentionally absent from the factory dependencies now.
+      expect(mockShowReconnectToast).toHaveBeenCalledTimes(1);
+      expect(mockRefreshUserMetadata).toHaveBeenCalledTimes(1);
     });
 
     it("reconnects SSE stream so the client gets a fresh session after revocation", () => {
@@ -172,12 +183,6 @@ describe("google-auth.util", () => {
 
       expect(mockCloseStream).toHaveBeenCalledTimes(1);
       expect(mockOpenStream).toHaveBeenCalledTimes(1);
-    });
-
-    it("marks Google as revoked in session state", () => {
-      handleGoogleRevoked();
-
-      expect(isGoogleRevoked()).toBe(true);
     });
   });
 });

--- a/packages/web/src/auth/google/util/google.auth.util.test.ts
+++ b/packages/web/src/auth/google/util/google.auth.util.test.ts
@@ -29,10 +29,15 @@ const mockOpenStream = mock();
 const mockMarkAccountReconnectRequired = mock((target) =>
   markAccountReconnectRequired(target),
 );
-const mockResolveRevokedAccount = mock(() => ({
-  connectionId: "conn-1",
-  accountEmail: "lance@example.com",
-}));
+const mockResolveRevokedAccount = mock(
+  (): {
+    connectionId: string;
+    accountEmail: string;
+  } | null => ({
+    connectionId: "conn-1",
+    accountEmail: "lance@example.com",
+  }),
+);
 
 const googleAuthUtil = createGoogleAuthUtil({
   closeStream: mockCloseStream,
@@ -169,7 +174,7 @@ describe("google-auth.util", () => {
     });
 
     it("does not prune Google events or flip the app onto local storage", () => {
-      handleGoogleRevoked();
+      handleGoogleRevoked({ calendarId: "cal-1" });
 
       // Former side effects were removeEventsByGoogleCalendars /
       // refreshEventRepositorySource / removeEventQueries / markGoogleAsRevoked.
@@ -178,8 +183,20 @@ describe("google-auth.util", () => {
       expect(mockRefreshUserMetadata).toHaveBeenCalledTimes(1);
     });
 
-    it("reconnects SSE stream so the client gets a fresh session after revocation", () => {
+    it("refreshes metadata without sticky-marking when the revoked account is ambiguous", () => {
+      mockResolveRevokedAccount.mockReturnValueOnce(null);
+
       handleGoogleRevoked();
+
+      expect(mockMarkAccountReconnectRequired).not.toHaveBeenCalled();
+      expect(mockShowReconnectToast).not.toHaveBeenCalled();
+      expect(mockRefreshUserMetadata).toHaveBeenCalledTimes(1);
+      expect(mockCloseStream).toHaveBeenCalledTimes(1);
+      expect(mockOpenStream).toHaveBeenCalledTimes(1);
+    });
+
+    it("reconnects SSE stream so the client gets a fresh session after revocation", () => {
+      handleGoogleRevoked({ calendarId: "cal-1" });
 
       expect(mockCloseStream).toHaveBeenCalledTimes(1);
       expect(mockOpenStream).toHaveBeenCalledTimes(1);

--- a/packages/web/src/auth/google/util/google.auth.util.ts
+++ b/packages/web/src/auth/google/util/google.auth.util.ts
@@ -6,9 +6,7 @@ import {
   markAccountReconnectRequired,
 } from "@web/auth/google/state/google.reconnect.state";
 import {
-  findPrimaryGoogleSyncConnectionFromMetadata,
   selectGoogleSyncConnections,
-  userMetadataActions,
   useUserMetadataStore,
 } from "@web/auth/state/user-metadata.store";
 import { calendarQueryKeys } from "@web/calendars/calendar.query";
@@ -21,9 +19,14 @@ import {
   type GoogleRevokedContext,
 } from "./google.auth.util.factory";
 
+/**
+ * Resolve which account a revoke signal belongs to. Returns null when the
+ * signal is ambiguous across multiple accounts — callers must not invent a
+ * sticky override for a healthy sibling.
+ */
 const resolveRevokedAccount = (
   context?: GoogleRevokedContext,
-): GoogleReconnectTarget => {
+): GoogleReconnectTarget | null => {
   if (context?.connectionId || context?.accountEmail) {
     return {
       connectionId: context.connectionId,
@@ -31,7 +34,6 @@ const resolveRevokedAccount = (
     };
   }
 
-  const metadata = useUserMetadataStore.getState().current;
   const connections = selectGoogleSyncConnections(
     useUserMetadataStore.getState(),
   );
@@ -68,22 +70,16 @@ const resolveRevokedAccount = (
     };
   }
 
-  const primary = metadata
-    ? findPrimaryGoogleSyncConnectionFromMetadata(metadata)
-    : null;
-  return {
-    connectionId: primary?.id ?? null,
-    accountEmail: primary?.accountEmail ?? null,
-  };
+  // Multi-account with no identity: wait for metadata Sync actionRequired.
+  return null;
 };
 
 const googleAuthUtil = createGoogleAuthUtil({
   closeStream,
   openStream,
-  // Wipe first (a concurrent in-flight metadata request may predate Sync
-  // flipping to actionRequired), then force a fresh fetch.
+  // Force a fresh fetch without wiping the store first — clearing would drop
+  // the toast's live connection lookup mid-click and start an unscoped OAuth.
   refreshUserMetadata: () => {
-    userMetadataActions.clear();
     void refreshUserMetadata({ force: true });
   },
   resolveRevokedAccount,

--- a/packages/web/src/auth/google/util/google.auth.util.ts
+++ b/packages/web/src/auth/google/util/google.auth.util.ts
@@ -1,55 +1,93 @@
 import { type Calendar } from "@core/types/calendar.contracts";
 import { queryClient } from "@web/api/query-client";
 import { refreshUserMetadata } from "@web/auth/compass/user/util/user-metadata.util";
-import { markGoogleAsRevoked } from "@web/auth/google/state/google.auth.state";
-import { userMetadataActions } from "@web/auth/state/user-metadata.store";
+import {
+  type GoogleReconnectTarget,
+  markAccountReconnectRequired,
+} from "@web/auth/google/state/google.reconnect.state";
+import {
+  findPrimaryGoogleSyncConnectionFromMetadata,
+  selectGoogleSyncConnections,
+  userMetadataActions,
+  useUserMetadataStore,
+} from "@web/auth/state/user-metadata.store";
 import { calendarQueryKeys } from "@web/calendars/calendar.query";
 import { syncLocalEventsToCloud } from "@web/common/utils/sync/local-event-sync.util";
 import { showGoogleReconnectToast } from "@web/common/utils/toast/google-reconnect.toast";
 import { getToast } from "@web/common/utils/toast/toast.port";
-import { removeEventsByCalendarFromQueries } from "@web/events/queries/event.query.cache";
-import { eventQueryKeys } from "@web/events/queries/event.query.keys";
-import { refreshEventRepositorySource } from "@web/events/repositories/event.repository.source.store";
 import { closeStream, openStream } from "@web/sse/client/sse.client";
-import { createGoogleAuthUtil } from "./google.auth.util.factory";
+import {
+  createGoogleAuthUtil,
+  type GoogleRevokedContext,
+} from "./google.auth.util.factory";
 
-const googleCalendarIds = (): Set<string> => {
-  const calendars =
-    queryClient.getQueryData<Calendar[]>(calendarQueryKeys.all) ?? [];
-  return new Set(
-    calendars
-      .filter((calendar) => calendar.provider === "google")
-      .map((calendar) => calendar.id),
+const resolveRevokedAccount = (
+  context?: GoogleRevokedContext,
+): GoogleReconnectTarget => {
+  if (context?.connectionId || context?.accountEmail) {
+    return {
+      connectionId: context.connectionId,
+      accountEmail: context.accountEmail,
+    };
+  }
+
+  const metadata = useUserMetadataStore.getState().current;
+  const connections = selectGoogleSyncConnections(
+    useUserMetadataStore.getState(),
   );
+
+  if (context?.calendarId) {
+    const calendars =
+      queryClient.getQueryData<Calendar[]>(calendarQueryKeys.all) ?? [];
+    const calendar = calendars.find((entry) => entry.id === context.calendarId);
+    if (calendar?.accountEmail) {
+      const connection = connections.find(
+        (entry) => entry.accountEmail === calendar.accountEmail,
+      );
+      return {
+        connectionId: connection?.id ?? null,
+        accountEmail: calendar.accountEmail,
+      };
+    }
+  }
+
+  const alreadyBroken = connections.find(
+    (connection) => connection.connectionState === "RECONNECT_REQUIRED",
+  );
+  if (alreadyBroken) {
+    return {
+      connectionId: alreadyBroken.id,
+      accountEmail: alreadyBroken.accountEmail,
+    };
+  }
+
+  if (connections.length === 1) {
+    return {
+      connectionId: connections[0]?.id ?? null,
+      accountEmail: connections[0]?.accountEmail ?? null,
+    };
+  }
+
+  const primary = metadata
+    ? findPrimaryGoogleSyncConnectionFromMetadata(metadata)
+    : null;
+  return {
+    connectionId: primary?.id ?? null,
+    accountEmail: primary?.accountEmail ?? null,
+  };
 };
 
 const googleAuthUtil = createGoogleAuthUtil({
   closeStream,
-  markGoogleAsRevoked,
   openStream,
-  refreshEventRepositorySource,
-  // Wipe first (a concurrent in-flight metadata request predates the server's
-  // prune, so its response is stale), then force a fresh fetch so the UI lands
-  // in RECONNECT_REQUIRED instead of a stale connected state.
+  // Wipe first (a concurrent in-flight metadata request may predate Sync
+  // flipping to actionRequired), then force a fresh fetch.
   refreshUserMetadata: () => {
     userMetadataActions.clear();
     void refreshUserMetadata({ force: true });
   },
-  removeEventsByGoogleCalendars: () =>
-    removeEventsByCalendarFromQueries(queryClient, googleCalendarIds()),
-  removeEventQueries: () =>
-    queryClient.removeQueries({
-      queryKey: eventQueryKeys.all,
-      predicate: ({ queryKey }) => {
-        const metadata = queryKey[2];
-        return (
-          typeof metadata === "object" &&
-          metadata !== null &&
-          "source" in metadata &&
-          metadata.source === "remote"
-        );
-      },
-    }),
+  resolveRevokedAccount,
+  markAccountReconnectRequired,
   showReconnectToast: showGoogleReconnectToast,
   syncLocalEventsToCloud: () => syncLocalEventsToCloud(),
   toastError: (content, options) => getToast().error(content, options),
@@ -62,6 +100,7 @@ const {
   syncPendingLocalEvents,
 } = googleAuthUtil;
 
+export type { GoogleRevokedContext };
 export {
   handleGoogleRevoked,
   showLocalEventsSyncFailure,

--- a/packages/web/src/calendars/calendar.util.test.ts
+++ b/packages/web/src/calendars/calendar.util.test.ts
@@ -81,6 +81,25 @@ describe("getWritableCalendars", () => {
       getWritableCalendars([local, google], { hasConnectedAccount: true }),
     ).toEqual([google]);
   });
+
+  it("excludes calendars whose Google account needs reconnect", () => {
+    const broken = makeCalendar({
+      provider: "google",
+      accountEmail: "broken@example.com",
+      id: "507f1f77bcf86cd799439012" as Calendar["id"],
+    });
+    const healthy = makeCalendar({
+      provider: "google",
+      accountEmail: "ok@example.com",
+      id: "507f1f77bcf86cd799439013" as Calendar["id"],
+    });
+    expect(
+      getWritableCalendars([broken, healthy], {
+        hasConnectedAccount: true,
+        reconnectRequiredEmails: ["broken@example.com"],
+      }),
+    ).toEqual([healthy]);
+  });
 });
 
 describe("getDefaultTargetCalendar", () => {
@@ -94,6 +113,27 @@ describe("getDefaultTargetCalendar", () => {
     expect(getDefaultTargetCalendar([local, primaryGoogle])).toBe(
       primaryGoogle,
     );
+  });
+
+  it("skips a reconnect-required account when choosing the default target", () => {
+    const brokenPrimary = makeCalendar({
+      provider: "google",
+      isPrimary: true,
+      accountEmail: "broken@example.com",
+      id: "507f1f77bcf86cd799439012" as Calendar["id"],
+    });
+    const healthyPrimary = makeCalendar({
+      provider: "google",
+      isPrimary: true,
+      accountEmail: "ok@example.com",
+      id: "507f1f77bcf86cd799439013" as Calendar["id"],
+    });
+    expect(
+      getDefaultTargetCalendar([brokenPrimary, healthyPrimary], {
+        accountEmailOrder: ["broken@example.com", "ok@example.com"],
+        reconnectRequiredEmails: ["broken@example.com"],
+      }),
+    ).toBe(healthyPrimary);
   });
 
   it("ignores a non-primary or read-only google calendar", () => {

--- a/packages/web/src/calendars/calendar.util.ts
+++ b/packages/web/src/calendars/calendar.util.ts
@@ -1,6 +1,6 @@
 import { type Calendar } from "@core/types/calendar.contracts";
 import { type GoogleSyncConnectionSummary } from "@core/types/user.types";
-import { isAccountReconnectRequired } from "@web/auth/google/state/google.reconnect.state";
+import { isCalendarReconnectRequired } from "@web/auth/google/state/google.reconnect.calendar";
 
 export function getLocalCalendar(calendars: Calendar[]): Calendar | undefined {
   return calendars.find((calendar) => calendar.provider === "local");
@@ -30,9 +30,8 @@ const toEmailSet = (
   emails: ReadonlySet<string> | readonly string[] | undefined,
 ): ReadonlySet<string> | null => {
   if (!emails) return null;
-  if (emails instanceof Set) return emails;
   return new Set(
-    emails.map((email) => email.trim().toLowerCase()).filter(Boolean),
+    [...emails].map((email) => email.trim().toLowerCase()).filter(Boolean),
   );
 };
 
@@ -42,9 +41,12 @@ const calendarNeedsReconnect = (
 ): boolean => {
   if (!calendar.accountEmail) return false;
   if (reconnectRequiredEmails) {
-    return reconnectRequiredEmails.has(calendar.accountEmail.toLowerCase());
+    return (
+      reconnectRequiredEmails.has(calendar.accountEmail.toLowerCase()) ||
+      isCalendarReconnectRequired(calendar)
+    );
   }
-  return isAccountReconnectRequired(calendar.accountEmail);
+  return isCalendarReconnectRequired(calendar);
 };
 
 /**

--- a/packages/web/src/calendars/calendar.util.ts
+++ b/packages/web/src/calendars/calendar.util.ts
@@ -1,5 +1,6 @@
 import { type Calendar } from "@core/types/calendar.contracts";
 import { type GoogleSyncConnectionSummary } from "@core/types/user.types";
+import { isAccountReconnectRequired } from "@web/auth/google/state/google.reconnect.state";
 
 export function getLocalCalendar(calendars: Calendar[]): Calendar | undefined {
   return calendars.find((calendar) => calendar.provider === "local");
@@ -17,7 +18,34 @@ export interface GetWritableCalendarsOptions {
    * a retention window after the connection itself is gone.
    */
   hasConnectedAccount?: boolean;
+  /**
+   * Account emails that currently need Google reconnect. Their calendars stay
+   * visible on the grid as read-only but must not be offered as create targets.
+   * Defaults to the session reconnect-required set.
+   */
+  reconnectRequiredEmails?: ReadonlySet<string> | readonly string[];
 }
+
+const toEmailSet = (
+  emails: ReadonlySet<string> | readonly string[] | undefined,
+): ReadonlySet<string> | null => {
+  if (!emails) return null;
+  if (emails instanceof Set) return emails;
+  return new Set(
+    emails.map((email) => email.trim().toLowerCase()).filter(Boolean),
+  );
+};
+
+const calendarNeedsReconnect = (
+  calendar: Calendar,
+  reconnectRequiredEmails: ReadonlySet<string> | null,
+): boolean => {
+  if (!calendar.accountEmail) return false;
+  if (reconnectRequiredEmails) {
+    return reconnectRequiredEmails.has(calendar.accountEmail.toLowerCase());
+  }
+  return isAccountReconnectRequired(calendar.accountEmail);
+};
 
 /**
  * Calendars offered as a create target: a reader/freeBusy-only calendar
@@ -30,11 +58,13 @@ export function getWritableCalendars(
   options: GetWritableCalendarsOptions = {},
 ): Calendar[] {
   const { hasConnectedAccount = false } = options;
+  const reconnectRequiredEmails = toEmailSet(options.reconnectRequiredEmails);
 
   return calendars.filter(
     (calendar) =>
       calendar.isActive &&
       calendar.capabilities.canWrite &&
+      !calendarNeedsReconnect(calendar, reconnectRequiredEmails) &&
       (!hasConnectedAccount || calendar.provider !== "local"),
   );
 }
@@ -144,10 +174,21 @@ export interface DefaultTargetCalendarOptions {
    * happened to sort first; this makes the oldest-connected account win.
    */
   accountEmailOrder?: readonly string[];
+  /**
+   * Account emails that currently need Google reconnect. Preferred/default
+   * calendars on those accounts are skipped so creates land on a healthy
+   * account instead. Defaults to the session reconnect-required set.
+   */
+  reconnectRequiredEmails?: ReadonlySet<string> | readonly string[];
 }
 
-const isWritableGoogleCalendar = (calendar: Calendar): boolean =>
-  calendar.provider === "google" && calendar.capabilities.canWrite;
+const isWritableGoogleCalendar = (
+  calendar: Calendar,
+  reconnectRequiredEmails: ReadonlySet<string> | null,
+): boolean =>
+  calendar.provider === "google" &&
+  calendar.capabilities.canWrite &&
+  !calendarNeedsReconnect(calendar, reconnectRequiredEmails);
 
 /**
  * Where a new event lands: the user's chosen default if it is still usable,
@@ -160,18 +201,24 @@ export function getDefaultTargetCalendar(
   options: DefaultTargetCalendarOptions = {},
 ): Calendar | undefined {
   const { preferredCalendarId, accountEmailOrder = [] } = options;
+  const reconnectRequiredEmails = toEmailSet(options.reconnectRequiredEmails);
 
   const preferred = preferredCalendarId
     ? calendars.find((calendar) => calendar.id === preferredCalendarId)
     : undefined;
   // The local calendar is a valid explicit choice even though it is not a
   // writable *Google* calendar.
-  if (preferred?.capabilities.canWrite) {
+  if (
+    preferred?.capabilities.canWrite &&
+    !calendarNeedsReconnect(preferred, reconnectRequiredEmails)
+  ) {
     return preferred;
   }
 
   const primaries = calendars.filter(
-    (calendar) => calendar.isPrimary && isWritableGoogleCalendar(calendar),
+    (calendar) =>
+      calendar.isPrimary &&
+      isWritableGoogleCalendar(calendar, reconnectRequiredEmails),
   );
   const byConnectionOrder = accountEmailOrder
     .map((email) =>

--- a/packages/web/src/calendars/isEventReadOnly.test.ts
+++ b/packages/web/src/calendars/isEventReadOnly.test.ts
@@ -4,12 +4,16 @@ import {
 } from "@core/types/calendar.contracts";
 import { CalendarIdSchema } from "@core/types/domain-primitives";
 import {
+  markAccountReconnectRequired,
+  resetGoogleReconnectRequiredForTests,
+} from "@web/auth/google/state/google.reconnect.state";
+import {
   buildCalendarLookup,
   isEventReadOnly,
   isGridEventInteractionReadOnly,
 } from "@web/calendars/useCalendarLookup";
 import { createObjectIdString } from "@web/common/utils/id/object-id.util";
-import { describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it } from "bun:test";
 
 // Pure unit coverage for the shared read-only rule - the
 // component-level tests (grid cards, shortcuts, context menu, form) each
@@ -34,11 +38,29 @@ const makeCalendar = (overrides: Partial<Calendar> = {}): Calendar => ({
 });
 
 describe("isEventReadOnly", () => {
+  afterEach(() => {
+    resetGoogleReconnectRequiredForTests();
+  });
+
   it("is writable for an event on an owner calendar", () => {
     const calendar = makeCalendar({ access: "owner" });
     const lookup = buildCalendarLookup([calendar]);
 
     expect(isEventReadOnly(lookup, calendar.id, false)).toBe(false);
+  });
+
+  it("is read-only when the calendar's Google account needs reconnect", () => {
+    const calendar = makeCalendar({
+      access: "owner",
+      accountEmail: "lance@example.com",
+    });
+    markAccountReconnectRequired({
+      connectionId: "conn-1",
+      accountEmail: "lance@example.com",
+    });
+    const lookup = buildCalendarLookup([calendar]);
+
+    expect(isEventReadOnly(lookup, calendar.id, false)).toBe(true);
   });
 
   it("is writable for an event on a writer calendar", () => {

--- a/packages/web/src/calendars/useCalendarLookup.ts
+++ b/packages/web/src/calendars/useCalendarLookup.ts
@@ -1,11 +1,7 @@
-import { useSyncExternalStore } from "react";
 import { type Calendar } from "@core/types/calendar.contracts";
 import { type CalendarId } from "@core/types/domain-primitives";
-import {
-  getGoogleReconnectRequiredVersion,
-  isAccountReconnectRequired,
-  subscribeToGoogleReconnectRequired,
-} from "@web/auth/google/state/google.reconnect.state";
+import { isCalendarReconnectRequired } from "@web/auth/google/state/google.reconnect.calendar";
+import { useGoogleReconnectRequiredVersion } from "@web/auth/google/state/google.reconnect.state";
 import { useCalendarsQuery } from "@web/calendars/calendar.query";
 import { type CrossAccountDuplicate } from "@web/common/types/web.event.types";
 
@@ -60,11 +56,7 @@ export function useCalendarLookup(): ReadonlyMap<CalendarId, Calendar> {
   const { data } = useCalendarsQuery();
   // Re-render grid/form consumers when a session reconnect override flips so
   // isEventReadOnly starts treating that account's events as read-only.
-  useSyncExternalStore(
-    subscribeToGoogleReconnectRequired,
-    getGoogleReconnectRequiredVersion,
-    getGoogleReconnectRequiredVersion,
-  );
+  useGoogleReconnectRequiredVersion();
 
   return getCalendarLookup(data);
 }
@@ -152,7 +144,7 @@ export function isEventReadOnly(
   const calendar = lookup.get(calendarId);
   if (!calendar) return false;
 
-  if (isAccountReconnectRequired(calendar.accountEmail)) {
+  if (isCalendarReconnectRequired(calendar)) {
     return true;
   }
 

--- a/packages/web/src/calendars/useCalendarLookup.ts
+++ b/packages/web/src/calendars/useCalendarLookup.ts
@@ -1,5 +1,11 @@
+import { useSyncExternalStore } from "react";
 import { type Calendar } from "@core/types/calendar.contracts";
 import { type CalendarId } from "@core/types/domain-primitives";
+import {
+  getGoogleReconnectRequiredVersion,
+  isAccountReconnectRequired,
+  subscribeToGoogleReconnectRequired,
+} from "@web/auth/google/state/google.reconnect.state";
 import { useCalendarsQuery } from "@web/calendars/calendar.query";
 import { type CrossAccountDuplicate } from "@web/common/types/web.event.types";
 
@@ -52,6 +58,13 @@ function getCalendarLookup(
  */
 export function useCalendarLookup(): ReadonlyMap<CalendarId, Calendar> {
   const { data } = useCalendarsQuery();
+  // Re-render grid/form consumers when a session reconnect override flips so
+  // isEventReadOnly starts treating that account's events as read-only.
+  useSyncExternalStore(
+    subscribeToGoogleReconnectRequired,
+    getGoogleReconnectRequiredVersion,
+    getGoogleReconnectRequiredVersion,
+  );
 
   return getCalendarLookup(data);
 }
@@ -118,6 +131,7 @@ export const isGridEventContentReadOnly = (event: {
  *   reader calendar whose real fields the server never sends, so there is
  *   nothing that could round-trip through an edit; forced read-only
  *   regardless of calendar capability, or
+ * - its calendar belongs to a Google account that needs reconnect, or
  * - its calendar resolves in the lookup and that calendar's
  *   capabilities.canWrite is false.
  *
@@ -137,6 +151,10 @@ export function isEventReadOnly(
 
   const calendar = lookup.get(calendarId);
   if (!calendar) return false;
+
+  if (isAccountReconnectRequired(calendar.accountEmail)) {
+    return true;
+  }
 
   return !calendar.capabilities.canWrite;
 }

--- a/packages/web/src/calendars/useDefaultTargetCalendar.ts
+++ b/packages/web/src/calendars/useDefaultTargetCalendar.ts
@@ -1,9 +1,8 @@
-import { useMemo, useSyncExternalStore } from "react";
+import { useMemo } from "react";
 import { type Calendar } from "@core/types/calendar.contracts";
 import {
   getGoogleReconnectRequiredAccountEmails,
-  getGoogleReconnectRequiredVersion,
-  subscribeToGoogleReconnectRequired,
+  useGoogleReconnectRequiredVersion,
 } from "@web/auth/google/state/google.reconnect.state";
 import {
   selectGoogleSyncConnections,
@@ -26,11 +25,7 @@ export function useDefaultTargetCalendar(
 ): Calendar | undefined {
   const preferredCalendarId = useDefaultCalendarId();
   const accountEmailOrder = useConnectedAccountEmails();
-  useSyncExternalStore(
-    subscribeToGoogleReconnectRequired,
-    getGoogleReconnectRequiredVersion,
-    getGoogleReconnectRequiredVersion,
-  );
+  useGoogleReconnectRequiredVersion();
   const reconnectRequiredEmails = getGoogleReconnectRequiredAccountEmails();
 
   return getDefaultTargetCalendar(calendars, {

--- a/packages/web/src/calendars/useDefaultTargetCalendar.ts
+++ b/packages/web/src/calendars/useDefaultTargetCalendar.ts
@@ -1,5 +1,10 @@
-import { useMemo } from "react";
+import { useMemo, useSyncExternalStore } from "react";
 import { type Calendar } from "@core/types/calendar.contracts";
+import {
+  getGoogleReconnectRequiredAccountEmails,
+  getGoogleReconnectRequiredVersion,
+  subscribeToGoogleReconnectRequired,
+} from "@web/auth/google/state/google.reconnect.state";
 import {
   selectGoogleSyncConnections,
   useUserMetadataStore,
@@ -21,10 +26,17 @@ export function useDefaultTargetCalendar(
 ): Calendar | undefined {
   const preferredCalendarId = useDefaultCalendarId();
   const accountEmailOrder = useConnectedAccountEmails();
+  useSyncExternalStore(
+    subscribeToGoogleReconnectRequired,
+    getGoogleReconnectRequiredVersion,
+    getGoogleReconnectRequiredVersion,
+  );
+  const reconnectRequiredEmails = getGoogleReconnectRequiredAccountEmails();
 
   return getDefaultTargetCalendar(calendars, {
     preferredCalendarId,
     accountEmailOrder,
+    reconnectRequiredEmails,
   });
 }
 

--- a/packages/web/src/common/utils/toast/google-reconnect.toast.test.tsx
+++ b/packages/web/src/common/utils/toast/google-reconnect.toast.test.tsx
@@ -25,16 +25,36 @@ describe("GoogleReconnectToast", () => {
 
   beforeEach(() => {
     mockConnect.mockClear();
+    mockUseConnectGoogle.mockClear();
     mocks.error.mockClear();
     mocks.dismiss.mockClear();
     mocks.isActive.mockReturnValue(false);
     registerToastPort(port);
   });
 
-  const renderToast = () =>
-    render(<GoogleReconnectToast toastId="google-revoked-api" />);
+  const renderToast = (accountEmail?: string) =>
+    render(
+      <GoogleReconnectToast
+        accountEmail={accountEmail}
+        connectionId="conn-1"
+        toastId="google-revoked-api"
+      />,
+    );
 
-  it("explains the disconnect without blaming the user or implying data loss", () => {
+  it("names the affected account when provided", () => {
+    renderToast("lance@example.com");
+
+    expect(
+      screen.getByText("Google Calendar disconnected (lance@example.com)"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Access for lance@example.com expired or was revoked. Your events are still safe in Google. Reconnect and Compass will re-import them.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("falls back to generic copy when no account email is known", () => {
     renderToast();
 
     expect(
@@ -48,7 +68,7 @@ describe("GoogleReconnectToast", () => {
   });
 
   it("dismisses itself and starts connect() on click", () => {
-    renderToast();
+    renderToast("lance@example.com");
 
     fireEvent.click(
       screen.getByRole("button", { name: "Reconnect Google Calendar" }),
@@ -71,8 +91,17 @@ describe("showGoogleReconnectToast", () => {
   it("does not stack a second toast while one is already visible", () => {
     mocks.isActive.mockReturnValue(true);
 
-    showGoogleReconnectToast();
+    showGoogleReconnectToast({ accountEmail: "lance@example.com" });
 
     expect(mocks.error).not.toHaveBeenCalled();
+  });
+
+  it("passes the affected account into the toast content", () => {
+    showGoogleReconnectToast({
+      accountEmail: "lance@example.com",
+      connectionId: "conn-1",
+    });
+
+    expect(mocks.error).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/web/src/common/utils/toast/google-reconnect.toast.tsx
+++ b/packages/web/src/common/utils/toast/google-reconnect.toast.tsx
@@ -1,5 +1,6 @@
 import { createElement } from "react";
 import { type Id } from "react-toastify";
+import { type GoogleSyncConnectionSummary } from "@core/types/user.types";
 import { useConnectGoogle } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle";
 import { type GoogleReconnectTarget } from "@web/auth/google/state/google.reconnect.state";
 import {
@@ -19,6 +20,19 @@ interface GoogleReconnectToastProps {
   connectionId?: string | null;
 }
 
+const toastScopedConnection = (
+  connectionId: string | null | undefined,
+  accountEmail: string | null | undefined,
+): GoogleSyncConnectionSummary => ({
+  id: connectionId?.trim() || "reconnect-target",
+  state: "actionRequired",
+  stateReason: "authorizationRevoked",
+  lastSyncedAt: null,
+  lastHealthyAt: null,
+  accountEmail: accountEmail ?? null,
+  connectionState: "RECONNECT_REQUIRED",
+});
+
 // Shown when Google reports invalid_grant, which covers both "access expired"
 // and "user revoked access" with no way to tell them apart, so the copy must
 // stay accurate for either cause. Hooks are fine here: ToastContainer renders
@@ -33,10 +47,15 @@ export const GoogleReconnectToast = ({
   connectionId,
 }: GoogleReconnectToastProps) => {
   const connections = useUserMetadataStore(selectGoogleSyncConnections);
-  const connection =
+  const connectionFromStore =
     connections.find((entry) => entry.id === connectionId) ??
     connections.find((entry) => entry.accountEmail === accountEmail) ??
     null;
+  // Props keep the target even while metadata is refetching, so Reconnect
+  // still binds OAuth to the broken connectionId instead of adding a new one.
+  const connection =
+    connectionFromStore ??
+    (connectionId ? toastScopedConnection(connectionId, accountEmail) : null);
   const { connect } = useConnectGoogle(connection ? { connection } : undefined);
 
   const handleReconnect = () => {

--- a/packages/web/src/common/utils/toast/google-reconnect.toast.tsx
+++ b/packages/web/src/common/utils/toast/google-reconnect.toast.tsx
@@ -1,6 +1,11 @@
 import { createElement } from "react";
 import { type Id } from "react-toastify";
 import { useConnectGoogle } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle";
+import { type GoogleReconnectTarget } from "@web/auth/google/state/google.reconnect.state";
+import {
+  selectGoogleSyncConnections,
+  useUserMetadataStore,
+} from "@web/auth/state/user-metadata.store";
 import { GOOGLE_REVOKED_TOAST_ID } from "@web/common/constants/toast.constants";
 import {
   ErrorToastSeverity,
@@ -10,6 +15,8 @@ import { getToast } from "@web/common/utils/toast/toast.port";
 
 interface GoogleReconnectToastProps {
   toastId: Id;
+  accountEmail?: string | null;
+  connectionId?: string | null;
 }
 
 // Shown when Google reports invalid_grant, which covers both "access expired"
@@ -22,22 +29,34 @@ interface GoogleReconnectToastProps {
 // this toast can't drift out of sync with the one place that flow lives.
 export const GoogleReconnectToast = ({
   toastId,
+  accountEmail,
+  connectionId,
 }: GoogleReconnectToastProps) => {
-  const { connect } = useConnectGoogle();
+  const connections = useUserMetadataStore(selectGoogleSyncConnections);
+  const connection =
+    connections.find((entry) => entry.id === connectionId) ??
+    connections.find((entry) => entry.accountEmail === accountEmail) ??
+    null;
+  const { connect } = useConnectGoogle(connection ? { connection } : undefined);
 
   const handleReconnect = () => {
     getToast().dismiss(toastId);
     connect();
   };
 
+  const namedAccount = accountEmail?.trim();
+
   return (
     <div className="flex w-full flex-col gap-2">
       <p className="font-medium text-sm text-text">
-        Google Calendar disconnected
+        {namedAccount
+          ? `Google Calendar disconnected (${namedAccount})`
+          : "Google Calendar disconnected"}
       </p>
       <p className="text-sm text-text">
-        This happens when access expires or is revoked. Your events are still
-        safe in Google. Reconnect and Compass will re-import them.
+        {namedAccount
+          ? `Access for ${namedAccount} expired or was revoked. Your events are still safe in Google. Reconnect and Compass will re-import them.`
+          : "This happens when access expires or is revoked. Your events are still safe in Google. Reconnect and Compass will re-import them."}
       </p>
       <button
         className="w-full rounded bg-accent-secondary px-3 py-2 font-medium text-on-accent text-sm transition-colors hover:bg-accent-secondary-hover"
@@ -50,12 +69,22 @@ export const GoogleReconnectToast = ({
   );
 };
 
-export function showGoogleReconnectToast(): Id {
+export function showGoogleReconnectToast(
+  target: GoogleReconnectTarget = {},
+): Id {
   return showErrorToast(
-    createElement(GoogleReconnectToast, { toastId: GOOGLE_REVOKED_TOAST_ID }),
+    createElement(GoogleReconnectToast, {
+      toastId: GOOGLE_REVOKED_TOAST_ID,
+      accountEmail: target.accountEmail,
+      connectionId: target.connectionId,
+    }),
     {
       toastId: GOOGLE_REVOKED_TOAST_ID,
       severity: ErrorToastSeverity.CRITICAL,
     },
   );
+}
+
+export function dismissGoogleReconnectToast(): void {
+  getToast().dismiss(GOOGLE_REVOKED_TOAST_ID);
 }

--- a/packages/web/src/common/utils/toast/google-reconnect.toast.tsx
+++ b/packages/web/src/common/utils/toast/google-reconnect.toast.tsx
@@ -14,6 +14,16 @@ import {
 } from "@web/common/utils/toast/error-toast.util";
 import { getToast } from "@web/common/utils/toast/toast.port";
 
+let hasShownReconnectToastThisLoad = false;
+
+/** True after any path has already raised the reconnect toast this page load. */
+export const hasShownGoogleReconnectToastThisLoad = (): boolean =>
+  hasShownReconnectToastThisLoad;
+
+export const clearGoogleReconnectToastGate = (): void => {
+  hasShownReconnectToastThisLoad = false;
+};
+
 interface GoogleReconnectToastProps {
   toastId: Id;
   accountEmail?: string | null;
@@ -91,6 +101,7 @@ export const GoogleReconnectToast = ({
 export function showGoogleReconnectToast(
   target: GoogleReconnectTarget = {},
 ): Id {
+  hasShownReconnectToastThisLoad = true;
   return showErrorToast(
     createElement(GoogleReconnectToast, {
       toastId: GOOGLE_REVOKED_TOAST_ID,

--- a/packages/web/src/components/Settings/SettingsModal.tsx
+++ b/packages/web/src/components/Settings/SettingsModal.tsx
@@ -1,10 +1,4 @@
-import {
-  type FC,
-  useEffect,
-  useRef,
-  useState,
-  useSyncExternalStore,
-} from "react";
+import { type FC, useEffect, useRef, useState } from "react";
 import { type Calendar } from "@core/types/calendar.contracts";
 import { type CalendarId } from "@core/types/domain-primitives";
 import { type GoogleSyncConnectionSummary } from "@core/types/user.types";
@@ -16,10 +10,6 @@ import {
   googleSyncSupportMailto,
 } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle.util";
 import { useDisconnectGoogleAccount } from "@web/auth/google/hooks/useDisconnectGoogleAccount";
-import {
-  getGoogleReconnectRequiredVersion,
-  subscribeToGoogleReconnectRequired,
-} from "@web/auth/google/state/google.reconnect.state";
 import { useGoogleSyncRefreshSnapshot } from "@web/auth/google/state/google.sync.refresh";
 import {
   selectGoogleSyncConnections,
@@ -90,13 +80,8 @@ export const SettingsModal: FC = () => {
   const { data } = useCalendarsQuery();
   const connections = useUserMetadataStore(selectGoogleSyncConnections);
   const accountEmailOrder = useConnectedAccountEmails();
-  // Session reconnect overrides must refresh Accounts status + writable set
-  // even before Sync metadata catches up to actionRequired.
-  useSyncExternalStore(
-    subscribeToGoogleReconnectRequired,
-    getGoogleReconnectRequiredVersion,
-    getGoogleReconnectRequiredVersion,
-  );
+  // useDefaultTargetCalendar subscribes to session reconnect overrides, so
+  // writableCalendars recomputes when a 410 lands before Sync metadata catches up.
   const writableCalendars = getWritableCalendars(data ?? [], {
     hasConnectedAccount: accountEmailOrder.length > 0,
   }).sort(compareCalendars(accountEmailOrder));

--- a/packages/web/src/components/Settings/SettingsModal.tsx
+++ b/packages/web/src/components/Settings/SettingsModal.tsx
@@ -1,4 +1,10 @@
-import { type FC, useEffect, useRef, useState } from "react";
+import {
+  type FC,
+  useEffect,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from "react";
 import { type Calendar } from "@core/types/calendar.contracts";
 import { type CalendarId } from "@core/types/domain-primitives";
 import { type GoogleSyncConnectionSummary } from "@core/types/user.types";
@@ -10,6 +16,10 @@ import {
   googleSyncSupportMailto,
 } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle.util";
 import { useDisconnectGoogleAccount } from "@web/auth/google/hooks/useDisconnectGoogleAccount";
+import {
+  getGoogleReconnectRequiredVersion,
+  subscribeToGoogleReconnectRequired,
+} from "@web/auth/google/state/google.reconnect.state";
 import { useGoogleSyncRefreshSnapshot } from "@web/auth/google/state/google.sync.refresh";
 import {
   selectGoogleSyncConnections,
@@ -80,6 +90,13 @@ export const SettingsModal: FC = () => {
   const { data } = useCalendarsQuery();
   const connections = useUserMetadataStore(selectGoogleSyncConnections);
   const accountEmailOrder = useConnectedAccountEmails();
+  // Session reconnect overrides must refresh Accounts status + writable set
+  // even before Sync metadata catches up to actionRequired.
+  useSyncExternalStore(
+    subscribeToGoogleReconnectRequired,
+    getGoogleReconnectRequiredVersion,
+    getGoogleReconnectRequiredVersion,
+  );
   const writableCalendars = getWritableCalendars(data ?? [], {
     hasConnectedAccount: accountEmailOrder.length > 0,
   }).sort(compareCalendars(accountEmailOrder));

--- a/packages/web/src/events/mutations/useEventMutations.ts
+++ b/packages/web/src/events/mutations/useEventMutations.ts
@@ -12,7 +12,7 @@ import {
   type RecurrenceScope,
   type ReplaceEventInput,
 } from "@core/types/event-command.contracts";
-import { isAccountReconnectRequired } from "@web/auth/google/state/google.reconnect.state";
+import { isCalendarReconnectRequired } from "@web/auth/google/state/google.reconnect.calendar";
 import { track } from "@web/auth/posthog/track";
 import {
   selectGoogleSyncConnections,
@@ -314,8 +314,7 @@ export function useEventMutations(
       const calendars =
         queryClient.getQueryData<Calendar[]>(calendarQueryKeys.all) ?? [];
       const calendar = calendars.find((entry) => entry.id === calendarId);
-      if (!calendar?.accountEmail) return false;
-      if (!isAccountReconnectRequired(calendar.accountEmail)) return false;
+      if (!calendar || !isCalendarReconnectRequired(calendar)) return false;
 
       const connection = selectGoogleSyncConnections(
         useUserMetadataStore.getState(),

--- a/packages/web/src/events/mutations/useEventMutations.ts
+++ b/packages/web/src/events/mutations/useEventMutations.ts
@@ -12,7 +12,12 @@ import {
   type RecurrenceScope,
   type ReplaceEventInput,
 } from "@core/types/event-command.contracts";
+import { isAccountReconnectRequired } from "@web/auth/google/state/google.reconnect.state";
 import { track } from "@web/auth/posthog/track";
+import {
+  selectGoogleSyncConnections,
+  useUserMetadataStore,
+} from "@web/auth/state/user-metadata.store";
 import { calendarQueryKeys } from "@web/calendars/calendar.query";
 import {
   buildCalendarLookup,
@@ -20,6 +25,7 @@ import {
 } from "@web/calendars/useCalendarLookup";
 import { handleError } from "@web/common/utils/event/event.util";
 import { createObjectIdString } from "@web/common/utils/id/object-id.util";
+import { showGoogleReconnectToast } from "@web/common/utils/toast/google-reconnect.toast";
 import {
   dismissRecurrenceScopeToast,
   dismissRecurrenceScopeToastFor,
@@ -298,6 +304,30 @@ export function useEventMutations(
         event.calendarId,
         event.content.kind === "busy",
       );
+    },
+    [queryClient],
+  );
+
+  const blockReconnectRequiredCalendar = useCallback(
+    (calendarId: Event["calendarId"] | null | undefined): boolean => {
+      if (!calendarId) return false;
+      const calendars =
+        queryClient.getQueryData<Calendar[]>(calendarQueryKeys.all) ?? [];
+      const calendar = calendars.find((entry) => entry.id === calendarId);
+      if (!calendar?.accountEmail) return false;
+      if (!isAccountReconnectRequired(calendar.accountEmail)) return false;
+
+      const connection = selectGoogleSyncConnections(
+        useUserMetadataStore.getState(),
+      ).find((entry) => entry.accountEmail === calendar.accountEmail);
+      showGoogleReconnectToast({
+        connectionId: connection?.id,
+        accountEmail: calendar.accountEmail,
+      });
+      console.warn(
+        `[useEventMutations] blocked write on reconnect-required calendar ${calendarId}`,
+      );
+      return true;
     },
     [queryClient],
   );
@@ -627,6 +657,9 @@ export function useEventMutations(
   return useMemo(
     () => ({
       create: (input: CreateEventInput, callbacks?: EventMutationCallbacks) => {
+        if (blockReconnectRequiredCalendar(input.calendarId)) {
+          return;
+        }
         const id = input.id ?? (createObjectIdString() as EventId);
         const finalInput = { ...input, id };
         recordEventCreateHistory({
@@ -665,6 +698,13 @@ export function useEventMutations(
           );
           return;
         }
+        if (
+          blockReconnectRequiredCalendar(
+            payload.input.calendarId ?? original?.calendarId,
+          )
+        ) {
+          return;
+        }
         const writeKey = seriesWriteKey(
           original,
           payload.input.scope,
@@ -699,16 +739,19 @@ export function useEventMutations(
         );
       },
       delete: (payload: { id: EventId; scope: RecurrenceScope }) => {
-        if (
-          !isRestoringHistory() &&
-          isTargetReadOnly(findEventInCache(queryClient, payload.id, source))
-        ) {
+        const original = findEventInCache(queryClient, payload.id, source);
+        if (!isRestoringHistory() && isTargetReadOnly(original)) {
           console.warn(
             `[useEventMutations] blocked delete on read-only event ${payload.id}`,
           );
           return;
         }
-        const original = findEventInCache(queryClient, payload.id, source);
+        if (
+          !isRestoringHistory() &&
+          blockReconnectRequiredCalendar(original?.calendarId)
+        ) {
+          return;
+        }
         const opportunityId =
           original &&
           original.recurrence.kind === "occurrence" &&
@@ -786,6 +829,7 @@ export function useEventMutations(
       queryClient,
       source,
       isTargetReadOnly,
+      blockReconnectRequiredCalendar,
       createMutation.mutate,
       deleteMutation.mutate,
       replaceMutation.mutate,

--- a/packages/web/src/events/repositories/event.repository.factory.ts
+++ b/packages/web/src/events/repositories/event.repository.factory.ts
@@ -7,13 +7,11 @@ type EventRepositoryDependencies = {
   createRemoteEventRepository: () => EventRepository;
   hasUserEverAuthenticated: () => boolean;
   isBackendUnavailable: () => boolean;
-  isGoogleRevoked: () => boolean;
 };
 
 export function createGetEventRepositorySource({
   hasUserEverAuthenticated,
   isBackendUnavailable,
-  isGoogleRevoked,
 }: Omit<
   EventRepositoryDependencies,
   "createLocalEventRepository" | "createRemoteEventRepository"
@@ -21,10 +19,8 @@ export function createGetEventRepositorySource({
   return function getEventRepositorySource(
     sessionExists: boolean,
   ): EventRepositorySource {
-    if (isGoogleRevoked()) {
-      return "local";
-    }
-
+    // Per-account reconnect-required must not demote healthy Google accounts
+    // to IndexedDB. Write gates block the broken account; remote stays active.
     if (isBackendUnavailable()) {
       return "local";
     }
@@ -62,12 +58,10 @@ export function createGetEventRepository({
   createRemoteEventRepository,
   hasUserEverAuthenticated,
   isBackendUnavailable,
-  isGoogleRevoked,
 }: EventRepositoryDependencies) {
   const getEventRepositorySource = createGetEventRepositorySource({
     hasUserEverAuthenticated,
     isBackendUnavailable,
-    isGoogleRevoked,
   });
   const getEventRepositoryBySource = createGetEventRepositoryBySource({
     createLocalEventRepository,

--- a/packages/web/src/events/repositories/event.repository.util.test.ts
+++ b/packages/web/src/events/repositories/event.repository.util.test.ts
@@ -9,18 +9,15 @@ import { beforeEach, describe, expect, it } from "bun:test";
 describe("getEventRepositorySource", () => {
   let hasUserEverAuthenticated = false;
   let isBackendUnavailable = false;
-  let isGoogleRevoked = false;
 
   const getEventRepositorySource = createGetEventRepositorySource({
     hasUserEverAuthenticated: () => hasUserEverAuthenticated,
     isBackendUnavailable: () => isBackendUnavailable,
-    isGoogleRevoked: () => isGoogleRevoked,
   });
 
   beforeEach(() => {
     hasUserEverAuthenticated = false;
     isBackendUnavailable = false;
-    isGoogleRevoked = false;
   });
 
   it("returns 'remote' when a session exists", () => {
@@ -37,17 +34,10 @@ describe("getEventRepositorySource", () => {
     expect(getEventRepositorySource(false)).toBe("remote");
   });
 
-  it("returns 'local' when Google disconnected Compass", () => {
-    isGoogleRevoked = true;
-
-    expect(getEventRepositorySource(true)).toBe("local");
-  });
-
-  it("returns 'local' when Google disconnected Compass for a returning user", () => {
+  it("keeps remote for authenticated sessions so a reconnect-required sibling cannot demote healthy accounts", () => {
     hasUserEverAuthenticated = true;
-    isGoogleRevoked = true;
 
-    expect(getEventRepositorySource(false)).toBe("local");
+    expect(getEventRepositorySource(true)).toBe("remote");
   });
 
   it("returns 'local' for a returning user when the backend is unavailable", () => {
@@ -67,20 +57,17 @@ describe("getEventRepositorySource", () => {
 describe("getEventRepository", () => {
   let hasUserEverAuthenticated = false;
   let isBackendUnavailable = false;
-  let isGoogleRevoked = false;
 
   const getEventRepository = createGetEventRepository({
     createLocalEventRepository: () => new LocalEventRepository(),
     createRemoteEventRepository: () => new RemoteEventRepository(),
     hasUserEverAuthenticated: () => hasUserEverAuthenticated,
     isBackendUnavailable: () => isBackendUnavailable,
-    isGoogleRevoked: () => isGoogleRevoked,
   });
 
   beforeEach(() => {
     hasUserEverAuthenticated = false;
     isBackendUnavailable = false;
-    isGoogleRevoked = false;
   });
 
   it("uses remote storage when a session exists", () => {
@@ -95,19 +82,6 @@ describe("getEventRepository", () => {
     hasUserEverAuthenticated = true;
 
     expect(getEventRepository(false)).toBeInstanceOf(RemoteEventRepository);
-  });
-
-  it("uses local storage when Google disconnected Compass", () => {
-    isGoogleRevoked = true;
-
-    expect(getEventRepository(true)).toBeInstanceOf(LocalEventRepository);
-  });
-
-  it("uses local storage when Google disconnected Compass for a returning user", () => {
-    hasUserEverAuthenticated = true;
-    isGoogleRevoked = true;
-
-    expect(getEventRepository(false)).toBeInstanceOf(LocalEventRepository);
   });
 
   it("uses local storage for a returning user when the backend is unavailable", () => {

--- a/packages/web/src/events/repositories/event.repository.util.ts
+++ b/packages/web/src/events/repositories/event.repository.util.ts
@@ -1,7 +1,9 @@
 /**
  * Repository selection entry point.
  * This factory decides whether event reads/writes go to local IndexedDB or the remote API.
- * Google connection state, remembered auth state, and current session state decide the target.
+ * Remembered auth state, backend availability, and current session state decide the target.
+ * Per-account Google reconnect-required is handled by write gates / read-only UI, not by
+ * flipping the whole app onto IndexedDB.
  * Reads flow through TanStack Query (see event.query.options.ts + the useXEventsQuery
  * hooks, which resolve the source via event.repository.source.store); mutations flow
  * through the event operations/listeners. The reactive source store must be refreshed at
@@ -12,7 +14,6 @@
 
 import { isBackendUnavailable } from "@web/api/util/backend-unavailable-error.util";
 import { hasUserEverAuthenticated } from "@web/auth/compass/state/auth.state.util";
-import { isGoogleRevoked } from "@web/auth/google/state/google.auth.state";
 import {
   createGetEventRepositoryBySource,
   createGetEventRepositorySource,
@@ -26,25 +27,22 @@ import { RemoteEventRepository } from "./remote.event.repository";
 export const getEventRepositorySource = createGetEventRepositorySource({
   hasUserEverAuthenticated,
   isBackendUnavailable,
-  isGoogleRevoked,
 });
 
 /**
  * Factory function to get the appropriate event repository based on session and authentication state.
  *
  * Repository selection logic:
- * 1. If Google disconnected Compass: Use LocalEventRepository
- *    - Graceful degradation until user re-authenticates
- *    - Prevents API errors from failed Google token refresh
- * 2. If the backend is unavailable: Use LocalEventRepository
+ * 1. If the backend is unavailable: Use LocalEventRepository
  *    - Keeps frontend-only development and self-hosted UI-only deployments usable
  *    - Events remain saved in IndexedDB instead of failing remote requests
- * 3. If user has EVER authenticated: Use RemoteEventRepository
+ * 2. If user has EVER authenticated: Use RemoteEventRepository
  *    - Prevents remote account events from disappearing when the session is temporarily missing
  *    - Remote requests can surface the auth problem instead of silently saving locally
- * 4. If a session exists: Use RemoteEventRepository
+ *    - A single Google account needing reconnect does not demote healthy accounts
+ * 3. If a session exists: Use RemoteEventRepository
  *    - Newly authenticated users persist through the backend even before remembered auth state updates
- * 5. If user has NEVER authenticated: Use LocalEventRepository (IndexedDB)
+ * 4. If user has NEVER authenticated: Use LocalEventRepository (IndexedDB)
  *    - Events stored locally until user decides to sign in
  *
  * @param sessionExists - Whether a session currently exists (from session.doesSessionExist())

--- a/packages/web/src/sse/hooks/useGcalSSE.ts
+++ b/packages/web/src/sse/hooks/useGcalSSE.ts
@@ -1,5 +1,8 @@
 import { queryClient } from "@web/api/query-client";
-import { refreshUserMetadata } from "@web/auth/compass/user/util/user-metadata.util";
+import {
+  applyUserMetadataSideEffects,
+  refreshUserMetadata,
+} from "@web/auth/compass/user/util/user-metadata.util";
 import { handleGoogleRevoked } from "@web/auth/google/util/google.auth.util";
 import { userMetadataActions } from "@web/auth/state/user-metadata.store";
 import { showErrorToast } from "@web/common/utils/toast/error-toast.util";
@@ -14,6 +17,9 @@ export const useGcalSSE = createUseGcalSSE({
     invalidateEventQueriesUnlessMutating(queryClient, eventQueryKeys.all),
   onServerMessage,
   refreshUserMetadata,
-  setUserMetadata: userMetadataActions.set,
+  setUserMetadata: (metadata) => {
+    userMetadataActions.set(metadata);
+    applyUserMetadataSideEffects(metadata);
+  },
   showErrorToast,
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the contradictory Google reconnect UX where a disconnected toast could sit beside “Calendar connected” / “Syncing in the background…”, events could flicker, and a `410` write was the first hard signal.

- Session-scoped per-account reconnect override keeps a live `GOOGLE_REVOKED` durable even if Sync metadata briefly still says healthy/catchingUp
- Reconnect-required wins in Settings, sidebar, and aggregate UI state
- Toast names the affected account, reconnects that connection (props survive metadata refetch), and dismisses when the requirement clears
- Last-known events stay visible read-only; writes on the broken account are hard-blocked; healthy sibling accounts keep CRUD/sync
- Ambiguous multi-account revoke signals refresh metadata instead of sticky-marking the wrong primary
- Acceptance Scenario 7 / 7b / 13 and regression checks updated

## Simplicity

- Shared `useGoogleReconnectRequiredVersion` for reconnect subscriptions
- Split connection-scoped vs aggregate reconnect helpers so healthy siblings stay calm
- Removed Settings duplicate subscription (default-calendar hook already re-renders)

## Automated validation

- Focused `bun test:web` on reconnect/status/toast/calendar/repository/api/settings suites — passing
- `bun run type-check` — passing
- `bun run knip` — passing
- `bun lint` — exit 0 (pre-existing unrelated warnings only)

## Independent review

Fresh read-only review found two blockers (toast OAuth losing connectionId during metadata clear; multi-account sticky override of primary). Both fixed in `fix(web): harden reconnect toast targeting and multi-account overrides`. Medium finding (connectionId-only override vs email write gates) addressed via `isCalendarReconnectRequired`.

## Test plan

- `bun test:web --` on touched reconnect/status/toast/calendar/settings tests
- `bun run type-check`
- `bun run knip`
- `bun lint`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3fad8532-6695-4f85-bfe9-e366e74c6dc5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3fad8532-6695-4f85-bfe9-e366e74c6dc5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

