### PR TITLE
feat(web): document hold-shift event jump keys

### DIFF
--- a/docs/acceptance/shortcuts.md
+++ b/docs/acceptance/shortcuts.md
@@ -54,6 +54,7 @@ Helpful notes:
 | `T`                         | Day view  | Go to today                       |
 | `I`                         | Day view  | Focus sidebar                     |
 | `U`                         | Day view  | Focus first calendar event        |
+| Hold `Shift`                | Day view  | Show event jump keys on visible events |
 | `C`                         | Day view  | Create timed event                |
 | `A`                         | Day view  | Create all-day event              |
 | `Delete`                    | Day view  | Delete focused event              |
@@ -77,6 +78,7 @@ Helpful notes:
 | `A`                         | Week view | Create all-day event              |
 | `I`                         | Week view | Focus sidebar                     |
 | `U`                         | Week view | Focus first calendar event        |
+| Hold `Shift`                | Week view | Show event jump keys on visible events |
 | `Delete`                    | Week view | Delete focused event              |
 | `ArrowUp` / `ArrowDown`     | Week view | Focus previous/next event         |
 | `Arrow keys`                | Week view | Move open draft event             |
@@ -325,7 +327,30 @@ After deleting or moving an event, pressing Cmd+Z (Mac) or Ctrl+Z (Windows/Linux
 
 ---
 
-## Scenario 12: Shortcuts Do Not Fire While Typing In Inputs
+## Scenario 12: Hold Shift To Jump Focus To A Visible Event
+
+### UX
+
+Holding `Shift` for a short beat (~200ms) assigns home-row jump keys to viewport-visible Week/Day events and paints a keycap chip on each. Pressing an assigned key focuses that event and clears the chips. Releasing `Shift` clears them. Quick chords such as Shift+J or Shift+Arrow do not flash hints. `j`/`k` are never assigned as jump keys.
+
+### Steps
+
+1. Navigate to `/week` with at least three timed events visible on the same day.
+2. Hold `Shift` for about a quarter second (do not tap quickly).
+3. Press the key shown on the middle event's chip (commonly `S` for the second event in chronological order).
+4. Repeat with a fast Shift+J chord and confirm no chips appear.
+
+### Expected Results
+
+- Distinct chips appear on the visible events while Shift is held past the threshold.
+- The assigned key focuses that event; chips disappear.
+- Releasing Shift without pressing a jump key also clears chips.
+- Fast Shift+J / Shift+Arrow do not flash chips.
+- While a modal holds the app lock, or focus is in an editable field, holding Shift does nothing.
+
+---
+
+## Scenario 13: Shortcuts Do Not Fire While Typing In Inputs
 
 ### UX
 
@@ -365,3 +390,4 @@ If time is limited, run these checks before shipping shortcut-related changes:
 12. With a focused event and no draft open, ArrowUp/ArrowDown move focus to the previous/next event chronologically.
 13. Cmd+D / Ctrl+D duplicates a focused event in Day and Week view.
 14. With a focused event, `E` then `T` opens the form with the title focused; bare `E` alone does nothing.
+15. Holding Shift shows event jump chips; an assigned key focuses that event; fast Shift+J does not flash chips.

--- a/e2e/timed/shift-hold-event-hints.spec.ts
+++ b/e2e/timed/shift-hold-event-hints.spec.ts
@@ -1,0 +1,72 @@
+import { expect, test } from "@playwright/test";
+import {
+  createEventTitle,
+  expectTimedEventVisible,
+  fillTitleAndSaveEventForm,
+  getMainGridPoint,
+  prepareCalendarPage,
+} from "../utils/event-test-utils";
+
+const createTimedEventAt = async (
+  page: Parameters<typeof prepareCalendarPage>[0],
+  title: string,
+  { xRatio, yRatio }: { xRatio: number; yRatio: number },
+) => {
+  const { x, y } = await getMainGridPoint(page, { xRatio, yRatio });
+  await page.mouse.click(x, y);
+  await fillTitleAndSaveEventForm(page, title);
+  await expectTimedEventVisible(page, title);
+};
+
+const shiftHintOverlay = (page: Parameters<typeof prepareCalendarPage>[0]) =>
+  page.locator("[data-shift-event-hints]");
+
+test("hold Shift shows jump keys and focuses the assigned event", async ({
+  page,
+}) => {
+  await prepareCalendarPage(page);
+
+  const earlyTitle = createEventTitle("Early Flash");
+  const middleTitle = createEventTitle("Middle Flash");
+  const lateTitle = createEventTitle("Late Flash");
+
+  // Same weekday column; earlier y ≈ earlier start for chronological hints.
+  await createTimedEventAt(page, earlyTitle, { xRatio: 0.42, yRatio: 0.25 });
+  await createTimedEventAt(page, middleTitle, { xRatio: 0.42, yRatio: 0.4 });
+  await createTimedEventAt(page, lateTitle, { xRatio: 0.42, yRatio: 0.55 });
+
+  const middleButton = page
+    .locator("#mainGrid")
+    .getByRole("button", { name: middleTitle });
+
+  await page.keyboard.down("Shift");
+  await page.waitForTimeout(250);
+
+  const overlay = shiftHintOverlay(page);
+  await expect(overlay.getByText("A", { exact: true })).toHaveCount(1);
+  await expect(overlay.getByText("S", { exact: true })).toHaveCount(1);
+  await expect(overlay.getByText("D", { exact: true })).toHaveCount(1);
+
+  await page.keyboard.down("s");
+  await page.keyboard.up("s");
+
+  await expect(middleButton).toBeFocused();
+  await expect(shiftHintOverlay(page)).toHaveCount(0);
+
+  await page.keyboard.up("Shift");
+});
+
+test("fast Shift+J does not flash event jump keys", async ({ page }) => {
+  await prepareCalendarPage(page);
+
+  const title = createEventTitle("Chord Quiet");
+  await createTimedEventAt(page, title, { xRatio: 0.42, yRatio: 0.35 });
+
+  await page.keyboard.down("Shift");
+  await page.keyboard.down("j");
+  await page.waitForTimeout(250);
+  await page.keyboard.up("j");
+  await page.keyboard.up("Shift");
+
+  await expect(shiftHintOverlay(page)).toHaveCount(0);
+});

--- a/packages/web/src/shortcuts/data/shortcuts.data.test.ts
+++ b/packages/web/src/shortcuts/data/shortcuts.data.test.ts
@@ -139,10 +139,12 @@ describe("shortcuts.data", () => {
       expect(stripMetadata(findFocus("day")?.shortcuts ?? [])).toEqual([
         { keys: ["i"], label: "Focus sidebar" },
         { keys: ["u"], label: "Focus calendar event" },
+        { keys: ["Hold", "Shift"], label: "Show event jump keys" },
       ]);
       expect(stripMetadata(findFocus("week")?.shortcuts ?? [])).toEqual([
         { keys: ["i"], label: "Focus sidebar" },
         { keys: ["u"], label: "Focus calendar event" },
+        { keys: ["Hold", "Shift"], label: "Show event jump keys" },
       ]);
       expect(stripMetadata(findFocus("week", true)?.shortcuts ?? [])).toEqual([
         { keys: ["i"], label: "Focus sidebar" },
@@ -151,10 +153,12 @@ describe("shortcuts.data", () => {
           keys: ["1-7"],
           label: "Focus first event on weekday column",
         },
+        { keys: ["Hold", "Shift"], label: "Show event jump keys" },
       ]);
       expect(stripMetadata(findFocus("day", true)?.shortcuts ?? [])).toEqual([
         { keys: ["i"], label: "Focus sidebar" },
         { keys: ["u"], label: "Focus calendar event" },
+        { keys: ["Hold", "Shift"], label: "Show event jump keys" },
       ]);
     });
 

--- a/packages/web/src/shortcuts/shift-hint/ShiftHintOverlay.tsx
+++ b/packages/web/src/shortcuts/shift-hint/ShiftHintOverlay.tsx
@@ -32,6 +32,7 @@ export function ShiftHintOverlay({ hints }: { hints: ActiveShiftHint[] }) {
     <div
       aria-hidden
       className="pointer-events-none fixed inset-0"
+      data-shift-event-hints=""
       style={{ zIndex: Z_INDEX_TOOLTIP }}
     >
       {hints.map((hint) => {

--- a/packages/web/src/shortcuts/shortcuts.registry.test.ts
+++ b/packages/web/src/shortcuts/shortcuts.registry.test.ts
@@ -62,6 +62,24 @@ describe("shortcuts.registry", () => {
       expect(ids).toContain("edit-save");
     });
 
+    it("lists hold-Shift event jump keys in day and week focus sections", () => {
+      for (const view of ["day", "week"] as const) {
+        const shortcuts = filterShortcutsByContext({
+          view,
+          isViewingCurrentPeriod: true,
+        });
+        expect(shortcuts.map((shortcut) => shortcut.id)).toContain(
+          "focus-shift-hold",
+        );
+      }
+
+      const life = filterShortcutsByContext({
+        view: "life",
+        isViewingCurrentPeriod: true,
+      }).map((shortcut) => shortcut.id);
+      expect(life).not.toContain("focus-shift-hold");
+    });
+
     it("hides event-focused edit sequences until an event is focused", () => {
       const idle = filterShortcutsByContext({
         view: "day",

--- a/packages/web/src/shortcuts/shortcuts.registry.ts
+++ b/packages/web/src/shortcuts/shortcuts.registry.ts
@@ -129,6 +129,12 @@ export const SHORTCUTS_REGISTRY: Shortcut[] = [
     section: "focus",
     when: { eventFocused: true },
   },
+  {
+    id: "focus-shift-hold",
+    keys: ["Hold", "Shift"],
+    label: "Show event jump keys",
+    section: "focus",
+  },
 
   // Edit
   {


### PR DESCRIPTION
## Summary
- Adds a Focus-section legend entry for holding Shift to show event jump keys.
- Documents the hold-Shift flash flow in the shortcuts acceptance runbook.
- Adds Playwright coverage for the 3-event focus path and quiet Shift+J chords.

## Simplicity
- Registry-only legend wiring; no parallel shortcut list.
- E2E scopes chips via the existing overlay root rather than page-wide keycaps.

## Automated validation
- `bun test src/shortcuts/shortcuts.registry.test.ts src/shortcuts/data/shortcuts.data.test.ts`
- `bunx playwright test e2e/timed/shift-hold-event-hints.spec.ts` (2 passed)

## Independent review
- Scoped e2e assertions after discovering unrelated `.c-keycap` nodes (e.g. create-all-day hints) matched bare `A`.

## Test plan
- Registry/legend unit tests above
- Playwright shift-hold specs above