### PR TITLE
feat(web): flash event jump keys while holding shift

### DIFF
--- a/packages/web/src/shortcuts/shift-hint/ShiftHintOverlay.tsx
+++ b/packages/web/src/shortcuts/shift-hint/ShiftHintOverlay.tsx
@@ -1,0 +1,64 @@
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+import { Z_INDEX_TOOLTIP } from "@web/common/constants/web.constants";
+import { ShortcutHint } from "@web/components/Shortcuts/ShortcutHint";
+import { type ActiveShiftHint } from "@web/shortcuts/shift-hint/useShiftHoldEventHints";
+
+/**
+ * Fixed-position keycap chips anchored to visible event cards while SHIFT is
+ * held. Portaled so overflow-hidden cards do not clip the hints.
+ */
+export function ShiftHintOverlay({ hints }: { hints: ActiveShiftHint[] }) {
+  const [, setLayoutTick] = useState(0);
+
+  useEffect(() => {
+    if (hints.length === 0) return;
+
+    const refresh = () => setLayoutTick((tick) => tick + 1);
+    window.addEventListener("resize", refresh);
+    // Capture scroll from nested grid scrollers.
+    window.addEventListener("scroll", refresh, true);
+    return () => {
+      window.removeEventListener("resize", refresh);
+      window.removeEventListener("scroll", refresh, true);
+    };
+  }, [hints.length]);
+
+  if (hints.length === 0 || typeof document === "undefined") {
+    return null;
+  }
+
+  return createPortal(
+    <div
+      aria-hidden
+      className="pointer-events-none fixed inset-0"
+      style={{ zIndex: Z_INDEX_TOOLTIP }}
+    >
+      {hints.map((hint) => {
+        const rect = hint.element.getBoundingClientRect();
+        // Skip off-screen cards instead of clamping chips into a corner pile.
+        if (
+          rect.width === 0 ||
+          rect.height === 0 ||
+          rect.bottom <= 0 ||
+          rect.right <= 0 ||
+          rect.top >= window.innerHeight ||
+          rect.left >= window.innerWidth
+        ) {
+          return null;
+        }
+
+        return (
+          <span
+            key={`${hint.eventId}:${hint.hint}`}
+            className="absolute"
+            style={{ top: rect.top + 4, left: rect.right - 22 }}
+          >
+            <ShortcutHint>{hint.hint.toUpperCase()}</ShortcutHint>
+          </span>
+        );
+      })}
+    </div>,
+    document.body,
+  );
+}

--- a/packages/web/src/shortcuts/shift-hint/assign-shift-hint-keys.test.ts
+++ b/packages/web/src/shortcuts/shift-hint/assign-shift-hint-keys.test.ts
@@ -1,0 +1,111 @@
+import {
+  assignShiftHintKeys,
+  filterHintsByPrefix,
+  generateHintKeys,
+  matchShiftHintKeystroke,
+  SHIFT_HINT_ALPHABET,
+} from "@web/shortcuts/shift-hint/assign-shift-hint-keys";
+import { describe, expect, it } from "bun:test";
+
+describe("assignShiftHintKeys", () => {
+  it("assigns home-row singles in chronological order", () => {
+    const assignments = assignShiftHintKeys([
+      { eventId: "c", startMs: 300, eventType: "timed" },
+      { eventId: "a", startMs: 100, eventType: "timed" },
+      { eventId: "b", startMs: 200, eventType: "timed" },
+    ]);
+
+    expect(assignments).toEqual([
+      { eventId: "a", hint: "a" },
+      { eventId: "b", hint: "s" },
+      { eventId: "c", hint: "d" },
+    ]);
+  });
+
+  it("excludes j and k from the alphabet", () => {
+    expect(SHIFT_HINT_ALPHABET).not.toContain("j");
+    expect(SHIFT_HINT_ALPHABET).not.toContain("k");
+    expect(generateHintKeys(SHIFT_HINT_ALPHABET.length)).toEqual([
+      ...SHIFT_HINT_ALPHABET,
+    ]);
+  });
+
+  it("switches to two-letter-only keys once singles cannot cover the set", () => {
+    const count = SHIFT_HINT_ALPHABET.length + 3;
+    const keys = generateHintKeys(count);
+    expect(keys.every((key) => key.length === 2)).toBe(true);
+    expect(keys.slice(0, 3)).toEqual(["aa", "as", "ad"]);
+  });
+
+  it("caps assignments when the alphabet cannot cover every target", () => {
+    const overflow =
+      SHIFT_HINT_ALPHABET.length * SHIFT_HINT_ALPHABET.length + 5;
+    const targets = Array.from({ length: overflow }, (_, index) => ({
+      eventId: `e${index}`,
+      startMs: index,
+      eventType: "timed" as const,
+    }));
+    const assignments = assignShiftHintKeys(targets);
+    expect(assignments).toHaveLength(
+      SHIFT_HINT_ALPHABET.length * SHIFT_HINT_ALPHABET.length,
+    );
+    expect(assignments.every((item) => item.hint.length > 0)).toBe(true);
+  });
+
+  it("prefers all-day before timed on equal start", () => {
+    const assignments = assignShiftHintKeys([
+      { eventId: "timed", startMs: 100, eventType: "timed" },
+      { eventId: "allday", startMs: 100, eventType: "all-day" },
+    ]);
+    expect(assignments.map((item) => item.eventId)).toEqual([
+      "allday",
+      "timed",
+    ]);
+  });
+
+  it("is stable for the same visible set", () => {
+    const targets = [
+      { eventId: "2", startMs: 2, eventType: "timed" as const },
+      { eventId: "1", startMs: 1, eventType: "timed" as const },
+    ];
+    expect(assignShiftHintKeys(targets)).toEqual(assignShiftHintKeys(targets));
+  });
+});
+
+describe("matchShiftHintKeystroke", () => {
+  const assignments = [
+    { eventId: "1", hint: "a" },
+    { eventId: "2", hint: "s" },
+    { eventId: "3", hint: "aa" },
+  ];
+
+  it("focuses an exact single-key match", () => {
+    expect(
+      matchShiftHintKeystroke({ assignments, key: "s", prefix: "" }),
+    ).toEqual({ kind: "focus", eventId: "2" });
+  });
+
+  it("narrows on the first letter of a two-letter combo", () => {
+    const many = [
+      { eventId: "1", hint: "aa" },
+      { eventId: "2", hint: "as" },
+      { eventId: "3", hint: "s" },
+    ];
+    expect(
+      matchShiftHintKeystroke({ assignments: many, key: "a", prefix: "" }),
+    ).toEqual({ kind: "prefix", prefix: "a" });
+    expect(filterHintsByPrefix(many, "a")).toEqual([
+      { eventId: "1", hint: "aa" },
+      { eventId: "2", hint: "as" },
+    ]);
+  });
+
+  it("ignores j and k", () => {
+    expect(
+      matchShiftHintKeystroke({ assignments, key: "j", prefix: "" }),
+    ).toBeNull();
+    expect(
+      matchShiftHintKeystroke({ assignments, key: "k", prefix: "" }),
+    ).toBeNull();
+  });
+});

