### PR TITLE
feat(web): focus weekday columns with digit keys 1-7

### DIFF
--- a/packages/web/src/grid/shortcuts/focus-adjacent-grid-event.test.ts
+++ b/packages/web/src/grid/shortcuts/focus-adjacent-grid-event.test.ts
@@ -4,6 +4,7 @@ import { type GridEvent } from "@web/common/types/web.event.types";
 import { gridEventDefaultPosition } from "@web/common/utils/event/event.util";
 import {
   getChronologicallyAdjacentTarget,
+  getFirstEventOnWeekdayColumn,
   getSpatiallyAdjacentTarget,
 } from "@web/grid/shortcuts/focus-adjacent-grid-event";
 import { describe, expect, it } from "bun:test";
@@ -183,5 +184,39 @@ describe("getSpatiallyAdjacentTarget", () => {
     });
 
     expect(next?.eventId).toBe("wed-noon");
+  });
+});
+
+describe("getFirstEventOnWeekdayColumn", () => {
+  it("returns the first chronological event on the leftmost column for digit 1", () => {
+    const mondayAllDay = target("mon-all", "all-day");
+    const mondayTimed = target("mon-am", "timed");
+    const wednesday = target("wed-noon", "timed");
+
+    const first = getFirstEventOnWeekdayColumn({
+      allDayEvents: [event("mon-all", "2026-05-18", true)],
+      columnIndex: 0,
+      timedEvents: [
+        event("mon-am", "2026-05-18T09:00:00.000"),
+        event("wed-noon", "2026-05-20T12:00:00.000"),
+      ],
+      visible: [mondayTimed, wednesday, mondayAllDay],
+      weekDays,
+    });
+
+    expect(first?.eventId).toBe("mon-all");
+  });
+
+  it("returns null when the column has no visible events", () => {
+    const wednesday = target("wed-noon", "timed");
+    expect(
+      getFirstEventOnWeekdayColumn({
+        allDayEvents: [],
+        columnIndex: 0,
+        timedEvents: [event("wed-noon", "2026-05-20T12:00:00.000")],
+        visible: [wednesday],
+        weekDays,
+      }),
+    ).toBeNull();
   });
 });

--- a/packages/web/src/grid/shortcuts/focus-adjacent-grid-event.ts
+++ b/packages/web/src/grid/shortcuts/focus-adjacent-grid-event.ts
@@ -180,3 +180,34 @@ export function getSpatiallyAdjacentTarget({
   }
   return nearest;
 }
+
+/**
+ * Week-view digit targeting: `1`–`7` map to leftmost→rightmost visible columns.
+ * Returns the chronologically first event on that day (all-day before timed),
+ * or null when the column has no visible events.
+ */
+export function getFirstEventOnWeekdayColumn({
+  allDayEvents,
+  columnIndex,
+  timedEvents,
+  visible,
+  weekDays,
+}: {
+  allDayEvents: GridEvent[];
+  /** 0-based index into `weekDays` (digit `1` → 0). */
+  columnIndex: number;
+  timedEvents: GridEvent[];
+  visible: FocusableGridEventTarget[];
+  weekDays: Dayjs[];
+}): FocusableGridEventTarget | null {
+  if (columnIndex < 0 || columnIndex >= weekDays.length) return null;
+
+  const dayKey = weekDays[columnIndex]!.format("YYYY-MM-DD");
+  const scheduleById = buildScheduleById(allDayEvents, timedEvents);
+  const dayTargets = visible.filter(
+    (target) => scheduleById.get(target.eventId)?.dayKey === dayKey,
+  );
+  if (dayTargets.length === 0) return null;
+
+  return sortVisibleChronologically(dayTargets, scheduleById)[0] ?? null;
+}

