### PR TITLE
fix(sync): drop durable calendarList discovery failures

### DIFF
--- a/docs/development/cli.md
+++ b/docs/development/cli.md
@@ -17,6 +17,33 @@ Primary file:
 | `bun run cli purge-user --email <address> [--apply] [--out report.json]` | `packages/scripts/src/commands/purge-user.ts` | Deletes one user's API, Sync, and SuperTokens data. Defaults to dry-run. |
 | `bun run cli purge-corrupt-sync-events [--apply]` | `packages/scripts/src/commands/purge-corrupt-sync-events.ts` | Deletes invalid Sync event documents. Defaults to dry-run. |
 | `bun run cli refresh-connection-states [--apply]` | `packages/scripts/src/commands/refresh-connection-states.ts` | Re-derives Sync connection state. Defaults to dry-run. |
+| `bun run cli manage-failed-jobs <list\|clear\|requeue> …` | `packages/scripts/src/commands/manage-failed-jobs.ts` | Operator tooling for Sync jobs that exhausted the self-heal requeue budget. Defaults to dry-run; pass `--apply` to persist. |
+
+### Manage exhausted Sync jobs
+
+Requires `SYNC_MONGO_URI` or `sync.mongoUri` in `compass.yaml` pointed at the
+isolated Sync Mongo database.
+
+```bash
+export SYNC_MONGO_URI='…'
+
+# Inventory exhausted jobs (JSON to stdout)
+bun run cli manage-failed-jobs list
+
+# Clear a stuck failed job so a new enqueue can take its coalescing key
+bun run cli manage-failed-jobs clear \
+  --id <SyncJobId> \
+  --coalescing-key <key> \
+  --apply
+
+# Or force another full retry ladder on the same job id
+bun run cli manage-failed-jobs requeue --id <SyncJobId> --apply
+```
+
+Prefer dry-run (omit `--apply`) before writing. Clear is the usual unblock when
+the underlying condition is durable (for example Google `notACalendarUser`);
+also fix or disconnect the Google account so daily calendar-list rediscovery
+does not recreate the same ladder.
 
 ## Sync Database Backup / Restore
 