--- a/packages/web/src/shortcuts/shift-hint/assign-shift-hint-keys.ts
+++ b/packages/web/src/shortcuts/shift-hint/assign-shift-hint-keys.ts
@@ -1,0 +1,111 @@
+/**
+ * Home-row-first hint alphabet. `j`/`k` are excluded so Shift+J/K week-window
+ * navigation stays unambiguous while hints are armed or pending.
+ */
+export const SHIFT_HINT_ALPHABET = ["a", "s", "d", "f", "g", "h", "l"] as const;
+
+export type ShiftHintTarget = {
+  eventId: string;
+  /** Stable sort key: earlier start first. */
+  startMs: number;
+  eventType: "all-day" | "timed";
+};
+
+export type ShiftHintAssignment = {
+  eventId: string;
+  hint: string;
+};
+
+/**
+ * Deterministic hint keys for the visible target set. Same targets → same keys
+ * across re-renders within a hold. Singles first, then two-letter combos from
+ * the same alphabet when more events are visible than single keys.
+ */
+export function assignShiftHintKeys(
+  targets: ShiftHintTarget[],
+): ShiftHintAssignment[] {
+  if (targets.length === 0) return [];
+
+  const sorted = [...targets].sort((a, b) => {
+    if (a.startMs !== b.startMs) return a.startMs - b.startMs;
+    if (a.eventType !== b.eventType) {
+      return a.eventType === "all-day" ? -1 : 1;
+    }
+    return a.eventId.localeCompare(b.eventId);
+  });
+
+  const keys = generateHintKeys(sorted.length);
+  return sorted.flatMap((target, index) => {
+    const hint = keys[index];
+    if (!hint) return [];
+    return [{ eventId: target.eventId, hint }];
+  });
+}
+
+export function generateHintKeys(count: number): string[] {
+  if (count <= 0) return [];
+
+  // Stay on singles while they cover the set. Past that, use only two-letter
+  // combos so the first keystroke always narrows instead of colliding with a
+  // single-letter assignment that shares the same prefix.
+  if (count <= SHIFT_HINT_ALPHABET.length) {
+    return SHIFT_HINT_ALPHABET.slice(0, count).map((key) => key);
+  }
+
+  const keys: string[] = [];
+  for (const first of SHIFT_HINT_ALPHABET) {
+    for (const second of SHIFT_HINT_ALPHABET) {
+      keys.push(`${first}${second}`);
+      if (keys.length >= count) return keys;
+    }
+  }
+
+  return keys.slice(0, count);
+}
+
+/** Narrow assignments whose hint starts with `prefix` (two-letter flow). */
+export function filterHintsByPrefix(
+  assignments: ShiftHintAssignment[],
+  prefix: string,
+): ShiftHintAssignment[] {
+  if (!prefix) return assignments;
+  return assignments.filter((assignment) => assignment.hint.startsWith(prefix));
+}
+
+/**
+ * Resolve a keystroke against current assignments + optional prefix buffer.
+ * Returns the focused event id, an updated prefix, or null when ignored.
+ */
+export function matchShiftHintKeystroke({
+  assignments,
+  key,
+  prefix,
+}: {
+  assignments: ShiftHintAssignment[];
+  key: string;
+  prefix: string;
+}):
+  | { kind: "focus"; eventId: string }
+  | { kind: "prefix"; prefix: string }
+  | null {
+  if (key.length !== 1) return null;
+  const lower = key.toLowerCase();
+  if (
+    !SHIFT_HINT_ALPHABET.includes(lower as (typeof SHIFT_HINT_ALPHABET)[number])
+  ) {
+    return null;
+  }
+
+  const next = `${prefix}${lower}`;
+  const exact = assignments.find((assignment) => assignment.hint === next);
+  if (exact) {
+    return { kind: "focus", eventId: exact.eventId };
+  }
+
+  const narrowed = filterHintsByPrefix(assignments, next);
+  if (narrowed.length === 0) {
+    return null;
+  }
+
+  return { kind: "prefix", prefix: next };
+}

