### PR TITLE
fix(web): refresh shortcut legend when a grid event is focused

### DIFF
--- a/packages/web/src/grid/shortcuts/useIsGridEventFocused.test.tsx
+++ b/packages/web/src/grid/shortcuts/useIsGridEventFocused.test.tsx
@@ -1,0 +1,57 @@
+import { HotkeyManager } from "@tanstack/react-hotkeys";
+import { act, cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useIsGridEventFocused } from "@web/grid/shortcuts/useIsGridEventFocused";
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+
+function Probe({
+  getFocused,
+}: {
+  getFocused: () => { eventId: string; eventType: "timed" } | null;
+}) {
+  const eventFocused = useIsGridEventFocused(getFocused);
+  return <div>{eventFocused ? "focused" : "idle"}</div>;
+}
+
+describe("useIsGridEventFocused", () => {
+  beforeEach(() => {
+    HotkeyManager.resetInstance();
+  });
+
+  afterEach(() => {
+    cleanup();
+    document.body.innerHTML = "";
+  });
+
+  it("updates when focus enters and leaves a grid event target", async () => {
+    const user = userEvent.setup();
+    const button = document.createElement("button");
+    button.textContent = "Event";
+    document.body.appendChild(button);
+
+    const getFocused = mock(() =>
+      document.activeElement === button
+        ? { eventId: "a", eventType: "timed" as const }
+        : null,
+    );
+
+    render(<Probe getFocused={getFocused} />);
+    expect(screen.getByText("idle")).toBeTruthy();
+
+    await act(async () => {
+      await user.click(button);
+      await new Promise<void>((resolve) => {
+        requestAnimationFrame(() => resolve());
+      });
+    });
+    expect(screen.getByText("focused")).toBeTruthy();
+
+    await act(async () => {
+      button.blur();
+      await new Promise<void>((resolve) => {
+        requestAnimationFrame(() => resolve());
+      });
+    });
+    expect(screen.getByText("idle")).toBeTruthy();
+  });
+});

--- a/packages/web/src/grid/shortcuts/useIsGridEventFocused.ts
+++ b/packages/web/src/grid/shortcuts/useIsGridEventFocused.ts
@@ -1,0 +1,35 @@
+import { useEffect, useState } from "react";
+import { type GridEventShortcutTarget } from "@web/grid/shortcuts/focus-adjacent-grid-event";
+
+/**
+ * Tracks whether a grid event currently has DOM focus so the shortcut legend
+ * can gate `when: { eventFocused: true }` rows. Reads `getFocused` after
+ * focus settles (rAF) so moves between two events don't flash the legend off.
+ */
+export function useIsGridEventFocused(
+  getFocused: () => GridEventShortcutTarget | null,
+) {
+  const [eventFocused, setEventFocused] = useState(() => getFocused() !== null);
+
+  useEffect(() => {
+    let frame = 0;
+    const sync = () => {
+      cancelAnimationFrame(frame);
+      frame = requestAnimationFrame(() => {
+        setEventFocused(getFocused() !== null);
+      });
+    };
+
+    document.addEventListener("focusin", sync);
+    document.addEventListener("focusout", sync);
+    sync();
+
+    return () => {
+      cancelAnimationFrame(frame);
+      document.removeEventListener("focusin", sync);
+      document.removeEventListener("focusout", sync);
+    };
+  }, [getFocused]);
+
+  return eventFocused;
+}

--- a/packages/web/src/views/Day/view/DayViewContent.tsx
+++ b/packages/web/src/views/Day/view/DayViewContent.tsx
@@ -22,6 +22,7 @@ import {
   useViewStore,
   viewActions,
 } from "@web/events/stores/view.store";
+import { useIsGridEventFocused } from "@web/grid/shortcuts/useIsGridEventFocused";
 import { getShortcutMenuSections } from "@web/shortcuts/data/shortcuts.data";
 import { DayCalendarGrid } from "@web/views/Day/components/Calendar/DayCalendarGrid";
 import { Header } from "@web/views/Day/components/Header/Header";
@@ -60,15 +61,17 @@ export const DayViewContent = memo(() => {
   useFocusSidebarShortcut();
   useSidebarShortcuts();
 
-  const shortcutSections = useMemo(() => {
-    const focusedEvent = getFocusedDayGridEventTarget();
-    return getShortcutMenuSections({
-      view: "day",
-      isViewingCurrentPeriod: isViewingToday,
-      eventFocused: focusedEvent !== null,
-      isFormOpen: isEventDetailsOpen,
-    });
-  }, [isViewingToday, isEventDetailsOpen]);
+  const eventFocused = useIsGridEventFocused(getFocusedDayGridEventTarget);
+  const shortcutSections = useMemo(
+    () =>
+      getShortcutMenuSections({
+        view: "day",
+        isViewingCurrentPeriod: isViewingToday,
+        eventFocused,
+        isFormOpen: isEventDetailsOpen,
+      }),
+    [eventFocused, isEventDetailsOpen, isViewingToday],
+  );
 
   const handleGoToToday = useCallback(() => {
     // Compare dates in the same timezone to avoid timezone issues

--- a/packages/web/src/views/Week/WeekView.tsx
+++ b/packages/web/src/views/Week/WeekView.tsx
@@ -20,6 +20,7 @@ import {
   useViewStore,
   viewActions,
 } from "@web/events/stores/view.store";
+import { useIsGridEventFocused } from "@web/grid/shortcuts/useIsGridEventFocused";
 import { getShortcutMenuSections } from "@web/shortcuts/data/shortcuts.data";
 import { Dedication } from "@web/views/Week/components/Dedication/Dedication";
 import { DraftProvider } from "@web/views/Week/components/Draft/context/DraftProvider";
@@ -105,15 +106,17 @@ export const WeekView = () => {
     });
   }, [scrollUtil, util]);
 
-  const shortcutSections = useMemo(() => {
-    const focusedEvent = getFocusedWeekGridEventTarget();
-    return getShortcutMenuSections({
-      view: "week",
-      isViewingCurrentPeriod: isCurrentWeek,
-      eventFocused: focusedEvent !== null,
-      isFormOpen: isEventDetailsOpen,
-    });
-  }, [isCurrentWeek, isEventDetailsOpen]);
+  const eventFocused = useIsGridEventFocused(getFocusedWeekGridEventTarget);
+  const shortcutSections = useMemo(
+    () =>
+      getShortcutMenuSections({
+        view: "week",
+        isViewingCurrentPeriod: isCurrentWeek,
+        eventFocused,
+        isFormOpen: isEventDetailsOpen,
+      }),
+    [eventFocused, isCurrentWeek, isEventDetailsOpen],
+  );
 
   const { calendarDate, goToDateFromSidebar } = useSidebarCalendarDate({
     goToDate: weekProps.state.goToDate,


### PR DESCRIPTION
## Summary

- The shortcut legend already filtered rows with `when: { eventFocused: true }` (for example `e` then field sequences), but Day/Week views only recomputed that flag when the form opened or the current-period toggle changed.
- Subscribe to `focusin`/`focusout` and refresh after focus settles so focusing a calendar event (`u`, click, arrows, digits) shows the event-focused legend rows immediately.

## Simplicity

One shared hook used by Day and Week; no new global store.

## Automated validation

- Unit test covers focus enter/leave updating the hook.
- Focused web test pass locally.

## Independent review

Self-reviewed for focus transition flicker (rAF settle) before opening.

## Test plan

- `bun test:web -- packages/web/src/grid/shortcuts/useIsGridEventFocused.test.tsx`
- `bun run lint`