--- a/packages/web/src/shortcuts/data/shortcuts.data.test.ts
+++ b/packages/web/src/shortcuts/data/shortcuts.data.test.ts
@@ -129,16 +129,30 @@ describe("shortcuts.data", () => {
     });
 
     it("lists u/i focus shortcuts per view", () => {
-      const findFocus = (view: "day" | "week") =>
-        getShortcutMenuSections({ view, isViewingCurrentPeriod: true }).find(
-          (section) => section.id === "focus",
-        );
+      const findFocus = (view: "day" | "week", eventFocused = false) =>
+        getShortcutMenuSections({
+          view,
+          isViewingCurrentPeriod: true,
+          eventFocused,
+        }).find((section) => section.id === "focus");
 
       expect(stripMetadata(findFocus("day")?.shortcuts ?? [])).toEqual([
         { keys: ["i"], label: "Focus sidebar" },
         { keys: ["u"], label: "Focus calendar event" },
       ]);
       expect(stripMetadata(findFocus("week")?.shortcuts ?? [])).toEqual([
+        { keys: ["i"], label: "Focus sidebar" },
+        { keys: ["u"], label: "Focus calendar event" },
+      ]);
+      expect(stripMetadata(findFocus("week", true)?.shortcuts ?? [])).toEqual([
+        { keys: ["i"], label: "Focus sidebar" },
+        { keys: ["u"], label: "Focus calendar event" },
+        {
+          keys: ["1-7"],
+          label: "Focus first event on weekday column",
+        },
+      ]);
+      expect(stripMetadata(findFocus("day", true)?.shortcuts ?? [])).toEqual([
         { keys: ["i"], label: "Focus sidebar" },
         { keys: ["u"], label: "Focus calendar event" },
       ]);

--- a/packages/web/src/shortcuts/shortcuts.registry.ts
+++ b/packages/web/src/shortcuts/shortcuts.registry.ts
@@ -122,6 +122,13 @@ export const SHORTCUTS_REGISTRY: Shortcut[] = [
     label: "Focus calendar event",
     section: "focus",
   },
+  {
+    id: "focus-weekday-column",
+    keys: ["1-7"],
+    label: "Focus first event on weekday column",
+    section: "focus",
+    when: { eventFocused: true },
+  },
 
   // Edit
   {
@@ -373,6 +380,10 @@ export const filterShortcutsByContext = (
         view === "day" &&
         (shortcut.id === "nav-shift-left" || shortcut.id === "nav-shift-right")
       ) {
+        return false;
+      }
+      // Digit weekday columns only apply in week view
+      if (view === "day" && shortcut.id === "focus-weekday-column") {
         return false;
       }
     }

--- a/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcutOwner.test.tsx
+++ b/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcutOwner.test.tsx
@@ -27,6 +27,7 @@ import { DraftContext } from "@web/views/Week/components/Draft/context/DraftCont
 import { weekEventRegistry } from "@web/views/Week/interaction/registry/week-event.registry";
 import {
   clearHoveredWeekGridEventTarget,
+  getFocusedWeekGridEventTarget,
   setHoveredWeekGridEventTarget,
 } from "@web/views/Week/interaction/targeting/week-event.targeting";
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
@@ -430,6 +431,28 @@ describe("useWeekShortcutOwner calendar event targeting", () => {
     pressKey("ArrowLeft");
 
     expect(document.activeElement).toBe(monday);
+  });
+
+  it("focuses the first event on the leftmost column with digit 1", () => {
+    const monday = addCalendarTarget(leftmostEvent.id);
+    const wednesday = addCalendarTarget(editableEvent.id);
+    wednesday.focus();
+    renderShortcuts({ includeLeftmostEvent: true });
+
+    pressKey("1");
+
+    expect(document.activeElement).toBe(monday);
+  });
+
+  it("does not change focus with digit 1 when nothing is focused", () => {
+    addCalendarTarget(leftmostEvent.id);
+    const wednesday = addCalendarTarget(editableEvent.id);
+    renderShortcuts({ includeLeftmostEvent: true });
+
+    pressKey("1");
+
+    expect(document.activeElement).not.toBe(wednesday);
+    expect(getFocusedWeekGridEventTarget()).toBeNull();
   });
 
   it("deletes pending calendar events with Delete", () => {

--- a/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcutOwner.ts
+++ b/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcutOwner.ts
@@ -10,9 +10,12 @@ import {
   createAlldayDraft,
   createTimedDraft,
 } from "@web/common/utils/draft/draft.util";
+import { isEditableKeyboardTarget } from "@web/common/utils/form/form.util";
 import { useFocusSidebarShortcut } from "@web/components/Sidebar/useFocusSidebarShortcut";
 import { useWeekEventViewModel } from "@web/events/queries/useWeekEventsQuery";
+import { useRecurrenceScopeOpportunityStore } from "@web/events/recurrence/recurrence-scope-opportunity.store";
 import { draftActions, isEventFormOpen } from "@web/events/stores/draft.store";
+import { getFirstEventOnWeekdayColumn } from "@web/grid/shortcuts/focus-adjacent-grid-event";
 import { useGridEventEditShortcuts } from "@web/grid/shortcuts/useGridEventEditShortcuts";
 import { useGridEventFormFieldSequences } from "@web/grid/shortcuts/useGridEventFormFieldSequences";
 import { useDraftContext } from "@web/views/Week/components/Draft/context/useDraftContext";
@@ -170,6 +173,33 @@ export const useWeekShortcutOwner = ({
     listVisible: listVisibleWeekGridEventTargets,
   };
 
+  const focusWeekdayColumn = useCallback(
+    (columnIndex: number, keyboardEvent: KeyboardEvent) => {
+      // Recurrence toast owns digits 1/2 while ready; don't steal them.
+      const opportunity =
+        useRecurrenceScopeOpportunityStore.getState().opportunity;
+      if (opportunity?.status === "ready") return false;
+
+      if (isEventFormOpen()) return false;
+      if (isEditableKeyboardTarget(keyboardEvent)) return false;
+      if (!getFocusedWeekGridEventTarget()) return false;
+
+      const target = getFirstEventOnWeekdayColumn({
+        allDayEvents,
+        columnIndex,
+        timedEvents,
+        visible: listVisibleWeekGridEventTargets(),
+        weekDays,
+      });
+      if (!target) return false;
+
+      target.element.scrollIntoView({ block: "nearest" });
+      focusWeekGridEventTarget(target);
+      return true;
+    },
+    [allDayEvents, timedEvents, weekDays],
+  );
+
   useGridEventEditShortcuts({
     allDayEvents,
     timedEvents,
@@ -193,5 +223,6 @@ export const useWeekShortcutOwner = ({
     onCreateAllDayDraft: emitCreateAllDayDraft,
     onCreateTimedDraft: emitCreateTimedDraft,
     onFocusCalendar: focusFirstCalendarEvent,
+    onFocusWeekdayColumn: focusWeekdayColumn,
   });
 };

--- a/packages/web/src/views/Week/hooks/shortcuts/useWeekViewShortcuts.ts
+++ b/packages/web/src/views/Week/hooks/shortcuts/useWeekViewShortcuts.ts
@@ -1,4 +1,7 @@
-import { useAppShortcutUp } from "@web/shortcuts/useAppShortcut";
+import {
+  useAppShortcut,
+  useAppShortcutUp,
+} from "@web/shortcuts/useAppShortcut";
 
 export interface WeekViewShortcutsConfig {
   onPreviousWeek?: () => void;
@@ -9,7 +12,22 @@ export interface WeekViewShortcutsConfig {
   onCreateAllDayDraft?: () => void;
   onCreateTimedDraft?: () => void;
   onFocusCalendar?: () => void;
+  /**
+   * Digit `1`–`7` → focus first event on that leftmost→rightmost week column.
+   * Return true when the digit was handled so the key event can be consumed.
+   */
+  onFocusWeekdayColumn?: (
+    columnIndex: number,
+    keyboardEvent: KeyboardEvent,
+  ) => boolean;
 }
+
+const DIGIT_HOTKEY_OPTIONS = {
+  ignoreInputs: false,
+  preventDefault: false,
+  stopPropagation: false,
+  conflictBehavior: "allow" as const,
+};
 
 /**
  * Registers Week view keyboard shortcuts only. Behavior lives in the owner
@@ -25,6 +43,7 @@ export function useWeekViewShortcuts(config: WeekViewShortcutsConfig) {
     onCreateAllDayDraft,
     onCreateTimedDraft,
     onFocusCalendar,
+    onFocusWeekdayColumn,
   } = config;
 
   useAppShortcutUp("J", () => {
@@ -51,4 +70,68 @@ export function useWeekViewShortcuts(config: WeekViewShortcutsConfig) {
   useAppShortcutUp("U", () => {
     onFocusCalendar?.();
   });
+
+  useAppShortcut(
+    "1",
+    (keyboardEvent) => {
+      if (!onFocusWeekdayColumn?.(0, keyboardEvent)) return;
+      keyboardEvent.preventDefault();
+      keyboardEvent.stopPropagation();
+    },
+    DIGIT_HOTKEY_OPTIONS,
+  );
+  useAppShortcut(
+    "2",
+    (keyboardEvent) => {
+      if (!onFocusWeekdayColumn?.(1, keyboardEvent)) return;
+      keyboardEvent.preventDefault();
+      keyboardEvent.stopPropagation();
+    },
+    DIGIT_HOTKEY_OPTIONS,
+  );
+  useAppShortcut(
+    "3",
+    (keyboardEvent) => {
+      if (!onFocusWeekdayColumn?.(2, keyboardEvent)) return;
+      keyboardEvent.preventDefault();
+      keyboardEvent.stopPropagation();
+    },
+    DIGIT_HOTKEY_OPTIONS,
+  );
+  useAppShortcut(
+    "4",
+    (keyboardEvent) => {
+      if (!onFocusWeekdayColumn?.(3, keyboardEvent)) return;
+      keyboardEvent.preventDefault();
+      keyboardEvent.stopPropagation();
+    },
+    DIGIT_HOTKEY_OPTIONS,
+  );
+  useAppShortcut(
+    "5",
+    (keyboardEvent) => {
+      if (!onFocusWeekdayColumn?.(4, keyboardEvent)) return;
+      keyboardEvent.preventDefault();
+      keyboardEvent.stopPropagation();
+    },
+    DIGIT_HOTKEY_OPTIONS,
+  );
+  useAppShortcut(
+    "6",
+    (keyboardEvent) => {
+      if (!onFocusWeekdayColumn?.(5, keyboardEvent)) return;
+      keyboardEvent.preventDefault();
+      keyboardEvent.stopPropagation();
+    },
+    DIGIT_HOTKEY_OPTIONS,
+  );
+  useAppShortcut(
+    "7",
+    (keyboardEvent) => {
+      if (!onFocusWeekdayColumn?.(6, keyboardEvent)) return;
+      keyboardEvent.preventDefault();
+      keyboardEvent.stopPropagation();
+    },
+    DIGIT_HOTKEY_OPTIONS,
+  );
 }


### PR DESCRIPTION
## Summary

- In Week view, with a grid event focused, pressing `1`–`7` moves focus to the first event on that leftmost-to-rightmost visible day column (all-day first when present).
- Empty columns are a no-op. Day/Life views do not register these keys. Digits yield to the recurrence-scope toast while it owns `1`/`2`, and stay inert in forms/editable fields.
- Shortcut legend shows the week-only entry when an event is focused.

### Product note (follows proposed semantics)

This PR implements **focus targeting** (not view jumping): digits move focus within the current visible week. Alternatives considered but not taken: digits shift the week window, or digits map to Mon–Sun fixed weekdays regardless of the leftmost column. Happy to revise if you'd rather those.

## Simplicity

One helper (`getFirstEventOnWeekdayColumn`) plus digit registration on the existing week shortcut boundary. No parallel shortcut list.

## Automated validation

- Focused web unit/integration tests for the helper, digit 1 focus, and legend filtering (all pass).

## Independent review

Self-reviewed against draft/form/recurrence conflicts before opening.

## Test plan

- `bun test:web -- packages/web/src/grid/shortcuts/focus-adjacent-grid-event.test.ts packages/web/src/views/Week/hooks/shortcuts/useWeekShortcutOwner.test.tsx packages/web/src/shortcuts/data/shortcuts.data.test.ts`
- `bun run lint`