### PR TITLE
fix(web): keep calendar chrome visible during event load

### DIFF
--- a/packages/web/src/grid/components/EventGrid.test.tsx
+++ b/packages/web/src/grid/components/EventGrid.test.tsx
@@ -184,7 +184,7 @@ describe("EventGrid", () => {
     expect(loader).not.toHaveClass("pointer-events-none");
   });
 
-  it("keeps first-load loader click-through for drag-create", () => {
+  it("keeps first-load loader click-through and leaves grid chrome visible", () => {
     render(
       <EventGrid
         allDayEventsLayer={<div />}
@@ -203,9 +203,17 @@ describe("EventGrid", () => {
       />,
     );
 
-    expect(screen.getByRole("status", { name: "Loading events" })).toHaveClass(
-      "pointer-events-none",
-    );
+    const loader = screen.getByRole("status", { name: "Loading events" });
+    expect(loader).toHaveClass("pointer-events-none");
+    expect(loader).toHaveClass("backdrop-blur-none");
+    expect(loader).not.toHaveClass("bg-background");
+    // Chrome is already mounted under the non-blocking indicator.
+    expect(
+      screen.getByRole("region", { name: "Timed events grid" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("region", { name: "All-day events" }),
+    ).toBeInTheDocument();
   });
 
   it("shows the loader for first load and for retry after error", () => {

--- a/packages/web/src/grid/components/EventGrid.tsx
+++ b/packages/web/src/grid/components/EventGrid.tsx
@@ -75,15 +75,15 @@ export const EventGrid: FC<EventGridProps> = ({
       data-testid="grid-focus-indicator"
     />
     {isLoadingEvents && (
-      // First load keeps pointer-events-none so drag-create still works under
-      // the spinner. Retry after error must block the grid — the overlay is
-      // opaque and should not click through.
+      // First load: keep grid chrome (hour lines, columns) visible under a
+      // small non-blocking spinner — no opaque fill or blur. Retry after
+      // error stays opaque and blocks the grid so Retry cannot click through.
       <AbsoluteOverflowLoader
         aria-label="Loading events"
         className={
           isErrorEvents
             ? "bg-background [&>div]:my-0"
-            : "pointer-events-none bg-background [&>div]:my-0"
+            : "pointer-events-none backdrop-blur-none [&>div]:my-0 [&>div]:h-10 [&>div]:w-10 [&>div]:border-2"
         }
         role="status"
         style={{ zIndex: ZIndex.MAX }}


### PR DESCRIPTION
## Summary

On cold / first event load, the grid overlay no longer covers the calendar with an opaque blurred background. Hour lines, columns, and the all-day row stay visible under a small non-blocking spinner. Retry-after-error still uses the blocking opaque cover.

## Simplicity

One className branch in EventGrid — no skeleton system.

## Automated validation

- `bun test:web packages/web/src/grid/components/EventGrid.test.tsx`
- `bun run verify`
- `bun run lint`

## Independent review

Self-reviewed: chrome already rendered under the loader; the opaque `bg-background` + backdrop blur were what hid it.

## Test plan

- `bun test:web packages/web/src/grid/components/EventGrid.test.tsx`
- `bun run verify`
- `bun run lint`