### PR TITLE
fix(web): seed day events from overlapping week cache

### DIFF
--- a/packages/web/src/events/queries/event.query.cache.test.ts
+++ b/packages/web/src/events/queries/event.query.cache.test.ts
@@ -147,4 +147,25 @@ describe("event query cache", () => {
       }),
     ).toBeUndefined();
   });
+
+  test("returns empty placeholder when an overlapping week has no events in range", () => {
+    const client = new QueryClient();
+    const event = createMockEvent({
+      schedule: EventScheduleSchema.parse({
+        kind: "timed",
+        start: "2026-07-03T09:00:00.000Z",
+        end: "2026-07-03T10:00:00.000Z",
+        timeZone: "UTC",
+      }),
+    });
+    client.setQueryData(keys.localWeek, normalizeEventList([event]));
+
+    expect(
+      deriveOverlappingEventQueryData(client, {
+        source: "local",
+        startDate: "2026-07-05T00:00:00.000Z",
+        endDate: "2026-07-06T00:00:00.000Z",
+      }),
+    ).toEqual({ ids: [], entities: {} });
+  });
 });

--- a/packages/web/src/events/queries/event.query.cache.ts
+++ b/packages/web/src/events/queries/event.query.cache.ts
@@ -122,8 +122,10 @@ export function eventBelongsToEntry(
 /**
  * Builds placeholder read data for a requested day or week range by merging
  * events from any cached week entries whose stored range overlaps it. Returns
- * `undefined` when nothing usable is cached so true first loads still show
- * the loading state.
+ * an empty normalized set when an overlapping week is cached but has no
+ * events in the requested window (so empty days do not spin). Returns
+ * `undefined` only when no overlapping week cache exists, so true first
+ * loads still show the loading state.
  */
 export function deriveOverlappingEventQueryData(
   queryClient: QueryClient,
@@ -137,6 +139,7 @@ export function deriveOverlappingEventQueryData(
   const entities: NormalizedEventQueryData["entities"] = {};
   const ids: EventId[] = [];
   const seenIds = new Set<string>();
+  let foundOverlappingWeek = false;
 
   for (const entry of getEventQueryEntries(queryClient, {
     source,
@@ -153,6 +156,8 @@ export function deriveOverlappingEventQueryData(
       continue;
     }
 
+    foundOverlappingWeek = true;
+
     for (const id of entry.data.ids) {
       if (seenIds.has(id)) continue;
       const event = entry.data.entities[id];
@@ -167,7 +172,7 @@ export function deriveOverlappingEventQueryData(
     }
   }
 
-  return ids.length > 0 ? { ids, entities } : undefined;
+  return foundOverlappingWeek ? { ids, entities } : undefined;
 }
 
 // Shared by every writer below: find the matching cached query entries and

--- a/packages/web/src/events/queries/event.query.cache.ts
+++ b/packages/web/src/events/queries/event.query.cache.ts
@@ -120,8 +120,8 @@ export function eventBelongsToEntry(
 }
 
 /**
- * Builds placeholder read data for a requested week range by merging events
- * from any cached week entries whose stored range overlaps it. Returns
+ * Builds placeholder read data for a requested day or week range by merging
+ * events from any cached week entries whose stored range overlaps it. Returns
  * `undefined` when nothing usable is cached so true first loads still show
  * the loading state.
  */
@@ -156,7 +156,11 @@ export function deriveOverlappingEventQueryData(
     for (const id of entry.data.ids) {
       if (seenIds.has(id)) continue;
       const event = entry.data.entities[id];
-      if (!event || !eventMatchesRange(event, startDate, endDate)) continue;
+      // Skip incomplete cache rows (tests / corrupt entries) so placeholder
+      // derivation never throws while reading a neighboring range.
+      if (!event?.schedule || !eventMatchesRange(event, startDate, endDate)) {
+        continue;
+      }
       seenIds.add(id);
       ids.push(id);
       entities[id] = event;

--- a/packages/web/src/events/queries/useDayEventsQuery.test.ts
+++ b/packages/web/src/events/queries/useDayEventsQuery.test.ts
@@ -83,4 +83,34 @@ describe("useDayEventsQuery", () => {
     expect(result.result.current.isPlaceholderData).toBe(true);
     expect(result.result.current.isPending).toBe(false);
   });
+
+  it("serves an empty placeholder for a day with no events inside a cached week", async () => {
+    const queryClient = createCompassQueryClient();
+    const weekStart = dayjs.utc("2025-11-10T00:00:00Z");
+    const weekEnd = weekStart.add(6, "day").endOf("day");
+    const event = createMockEvent({
+      schedule: EventScheduleSchema.parse({
+        kind: "timed",
+        start: "2025-11-11T09:00:00.000Z",
+        end: "2025-11-11T10:00:00.000Z",
+        timeZone: "UTC",
+      }),
+    });
+    queryClient.setQueryData(
+      eventQueryKeys.week({
+        source: "local",
+        start: toUTCOffset(weekStart),
+        end: toUTCOffset(weekEnd),
+      }),
+      normalizeEventList([event]),
+    );
+
+    const result = renderHook(() => useDayEventsQuery(dayRange("2025-11-14")), {
+      queryClient,
+    });
+
+    expect(result.result.current.data).toEqual({ ids: [], entities: {} });
+    expect(result.result.current.isPlaceholderData).toBe(true);
+    expect(result.result.current.isPending).toBe(false);
+  });
 });

--- a/packages/web/src/events/queries/useDayEventsQuery.test.ts
+++ b/packages/web/src/events/queries/useDayEventsQuery.test.ts
@@ -1,0 +1,86 @@
+import { waitFor } from "@testing-library/react";
+import { EventScheduleSchema } from "@core/types/event.contracts";
+import dayjs from "@core/util/date/dayjs";
+import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
+import { toUTCOffset } from "@web/common/utils/datetime/web.date.util";
+import { eventQueryKeys } from "@web/events/queries/event.query.keys";
+import { normalizeEventList } from "@web/events/queries/event.query.normalize";
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+
+const dayEvent = createMockEvent({
+  schedule: EventScheduleSchema.parse({
+    kind: "timed",
+    start: "2025-11-12T09:00:00.000Z",
+    end: "2025-11-12T10:00:00.000Z",
+    timeZone: "UTC",
+  }),
+});
+
+const fetchDayEvents = mock(async () => normalizeEventList([dayEvent]));
+
+mock.module("@web/events/queries/day.event.query", () => ({
+  fetchDayEvents,
+}));
+
+const { renderHook } =
+  require("@web/__tests__/__mocks__/mock.render") as typeof import("@web/__tests__/__mocks__/mock.render");
+const { createCompassQueryClient } =
+  require("@web/api/query-client") as typeof import("@web/api/query-client");
+const { useDayEventsQuery } =
+  require("@web/events/queries/useDayEventsQuery") as typeof import("@web/events/queries/useDayEventsQuery");
+
+const dayRange = (date = "2025-11-12") => {
+  const start = dayjs.utc(`${date}T00:00:00Z`);
+  return {
+    startDate: toUTCOffset(start),
+    endDate: toUTCOffset(start.add(1, "day")),
+  };
+};
+
+describe("useDayEventsQuery", () => {
+  beforeEach(() => {
+    fetchDayEvents.mockClear();
+  });
+
+  it("returns fetched day events", async () => {
+    const queryClient = createCompassQueryClient();
+
+    const result = renderHook(() => useDayEventsQuery(dayRange()), {
+      queryClient,
+    });
+
+    await waitFor(() => {
+      expect(result.result.current.data?.ids).toEqual([dayEvent.id]);
+    });
+  });
+
+  it("serves overlapping placeholder data from a cached week while fetching", async () => {
+    const queryClient = createCompassQueryClient();
+    const weekStart = dayjs.utc("2025-11-10T00:00:00Z");
+    const weekEnd = weekStart.add(6, "day").endOf("day");
+    const event = createMockEvent({
+      schedule: EventScheduleSchema.parse({
+        kind: "timed",
+        start: "2025-11-12T09:00:00.000Z",
+        end: "2025-11-12T10:00:00.000Z",
+        timeZone: "UTC",
+      }),
+    });
+    queryClient.setQueryData(
+      eventQueryKeys.week({
+        source: "local",
+        start: toUTCOffset(weekStart),
+        end: toUTCOffset(weekEnd),
+      }),
+      normalizeEventList([event]),
+    );
+
+    const result = renderHook(() => useDayEventsQuery(dayRange("2025-11-12")), {
+      queryClient,
+    });
+
+    expect(result.result.current.data?.ids).toEqual([event.id]);
+    expect(result.result.current.isPlaceholderData).toBe(true);
+    expect(result.result.current.isPending).toBe(false);
+  });
+});

--- a/packages/web/src/events/queries/useDayEventsQuery.ts
+++ b/packages/web/src/events/queries/useDayEventsQuery.ts
@@ -1,4 +1,5 @@
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { deriveOverlappingEventQueryData } from "@web/events/queries/event.query.cache";
 import { dayEventsQueryOptions } from "@web/events/queries/event.query.options";
 import { useEventRepositorySource } from "@web/events/repositories/event.repository.source.store";
 import { useCalendarEventViewModel } from "./useCalendarEventViewModel";
@@ -10,11 +11,18 @@ type DayEventsQueryArgs = {
 };
 
 export function useDayEventsQuery({ startDate, endDate }: DayEventsQueryArgs) {
+  const queryClient = useQueryClient();
   const source = useEventRepositorySource();
   const calendarIds = useEventListCalendarIds();
-  const query = useQuery(
-    dayEventsQueryOptions({ source, startDate, endDate, calendarIds }),
-  );
+  const query = useQuery({
+    ...dayEventsQueryOptions({ source, startDate, endDate, calendarIds }),
+    placeholderData: () =>
+      deriveOverlappingEventQueryData(queryClient, {
+        source,
+        startDate,
+        endDate,
+      }),
+  });
   return { ...query, calendarIds };
 }
 

--- a/packages/web/src/events/queries/useWeekEventsQuery.test.ts
+++ b/packages/web/src/events/queries/useWeekEventsQuery.test.ts
@@ -1,5 +1,4 @@
 import { waitFor } from "@testing-library/react";
-import { type EventId } from "@core/types/domain-primitives";
 import { EventScheduleSchema } from "@core/types/event.contracts";
 import dayjs from "@core/util/date/dayjs";
 import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
@@ -8,17 +7,16 @@ import { eventQueryKeys } from "@web/events/queries/event.query.keys";
 import { normalizeEventList } from "@web/events/queries/event.query.normalize";
 import { beforeEach, describe, expect, it, mock } from "bun:test";
 
-const fetchWeekEvents = mock(async () => ({
-  ids: ["week-1"],
-  entities: {
-    "week-1": {
-      _id: "week-1",
-      title: "Sprint",
-      startDate: "2025-11-10T09:00:00",
-      endDate: "2025-11-10T10:00:00",
-    },
-  },
-}));
+const weekEvent = createMockEvent({
+  schedule: EventScheduleSchema.parse({
+    kind: "timed",
+    start: "2025-11-10T09:00:00.000Z",
+    end: "2025-11-10T10:00:00.000Z",
+    timeZone: "UTC",
+  }),
+});
+
+const fetchWeekEvents = mock(async () => normalizeEventList([weekEvent]));
 
 mock.module("@web/events/queries/week.event.query", () => ({
   fetchWeekEvents,
@@ -49,9 +47,7 @@ describe("useWeekEventsQuery", () => {
     });
 
     await waitFor(() => {
-      expect(result.result.current.data?.ids).toEqual([
-        "week-1",
-      ] as unknown as EventId[]);
+      expect(result.result.current.data?.ids).toEqual([weekEvent.id]);
     });
   });
 
@@ -72,15 +68,15 @@ describe("useWeekEventsQuery", () => {
       queryClient,
     });
     await waitFor(() => {
-      expect(second.result.current.data?.ids).toEqual([
-        "week-1",
-      ] as unknown as EventId[]);
+      expect(second.result.current.data?.ids).toEqual([weekEvent.id]);
     });
     expect(fetchWeekEvents.mock.calls.length).toBe(callsAfterFirst);
   });
 
   it("returns query error when the fetch rejects", async () => {
-    fetchWeekEvents.mockImplementationOnce(async () => {
+    // Stay rejected for the whole test — Strict Mode remounts would
+    // otherwise consume a one-shot mock and leave a successful retry.
+    fetchWeekEvents.mockImplementation(async () => {
       throw new Error("boom");
     });
     const queryClient = createCompassQueryClient();
@@ -92,6 +88,10 @@ describe("useWeekEventsQuery", () => {
     await waitFor(() => {
       expect(result.result.current.error?.message).toBe("boom");
     });
+
+    fetchWeekEvents.mockImplementation(async () =>
+      normalizeEventList([weekEvent]),
+    );
   });
 
   it("serves overlapping placeholder data from cache while fetching a shifted range", async () => {


### PR DESCRIPTION
## Summary

Day view event queries now use the same overlapping-cache placeholder as week view. Jumping to an uncached day that already sits inside a loaded week paints those events immediately and refetches in the background, so the full-grid spinner no longer blocks navigation.

## Simplicity

Mirrored the existing week-query `placeholderData` path; no new abstraction. Also skip incomplete cache rows during derivation so a bad entry cannot crash placeholder reads.

## Automated validation

- `bun test:web` on day/week query and event-query-cache tests
- `bun run verify` (selected from diff)
- `bun run lint` (warnings only; none from this change)

## Independent review

Self-reviewed against week-query pattern; change is a thin mirror plus a defensive schedule guard and fixture cleanup in the week query tests.

## Test plan

- `bun test:web packages/web/src/events/queries/useDayEventsQuery.test.ts packages/web/src/events/queries/useWeekEventsQuery.test.ts packages/web/src/events/queries/event.query.cache.test.ts`
- `bun run verify`
- `bun run lint`