### PR TITLE
feat(web): make event focus arrows spatial in week and day

### DIFF
--- a/e2e/timed/spatial-focus-arrows.spec.ts
+++ b/e2e/timed/spatial-focus-arrows.spec.ts
@@ -1,0 +1,46 @@
+import { expect, test } from "@playwright/test";
+import {
+  createEventTitle,
+  expectTimedEventVisible,
+  fillTitleAndSaveEventForm,
+  getMainGridPoint,
+  prepareCalendarPage,
+} from "../utils/event-test-utils";
+
+const createTimedEventAt = async (
+  page: Parameters<typeof prepareCalendarPage>[0],
+  title: string,
+  { xRatio }: { xRatio: number },
+) => {
+  const { x, y } = await getMainGridPoint(page, { xRatio, yRatio: 0.35 });
+  await page.mouse.click(x, y);
+  await fillTitleAndSaveEventForm(page, title);
+  await expectTimedEventVisible(page, title);
+};
+
+test("ArrowRight moves focus to the nearest event on the next non-empty day", async ({
+  page,
+}) => {
+  await prepareCalendarPage(page);
+
+  const mondayTitle = createEventTitle("Monday Focus");
+  const wednesdayTitle = createEventTitle("Wednesday Focus");
+
+  // Leftmost columns are earlier weekdays; ratios stay inside timed columns.
+  await createTimedEventAt(page, mondayTitle, { xRatio: 0.12 });
+  await createTimedEventAt(page, wednesdayTitle, { xRatio: 0.42 });
+
+  const mondayButton = page
+    .locator("#mainGrid")
+    .getByRole("button", { name: mondayTitle });
+  const wednesdayButton = page
+    .locator("#mainGrid")
+    .getByRole("button", { name: wednesdayTitle });
+
+  await mondayButton.focus();
+  await expect(mondayButton).toBeFocused();
+
+  await page.keyboard.press("ArrowRight");
+
+  await expect(wednesdayButton).toBeFocused();
+});

--- a/packages/web/src/grid/shortcuts/focus-adjacent-grid-event.test.ts
+++ b/packages/web/src/grid/shortcuts/focus-adjacent-grid-event.test.ts
@@ -1,7 +1,11 @@
 import { Origin } from "@core/constants/core.constants";
+import dayjs from "@core/util/date/dayjs";
 import { type GridEvent } from "@web/common/types/web.event.types";
 import { gridEventDefaultPosition } from "@web/common/utils/event/event.util";