--- a/packages/web/src/shortcuts/shift-hint/shift-hold-detector.test.ts
+++ b/packages/web/src/shortcuts/shift-hint/shift-hold-detector.test.ts
@@ -1,0 +1,115 @@
+import {
+  createShiftHoldState,
+  isShiftDoubleTapCandidate,
+  reduceShiftHold,
+  SHIFT_HOLD_HINT_THRESHOLD_MS,
+} from "@web/shortcuts/shift-hint/shift-hold-detector";
+import { describe, expect, it } from "bun:test";
+
+describe("reduceShiftHold", () => {
+  it("activates only after the hold threshold", () => {
+    let state = createShiftHoldState();
+    state = reduceShiftHold(state, {
+      type: "shiftDown",
+      now: 1000,
+      blocked: false,
+    });
+    expect(state.phase).toBe("pending");
+    expect(state.pendingStartedAt).toBe(1000);
+
+    state = reduceShiftHold(state, { type: "thresholdReached" });
+    expect(state.phase).toBe("active");
+  });
+
+  it("treats a quick Shift tap as idle and records release time", () => {
+    let state = createShiftHoldState();
+    state = reduceShiftHold(state, {
+      type: "shiftDown",
+      now: 1000,
+      blocked: false,
+    });
+    state = reduceShiftHold(state, { type: "shiftUp", now: 1100 });
+
+    expect(state.phase).toBe("idle");
+    expect(state.lastShiftReleaseAt).toBe(1100);
+    expect(state.pendingStartedAt).toBeNull();
+  });
+
+  it("cancels pending on chord key so Shift+J never flashes hints", () => {
+    let state = createShiftHoldState();
+    state = reduceShiftHold(state, {
+      type: "shiftDown",
+      now: 1000,
+      blocked: false,
+    });
+    state = reduceShiftHold(state, { type: "chordKeyDown" });
+    expect(state.phase).toBe("idle");
+
+    state = reduceShiftHold(state, { type: "thresholdReached" });
+    expect(state.phase).toBe("idle");
+  });
+
+  it("does not start pending when blocked (editable / app lock)", () => {
+    let state = createShiftHoldState();
+    state = reduceShiftHold(state, {
+      type: "shiftDown",
+      now: 1000,
+      blocked: true,
+    });
+    expect(state.phase).toBe("idle");
+  });
+
+  it("dismisses active hints on Shift release without stamping a tap", () => {
+    let state = createShiftHoldState();
+    state = reduceShiftHold(state, {
+      type: "shiftDown",
+      now: 1000,
+      blocked: false,
+    });
+    state = reduceShiftHold(state, { type: "thresholdReached" });
+    state = reduceShiftHold(state, { type: "shiftUp", now: 1300 });
+    expect(state.phase).toBe("idle");
+    expect(state.lastShiftReleaseAt).toBeNull();
+  });
+});
+
+describe("hold vs double-tap coordination", () => {
+  it("records release times so a future SHIFT-SHIFT detector can use them", () => {
+    let state = createShiftHoldState();
+    state = reduceShiftHold(state, {
+      type: "shiftDown",
+      now: 1000,
+      blocked: false,
+    });
+    state = reduceShiftHold(state, { type: "shiftUp", now: 1050 });
+    expect(
+      isShiftDoubleTapCandidate({
+        lastShiftReleaseAt: state.lastShiftReleaseAt,
+        now: 1050 + 100,
+        maxGapMs: 300,
+      }),
+    ).toBe(true);
+
+    // A completed hold also releases, but pending never became active on a
+    // double-tap path: two quick taps stay idle.
+    state = reduceShiftHold(state, {
+      type: "shiftDown",
+      now: 1150,
+      blocked: false,
+    });
+    state = reduceShiftHold(state, { type: "shiftUp", now: 1200 });
+    expect(state.phase).toBe("idle");
+    expect(state.lastShiftReleaseAt).toBe(1200);
+  });
+
+  it("does not treat a long hold release as a double-tap candidate gap start only", () => {
+    expect(SHIFT_HOLD_HINT_THRESHOLD_MS).toBeGreaterThan(100);
+    expect(
+      isShiftDoubleTapCandidate({
+        lastShiftReleaseAt: 1000,
+        now: 1000 + 1000,
+        maxGapMs: 300,
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/web/src/shortcuts/shift-hint/shift-hold-detector.ts
+++ b/packages/web/src/shortcuts/shift-hint/shift-hold-detector.ts
@@ -1,0 +1,132 @@
+/**
+ * Pure SHIFT-hold state for event flash hints.
+ *
+ * Hold (≥ threshold) → active. Quick tap → idle (records release time for a
+ * future SHIFT-SHIFT detector). A chord key while pending cancels before
+ * hints appear, so Shift+J / Shift+Arrow never flash.
+ */
+
+export const SHIFT_HOLD_HINT_THRESHOLD_MS = 200;
+
+export type ShiftHoldPhase = "idle" | "pending" | "active";
+
+export type ShiftHoldState = {
+  phase: ShiftHoldPhase;
+  pendingStartedAt: number | null;
+  /**
+   * Timestamp of the last completed Shift keyup. Keyboard-only mode (double
+   * Shift) can read this without sharing the hold timer.
+   */
+  lastShiftReleaseAt: number | null;
+  hintPrefix: string;
+};
+
+export const createShiftHoldState = (): ShiftHoldState => ({
+  phase: "idle",
+  pendingStartedAt: null,
+  lastShiftReleaseAt: null,
+  hintPrefix: "",
+});
+
+export type ShiftHoldEvent =
+  | { type: "shiftDown"; now: number; blocked: boolean }
+  | { type: "shiftUp"; now: number }
+  | { type: "thresholdReached" }
+  | { type: "chordKeyDown" }
+  | { type: "setPrefix"; prefix: string }
+  | { type: "dismiss" };
+
+export function reduceShiftHold(
+  state: ShiftHoldState,
+  event: ShiftHoldEvent,
+): ShiftHoldState {
+  switch (event.type) {
+    case "shiftDown": {
+      if (event.blocked) {
+        return {
+          ...state,
+          phase: "idle",
+          pendingStartedAt: null,
+          hintPrefix: "",
+        };
+      }
+      if (state.phase === "active") {
+        return state;
+      }
+      return {
+        ...state,
+        phase: "pending",
+        pendingStartedAt: event.now,
+        hintPrefix: "",
+      };
+    }
+    case "shiftUp": {
+      // Only short taps (pending → idle without activating) stamp
+      // lastShiftReleaseAt for a future SHIFT-SHIFT detector. Completed holds
+      // and idle/blocked ups must not look like double-tap candidates.
+      if (state.phase === "pending") {
+        return {
+          ...state,
+          phase: "idle",
+          pendingStartedAt: null,
+          lastShiftReleaseAt: event.now,
+          hintPrefix: "",
+        };
+      }
+      if (state.phase === "active") {
+        return {
+          ...state,
+          phase: "idle",
+          pendingStartedAt: null,
+          hintPrefix: "",
+        };
+      }
+      return state;
+    }
+    case "thresholdReached": {
+      if (state.phase !== "pending") return state;
+      return {
+        ...state,
+        phase: "active",
+        pendingStartedAt: null,
+        hintPrefix: "",
+      };
+    }
+    case "chordKeyDown": {
+      if (state.phase !== "pending") return state;
+      return {
+        ...state,
+        phase: "idle",
+        pendingStartedAt: null,
+        hintPrefix: "",
+      };
+    }
+    case "setPrefix": {
+      if (state.phase !== "active") return state;
+      return { ...state, hintPrefix: event.prefix };
+    }
+    case "dismiss": {
+      return {
+        ...state,
+        phase: "idle",
+        pendingStartedAt: null,
+        hintPrefix: "",
+      };
+    }
+  }
+}
+
+/** True when a second Shift tap would count as double-tap, not a hold. */
+export function isShiftDoubleTapCandidate({
+  lastShiftReleaseAt,
+  now,
+  maxGapMs,
+}: {
+  lastShiftReleaseAt: number | null;
+  now: number;
+  maxGapMs: number;
+}): boolean {
+  if (lastShiftReleaseAt === null) return false;
+  const gap = now - lastShiftReleaseAt;
+  return gap >= 0 && gap <= maxGapMs;
+}

--- a/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.test.tsx
+++ b/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.test.tsx
@@ -1,0 +1,194 @@
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { EventIdSchema } from "@core/types/domain-primitives";
+import { type GridEvent } from "@web/common/types/web.event.types";
+import { clearAppLockReasons, setAppLockReason } from "@web/shortcuts/app-lock";
+import { SHIFT_HOLD_HINT_THRESHOLD_MS } from "@web/shortcuts/shift-hint/shift-hold-detector";
+import { useShiftHoldEventHints } from "@web/shortcuts/shift-hint/useShiftHoldEventHints";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  mock,
+  spyOn,
+} from "bun:test";
+
+const EVENT_A = EventIdSchema.parse("aaaaaaaaaaaaaaaaaaaaaaaa");
+const EVENT_B = EventIdSchema.parse("bbbbbbbbbbbbbbbbbbbbbbbb");
+const EVENT_C = EventIdSchema.parse("cccccccccccccccccccccccc");
+
+const dispatch = (
+  type: "keydown" | "keyup",
+  key: string,
+  init: KeyboardEventInit = {},
+) => {
+  document.dispatchEvent(
+    new KeyboardEvent(type, {
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+      key,
+      ...init,
+    }),
+  );
+};
+
+const timedFixture = (id: string, startDate: string): GridEvent =>
+  ({
+    _id: id,
+    startDate,
+    endDate: startDate,
+    title: id,
+    isAllDay: false,
+  }) as GridEvent;
+
+describe("useShiftHoldEventHints", () => {
+  let timeoutCb: (() => void) | null = null;
+  let setTimeoutSpy: ReturnType<typeof spyOn>;
+  let clearTimeoutSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    clearAppLockReasons();
+    timeoutCb = null;
+    setTimeoutSpy = spyOn(globalThis, "setTimeout").mockImplementation(((
+      handler: TimerHandler,
+    ) => {
+      timeoutCb = () => {
+        if (typeof handler === "function") handler();
+      };
+      return 1 as unknown as ReturnType<typeof setTimeout>;
+    }) as unknown as typeof setTimeout);
+    clearTimeoutSpy = spyOn(globalThis, "clearTimeout").mockImplementation(
+      (() => {}) as typeof clearTimeout,
+    );
+  });
+
+  afterEach(() => {
+    cleanup();
+    clearAppLockReasons();
+    document.body.innerHTML = "";
+    setTimeoutSpy.mockRestore();
+    clearTimeoutSpy.mockRestore();
+  });
+
+  const mountHints = () => {
+    const focus = mock((_target: { eventId: string }) => {});
+    const elements = [EVENT_A, EVENT_B, EVENT_C].map((id, index) => {
+      const el = document.createElement("button");
+      el.textContent = id;
+      // jsdom has no layout; stub a viewport rect so flash targeting can arm.
+      el.getBoundingClientRect = () =>
+        ({
+          x: 40,
+          y: 80 + index * 40,
+          top: 80 + index * 40,
+          left: 40,
+          bottom: 110 + index * 40,
+          right: 200,
+          width: 160,
+          height: 30,
+          toJSON: () => ({}),
+        }) as DOMRect;
+      document.body.appendChild(el);
+      return el;
+    });
+
+    const timedEvents = [
+      timedFixture(EVENT_A, "2026-05-20T09:00:00.000Z"),
+      timedFixture(EVENT_B, "2026-05-20T11:00:00.000Z"),
+      timedFixture(EVENT_C, "2026-05-20T13:00:00.000Z"),
+    ];
+
+    const { result } = renderHook(() =>
+      useShiftHoldEventHints({
+        focus: (target) => focus(target),
+        listVisible: () => [
+          { eventId: EVENT_A, eventType: "timed", element: elements[0]! },
+          { eventId: EVENT_B, eventType: "timed", element: elements[1]! },
+          { eventId: EVENT_C, eventType: "timed", element: elements[2]! },
+        ],
+        timedEvents,
+      }),
+    );
+
+    return { focus, result, elements };
+  };
+
+  it("shows hints after the hold threshold and focuses on an assigned key", () => {
+    const { focus, result, elements } = mountHints();
+
+    act(() => {
+      dispatch("keydown", "Shift");
+    });
+    expect(result.current).toEqual([]);
+    expect(setTimeoutSpy).toHaveBeenCalledWith(
+      expect.any(Function),
+      SHIFT_HOLD_HINT_THRESHOLD_MS,
+    );
+
+    act(() => {
+      timeoutCb?.();
+    });
+
+    expect(result.current.map((hint) => hint.hint)).toEqual(["a", "s", "d"]);
+    expect(result.current.map((hint) => hint.eventId)).toEqual([
+      EVENT_A,
+      EVENT_B,
+      EVENT_C,
+    ]);
+
+    act(() => {
+      dispatch("keydown", "s", { shiftKey: true });
+      dispatch("keyup", "s", { shiftKey: true });
+    });
+
+    expect(focus).toHaveBeenCalledWith(
+      expect.objectContaining({ eventId: EVENT_B, element: elements[1] }),
+    );
+    expect(result.current).toEqual([]);
+  });
+
+  it("does not flash hints on a quick Shift chord (Shift+J)", () => {
+    const { result } = mountHints();
+
+    act(() => {
+      dispatch("keydown", "Shift");
+      dispatch("keydown", "j", { shiftKey: true });
+    });
+    act(() => {
+      timeoutCb?.();
+    });
+
+    expect(result.current).toEqual([]);
+  });
+
+  it("stays inert while app-locked", () => {
+    setAppLockReason("test-modal", true);
+    const { result } = mountHints();
+
+    act(() => {
+      dispatch("keydown", "Shift");
+    });
+    act(() => {
+      timeoutCb?.();
+    });
+
+    expect(result.current).toEqual([]);
+  });
+
+  it("clears hints when Shift is released", () => {
+    const { result } = mountHints();
+
+    act(() => {
+      dispatch("keydown", "Shift");
+      timeoutCb?.();
+    });
+    expect(result.current).toHaveLength(3);
+
+    act(() => {
+      dispatch("keyup", "Shift");
+    });
+    expect(result.current).toEqual([]);
+  });
+});

--- a/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.ts
+++ b/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.ts
@@ -1,0 +1,299 @@
+import { useEffect, useRef, useState } from "react";
+import dayjs from "@core/util/date/dayjs";
+import { type GridEvent } from "@web/common/types/web.event.types";
+import { isEditableKeyboardTarget } from "@web/common/utils/form/form.util";
+import {
+  assignShiftHintKeys,
+  filterHintsByPrefix,
+  matchShiftHintKeystroke,
+  type ShiftHintAssignment,
+} from "@web/shortcuts/shift-hint/assign-shift-hint-keys";
+import {
+  createShiftHoldState,
+  reduceShiftHold,
+  SHIFT_HOLD_HINT_THRESHOLD_MS,
+  type ShiftHoldState,
+} from "@web/shortcuts/shift-hint/shift-hold-detector";
+
+export type ShiftHintFocusTarget = {
+  eventId: string;
+  eventType: "all-day" | "timed";
+  element: HTMLElement;
+};
+
+export type ActiveShiftHint = ShiftHintAssignment & {
+  element: HTMLElement;
+};
+
+const isAppLocked = () => document.body.dataset.appLocked === "true";
+
+const isShiftKey = (event: KeyboardEvent) =>
+  event.key === "Shift" ||
+  event.code === "ShiftLeft" ||
+  event.code === "ShiftRight";
+
+const scheduleStartMs = (event: GridEvent): number => {
+  if (!event.startDate) return 0;
+  return dayjs(event.startDate).valueOf();
+};
+
+/** True when any part of the element intersects the viewport. */
+const isInViewport = (element: HTMLElement): boolean => {
+  const rect = element.getBoundingClientRect();
+  if (rect.width === 0 && rect.height === 0) return false;
+  return (
+    rect.bottom > 0 &&
+    rect.right > 0 &&
+    rect.top < window.innerHeight &&
+    rect.left < window.innerWidth
+  );
+};
+
+/**
+ * Hold SHIFT (≥ threshold) to flash home-row hint chips on visible grid events.
+ * Assigned key focuses the event and dismisses. Release clears. Quick chords
+ * (Shift+J, Shift+Arrow) cancel before hints appear.
+ */
+export function useShiftHoldEventHints({
+  allDayEvents = [],
+  enabled = true,
+  focus,
+  listVisible,
+  timedEvents,
+}: {
+  allDayEvents?: GridEvent[];
+  enabled?: boolean;
+  focus: (target: ShiftHintFocusTarget) => void;
+  listVisible: () => ShiftHintFocusTarget[];
+  timedEvents: GridEvent[];
+}): ActiveShiftHint[] {
+  const [hints, setHints] = useState<ActiveShiftHint[]>([]);
+  const stateRef = useRef<ShiftHoldState>(createShiftHoldState());
+  const assignmentsRef = useRef<ShiftHintAssignment[]>([]);
+  const visibleByIdRef = useRef<Map<string, ShiftHintFocusTarget>>(new Map());
+  const thresholdTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const suppressKeyUpRef = useRef(new Set<string>());
+  const focusRef = useRef(focus);
+  const listVisibleRef = useRef(listVisible);
+  const allDayEventsRef = useRef(allDayEvents);
+  const timedEventsRef = useRef(timedEvents);
+
+  focusRef.current = focus;
+  listVisibleRef.current = listVisible;
+  allDayEventsRef.current = allDayEvents;
+  timedEventsRef.current = timedEvents;
+
+  useEffect(() => {
+    if (!enabled) {
+      stateRef.current = createShiftHoldState();
+      assignmentsRef.current = [];
+      setHints([]);
+      return;
+    }
+
+    const clearThresholdTimer = () => {
+      if (thresholdTimerRef.current !== null) {
+        clearTimeout(thresholdTimerRef.current);
+        thresholdTimerRef.current = null;
+      }
+    };
+
+    const publishHints = (next: ActiveShiftHint[]) => {
+      setHints(next);
+    };
+
+    const clearHints = () => {
+      assignmentsRef.current = [];
+      visibleByIdRef.current = new Map();
+      publishHints([]);
+    };
+
+    const buildAssignments = () => {
+      // Targeting adapters include laid-out-but-scrolled-off cards; flash
+      // hints only for events intersecting the viewport.
+      const visible = listVisibleRef
+        .current()
+        .filter((target) => isInViewport(target.element));
+      const scheduleById = new Map<string, number>();
+      for (const event of [
+        ...allDayEventsRef.current,
+        ...timedEventsRef.current,
+      ]) {
+        if (!event._id) continue;
+        scheduleById.set(event._id, scheduleStartMs(event));
+      }
+
+      const targets = visible.map((target) => ({
+        eventId: target.eventId,
+        eventType: target.eventType,
+        startMs: scheduleById.get(target.eventId) ?? 0,
+      }));
+
+      const assignments = assignShiftHintKeys(targets);
+      assignmentsRef.current = assignments;
+      visibleByIdRef.current = new Map(
+        visible.map((target) => [target.eventId, target]),
+      );
+
+      return assignments.flatMap((assignment) => {
+        const target = visibleByIdRef.current.get(assignment.eventId);
+        if (!target) return [];
+        return [{ ...assignment, element: target.element }];
+      });
+    };
+
+    const activate = () => {
+      stateRef.current = reduceShiftHold(stateRef.current, {
+        type: "thresholdReached",
+      });
+      if (stateRef.current.phase !== "active") return;
+      publishHints(buildAssignments());
+    };
+
+    const dismiss = () => {
+      clearThresholdTimer();
+      stateRef.current = reduceShiftHold(stateRef.current, { type: "dismiss" });
+      clearHints();
+    };
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.defaultPrevented) return;
+
+      if (isShiftKey(event)) {
+        if (event.repeat) return;
+        const blocked = isAppLocked() || isEditableKeyboardTarget(event);
+        stateRef.current = reduceShiftHold(stateRef.current, {
+          type: "shiftDown",
+          now: Date.now(),
+          blocked,
+        });
+        clearThresholdTimer();
+        if (stateRef.current.phase !== "pending") return;
+
+        thresholdTimerRef.current = setTimeout(() => {
+          thresholdTimerRef.current = null;
+          if (stateRef.current.phase !== "pending") return;
+          if (isAppLocked()) {
+            dismiss();
+            return;
+          }
+          activate();
+        }, SHIFT_HOLD_HINT_THRESHOLD_MS);
+        return;
+      }
+
+      if (stateRef.current.phase === "pending") {
+        // Any other key while pending is a chord (Shift+J, Shift+Arrow, …).
+        clearThresholdTimer();
+        stateRef.current = reduceShiftHold(stateRef.current, {
+          type: "chordKeyDown",
+        });
+        return;
+      }
+
+      if (stateRef.current.phase !== "active") return;
+      if (isAppLocked() || isEditableKeyboardTarget(event)) {
+        dismiss();
+        return;
+      }
+
+      // Escape / arrows dismiss and let existing handlers run.
+      if (
+        event.key === "Escape" ||
+        event.key.startsWith("Arrow") ||
+        event.key === "j" ||
+        event.key === "J" ||
+        event.key === "k" ||
+        event.key === "K"
+      ) {
+        dismiss();
+        return;
+      }
+
+      if (event.metaKey || event.ctrlKey || event.altKey) {
+        dismiss();
+        return;
+      }
+
+      const key = event.key.length === 1 ? event.key.toLowerCase() : event.key;
+      const match = matchShiftHintKeystroke({
+        assignments: assignmentsRef.current,
+        key,
+        prefix: stateRef.current.hintPrefix,
+      });
+
+      if (!match) return;
+
+      event.preventDefault();
+      event.stopPropagation();
+      suppressKeyUpRef.current.add(key);
+
+      if (match.kind === "prefix") {
+        stateRef.current = reduceShiftHold(stateRef.current, {
+          type: "setPrefix",
+          prefix: match.prefix,
+        });
+        const narrowed = filterHintsByPrefix(
+          assignmentsRef.current,
+          match.prefix,
+        );
+        publishHints(
+          narrowed.flatMap((assignment) => {
+            const target = visibleByIdRef.current.get(assignment.eventId);
+            if (!target) return [];
+            return [{ ...assignment, element: target.element }];
+          }),
+        );
+        return;
+      }
+
+      const target = visibleByIdRef.current.get(match.eventId);
+      dismiss();
+      if (!target) return;
+      target.element.scrollIntoView({ block: "nearest" });
+      focusRef.current(target);
+    };
+
+    const onKeyUp = (event: KeyboardEvent) => {
+      if (isShiftKey(event)) {
+        // Keep holding if the other Shift key is still down.
+        if (event.shiftKey) return;
+
+        const wasActive = stateRef.current.phase === "active";
+        clearThresholdTimer();
+        stateRef.current = reduceShiftHold(stateRef.current, {
+          type: "shiftUp",
+          now: Date.now(),
+        });
+        if (wasActive || assignmentsRef.current.length > 0) {
+          clearHints();
+        }
+        return;
+      }
+
+      const key = event.key.length === 1 ? event.key.toLowerCase() : event.key;
+      if (!suppressKeyUpRef.current.has(key)) return;
+      suppressKeyUpRef.current.delete(key);
+      event.preventDefault();
+      event.stopPropagation();
+    };
+
+    const onBlur = () => {
+      dismiss();
+    };
+
+    document.addEventListener("keydown", onKeyDown, true);
+    document.addEventListener("keyup", onKeyUp, true);
+    window.addEventListener("blur", onBlur);
+
+    return () => {
+      clearThresholdTimer();
+      suppressKeyUpRef.current.clear();
+      document.removeEventListener("keydown", onKeyDown, true);
+      document.removeEventListener("keyup", onKeyUp, true);
+      window.removeEventListener("blur", onBlur);
+    };
+  }, [enabled]);
+
+  return hints;
+}

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
@@ -30,6 +30,7 @@ import { EventGrid, isEventGridLoading } from "@web/grid/components/EventGrid";
 import { useAllDayDraftCreation } from "@web/grid/hooks/useAllDayDraftCreation";
 import { useGridCoordinates } from "@web/grid/hooks/useGridCoordinates";
 import { useGridMeasurements } from "@web/grid/hooks/useGridMeasurements";
+import { ShiftHintOverlay } from "@web/shortcuts/shift-hint/ShiftHintOverlay";
 import { dayEventQueryRange } from "@web/views/Day/hooks/events/useDayEvents";
 import { useDateInView } from "@web/views/Day/hooks/navigation/useDateInView";
 import { useDateNavigation } from "@web/views/Day/hooks/navigation/useDateNavigation";
@@ -111,7 +112,7 @@ export function DayCalendarGrid() {
     gridRefs.mainGridRef,
     visibleDates,
   );
-  useDayEventNudgeShortcuts({
+  const { shiftHints } = useDayEventNudgeShortcuts({
     allDayEvents: displayedAllDayEvents,
     navigateToDate,
     navigateToNextDay,
@@ -408,6 +409,7 @@ export function DayCalendarGrid() {
         />
       </DayInteractionCoordinator>
       {contextMenu}
+      <ShiftHintOverlay hints={shiftHints} />
     </section>
   );
 }

--- a/packages/web/src/views/Day/hooks/shortcuts/useDayEventNudgeShortcuts.ts
+++ b/packages/web/src/views/Day/hooks/shortcuts/useDayEventNudgeShortcuts.ts
@@ -5,6 +5,10 @@ import { type EventMutationDependencies } from "@web/events/mutations/useEventMu
 import { draftActions, useDraftStore } from "@web/events/stores/draft.store";
 import { useGridEventEditShortcuts } from "@web/grid/shortcuts/useGridEventEditShortcuts";
 import { useGridEventFormFieldSequences } from "@web/grid/shortcuts/useGridEventFormFieldSequences";
+import {
+  type ActiveShiftHint,
+  useShiftHoldEventHints,
+} from "@web/shortcuts/shift-hint/useShiftHoldEventHints";
 import { requestFocusFirstDayCalendarEvent } from "@web/views/Day/interaction/day-event.focus";
 import {
   focusDayGridEventTarget,
@@ -35,7 +39,7 @@ export function useDayEventNudgeShortcuts({
   navigateToNextDay?: () => void;
   navigateToPreviousDay?: () => void;
   timedEvents: GridEvent[];
-}) {
+}): { shiftHints: ActiveShiftHint[] } {
   const targeting = {
     focus: focusDayGridEventTarget,
     getFocused: getFocusedDayGridEventTarget,
@@ -87,4 +91,13 @@ export function useDayEventNudgeShortcuts({
     targeting,
     timedEvents,
   });
+
+  const shiftHints = useShiftHoldEventHints({
+    allDayEvents,
+    focus: focusDayGridEventTarget,
+    listVisible: listVisibleDayGridEventTargets,
+    timedEvents,
+  });
+
+  return { shiftHints };
 }

--- a/packages/web/src/views/Week/components/Shortcuts.tsx
+++ b/packages/web/src/views/Week/components/Shortcuts.tsx
@@ -1,3 +1,4 @@
+import { ShiftHintOverlay } from "@web/shortcuts/shift-hint/ShiftHintOverlay";
 import {
   type ShortcutProps,
   useWeekShortcutOwner,
@@ -10,7 +11,12 @@ export function Shortcuts({
   children: React.ReactNode;
   shortcutsProps: ShortcutProps;
 }) {
-  useWeekShortcutOwner(shortcutsProps);
+  const { shiftHints } = useWeekShortcutOwner(shortcutsProps);
 
-  return children;
+  return (
+    <>
+      {children}
+      <ShiftHintOverlay hints={shiftHints} />
+    </>
+  );
 }

--- a/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcutOwner.ts
+++ b/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcutOwner.ts
@@ -18,6 +18,10 @@ import { draftActions, isEventFormOpen } from "@web/events/stores/draft.store";
 import { getFirstEventOnWeekdayColumn } from "@web/grid/shortcuts/focus-adjacent-grid-event";
 import { useGridEventEditShortcuts } from "@web/grid/shortcuts/useGridEventEditShortcuts";
 import { useGridEventFormFieldSequences } from "@web/grid/shortcuts/useGridEventFormFieldSequences";
+import {
+  type ActiveShiftHint,
+  useShiftHoldEventHints,
+} from "@web/shortcuts/shift-hint/useShiftHoldEventHints";
 import { useDraftContext } from "@web/views/Week/components/Draft/context/useDraftContext";
 import { type Util_Scroll } from "@web/views/Week/hooks/grid/useScroll";
 import { useWeekViewShortcuts } from "@web/views/Week/hooks/shortcuts/useWeekViewShortcuts";
@@ -54,7 +58,7 @@ export const useWeekShortcutOwner = ({
   weekDays,
   util,
   scrollUtil,
-}: ShortcutProps) => {
+}: ShortcutProps): { shiftHints: ActiveShiftHint[] } => {
   const { data: calendars = [], isPending: isCalendarsPending } =
     useCalendarsQuery();
   const defaultTargetCalendarId =
@@ -225,4 +229,13 @@ export const useWeekShortcutOwner = ({
     onFocusCalendar: focusFirstCalendarEvent,
     onFocusWeekdayColumn: focusWeekdayColumn,
   });
+
+  const shiftHints = useShiftHoldEventHints({
+    allDayEvents,
+    focus: focusWeekGridEventTarget,
+    listVisible: listVisibleWeekGridEventTargets,
+    timedEvents,
+  });
+
+  return { shiftHints };
 };


### PR DESCRIPTION
## Summary
- Holding Shift for ~200ms shows home-row hint chips on viewport-visible Week and Day events (timed + all-day).
- Pressing an assigned key focuses that event and clears the chips; releasing Shift clears them.
- Quick Shift chords (Shift+J/K, Shift+Arrow) do not flash hints. Hint keys exclude `j`/`k` so week-window shift stays unambiguous.
- v1 targets events only (not sidebar/menus), matching the flash-targeting vision for launch.

## Simplicity
- Pure assignment + hold-state helpers with a thin document listener hook and a portaled chip overlay.
- No parallel shortcut list; Week/Day owners reuse existing visible-event targeting.

## Automated validation
- jsdom: assignment, hold threshold vs quick tap/chord, app-lock inert, focus on assigned key, hold vs future double-tap release stamping.
- Related Week/Day shortcut owner suites still green.

## Independent review
- Fixed dual-Shift keyup dismissing while the other Shift is held.
- Fixed off-screen laid-out events stealing early keys / clamping chips.
- Capped assignments when the alphabet is exhausted; hold releases no longer stamp double-tap candidate times.

## Test plan
- `bun test src/shortcuts/shift-hint/` (from `packages/web`)
- `bun test src/views/Week/hooks/shortcuts/useWeekShortcutOwner.test.tsx src/views/Day/hooks/shortcuts/useDayEventNudgeShortcuts.test.tsx`
- `bun run verify` (web → type-check → lint → test:a11y)