--- a/packages/scripts/src/commands/manage-failed-jobs.ts
+++ b/packages/scripts/src/commands/manage-failed-jobs.ts
@@ -67,6 +67,8 @@ export async function runManageFailedJobs(): Promise<void> {
           id: job.id,
           coalescingKey: job.coalescingKey,
           connectionId: job.connectionId,
+          tenantId: job.tenantId,
+          principalId: job.principalId,
           failureClass: job.failureClass,
           requeuedCount: job.requeuedCount,
           updatedAt: job.updatedAt.toISOString(),

--- a/packages/sync/src/app.ts
+++ b/packages/sync/src/app.ts
@@ -561,6 +561,8 @@ function buildSchedulers(
                 id: job.id,
                 coalescingKey: job.coalescingKey,
                 connectionId: job.connectionId,
+                tenantId: job.tenantId,
+                principalId: job.principalId,
                 failureClass: job.failureClass,
                 requeuedCount: job.requeuedCount,
                 updatedAt: job.updatedAt.toISOString(),

--- a/packages/sync/src/domain/calendar-list-sync.service.db.test.ts
+++ b/packages/sync/src/domain/calendar-list-sync.service.db.test.ts
@@ -237,6 +237,41 @@ describe("syncCalendarList", () => {
     expect(primary?.active).toBe(true);
   });
 
+  it("clears a prior discovery failure even when rediscovery returns no cursor", async () => {
+    const conn = connection();
+    const list = await resources.ensure({
+      tenantId: conn.tenantId,
+      principalId: conn.principalId,
+      connectionId: conn._id,
+      resourceKind: "calendarList",
+      calendarId: null,
+    });
+    await resources.markReadFailure(
+      conn.tenantId,
+      conn.principalId,
+      list._id,
+      new Date("2026-07-01T00:00:00.000Z"),
+      "The user must be signed up for Google Calendar. (HTTP 403, reason notACalendarUser)",
+    );
+
+    await syncCalendarList(
+      deps(
+        new FakeDiscovery([
+          { calendars: [discovered("primary")], cursor: null },
+        ]),
+      ),
+      conn,
+      now,
+    );
+
+    const after = await calendarListResource(conn);
+    expect(after?.lastReadFailureAt).toBeNull();
+    expect(after?.lastReadFailureDetail).toBeNull();
+    expect(after?.lastSuccessAt).toEqual(now());
+    // Null discovery cursor must not wipe/store a cursor — next pass full-lists.
+    expect(after?.syncCursor).toBeNull();
+  });
+
   it("stamps lastAttemptAt on the calendarList resource before it can fail", async () => {
     // Without this, the rediscovery sweep's rotation sort (lastAttemptAt) ties
     // at null forever for a permanently-failing connection, and it re-wins the

--- a/packages/sync/src/domain/calendar-list-sync.service.ts
+++ b/packages/sync/src/domain/calendar-list-sync.service.ts
@@ -90,7 +90,9 @@ export async function syncCalendarList(
       fullList = true;
       discovery = await deps.discovery.discoverCalendars({ accessToken });
     } else {
-      // discoveryFailed or unexpected: transient, let the worker retry.
+      // transient / discoveryFailed / unexpected: rethrow. Durable discovery
+      // refusals (discoveryFailed) are settled as drops in dispatchSyncJob;
+      // transient failures stay on the worker retry ladder.
       throw error;
     }
   }

--- a/packages/sync/src/domain/calendar-list-sync.service.ts
+++ b/packages/sync/src/domain/calendar-list-sync.service.ts
@@ -211,18 +211,17 @@ export async function syncCalendarList(
     imported += 1;
   }
 
-  // Record the new discovery cursor so the next pass lists incrementally. Google
-  // always returns a nextSyncToken on the final page; if a provider ever returns
-  // none, we simply full-list again next pass rather than store a null cursor.
-  if (discovery.cursor) {
-    await deps.resources.advanceCursor(
-      tenantId,
-      principalId,
-      resource._id,
-      discovery.cursor,
-      now(),
-    );
-  }
+  // Stamp success (and clear any prior durable discovery failure) even when the
+  // provider returns no next sync token. Google normally returns a nextSyncToken
+  // on the final page; a null cursor means leave the stored token alone and
+  // full-list again next pass rather than writing null.
+  await deps.resources.advanceCursor(
+    tenantId,
+    principalId,
+    resource._id,
+    discovery.cursor,
+    now(),
+  );
 
   return { discovered: discovery.calendars.length, imported };
 }

--- a/packages/sync/src/domain/connection-state-refresh.service.db.test.ts
+++ b/packages/sync/src/domain/connection-state-refresh.service.db.test.ts
@@ -555,6 +555,60 @@ describe("refreshConnectionState", () => {
     expect(after.stateReason).toBe("providerErrors");
   });
 
+  it("reports delayed/providerErrors when calendarList discovery durably fails", async () => {
+    const connection = await seedImportingConnection();
+    const listResource = await resources.ensure({
+      tenantId: connection.tenantId,
+      principalId: connection.principalId,
+      connectionId: connection._id,
+      resourceKind: "calendarList",
+      calendarId: null,
+    });
+    // No active calendars and no events marker — connection-wide discovery
+    // refusal used to leave the connection stuck on "importing" forever.
+    await resources.markReadFailure(
+      connection.tenantId,
+      connection.principalId,
+      listResource._id,
+      new Date(),
+      "The user must be signed up for Google Calendar. (HTTP 403, reason notACalendarUser)",
+    );
+
+    const after = await refreshConnectionState(deps(), connection);
+    expect(after.state).toBe("delayed");
+    expect(after.stateReason).toBe("providerErrors");
+  });
+
+  it("clears calendarList discovery failure once rediscovery succeeds", async () => {
+    const connection = await seedImportingConnection();
+    const listResource = await resources.ensure({
+      tenantId: connection.tenantId,
+      principalId: connection.principalId,
+      connectionId: connection._id,
+      resourceKind: "calendarList",
+      calendarId: null,
+    });
+    await resources.markReadFailure(
+      connection.tenantId,
+      connection.principalId,
+      listResource._id,
+      new Date(),
+      "The user must be signed up for Google Calendar. (HTTP 403, reason notACalendarUser)",
+    );
+    // Successful rediscovery advances the cursor and clears the marker.
+    await resources.advanceCursor(
+      connection.tenantId,
+      connection.principalId,
+      listResource._id,
+      "list-cursor",
+      new Date(),
+    );
+
+    const after = await refreshConnectionState(deps(), connection);
+    expect(after.state).toBe("healthy");
+    expect(after.stateReason).toBeNull();
+  });
+
   it("ignores a read-failure marker on a calendar that is no longer active", async () => {
     const connection = await seedImportingConnection();
     const calendar = await calendars.upsertByProviderCalendar({

--- a/packages/sync/src/domain/connection-state-refresh.service.ts
+++ b/packages/sync/src/domain/connection-state-refresh.service.ts
@@ -154,11 +154,14 @@ export async function gatherConnectionStateEvidence(
   return {
     disconnectedAt: connection.disconnectedAt,
     credential: credentialState(credential),
-    // Only ACTIVE calendars count: a deactivated calendar's stale marker is not
-    // a problem the user can act on, and its jobs are dropped anyway.
-    durableReadFailure: activeCalendars.some(
-      (c) => eventsByCalendar.get(c._id)?.lastReadFailureAt != null,
-    ),
+    // Connection-wide calendarList discovery failure OR an ACTIVE calendar's
+    // event-read failure. A deactivated calendar's stale marker is not a
+    // problem the user can act on, and its jobs are dropped anyway.
+    durableReadFailure:
+      calendarList?.lastReadFailureAt != null ||
+      activeCalendars.some(
+        (c) => eventsByCalendar.get(c._id)?.lastReadFailureAt != null,
+      ),
     accountIdentified: Boolean(connection.account.providerAccountId),
     // Discovery must have finished, and every currently-active calendar must
     // have a cursor plus a successful post-watch catch-up pull. A cursor alone

--- a/packages/sync/src/domain/connection-state.ts
+++ b/packages/sync/src/domain/connection-state.ts
@@ -40,11 +40,13 @@ export interface ConnectionStateEvidence {
   // The user ended this connection; nothing else matters.
   readonly disconnectedAt: Date | null;
   readonly credential: CredentialState;
-  // At least one ACTIVE calendar's reads are durably rejected by the provider
-  // (see the readFailed settlement in sync-job-dispatch). Its job was settled
-  // rather than left retrying, so no overdue-work signal remains to notice —
-  // without this, a connection whose primary calendar had been dead for days
-  // still reported healthy, every other signal green (2026-07-30).
+  // At least one ACTIVE calendar's event reads are durably rejected, OR the
+  // connection's calendarList discovery was durably rejected (see the
+  // readFailed / discoveryFailed settlements in sync-job-dispatch). Those jobs
+  // are settled as drops rather than left retrying, so no overdue-work signal
+  // remains to notice — without this, a connection whose primary calendar or
+  // account-level discovery had been dead for days still reported healthy,
+  // every other signal green (2026-07-30 / 2026-08-08).
   readonly durableReadFailure: boolean;
   // The provider account identity has been resolved.
   readonly accountIdentified: boolean;

--- a/packages/sync/src/domain/sync-job-dispatch.service.db.test.ts
+++ b/packages/sync/src/domain/sync-job-dispatch.service.db.test.ts
@@ -9,6 +9,7 @@ import {
   type SyncJobDispatchDeps,
 } from "@sync/domain/sync-job-dispatch.service";
 import { ProviderAuthError } from "@sync/providers/provider-auth.port";
+import { ProviderCalendarError } from "@sync/providers/provider-calendar.port";
 import {
   type ProviderEvent,
   type ProviderEventRead,
@@ -172,13 +173,14 @@ describe("dispatchSyncJob", () => {
     reader: FakeReader,
     custody: SyncJobDispatchDeps["custody"] = tokenSource,
     notificationsOverride: SyncJobDispatchDeps["notifications"] = notifications,
+    discoveryOverride: SyncJobDispatchDeps["discovery"] = discovery,
   ): SyncJobDispatchDeps => ({
     events,
     occurrences,
     resources,
     calendars,
     connections,
-    discovery,
+    discovery: discoveryOverride,
     jobs,
     commands,
     reader,
@@ -805,5 +807,85 @@ describe("dispatchSyncJob", () => {
       expect(outcome.reason).toContain("authorizationRevoked");
     }
     expect(discarded).toEqual([connectionId]);
+  });
+
+  it("drops a durable calendarList discovery failure and marks the calendarList resource", async () => {
+    const tenantId = objectId();
+    const principalId = objectId();
+    const connectionId = objectId();
+    stubbedConnection = {
+      _id: connectionId,
+      tenantId,
+      principalId,
+    } as ProviderConnectionRecord;
+    const failingDiscovery: SyncJobDispatchDeps["discovery"] = {
+      provider: "google",
+      discoverCalendars: async () => {
+        throw new ProviderCalendarError(
+          "discoveryFailed",
+          "Google rejected the calendar list read",
+          {
+            cause: new Error(
+              "The user must be signed up for Google Calendar. (HTTP 403, reason notACalendarUser)",
+            ),
+          },
+        );
+      },
+    };
+
+    const outcome = await dispatchSyncJob(
+      deps(new FakeReader([]), tokenSource, notifications, failingDiscovery),
+      calendarListJob(connectionId, tenantId, principalId),
+      now,
+    );
+
+    expect(outcome.result).toBe("drop");
+    if (outcome.result === "drop") {
+      expect(outcome.reason).toContain("notACalendarUser");
+      expect(outcome.reason).toContain(connectionId);
+    }
+    const listResource = (
+      await resources.listByConnection(
+        tenantId as ProviderConnectionRecord["tenantId"],
+        principalId as ProviderConnectionRecord["principalId"],
+        connectionId as ProviderConnectionRecord["_id"],
+      )
+    ).find((resource) => resource.resourceKind === "calendarList");
+    expect(listResource?.lastReadFailureAt).toEqual(now());
+    expect(listResource?.lastReadFailureDetail).toContain("notACalendarUser");
+  });
+
+  it("rethrows a transient calendarList discovery failure for the worker retry ladder", async () => {
+    const tenantId = objectId();
+    const principalId = objectId();
+    const connectionId = objectId();
+    stubbedConnection = {
+      _id: connectionId,
+      tenantId,
+      principalId,
+    } as ProviderConnectionRecord;
+    const transientDiscovery: SyncJobDispatchDeps["discovery"] = {
+      provider: "google",
+      discoverCalendars: async () => {
+        throw new ProviderCalendarError(
+          "transient",
+          "Google rejected the calendar list read",
+          { cause: new Error("HTTP 503") },
+        );
+      },
+    };
+
+    await expect(
+      dispatchSyncJob(
+        deps(
+          new FakeReader([]),
+          tokenSource,
+          notifications,
+          transientDiscovery,
+        ),
+        calendarListJob(connectionId, tenantId, principalId),
+        now,
+      ),
+    ).rejects.toMatchObject({ reason: "transient" });
   });
 });

--- a/packages/sync/src/domain/sync-job-dispatch.service.ts
+++ b/packages/sync/src/domain/sync-job-dispatch.service.ts
@@ -5,7 +5,10 @@ import { repairCalendar } from "@sync/domain/calendar-repair.service";
 import { type AccessTokenSource } from "@sync/domain/provider-command.service";
 import { maintainSubscription } from "@sync/domain/subscription-maintenance.service";
 import { ProviderAuthError } from "@sync/providers/provider-auth.port";
-import { type ProviderCalendarAdapter } from "@sync/providers/provider-calendar.port";
+import {
+  type ProviderCalendarAdapter,
+  ProviderCalendarError,
+} from "@sync/providers/provider-calendar.port";
 import {
   ProviderEventReadError,
   type ProviderEventReader,
@@ -140,6 +143,38 @@ export async function dispatchSyncJob(
       return {
         result: "drop",
         reason: `provider durably rejected reads for resource ${job.resourceId} (${detail}); sync resumes once the calendar is readable again`,
+      };
+    }
+
+    // Durable calendar-list discovery refusal (e.g. notACalendarUser). Same
+    // drop-not-fail rationale as readFailed above. calendarListSync jobs carry
+    // resourceId: null, so resolve the connection's calendarList resource for
+    // the health marker — syncCalendarList ensured it before discovery threw.
+    if (
+      error instanceof ProviderCalendarError &&
+      error.reason === "discoveryFailed"
+    ) {
+      const detail =
+        error.cause instanceof Error ? error.cause.message : error.message;
+      const calendarList = (
+        await deps.resources.listByConnection(
+          job.tenantId,
+          job.principalId,
+          job.connectionId,
+        )
+      ).find((resource) => resource.resourceKind === "calendarList");
+      if (calendarList) {
+        await deps.resources.markReadFailure(
+          job.tenantId,
+          job.principalId,
+          calendarList._id,
+          now(),
+          detail,
+        );
+      }
+      return {
+        result: "drop",
+        reason: `provider durably rejected calendar-list discovery for connection ${job.connectionId} (${detail}); sync resumes once the account can list calendars again`,
       };
     }
     throw error;

--- a/packages/sync/src/domain/sync-job-worker.service.db.test.ts
+++ b/packages/sync/src/domain/sync-job-worker.service.db.test.ts
@@ -5,6 +5,7 @@ import {
   SyncJobWorker,
   type SyncJobWorkerDeps,
 } from "@sync/domain/sync-job-worker.service";
+import { ProviderCalendarError } from "@sync/providers/provider-calendar.port";
 import {
   type ProviderEvent,
   type ProviderEventRead,
@@ -112,16 +113,21 @@ describe("SyncJobWorker", () => {
     invalidations = new InvalidationRepository(storage.db());
   });
 
-  const deps = (reader: FakeReader): SyncJobWorkerDeps => ({
+  const defaultDiscovery: SyncJobWorkerDeps["discovery"] = {
+    provider: "google",
+    discoverCalendars: async () => ({ calendars: [], cursor: null }),
+  };
+
+  const deps = (
+    reader: FakeReader,
+    discoveryOverride: SyncJobWorkerDeps["discovery"] = defaultDiscovery,
+  ): SyncJobWorkerDeps => ({
     events,
     occurrences,
     resources,
     calendars,
     connections,
-    discovery: {
-      provider: "google",
-      discoverCalendars: async () => ({ calendars: [], cursor: null }),
-    },
+    discovery: discoveryOverride,
     commands,
     jobs,
     reader,
@@ -143,9 +149,12 @@ describe("SyncJobWorker", () => {
 
   // A worker that records every drop reason, so a test can assert the drop path
   // was taken (and why) rather than only that the job row vanished.
-  const workerRecordingDrops = (reader: FakeReader) => {
+  const workerRecordingDrops = (
+    reader: FakeReader,
+    discoveryOverride: SyncJobWorkerDeps["discovery"] = defaultDiscovery,
+  ) => {
     const drops: string[] = [];
-    const w = new SyncJobWorker(deps(reader), OWNER, {
+    const w = new SyncJobWorker(deps(reader, discoveryOverride), OWNER, {
       now,
       onDrop: (_job, reason) => drops.push(reason),
     });
@@ -516,6 +525,84 @@ describe("SyncJobWorker", () => {
       capabilities: calendar.capabilities,
     });
     const requeued = await enqueue(resource, "initialImport");
+    expect(requeued.state).toBe("pending");
+  });
+
+  it("settles a durable calendarList discovery failure instead of burning the retry ladder", async () => {
+    const connection = await connections.upsertByProviderAccount({
+      tenantId: objectId(),
+      principalId: objectId(),
+      provider: "google",
+      account: {
+        providerAccountId: "acct-not-cal",
+        email: "nocal@example.com",
+        displayName: "No Cal",
+      },
+      capabilities: ["readEvents", "readBusy", "writeEvents"],
+      state: "importing",
+      stateReason: null,
+      lastSyncedAt: null,
+      lastHealthyAt: null,
+    });
+    const job = await jobs.enqueue({
+      tenantId: connection.tenantId,
+      principalId: connection.principalId,
+      connectionId: connection._id,
+      resourceId: null,
+      commandId: null,
+      kind: "calendarListSync",
+      priority: 0,
+      runAfter: now(),
+      coalescingKey: `calendarListSync:${connection._id}`,
+    });
+    const failingDiscovery: SyncJobWorkerDeps["discovery"] = {
+      provider: "google",
+      discoverCalendars: async () => {
+        throw new ProviderCalendarError(
+          "discoveryFailed",
+          "Google rejected the calendar list read",
+          {
+            cause: new Error(
+              "The user must be signed up for Google Calendar. (HTTP 403, reason notACalendarUser)",
+            ),
+          },
+        );
+      },
+    };
+
+    const { worker: w, drops } = workerRecordingDrops(
+      new FakeReader([]),
+      failingDiscovery,
+    );
+    await w.runOnce();
+
+    expect(
+      await jobs.findById(connection.tenantId, connection.principalId, job._id),
+    ).toBeNull();
+    expect(drops).toHaveLength(1);
+    expect(drops[0]).toContain("notACalendarUser");
+
+    const listResource = (
+      await resources.listByConnection(
+        connection.tenantId,
+        connection.principalId,
+        connection._id,
+      )
+    ).find((resource) => resource.resourceKind === "calendarList");
+    expect(listResource?.lastReadFailureAt).toEqual(now());
+
+    // Drop frees the coalescing key so rediscovery/reconnect can re-enqueue.
+    const requeued = await jobs.enqueue({
+      tenantId: connection.tenantId,
+      principalId: connection.principalId,
+      connectionId: connection._id,
+      resourceId: null,
+      commandId: null,
+      kind: "calendarListSync",
+      priority: 0,
+      runAfter: now(),
+      coalescingKey: `calendarListSync:${connection._id}`,
+    });
     expect(requeued.state).toBe("pending");
   });
 

--- a/packages/sync/src/providers/google/google-calendar.adapter.test.ts
+++ b/packages/sync/src/providers/google/google-calendar.adapter.test.ts
@@ -381,15 +381,23 @@ describe("GoogleCalendarAdapter", () => {
     expect(error.reason).toBe("cursorExpired");
   });
 
-  it("maps any other provider error to discoveryFailed and redacts the cause", async () => {
+  it("maps a durable 403 (notACalendarUser) to discoveryFailed with triage facts", async () => {
     // A gaxios-shaped error whose config carries the bearer token must never
-    // survive onto the ProviderCalendarError cause chain.
-    const leaky = Object.assign(new Error("Request failed with status 403"), {
-      config: {
-        headers: { Authorization: "Bearer super-secret-access-token" },
+    // survive onto the ProviderCalendarError cause chain; status/reason must.
+    const leaky = Object.assign(
+      new Error("The user must be signed up for Google Calendar."),
+      {
+        config: {
+          headers: { Authorization: "Bearer super-secret-access-token" },
+        },
+        response: {
+          status: 403,
+          data: {
+            error: { errors: [{ reason: "notACalendarUser" }] },
+          },
+        },
       },
-      response: { status: 403 },
-    });
+    );
     const api = new FakeCalendarListApi([], leaky);
     const { adapter } = adapterWith(api);
 
@@ -399,9 +407,54 @@ describe("GoogleCalendarAdapter", () => {
 
     expect(error.reason).toBe("discoveryFailed");
     expect(error.cause).toBeInstanceOf(Error);
+    expect((error.cause as Error).message).toContain("HTTP 403");
+    expect((error.cause as Error).message).toContain("reason notACalendarUser");
     expect((error.cause as { config?: unknown }).config).toBeUndefined();
     expect(JSON.stringify(error.cause)).not.toContain(
       "super-secret-access-token",
     );
+  });
+
+  it("maps a network failure to transient", async () => {
+    const api = new FakeCalendarListApi([], new Error("socket hang up"));
+    const { adapter } = adapterWith(api);
+
+    const error = (await adapter
+      .discoverCalendars({ accessToken: "at" })
+      .catch((e) => e)) as ProviderCalendarError;
+
+    expect(error.reason).toBe("transient");
+  });
+
+  it("maps a 5xx provider error to transient", async () => {
+    const api = new FakeCalendarListApi([], {
+      response: { status: 503 },
+    });
+    const { adapter } = adapterWith(api);
+
+    const error = (await adapter
+      .discoverCalendars({ accessToken: "at" })
+      .catch((e) => e)) as ProviderCalendarError;
+
+    expect(error.reason).toBe("transient");
+  });
+
+  it("maps a quota 403 to transient rather than discoveryFailed", async () => {
+    const quota = Object.assign(new Error("Request failed with status 403"), {
+      response: {
+        status: 403,
+        data: {
+          error: { errors: [{ reason: "rateLimitExceeded" }] },
+        },
+      },
+    });
+    const api = new FakeCalendarListApi([], quota);
+    const { adapter } = adapterWith(api);
+
+    const error = (await adapter
+      .discoverCalendars({ accessToken: "at" })
+      .catch((e) => e)) as ProviderCalendarError;
+
+    expect(error.reason).toBe("transient");
   });
 });

--- a/packages/sync/src/providers/google/google-calendar.adapter.test.ts
+++ b/packages/sync/src/providers/google/google-calendar.adapter.test.ts
@@ -439,12 +439,17 @@ describe("GoogleCalendarAdapter", () => {
     expect(error.reason).toBe("transient");
   });
 
-  it("maps a quota 403 to transient rather than discoveryFailed", async () => {
+  it.each([
+    "rateLimitExceeded",
+    "userRateLimitExceeded",
+    "quotaExceeded",
+    "dailyLimitExceeded",
+  ])("maps a 403 %s to transient rather than discoveryFailed", async (reason) => {
     const quota = Object.assign(new Error("Request failed with status 403"), {
       response: {
         status: 403,
         data: {
-          error: { errors: [{ reason: "rateLimitExceeded" }] },
+          error: { errors: [{ reason }] },
         },
       },
     });

--- a/packages/sync/src/providers/google/google-calendar.adapter.ts
+++ b/packages/sync/src/providers/google/google-calendar.adapter.ts
@@ -253,6 +253,7 @@ const TRANSIENT_REASONS = [
   "rateLimitExceeded",
   "userRateLimitExceeded",
   "quotaExceeded",
+  "dailyLimitExceeded",
   "backendError",
   "internalError",
 ];

--- a/packages/sync/src/providers/google/google-calendar.adapter.ts
+++ b/packages/sync/src/providers/google/google-calendar.adapter.ts
@@ -151,12 +151,13 @@ export class GoogleCalendarAdapter implements ProviderCalendarAdapter {
       return await api.listPage(params);
     } catch (error) {
       // An expired syncToken (410 Gone) is not retryable with the same token:
-      // the caller must drop it and re-list in full. Everything else is a
-      // generic discovery failure.
+      // the caller must drop it and re-list in full. Transient failures stay
+      // retryable; durable refusals (notACalendarUser, etc.) surface as
+      // discoveryFailed so dispatch can drop instead of burning the ladder.
       throw new ProviderCalendarError(
-        isCursorExpired(error) ? "cursorExpired" : "discoveryFailed",
+        classifyDiscoveryError(error),
         "Google rejected the calendar list read",
-        { cause: redactedCause(error) },
+        { cause: discoveryFailureCause(error) },
       );
     }
   }
@@ -234,11 +235,74 @@ function mapAccessRole(
   return (googleRole && ACCESS_ROLE_BY_GOOGLE[googleRole]) || "busyOnly";
 }
 
-// Google signals an expired calendar-list syncToken with HTTP 410 Gone. The
-// status lives on the response, so reading it does not touch the request.
-function isCursorExpired(error: unknown): boolean {
+// Map a Google calendarList.list failure to a discovery-error reason. An
+// expired syncToken (410 Gone) forces a full re-list; network / rate-limit /
+// quota / server errors are retryable; other 4xx (including notACalendarUser)
+// are durable refusals. Quota arrives as 403, so status alone cannot separate
+// it from a durable 403 — same TRANSIENT_REASONS set as the watch/writer path.
+function classifyDiscoveryError(
+  error: unknown,
+): "cursorExpired" | "transient" | "discoveryFailed" {
+  const status = googleStatus(error);
+  if (status === 410) return "cursorExpired";
+  if (isDiscoveryTransient(error, status)) return "transient";
+  return "discoveryFailed";
+}
+
+const TRANSIENT_REASONS = [
+  "rateLimitExceeded",
+  "userRateLimitExceeded",
+  "quotaExceeded",
+  "backendError",
+  "internalError",
+];
+
+function isDiscoveryTransient(
+  error: unknown,
+  status: number | undefined,
+): boolean {
+  if (status === undefined || status === 429 || status >= 500) return true;
+  return googleErrorReasons(error).some((reason) =>
+    TRANSIENT_REASONS.includes(reason),
+  );
+}
+
+// Like redactedCause: drop request-derived fields (bearer token on config), but
+// keep the two response facts triage needs — numeric HTTP status and Google's
+// machine-readable reason. Mirrors readFailureCause / watchFailureCause.
+function discoveryFailureCause(error: unknown): Error | undefined {
+  const status = googleStatus(error);
+  const reason = googleErrorReasons(error)[0];
+  const facts = [
+    ...(status === undefined ? [] : [`HTTP ${status}`]),
+    ...(reason === undefined ? [] : [`reason ${reason}`]),
+  ];
+  if (facts.length === 0) return redactedCause(error);
+  const message = error instanceof Error ? error.message : null;
+  return new Error(
+    message ? `${message} (${facts.join(", ")})` : facts.join(", "),
+  );
+}
+
+function googleErrorReasons(error: unknown): string[] {
+  const fromBody = (
+    error as {
+      response?: {
+        data?: { error?: { errors?: Array<{ reason?: unknown }> } };
+      };
+    }
+  )?.response?.data?.error?.errors;
+  const fromError = (error as { errors?: Array<{ reason?: unknown }> })?.errors;
+  const reasons: string[] = [];
+  for (const entry of [...(fromBody ?? []), ...(fromError ?? [])]) {
+    if (typeof entry?.reason === "string") reasons.push(entry.reason);
+  }
+  return reasons;
+}
+
+function googleStatus(error: unknown): number | undefined {
   const status =
     (error as { response?: { status?: number } })?.response?.status ??
     (error as { code?: number })?.code;
-  return status === 410;
+  return typeof status === "number" ? status : undefined;
 }

--- a/packages/sync/src/providers/google/google-notifications.adapter.test.ts
+++ b/packages/sync/src/providers/google/google-notifications.adapter.test.ts
@@ -189,6 +189,7 @@ describe("GoogleNotificationAdapter watch/stop", () => {
     "rateLimitExceeded",
     "userRateLimitExceeded",
     "quotaExceeded",
+    "dailyLimitExceeded",
   ])("keeps a 403 %s transient, not durable", async (reason) => {
     const api = new FakeChannelsApi({ watch: gError(403, reason) });
     const { adapter } = adapterWith(api);

--- a/packages/sync/src/providers/google/google-notifications.adapter.ts
+++ b/packages/sync/src/providers/google/google-notifications.adapter.ts
@@ -235,6 +235,7 @@ const TRANSIENT_REASONS = [
   "rateLimitExceeded",
   "userRateLimitExceeded",
   "quotaExceeded",
+  "dailyLimitExceeded",
   "backendError",
   "internalError",
 ];

--- a/packages/sync/src/providers/provider-calendar.port.ts
+++ b/packages/sync/src/providers/provider-calendar.port.ts
@@ -56,9 +56,13 @@ export interface ProviderCalendarAdapter {
 
 // Why a discovery attempt could not complete. `cursorExpired` is distinct so the
 // caller can drop the stale cursor and re-list in full instead of retrying with
-// a token the provider will keep rejecting.
+// a token the provider will keep rejecting. `transient` is a retryable
+// network/quota/server failure; `discoveryFailed` is a durable provider refusal
+// (e.g. notACalendarUser) that dispatch must drop rather than burn the retry
+// ladder on.
 export type ProviderCalendarErrorReason =
-  | "discoveryFailed" // the provider rejected or failed the calendar-list read
+  | "discoveryFailed" // durable: the provider rejected the calendar-list read
+  | "transient" // retryable: network, rate limit, quota, or server error
   | "cursorExpired"; // the incremental cursor is too old; a full re-list is required
 
 export class ProviderCalendarError extends ProviderError<ProviderCalendarErrorReason> {}

--- a/packages/sync/src/storage/contracts/sync-resource.contracts.ts
+++ b/packages/sync/src/storage/contracts/sync-resource.contracts.ts
@@ -61,7 +61,8 @@ export const SyncResourceRecordSchema = z.strictObject({
   // Set when the provider durably rejects reads for this resource (a
   // non-transient 4xx retries cannot fix — see the readFailed settlement for
   // events resources and the discoveryFailed settlement for calendarList in
-  // sync-job-dispatch). Cleared by the next successful pass (advanceCursor).
+  // sync-job-dispatch). Cleared by the next successful pass (advanceCursor),
+  // including when that pass advances with a null cursor.
   // Connection health surfaces a non-null marker on an active events calendar
   // or on the connection's calendarList resource as delayed/providerErrors.
   // Defaults tolerate rows written before the field.

--- a/packages/sync/src/storage/contracts/sync-resource.contracts.ts
+++ b/packages/sync/src/storage/contracts/sync-resource.contracts.ts
@@ -59,10 +59,12 @@ export const SyncResourceRecordSchema = z.strictObject({
   lastAttemptAt: z.date().nullable(),
   lastSuccessAt: z.date().nullable(),
   // Set when the provider durably rejects reads for this resource (a
-  // non-transient 4xx retries cannot fix — see the readFailed settlement in
+  // non-transient 4xx retries cannot fix — see the readFailed settlement for
+  // events resources and the discoveryFailed settlement for calendarList in
   // sync-job-dispatch). Cleared by the next successful pass (advanceCursor).
-  // Connection health surfaces a non-null marker on an active calendar as
-  // delayed/providerErrors. Defaults tolerate rows written before the field.
+  // Connection health surfaces a non-null marker on an active events calendar
+  // or on the connection's calendarList resource as delayed/providerErrors.
+  // Defaults tolerate rows written before the field.
   lastReadFailureAt: z.date().nullable().default(null),
   // The redacted failure detail (HTTP status + provider reason) for triage.
   lastReadFailureDetail: z.string().min(1).nullable().default(null),

--- a/packages/sync/src/storage/repositories/job.repository.ts
+++ b/packages/sync/src/storage/repositories/job.repository.ts
@@ -18,6 +18,8 @@ export type ExhaustedFailedJob = {
   id: SyncJobId;
   coalescingKey: string;
   connectionId: ConnectionId;
+  tenantId: TenantId;
+  principalId: PrincipalId;
   failureClass: Exclude<JobRecord["failureClass"], null>;
   requeuedCount: number;
   updatedAt: Date;
@@ -433,6 +435,8 @@ export class JobRepository {
         _id: 1,
         coalescingKey: 1,
         connectionId: 1,
+        tenantId: 1,
+        principalId: 1,
         failureClass: 1,
         requeuedCount: 1,
         updatedAt: 1,
@@ -443,6 +447,8 @@ export class JobRepository {
       id: row["_id"] as SyncJobId,
       coalescingKey: String(row["coalescingKey"]),
       connectionId: row["connectionId"] as ConnectionId,
+      tenantId: row["tenantId"] as TenantId,
+      principalId: row["principalId"] as PrincipalId,
       failureClass: (row["failureClass"] ?? "retryableTransient") as Exclude<
         JobRecord["failureClass"],
         null

--- a/packages/sync/src/storage/repositories/sync-resource.repository.db.test.ts
+++ b/packages/sync/src/storage/repositories/sync-resource.repository.db.test.ts
@@ -248,6 +248,42 @@ describe("SyncResourceRepository", () => {
     expect(after?.lastReadFailureDetail).toBeNull();
   });
 
+  it("clears the read-failure marker on success even when syncCursor is null", async () => {
+    const resource = await repo.ensure(upsert());
+    await repo.advanceCursor(
+      resource.tenantId,
+      resource.principalId,
+      resource._id,
+      "kept-cursor",
+      new Date("2026-07-20T12:00:00.000Z"),
+    );
+    await repo.markReadFailure(
+      resource.tenantId,
+      resource.principalId,
+      resource._id,
+      new Date("2026-07-21T12:00:00.000Z"),
+      "The user must be signed up for Google Calendar. (HTTP 403, reason notACalendarUser)",
+    );
+    const succeededAt = new Date("2026-07-24T12:00:00.000Z");
+    await repo.advanceCursor(
+      resource.tenantId,
+      resource.principalId,
+      resource._id,
+      null,
+      succeededAt,
+    );
+
+    const after = await repo.findById(
+      resource.tenantId,
+      resource.principalId,
+      resource._id,
+    );
+    expect(after?.syncCursor).toBe("kept-cursor");
+    expect(after?.lastSuccessAt).toEqual(succeededAt);
+    expect(after?.lastReadFailureAt).toBeNull();
+    expect(after?.lastReadFailureDetail).toBeNull();
+  });
+
   it("updates and clears the push subscription", async () => {
     const resource = await repo.ensure(upsert());
     await repo.updateSubscription(

--- a/packages/sync/src/storage/repositories/sync-resource.repository.ts
+++ b/packages/sync/src/storage/repositories/sync-resource.repository.ts
@@ -129,24 +129,24 @@ export class SyncResourceRepository {
     );
   }
 
-  // Advance the incremental cursor after a batch fully commits, clearing the
-  // mid-batch checkpoint and recording success. A successful pass also clears
-  // any durable read-failure marker: the provider is answering again, so the
-  // connection must stop reporting delayed/providerErrors without an operator
-  // having to clear anything by hand.
+  // Record a successful read pass. When `syncCursor` is a string, store it and
+  // clear the mid-batch page checkpoint; when null, leave the stored cursor
+  // alone (calendarList rediscovery may succeed without a next sync token and
+  // intentionally full-list next pass). Either way clears any durable
+  // read-failure marker so connection health stops reporting
+  // delayed/providerErrors without an operator clearing anything by hand.
   async advanceCursor(
     tenantId: TenantId,
     principalId: PrincipalId,
     id: string,
-    syncCursor: string,
+    syncCursor: string | null,
     succeededAt: Date,
   ): Promise<void> {
     await this.collection.updateOne(
       { _id: id, tenantId, principalId },
       {
         $set: {
-          syncCursor,
-          pageCursor: null,
+          ...(syncCursor === null ? {} : { syncCursor, pageCursor: null }),
           lastSuccessAt: succeededAt,
           lastReadFailureAt: null,
           lastReadFailureDetail: null,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Stops Google `notACalendarUser` (and other durable calendar-list 4xx) from burning the self-heal requeue budget and spamming PostHog with “exhausted their requeue budget” errors.

- Classify calendar-list errors like the watch/writer path: `410` → `cursorExpired`, quota/network/5xx (including `dailyLimitExceeded`) → `transient`, other 4xx (including `notACalendarUser`) → durable `discoveryFailed`
- `dispatchSyncJob` drops durable discovery failures, marks `calendarList.lastReadFailureAt`, and frees the coalescing key (same rationale as event `readFailed`)
- Successful rediscovery always stamps success / clears the durable marker, even when the provider returns a null next sync token
- Connection health treats calendarList durable markers as `delayed` / `providerErrors`
- Exhausted-job samples and `manage-failed-jobs list` now include `tenantId` / `principalId` for triage
- Documented `manage-failed-jobs` in `docs/development/cli.md`

## Simplicity

Diff stays on the existing event-read durable-drop path; no new job kinds or health states. Shared Google `TRANSIENT_REASONS` helpers across adapters were considered and deferred — discovery/watch lists now match the writer’s quota reasons (`dailyLimitExceeded` included) without a cross-adapter refactor.

## Automated validation

- `bun test:sync --` focused adapter, calendar-list-sync, sync-resource repository, dispatch, worker, and connection-state-refresh tests (pass)
- `bun lint` (no new issues in touched files; pre-existing warnings only)

## Independent review

Fresh review found two highs; both fixed in `7c84da2a`:

1. `dailyLimitExceeded` was missing from discovery/watch transient reason lists (writer already had it) — quota daily-limit 403 could be wrongly durable-dropped
2. Successful rediscovery with a null discovery cursor never called `advanceCursor`, so `lastReadFailureAt` could stick and leave health on `delayed`/`providerErrors`

## Test plan

- [x] Adapter unit tests cover durable `notACalendarUser` and transient quota reasons including `dailyLimitExceeded`
- [x] Dispatch/worker DB tests drop `discoveryFailed`, mark calendarList, free coalescing key
- [x] Connection-state-refresh treats calendarList `lastReadFailureAt` as providerErrors
- [x] Null-cursor rediscovery clears a prior discovery failure marker
- [x] Stuck staging job already cleared via `manage-failed-jobs clear --apply`

## Immediate ops note

Stuck job `6a76454e6a9f4b8649b55e41` / `calendarListSync:6a6539741eaf145653f64365` was cleared. Enable Google Calendar on that account or disconnect it in Compass so rediscovery can succeed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9cf58c68-5037-4d51-8f41-1ffdbe6bc7d8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9cf58c68-5037-4d51-8f41-1ffdbe6bc7d8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