-import { getChronologicallyAdjacentTarget } from "@web/grid/shortcuts/focus-adjacent-grid-event";
+import {
+  getChronologicallyAdjacentTarget,
+  getSpatiallyAdjacentTarget,
+} from "@web/grid/shortcuts/focus-adjacent-grid-event";
 import { describe, expect, it } from "bun:test";
 
 const event = (id: string, startDate: string, isAllDay = false): GridEvent => ({
@@ -20,6 +24,10 @@ const target = (
   eventType: "all-day" | "timed",
   element = document.createElement("button"),
 ) => ({ element, eventId, eventType });
+
+const weekDays = Array.from({ length: 7 }, (_, index) =>
+  dayjs("2026-05-18").add(index, "day"),
+);
 
 describe("getChronologicallyAdjacentTarget", () => {
   it("returns the next later event", () => {
@@ -81,5 +89,99 @@ describe("getChronologicallyAdjacentTarget", () => {
         visible: [only],
       }),
     ).toBeNull();
+  });
+});
+
+describe("getSpatiallyAdjacentTarget", () => {
+  const mondayMorning = target("mon-am", "timed");
+  const mondayAfternoon = target("mon-pm", "timed");
+  const mondayEvening = target("mon-eve", "timed");
+  const wednesdayNoon = target("wed-noon", "timed");
+  const wednesdayLater = target("wed-later", "timed");
+  const fridayMorning = target("fri-am", "timed");
+
+  const timedEvents = [
+    event("mon-am", "2026-05-18T09:00:00.000"),
+    event("mon-pm", "2026-05-18T14:00:00.000"),
+    event("mon-eve", "2026-05-18T17:00:00.000"),
+    event("wed-noon", "2026-05-20T12:00:00.000"),
+    event("wed-later", "2026-05-20T15:00:00.000"),
+    event("fri-am", "2026-05-22T09:00:00.000"),
+  ];
+
+  const visible = [
+    mondayMorning,
+    mondayAfternoon,
+    mondayEvening,
+    wednesdayNoon,
+    wednesdayLater,
+    fridayMorning,
+  ];
+
+  it("keeps ArrowDown on the same day", () => {
+    const next = getSpatiallyAdjacentTarget({
+      allDayEvents: [],
+      direction: "down",
+      focused: mondayMorning,
+      timedEvents,
+      visible,
+      weekDays,
+    });
+
+    expect(next?.eventId).toBe("mon-pm");
+  });
+
+  it("does not leave the day at the bottom", () => {
+    expect(
+      getSpatiallyAdjacentTarget({
+        allDayEvents: [],
+        direction: "down",
+        focused: mondayEvening,
+        timedEvents,
+        visible,
+        weekDays,
+      }),
+    ).toBeNull();
+  });
+
+  it("skips empty days and picks the time-nearest event", () => {
+    // Monday 5pm -> skip Tuesday -> Wednesday, nearest to 17:00 is 15:00.
+    const next = getSpatiallyAdjacentTarget({
+      allDayEvents: [],
+      direction: "right",
+      focused: mondayEvening,
+      timedEvents,
+      visible,
+      weekDays,
+    });
+
+    expect(next?.eventId).toBe("wed-later");
+  });
+
+  it("moves left to the nearest event on the previous non-empty day", () => {
+    const previous = getSpatiallyAdjacentTarget({
+      allDayEvents: [],
+      direction: "left",
+      focused: fridayMorning,
+      timedEvents,
+      visible,
+      weekDays,
+    });
+
+    expect(previous?.eventId).toBe("wed-noon");
+  });
+
+  it("treats all-day as the first event on its day for Up/Down", () => {
+    const allDay = target("wed-all", "all-day");
+    const next = getSpatiallyAdjacentTarget({
+      allDayEvents: [event("wed-all", "2026-05-20", true)],
+      direction: "down",
+      focused: allDay,
+      timedEvents: [event("wed-noon", "2026-05-20T12:00:00.000")],
+      visible: [wednesdayNoon, allDay],
+      weekDays,
+    });
+
+    expect(next?.eventId).toBe("wed-noon");
   });
 });

--- a/packages/web/src/grid/shortcuts/focus-adjacent-grid-event.ts
+++ b/packages/web/src/grid/shortcuts/focus-adjacent-grid-event.ts
@@ -1,4 +1,4 @@
-import dayjs from "@core/util/date/dayjs";
+import dayjs, { type Dayjs } from "@core/util/date/dayjs";
 import { type GridEvent } from "@web/common/types/web.event.types";
 
 export type GridEventShortcutTarget = {
@@ -9,6 +9,73 @@ export type GridEventShortcutTarget = {
 export type FocusableGridEventTarget = GridEventShortcutTarget & {
   element: HTMLElement;
 };
+
+type TargetSchedule = {
+  dayKey: string;
+  /** Absolute start for chronological ordering within a day. */
+  startMs: number;
+  /**
+   * Minutes from local midnight. Cross-day Left/Right pick the event whose
+   * clock time is nearest the focused event (not absolute datetime distance).
+   */
+  minutesFromMidnight: number;
+};
+
+const dayKeyFromStart = (startDate: string) =>
+  dayjs(startDate).format("YYYY-MM-DD");
+
+const minutesFromMidnight = (startDate: string) => {
+  const start = dayjs(startDate);
+  return start.hour() * 60 + start.minute();
+};
+
+const buildScheduleById = (
+  allDayEvents: GridEvent[],
+  timedEvents: GridEvent[],
+) => {
+  const scheduleById = new Map<string, TargetSchedule>();
+  for (const event of [...allDayEvents, ...timedEvents]) {
+    if (!event._id || !event.startDate) continue;
+    scheduleById.set(event._id, {
+      dayKey: dayKeyFromStart(event.startDate),
+      startMs: dayjs(event.startDate).valueOf(),
+      minutesFromMidnight: minutesFromMidnight(event.startDate),
+    });
+  }
+  return scheduleById;
+};
+
+const compareTargetsChronologically = (
+  a: FocusableGridEventTarget,
+  b: FocusableGridEventTarget,
+  scheduleById: Map<string, TargetSchedule>,
+) => {
+  const aStart = scheduleById.get(a.eventId)?.startMs ?? 0;
+  const bStart = scheduleById.get(b.eventId)?.startMs ?? 0;
+  if (aStart !== bStart) return aStart - bStart;
+  if (a.eventType !== b.eventType) {
+    return a.eventType === "all-day" ? -1 : 1;
+  }
+  return a.eventId.localeCompare(b.eventId);
+};
+
+const sortVisibleChronologically = (
+  visible: FocusableGridEventTarget[],
+  scheduleById: Map<string, TargetSchedule>,
+) =>
+  [...visible].sort((a, b) =>
+    compareTargetsChronologically(a, b, scheduleById),
+  );
+
+const findFocusedIndex = (
+  sorted: FocusableGridEventTarget[],
+  focused: GridEventShortcutTarget,
+) =>
+  sorted.findIndex(
+    (target) =>
+      target.eventId === focused.eventId &&
+      target.eventType === focused.eventType,
+  );
 
 /**
  * Order visible grid targets chronologically: earlier start first; on a tie,
@@ -29,30 +96,87 @@ export function getChronologicallyAdjacentTarget({
 }): FocusableGridEventTarget | null {
   if (visible.length === 0 || !focused) return null;
 
-  const startMsById = new Map<string, number>();
-  for (const event of [...allDayEvents, ...timedEvents]) {
-    if (event._id && event.startDate) {
-      startMsById.set(event._id, dayjs(event.startDate).valueOf());
-    }
-  }
-
-  const sorted = [...visible].sort((a, b) => {
-    const aStart = startMsById.get(a.eventId) ?? 0;
-    const bStart = startMsById.get(b.eventId) ?? 0;
-    if (aStart !== bStart) return aStart - bStart;
-    if (a.eventType !== b.eventType) {
-      return a.eventType === "all-day" ? -1 : 1;
-    }
-    return a.eventId.localeCompare(b.eventId);
-  });
-
-  const index = sorted.findIndex(
-    (target) =>
-      target.eventId === focused.eventId &&
-      target.eventType === focused.eventType,
-  );
+  const scheduleById = buildScheduleById(allDayEvents, timedEvents);
+  const sorted = sortVisibleChronologically(visible, scheduleById);
+  const index = findFocusedIndex(sorted, focused);
   if (index < 0) return null;
 
   const nextIndex = direction === "previous" ? index - 1 : index + 1;
   return sorted[nextIndex] ?? null;
+}
+
+/**
+ * Week-view spatial focus: Up/Down stay on the focused day; Left/Right jump to
+ * the time-nearest event on the next/previous non-empty day (skip empty days).
+ * All-day counts as the first position on its day. No wrap at day or week ends.
+ */
+export function getSpatiallyAdjacentTarget({
+  allDayEvents,
+  direction,
+  focused,
+  timedEvents,
+  visible,
+  weekDays,
+}: {
+  allDayEvents: GridEvent[];
+  direction: "up" | "down" | "left" | "right";
+  focused: GridEventShortcutTarget | null;
+  timedEvents: GridEvent[];
+  visible: FocusableGridEventTarget[];
+  weekDays: Dayjs[];
+}): FocusableGridEventTarget | null {
+  if (visible.length === 0 || !focused) return null;
+
+  const scheduleById = buildScheduleById(allDayEvents, timedEvents);
+  const focusedSchedule = scheduleById.get(focused.eventId);
+  if (!focusedSchedule) return null;
+
+  if (direction === "up" || direction === "down") {
+    const sameDay = visible.filter(
+      (target) =>
+        scheduleById.get(target.eventId)?.dayKey === focusedSchedule.dayKey,
+    );
+    const sorted = sortVisibleChronologically(sameDay, scheduleById);
+    const index = findFocusedIndex(sorted, focused);
+    if (index < 0) return null;
+    const nextIndex = direction === "up" ? index - 1 : index + 1;
+    return sorted[nextIndex] ?? null;
+  }
+
+  const weekDayKeys = weekDays.map((day) => day.format("YYYY-MM-DD"));
+  const occupiedDayKeys = weekDayKeys.filter((dayKey) =>
+    visible.some(
+      (target) => scheduleById.get(target.eventId)?.dayKey === dayKey,
+    ),
+  );
+  const focusedDayIndex = occupiedDayKeys.indexOf(focusedSchedule.dayKey);
+  if (focusedDayIndex < 0) return null;
+
+  const adjacentDayIndex =
+    direction === "left" ? focusedDayIndex - 1 : focusedDayIndex + 1;
+  const adjacentDayKey = occupiedDayKeys[adjacentDayIndex];
+  if (!adjacentDayKey) return null;
+
+  const dayTargets = visible.filter(
+    (target) => scheduleById.get(target.eventId)?.dayKey === adjacentDayKey,
+  );
+  if (dayTargets.length === 0) return null;
+
+  let nearest = dayTargets[0]!;
+  let nearestDelta = Number.POSITIVE_INFINITY;
+  for (const target of dayTargets) {
+    const minutes = scheduleById.get(target.eventId)?.minutesFromMidnight ?? 0;
+    const delta = Math.abs(minutes - focusedSchedule.minutesFromMidnight);
+    if (delta < nearestDelta) {
+      nearest = target;
+      nearestDelta = delta;
+      continue;
+    }
+    if (delta > nearestDelta) continue;
+    // Tie: prefer all-day, then stable id order.
+    if (compareTargetsChronologically(target, nearest, scheduleById) < 0) {
+      nearest = target;
+    }
+  }
+  return nearest;
 }

--- a/packages/web/src/grid/shortcuts/useGridEventEditShortcuts.ts
+++ b/packages/web/src/grid/shortcuts/useGridEventEditShortcuts.ts
@@ -26,6 +26,7 @@ import {
   type FocusableGridEventTarget,
   type GridEventShortcutTarget,
   getChronologicallyAdjacentTarget,
+  getSpatiallyAdjacentTarget,
 } from "@web/grid/shortcuts/focus-adjacent-grid-event";
 import { useAppShortcut } from "@web/shortcuts/useAppShortcut";
 import { deleteEventAndDiscardDraft } from "@web/views/Forms/hooks/useDeleteEvent";
@@ -36,11 +37,24 @@ const DRAFT_MOVEMENT_HOTKEY_OPTIONS = {
   stopPropagation: false,
 } as const;
 
+const isArrowKey = (
+  key: string,
+): key is "ArrowUp" | "ArrowDown" | "ArrowLeft" | "ArrowRight" =>
+  key === "ArrowUp" ||
+  key === "ArrowDown" ||
+  key === "ArrowLeft" ||
+  key === "ArrowRight";
+
 export type GridEventEditDayBoundary =
   | {
       kind: "follow";
       /** Day view: navigate so a day-crossing nudge stays on screen. */
       onCrossed: (date: Dayjs) => void;
+      /**
+       * Day view: ArrowLeft/Right page the visible day and focus that day's
+       * first event after the route settles (when provided).
+       */
+      onFocusPageDay?: (direction: "previous" | "next") => void;
     }
   | {
       kind: "clamp";
@@ -205,16 +219,67 @@ export function useGridEventEditShortcuts({
     }
 
     if (isEventFormOpen()) return;
-    if (keyboardEvent.key !== "ArrowUp" && keyboardEvent.key !== "ArrowDown") {
+    if (!isArrowKey(keyboardEvent.key)) return;
+
+    // Day view: Left/Right page the calendar day, then focus its first event.
+    // Require a focused grid event (same as Up/Down) so sidebar focus and
+    // idle grid don't steal the day under the user.
+    if (
+      dayBoundary.kind === "follow" &&
+      (keyboardEvent.key === "ArrowLeft" ||
+        keyboardEvent.key === "ArrowRight") &&
+      dayBoundary.onFocusPageDay
+    ) {
+      if (isFocusInSidebar() || !targeting.getFocused()) return;
+
+      keyboardEvent.preventDefault();
+      keyboardEvent.stopPropagation();
+      dayBoundary.onFocusPageDay(
+        keyboardEvent.key === "ArrowLeft" ? "previous" : "next",
+      );
       return;
     }
 
-    const adjacent = getChronologicallyAdjacentTarget({
+    if (dayBoundary.kind === "follow") {
+      if (
+        keyboardEvent.key !== "ArrowUp" &&
+        keyboardEvent.key !== "ArrowDown"
+      ) {
+        return;
+      }
+
+      const adjacent = getChronologicallyAdjacentTarget({
+        allDayEvents,
+        direction: keyboardEvent.key === "ArrowUp" ? "previous" : "next",
+        focused: targeting.getFocused(),
+        timedEvents,
+        visible: targeting.listVisible(),
+      });
+      if (!adjacent) return;
+
+      keyboardEvent.preventDefault();
+      keyboardEvent.stopPropagation();
+      adjacent.element.scrollIntoView({ block: "nearest" });
+      targeting.focus(adjacent);
+      return;
+    }
+
+    const spatialDirection =
+      keyboardEvent.key === "ArrowUp"
+        ? "up"
+        : keyboardEvent.key === "ArrowDown"
+          ? "down"
+          : keyboardEvent.key === "ArrowLeft"
+            ? "left"
+            : "right";
+
+    const adjacent = getSpatiallyAdjacentTarget({
       allDayEvents,
-      direction: keyboardEvent.key === "ArrowUp" ? "previous" : "next",
+      direction: spatialDirection,
       focused: targeting.getFocused(),
       timedEvents,
       visible: targeting.listVisible(),
+      weekDays: dayBoundary.weekDays,
     });
     if (!adjacent) return;
 

--- a/packages/web/src/shortcuts/data/shortcuts.data.test.ts
+++ b/packages/web/src/shortcuts/data/shortcuts.data.test.ts
@@ -161,11 +161,29 @@ describe("shortcuts.data", () => {
         });
         expect(stripMetadata(edit?.shortcuts ?? [])).toContainEqual({
           keys: ["ArrowUp"],
-          label: "Focus previous event",
+          label:
+            view === "week"
+              ? "Focus previous event on day"
+              : "Focus previous event",
         });
         expect(stripMetadata(edit?.shortcuts ?? [])).toContainEqual({
           keys: ["ArrowDown"],
-          label: "Focus next event",
+          label:
+            view === "week" ? "Focus next event on day" : "Focus next event",
+        });
+        expect(stripMetadata(edit?.shortcuts ?? [])).toContainEqual({
+          keys: ["ArrowLeft"],
+          label:
+            view === "day"
+              ? "Previous day and focus first event"
+              : "Focus event on previous day",
+        });
+        expect(stripMetadata(edit?.shortcuts ?? [])).toContainEqual({
+          keys: ["ArrowRight"],
+          label:
+            view === "day"
+              ? "Next day and focus first event"
+              : "Focus event on next day",
         });
         expect(stripMetadata(edit?.shortcuts ?? [])).toContainEqual({
           keys: ["Enter"],

--- a/packages/web/src/shortcuts/shortcuts.registry.ts
+++ b/packages/web/src/shortcuts/shortcuts.registry.ts
@@ -204,6 +204,18 @@ export const SHORTCUTS_REGISTRY: Shortcut[] = [
     section: "edit",
   },
   {
+    id: "edit-focus-left",
+    keys: ["ArrowLeft"],
+    label: "Focus event on previous day",
+    section: "edit",
+  },
+  {
+    id: "edit-focus-right",
+    keys: ["ArrowRight"],
+    label: "Focus event on next day",
+    section: "edit",
+  },
+  {
     id: "edit-move",
     keys: ["Arrow keys"],
     label: "Move draft event",
@@ -305,6 +317,23 @@ export const filterShortcutsByContext = (
       } else {
         label = "Go to today";
       }
+    } else if (shortcut.id === "edit-focus-prev") {
+      label =
+        view === "week"
+          ? "Focus previous event on day"
+          : "Focus previous event";
+    } else if (shortcut.id === "edit-focus-next") {
+      label = view === "week" ? "Focus next event on day" : "Focus next event";
+    } else if (shortcut.id === "edit-focus-left") {
+      label =
+        view === "day"
+          ? "Previous day and focus first event"
+          : "Focus event on previous day";
+    } else if (shortcut.id === "edit-focus-right") {
+      label =
+        view === "day"
+          ? "Next day and focus first event"
+          : "Focus event on next day";
     }
 
     return { ...shortcut, label };

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
@@ -35,6 +35,7 @@ import { useDateInView } from "@web/views/Day/hooks/navigation/useDateInView";
 import { useDateNavigation } from "@web/views/Day/hooks/navigation/useDateNavigation";
 import { useDayEventNudgeShortcuts } from "@web/views/Day/hooks/shortcuts/useDayEventNudgeShortcuts";
 import { DayInteractionCoordinator } from "@web/views/Day/interaction/DayInteractionCoordinator";
+import { consumePendingFocusFirstDayCalendarEvent } from "@web/views/Day/interaction/day-event.focus";
 import { DayCalendarBusyPeriodsLayer } from "./DayCalendarBusyPeriods";
 import { DayCalendarColumnHeaders } from "./DayCalendarColumnHeaders";
 import { useDayCalendarContextMenu } from "./DayCalendarContextMenu";
@@ -65,7 +66,8 @@ const isDayInteractionMotionActive = () => false;
 
 export function DayCalendarGrid() {
   const dateInView = useDateInView();
-  const { navigateToDate } = useDateNavigation();
+  const { navigateToDate, navigateToNextDay, navigateToPreviousDay } =
+    useDateNavigation();
   const today = useMemo(() => dayjs(), []);
   const { data: calendars = [], isPending: isCalendarsPending } =
     useCalendarsQuery();
@@ -112,8 +114,23 @@ export function DayCalendarGrid() {
   useDayEventNudgeShortcuts({
     allDayEvents: displayedAllDayEvents,
     navigateToDate,
+    navigateToNextDay,
+    navigateToPreviousDay,
     timedEvents: displayedTimedEvents,
   });
+  // ArrowLeft/Right page the day asynchronously; focus the first event once
+  // the destination day's targets are registered.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: re-run after day navigation and event paint so pending focus can find new targets.
+  useEffect(() => {
+    consumePendingFocusFirstDayCalendarEvent({
+      allowEmpty: !isLoadingEvents,
+    });
+  }, [
+    dateInView,
+    displayedAllDayEvents,
+    displayedTimedEvents,
+    isLoadingEvents,
+  ]);
   const gridDraft = useDraftStore(selectGridDraft);
   // Strip height must include the all-day draft: layer rendering used to
   // re-stack with the draft while EventGrid still sized from saved events only.

--- a/packages/web/src/views/Day/hooks/shortcuts/useDayEventNudgeShortcuts.test.tsx
+++ b/packages/web/src/views/Day/hooks/shortcuts/useDayEventNudgeShortcuts.test.tsx
@@ -105,10 +105,14 @@ const focusCalendarTarget = (
 const renderEditShortcuts = ({
   allDayEvents = [],
   navigateToDate,
+  navigateToNextDay,
+  navigateToPreviousDay,
   timedEvents = [timedEvent],
 }: {
   allDayEvents?: GridEvent[];
   navigateToDate?: (date: Dayjs) => void;
+  navigateToNextDay?: () => void;
+  navigateToPreviousDay?: () => void;
   timedEvents?: GridEvent[];
 } = {}) => {
   const queryClient = createCompassQueryClient();
@@ -147,6 +151,8 @@ const renderEditShortcuts = ({
         allDayEvents,
         dependencies,
         navigateToDate,
+        navigateToNextDay,
+        navigateToPreviousDay,
         timedEvents,
       }),
     {
@@ -340,6 +346,35 @@ describe("useDayEventNudgeShortcuts", () => {
     pressKey("ArrowDown");
 
     expect(document.activeElement).toBe(later);
+  });
+
+  it("pages to the next day with ArrowRight when a grid event is focused", () => {
+    focusCalendarTarget(TIMED_EVENT_ID, "timed");
+    const navigateToNextDay = mock(() => {});
+    renderEditShortcuts({ navigateToNextDay });
+
+    pressKey("ArrowRight");
+
+    expect(navigateToNextDay).toHaveBeenCalledTimes(1);
+  });
+
+  it("pages to the previous day with ArrowLeft when a grid event is focused", () => {
+    focusCalendarTarget(TIMED_EVENT_ID, "timed");
+    const navigateToPreviousDay = mock(() => {});
+    renderEditShortcuts({ navigateToPreviousDay });
+
+    pressKey("ArrowLeft");
+
+    expect(navigateToPreviousDay).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not page the day with ArrowRight when nothing is focused", () => {
+    const navigateToNextDay = mock(() => {});
+    renderEditShortcuts({ navigateToNextDay });
+
+    pressKey("ArrowRight");
+
+    expect(navigateToNextDay).not.toHaveBeenCalled();
   });
 
   it("does not delete a grid event when Delete is pressed inside an open event form", () => {

--- a/packages/web/src/views/Day/hooks/shortcuts/useDayEventNudgeShortcuts.ts
+++ b/packages/web/src/views/Day/hooks/shortcuts/useDayEventNudgeShortcuts.ts
@@ -5,6 +5,7 @@ import { type EventMutationDependencies } from "@web/events/mutations/useEventMu
 import { draftActions, useDraftStore } from "@web/events/stores/draft.store";
 import { useGridEventEditShortcuts } from "@web/grid/shortcuts/useGridEventEditShortcuts";
 import { useGridEventFormFieldSequences } from "@web/grid/shortcuts/useGridEventFormFieldSequences";
+import { requestFocusFirstDayCalendarEvent } from "@web/views/Day/interaction/day-event.focus";
 import {
   focusDayGridEventTarget,
   getFocusedDayGridEventTarget,
@@ -14,7 +15,8 @@ import {
 /**
  * Day-view edit shortcuts: Delete, Mod+D, Shift+arrows (nudge / day-move),
  * Arrow keys to reposition an open draft or focus the neighboring event,
- * and `e`+field sequences to open/focus form fields.
+ * ArrowLeft/Right to page the day and focus its first event, and `e`+field
+ * sequences to open/focus form fields.
  * Shift+ArrowLeft/Right move a focused event by one day and follow that day
  * in the Day view.
  */
@@ -22,12 +24,16 @@ export function useDayEventNudgeShortcuts({
   allDayEvents = [],
   dependencies = {},
   navigateToDate,
+  navigateToNextDay,
+  navigateToPreviousDay,
   timedEvents,
 }: {
   allDayEvents?: GridEvent[];
   dependencies?: EventMutationDependencies;
   /** Follow draft Left/Right moves so the draft stays on screen. */
   navigateToDate?: (date: Dayjs) => void;
+  navigateToNextDay?: () => void;
+  navigateToPreviousDay?: () => void;
   timedEvents: GridEvent[];
 }) {
   const targeting = {
@@ -43,6 +49,14 @@ export function useDayEventNudgeShortcuts({
     dayBoundary: {
       kind: "follow",
       onCrossed: (date) => navigateToDate?.(date),
+      onFocusPageDay: (direction) => {
+        if (direction === "previous") {
+          navigateToPreviousDay?.();
+        } else {
+          navigateToNextDay?.();
+        }
+        requestFocusFirstDayCalendarEvent();
+      },
     },
     targeting,
     repositionDraftByKey: (key) => {

--- a/packages/web/src/views/Day/interaction/day-event.focus.ts
+++ b/packages/web/src/views/Day/interaction/day-event.focus.ts
@@ -3,6 +3,9 @@ import {
   getFirstVisibleDayGridEventTarget,
 } from "@web/views/Day/interaction/targeting/day-event.targeting";
 
+/** Set when ArrowLeft/Right pages the day; consumed once events for the new day paint. */
+let pendingFocusFirstDayEvent = false;
+
 export function focusFirstDayCalendarEvent() {
   const target = getFirstVisibleDayGridEventTarget();
 
@@ -10,6 +13,36 @@ export function focusFirstDayCalendarEvent() {
     return;
   }
 
+  target.element.scrollIntoView({ block: "nearest" });
+  focusDayGridEventTarget(target);
+}
+
+export function requestFocusFirstDayCalendarEvent() {
+  pendingFocusFirstDayEvent = true;
+}
+
+/**
+ * Focus the first visible event if a day-page Left/Right asked for it.
+ * Keeps the pending flag while the destination day is still loading so a
+ * later paint can retry. Clears without focusing when `allowEmpty` is true
+ * (day settled with no events).
+ */
+export function consumePendingFocusFirstDayCalendarEvent({
+  allowEmpty = false,
+}: {
+  allowEmpty?: boolean;
+} = {}) {
+  if (!pendingFocusFirstDayEvent) return;
+
+  const target = getFirstVisibleDayGridEventTarget();
+  if (!target) {
+    if (allowEmpty) {
+      pendingFocusFirstDayEvent = false;
+    }
+    return;
+  }
+
+  pendingFocusFirstDayEvent = false;
   target.element.scrollIntoView({ block: "nearest" });
   focusDayGridEventTarget(target);
 }

--- a/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcutOwner.test.tsx
+++ b/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcutOwner.test.tsx
@@ -377,26 +377,59 @@ describe("useWeekShortcutOwner calendar event targeting", () => {
     expect(state.gridDraft?.values.title).toBe("Editable event");
   });
 
-  it("focuses the chronologically next event with ArrowDown", () => {
-    const earlier = addCalendarTarget(leftmostEvent.id);
-    const later = addCalendarTarget(editableEvent.id);
+  it("keeps ArrowDown on the same day when a later event exists that day", () => {
+    const sameDayLaterId = EventIdSchema.parse("dddddddddddddddddddddddd");
+    const sameDayLater = createMockEvent({
+      id: sameDayLaterId,
+      content: { kind: "details", title: "Same day later", description: "" },
+      schedule: EventScheduleSchema.parse({
+        kind: "timed",
+        start: "2026-05-20T14:00:00.000Z",
+        end: "2026-05-20T15:00:00.000Z",
+        timeZone: "UTC",
+      }),
+    });
+    const earlier = addCalendarTarget(editableEvent.id);
+    const later = addCalendarTarget(sameDayLaterId);
     earlier.focus();
-    renderShortcuts({ includeLeftmostEvent: true });
+    renderShortcuts({ extraEvents: [sameDayLater] });
 
     pressKey("ArrowDown");
 
     expect(document.activeElement).toBe(later);
   });
 
-  it("focuses the chronologically previous event with ArrowUp", () => {
+  it("does not leave the day with ArrowDown when no later same-day event exists", () => {
     const earlier = addCalendarTarget(leftmostEvent.id);
-    const later = addCalendarTarget(editableEvent.id);
-    later.focus();
+    addCalendarTarget(editableEvent.id);
+    earlier.focus();
     renderShortcuts({ includeLeftmostEvent: true });
 
-    pressKey("ArrowUp");
+    pressKey("ArrowDown");
 
     expect(document.activeElement).toBe(earlier);
+  });
+
+  it("focuses the time-nearest event on the next non-empty day with ArrowRight", () => {
+    const monday = addCalendarTarget(leftmostEvent.id);
+    const wednesday = addCalendarTarget(editableEvent.id);
+    monday.focus();
+    renderShortcuts({ includeLeftmostEvent: true });
+
+    pressKey("ArrowRight");
+
+    expect(document.activeElement).toBe(wednesday);
+  });
+
+  it("focuses the time-nearest event on the previous non-empty day with ArrowLeft", () => {
+    const monday = addCalendarTarget(leftmostEvent.id);
+    const wednesday = addCalendarTarget(editableEvent.id);
+    wednesday.focus();
+    renderShortcuts({ includeLeftmostEvent: true });
+
+    pressKey("ArrowLeft");
+
+    expect(document.activeElement).toBe(monday);
   });
 
   it("deletes pending calendar events with Delete", () => {


### PR DESCRIPTION
## Summary

- Week view: ArrowUp/Down move focus within the focused event's day; ArrowLeft/Right jump to the time-nearest event on the previous/next non-empty day (skip empty days; all-day counts as first on its day).
- Day view: ArrowLeft/Right page to the previous/next day and focus that day's first event once it paints (no-op without a focused grid event; empty days clear pending focus without crashing).
- Shortcut legend lists the new Left/Right focus actions with view-specific labels. Draft reposition and open-form guards are unchanged.

## Simplicity

Extended the existing focus-adjacent helper and shared edit-shortcut hook instead of adding a parallel navigation path. Day paging reuses the date navigation context and a small pending-focus flag consumed after the destination day paints.

## Automated validation

- `bun test:web` on focus-adjacent, week shortcut owner, day nudge shortcuts, and shortcut legend tests (all pass).
- Independent review findings fixed: pending focus no longer cleared before targets exist; Day Left/Right require a focused grid event.

## Independent review

Fresh diff review found two Day-paging issues (pending focus dropped on async load; Left/Right without focus). Both fixed before opening this PR.

## Test plan

- `bun test:web -- packages/web/src/grid/shortcuts/focus-adjacent-grid-event.test.ts packages/web/src/views/Week/hooks/shortcuts/useWeekShortcutOwner.test.tsx packages/web/src/views/Day/hooks/shortcuts/useDayEventNudgeShortcuts.test.tsx packages/web/src/shortcuts/data/shortcuts.data.test.ts`
- `bun run lint`
- E2E: `e2e/timed/spatial-focus-arrows.spec.ts` (Week ArrowRight traversal)