### PR TITLE
feat(web): add shift-shift keyboard-only mode

### DIFF
--- a/e2e/timed/keyboard-only-mode.spec.ts
+++ b/e2e/timed/keyboard-only-mode.spec.ts
@@ -1,0 +1,78 @@
+import { expect, test } from "@playwright/test";
+import {
+  createEventTitle,
+  expectTimedEventVisible,
+  fillTitleAndSaveEventForm,
+  getMainGridPoint,
+  prepareCalendarPage,
+} from "../utils/event-test-utils";
+
+const keyboardOnlyIndicator = (
+  page: Parameters<typeof prepareCalendarPage>[0],
+) => page.locator("[data-keyboard-only-indicator]");
+
+const tapShift = async (page: Parameters<typeof prepareCalendarPage>[0]) => {
+  await page.keyboard.down("Shift");
+  await page.keyboard.up("Shift");
+};
+
+test("SHIFT-SHIFT enters keyboard-only mode; clicks are inert until Escape", async ({
+  page,
+}) => {
+  await prepareCalendarPage(page);
+
+  const title = createEventTitle("Keyboard Only Target");
+  const { x, y } = await getMainGridPoint(page, {
+    xRatio: 0.42,
+    yRatio: 0.35,
+  });
+  await page.mouse.click(x, y);
+  await fillTitleAndSaveEventForm(page, title);
+  await expectTimedEventVisible(page, title);
+
+  const eventButton = page
+    .locator("#mainGrid")
+    .getByRole("button", { name: title });
+
+  await tapShift(page);
+  await tapShift(page);
+
+  await expect(keyboardOnlyIndicator(page)).toContainText("Keyboard only");
+  await expect(keyboardOnlyIndicator(page)).toContainText("ESC to exit");
+
+  // Shortcuts overlay stays mounted with role=dialog even when closed, so
+  // assert the event form did not open rather than dialog count.
+  await eventButton.click({ force: true });
+  await expect(page.getByLabel("Title")).toHaveCount(0);
+  await expect(keyboardOnlyIndicator(page)).toBeVisible();
+  await expect(eventButton).not.toBeFocused();
+
+  await page.keyboard.press("Escape");
+  await expect(keyboardOnlyIndicator(page)).toHaveCount(0);
+
+  await eventButton.click();
+  await expect(page.getByLabel("Title")).toBeVisible();
+});
+
+test("hold Shift still flashes jump keys and does not enter keyboard-only mode", async ({
+  page,
+}) => {
+  await prepareCalendarPage(page);
+
+  const title = createEventTitle("Hold Not Double");
+  const { x, y } = await getMainGridPoint(page, {
+    xRatio: 0.42,
+    yRatio: 0.35,
+  });
+  await page.mouse.click(x, y);
+  await fillTitleAndSaveEventForm(page, title);
+  await expectTimedEventVisible(page, title);
+
+  await page.keyboard.down("Shift");
+  await page.waitForTimeout(250);
+  await expect(page.locator("[data-shift-event-hints]")).toHaveCount(1);
+  await expect(keyboardOnlyIndicator(page)).toHaveCount(0);
+  await page.keyboard.up("Shift");
+  await expect(page.locator("[data-shift-event-hints]")).toHaveCount(0);
+  await expect(keyboardOnlyIndicator(page)).toHaveCount(0);
+});

--- a/packages/web/src/components/RootShell/RootShell.tsx
+++ b/packages/web/src/components/RootShell/RootShell.tsx
@@ -12,6 +12,7 @@ import {
   selectWelcomeGuideOpen,
   useWelcomeGuideStore,
 } from "@web/components/WelcomeModal/welcome.guide.store";
+import { useKeyboardOnlyMode } from "@web/shortcuts/keyboard-only/useKeyboardOnlyMode";
 import {
   useCalendarShellShortcuts,
   useNavigationShortcuts,
@@ -30,6 +31,7 @@ export function RootShell() {
   const isWelcomeGuideOpen = useWelcomeGuideStore(selectWelcomeGuideOpen);
   useNavigationShortcuts();
   useCalendarShellShortcuts();
+  useKeyboardOnlyMode();
 
   return (
     <AuthModalProvider>

--- a/packages/web/src/components/Sidebar/SidebarStatusBar.tsx
+++ b/packages/web/src/components/Sidebar/SidebarStatusBar.tsx
@@ -5,6 +5,11 @@ import { useGoogleSyncRefreshSnapshot } from "@web/auth/google/state/google.sync
 import { SYNC_STATUS_VARIANT_CLASSNAME } from "@web/calendars/sync-status.types";
 import { useHasPendingEventMutations } from "@web/events/mutations/useEventPending";
 import { settingsActions } from "@web/settings/settings.store";
+import { KeyboardOnlyIndicator } from "@web/shortcuts/keyboard-only/KeyboardOnlyIndicator";
+import {
+  selectKeyboardOnlyActive,
+  useKeyboardOnlyStore,
+} from "@web/shortcuts/keyboard-only/keyboard-only.store";
 
 /**
  * Pinned status bar at the bottom of the sidebar, just above the actions bar.
@@ -18,6 +23,7 @@ import { settingsActions } from "@web/settings/settings.store";
  * the meaning; `title` is the safety net if anything still overflows.
  */
 export const SidebarStatusBar: FC = () => {
+  const isKeyboardOnly = useKeyboardOnlyStore(selectKeyboardOnlyActive);
   const isSaving = useHasPendingEventMutations();
   // The unscoped hook's `connection` is the primary connection (the one
   // whose own state matches the aggregate) - without it, an account's
@@ -41,23 +47,29 @@ export const SidebarStatusBar: FC = () => {
 
   return (
     <div className="flex h-6 shrink-0 items-center px-4">
-      <button
-        aria-label={
-          text ? `${text}. Open account settings` : "Open account settings"
-        }
-        className="c-focus-ring flex h-full min-w-0 flex-1 items-center rounded-xs text-left"
-        onClick={settingsActions.openSettings}
-        title={text || undefined}
-        type="button"
-      >
-        <span
-          aria-live="polite"
-          className={`truncate text-xs ${status ? SYNC_STATUS_VARIANT_CLASSNAME[status.variant] : ""}`}
-          role="status"
+      {isKeyboardOnly ? (
+        <div className="flex h-full min-w-0 flex-1 items-center">
+          <KeyboardOnlyIndicator />
+        </div>
+      ) : (
+        <button
+          aria-label={
+            text ? `${text}. Open account settings` : "Open account settings"
+          }
+          className="c-focus-ring flex h-full min-w-0 flex-1 items-center rounded-xs text-left"
+          onClick={settingsActions.openSettings}
+          title={text || undefined}
+          type="button"
         >
-          {text}
-        </span>
-      </button>
+          <span
+            aria-live="polite"
+            className={`truncate text-xs ${status ? SYNC_STATUS_VARIANT_CLASSNAME[status.variant] : ""}`}
+            role="status"
+          >
+            {text}
+          </span>
+        </button>
+      )}
     </div>
   );
 };

--- a/packages/web/src/shortcuts/data/shortcuts.data.test.ts
+++ b/packages/web/src/shortcuts/data/shortcuts.data.test.ts
@@ -273,6 +273,10 @@ describe("shortcuts.data", () => {
         label: "Undo last change",
       });
       expect(stripMetadata(other?.shortcuts ?? [])).toContainEqual({
+        keys: ["Shift", "Shift"],
+        label: "Enter keyboard-only mode",
+      });
+      expect(stripMetadata(other?.shortcuts ?? [])).toContainEqual({
         keys: ["Mod", "Shift", "Z"],
         label: "Redo last change",
       });

--- a/packages/web/src/shortcuts/keyboard-only/KeyboardOnlyIndicator.tsx
+++ b/packages/web/src/shortcuts/keyboard-only/KeyboardOnlyIndicator.tsx
@@ -1,0 +1,36 @@
+import { type FC, useEffect, useState } from "react";
+import {
+  selectKeyboardOnlyActive,
+  selectKeyboardOnlyPulse,
+  useKeyboardOnlyStore,
+} from "@web/shortcuts/keyboard-only/keyboard-only.store";
+
+/**
+ * Persistent badge while keyboard-only mode is on. Pulses when a click is
+ * blocked so the user sees why the pointer did nothing.
+ */
+export const KeyboardOnlyIndicator: FC = () => {
+  const isActive = useKeyboardOnlyStore(selectKeyboardOnlyActive);
+  const pulse = useKeyboardOnlyStore(selectKeyboardOnlyPulse);
+  const [isPulsing, setIsPulsing] = useState(false);
+
+  useEffect(() => {
+    if (pulse === 0) return;
+    setIsPulsing(true);
+    const timer = window.setTimeout(() => setIsPulsing(false), 220);
+    return () => window.clearTimeout(timer);
+  }, [pulse]);
+
+  if (!isActive) return null;
+
+  return (
+    <span
+      aria-live="polite"
+      className={`truncate text-text text-xs ${isPulsing ? "font-semibold opacity-100" : "opacity-80"}`}
+      data-keyboard-only-indicator=""
+      role="status"
+    >
+      Keyboard only · ESC to exit
+    </span>
+  );
+};

--- a/packages/web/src/shortcuts/keyboard-only/keyboard-only-detector.test.ts
+++ b/packages/web/src/shortcuts/keyboard-only/keyboard-only-detector.test.ts
@@ -1,0 +1,126 @@
+import {
+  createKeyboardOnlyDetectorState,
+  reduceKeyboardOnlyDetector,
+  SHIFT_DOUBLE_TAP_MAX_GAP_MS,
+  SHIFT_HOLD_HINT_THRESHOLD_MS,
+} from "@web/shortcuts/keyboard-only/keyboard-only-detector";
+import { describe, expect, it } from "bun:test";
+
+describe("reduceKeyboardOnlyDetector", () => {
+  it("enters on two quick Shift taps within the gap", () => {
+    const state = createKeyboardOnlyDetectorState();
+
+    let result = reduceKeyboardOnlyDetector(state, {
+      type: "shiftDown",
+      now: 1000,
+      blocked: false,
+    });
+    result = reduceKeyboardOnlyDetector(result.state, {
+      type: "shiftUp",
+      now: 1050,
+    });
+    expect(result.entered).toBe(false);
+    expect(result.state.lastTapReleasedAt).toBe(1050);
+
+    result = reduceKeyboardOnlyDetector(result.state, {
+      type: "shiftDown",
+      now: 1100,
+      blocked: false,
+    });
+    result = reduceKeyboardOnlyDetector(result.state, {
+      type: "shiftUp",
+      now: 1150,
+    });
+    expect(result.entered).toBe(true);
+    expect(result.state.lastTapReleasedAt).toBeNull();
+  });
+
+  it("does not enter when the second tap is too slow", () => {
+    const state = createKeyboardOnlyDetectorState();
+    let result = reduceKeyboardOnlyDetector(state, {
+      type: "shiftDown",
+      now: 1000,
+      blocked: false,
+    });
+    result = reduceKeyboardOnlyDetector(result.state, {
+      type: "shiftUp",
+      now: 1050,
+    });
+    result = reduceKeyboardOnlyDetector(result.state, {
+      type: "shiftDown",
+      now: 1050 + SHIFT_DOUBLE_TAP_MAX_GAP_MS + 1,
+      blocked: false,
+    });
+    result = reduceKeyboardOnlyDetector(result.state, {
+      type: "shiftUp",
+      now: 1050 + SHIFT_DOUBLE_TAP_MAX_GAP_MS + 40,
+    });
+    expect(result.entered).toBe(false);
+    expect(result.state.lastTapReleasedAt).toBe(
+      1050 + SHIFT_DOUBLE_TAP_MAX_GAP_MS + 40,
+    );
+  });
+
+  it("does not treat a hold as a tap", () => {
+    const state = createKeyboardOnlyDetectorState();
+    let result = reduceKeyboardOnlyDetector(state, {
+      type: "shiftDown",
+      now: 1000,
+      blocked: false,
+    });
+    result = reduceKeyboardOnlyDetector(result.state, {
+      type: "shiftUp",
+      now: 1000 + SHIFT_HOLD_HINT_THRESHOLD_MS + 10,
+    });
+    expect(result.entered).toBe(false);
+    expect(result.state.lastTapReleasedAt).toBeNull();
+
+    result = reduceKeyboardOnlyDetector(result.state, {
+      type: "shiftDown",
+      now: 1300,
+      blocked: false,
+    });
+    result = reduceKeyboardOnlyDetector(result.state, {
+      type: "shiftUp",
+      now: 1350,
+    });
+    expect(result.entered).toBe(false);
+  });
+
+  it("cancels a pending tap on chord keys (Shift+J)", () => {
+    const state = createKeyboardOnlyDetectorState();
+    let result = reduceKeyboardOnlyDetector(state, {
+      type: "shiftDown",
+      now: 1000,
+      blocked: false,
+    });
+    result = reduceKeyboardOnlyDetector(result.state, { type: "chordKeyDown" });
+    expect(result.state.phase).toBe("idle");
+    expect(result.state.lastTapReleasedAt).toBeNull();
+
+    result = reduceKeyboardOnlyDetector(result.state, {
+      type: "shiftUp",
+      now: 1100,
+    });
+    expect(result.entered).toBe(false);
+  });
+
+  it("ignores blocked Shift downs (app lock / editable)", () => {
+    const state = createKeyboardOnlyDetectorState();
+    const result = reduceKeyboardOnlyDetector(state, {
+      type: "shiftDown",
+      now: 1000,
+      blocked: true,
+    });
+    expect(result.state.phase).toBe("idle");
+    expect(result.state.downAt).toBeNull();
+  });
+});
+
+describe("hold vs double-tap coexistence", () => {
+  it("uses a gap larger than the hold threshold so both detectors can share Shift", () => {
+    expect(SHIFT_DOUBLE_TAP_MAX_GAP_MS).toBeGreaterThan(
+      SHIFT_HOLD_HINT_THRESHOLD_MS,
+    );
+  });
+});

--- a/packages/web/src/shortcuts/keyboard-only/keyboard-only-detector.ts
+++ b/packages/web/src/shortcuts/keyboard-only/keyboard-only-detector.ts
@@ -1,0 +1,126 @@
+/**
+ * Pure SHIFT-SHIFT double-tap detector for keyboard-only mode.
+ *
+ * A tap is keydown → keyup with no other key between and duration below the
+ * hold threshold (so hold-to-hint never counts as a tap). Two taps whose
+ * release times are within {@link SHIFT_DOUBLE_TAP_MAX_GAP_MS} enter the mode.
+ */
+
+import {
+  isShiftDoubleTapCandidate,
+  SHIFT_DOUBLE_TAP_MAX_GAP_MS,
+  SHIFT_HOLD_HINT_THRESHOLD_MS,
+} from "@web/shortcuts/shift-hint/shift-hold-detector";
+
+export { SHIFT_DOUBLE_TAP_MAX_GAP_MS, SHIFT_HOLD_HINT_THRESHOLD_MS };
+
+export type KeyboardOnlyDetectorPhase = "idle" | "down";
+
+export type KeyboardOnlyDetectorState = {
+  phase: KeyboardOnlyDetectorPhase;
+  downAt: number | null;
+  lastTapReleasedAt: number | null;
+};
+
+export const createKeyboardOnlyDetectorState =
+  (): KeyboardOnlyDetectorState => ({
+    phase: "idle",
+    downAt: null,
+    lastTapReleasedAt: null,
+  });
+
+export type KeyboardOnlyDetectorEvent =
+  | { type: "shiftDown"; now: number; blocked: boolean }
+  | { type: "shiftUp"; now: number }
+  | { type: "chordKeyDown" }
+  | { type: "reset" };
+
+export type KeyboardOnlyDetectorResult = {
+  state: KeyboardOnlyDetectorState;
+  /** True when this event completed a second quick Shift tap. */
+  entered: boolean;
+};
+
+export function reduceKeyboardOnlyDetector(
+  state: KeyboardOnlyDetectorState,
+  event: KeyboardOnlyDetectorEvent,
+): KeyboardOnlyDetectorResult {
+  switch (event.type) {
+    case "shiftDown": {
+      if (event.blocked) {
+        return {
+          state: {
+            phase: "idle",
+            downAt: null,
+            lastTapReleasedAt: state.lastTapReleasedAt,
+          },
+          entered: false,
+        };
+      }
+      if (state.phase === "down") {
+        return { state, entered: false };
+      }
+      return {
+        state: {
+          ...state,
+          phase: "down",
+          downAt: event.now,
+        },
+        entered: false,
+      };
+    }
+    case "shiftUp": {
+      if (state.phase !== "down" || state.downAt === null) {
+        return { state, entered: false };
+      }
+
+      const heldMs = event.now - state.downAt;
+      // Held long enough to be a hold-to-hint, not a tap.
+      if (heldMs >= SHIFT_HOLD_HINT_THRESHOLD_MS) {
+        return {
+          state: {
+            phase: "idle",
+            downAt: null,
+            lastTapReleasedAt: null,
+          },
+          entered: false,
+        };
+      }
+
+      const entered = isShiftDoubleTapCandidate({
+        lastShiftReleaseAt: state.lastTapReleasedAt,
+        now: event.now,
+        maxGapMs: SHIFT_DOUBLE_TAP_MAX_GAP_MS,
+      });
+
+      return {
+        state: {
+          phase: "idle",
+          downAt: null,
+          // After entering, clear so a third tap does not re-trigger.
+          lastTapReleasedAt: entered ? null : event.now,
+        },
+        entered,
+      };
+    }
+    case "chordKeyDown": {
+      if (state.phase !== "down") {
+        return { state, entered: false };
+      }
+      return {
+        state: {
+          phase: "idle",
+          downAt: null,
+          lastTapReleasedAt: null,
+        },
+        entered: false,
+      };
+    }
+    case "reset": {
+      return {
+        state: createKeyboardOnlyDetectorState(),
+        entered: false,
+      };
+    }
+  }
+}

--- a/packages/web/src/shortcuts/keyboard-only/keyboard-only.store.ts
+++ b/packages/web/src/shortcuts/keyboard-only/keyboard-only.store.ts
@@ -1,0 +1,46 @@
+import { create } from "zustand";
+import { devtools } from "zustand/middleware";
+import { IS_DEV } from "@web/common/constants/env.constants";
+
+export type KeyboardOnlyState = {
+  isActive: boolean;
+  /** Increments when a click is blocked so the indicator can pulse. */
+  blockedClickPulse: number;
+};
+
+export const initialKeyboardOnlyState: KeyboardOnlyState = {
+  isActive: false,
+  blockedClickPulse: 0,
+};
+
+export const useKeyboardOnlyStore = create<KeyboardOnlyState>()(
+  devtools(() => initialKeyboardOnlyState, {
+    name: "compass/keyboard-only",
+    enabled: IS_DEV,
+  }),
+);
+
+export const keyboardOnlyActions = {
+  enter: () =>
+    useKeyboardOnlyStore.setState({ isActive: true }, false, {
+      type: "enter",
+    }),
+  exit: () =>
+    useKeyboardOnlyStore.setState(
+      { isActive: false, blockedClickPulse: 0 },
+      false,
+      { type: "exit" },
+    ),
+  pulseBlockedClick: () =>
+    useKeyboardOnlyStore.setState(
+      (state) => ({ blockedClickPulse: state.blockedClickPulse + 1 }),
+      false,
+      { type: "pulseBlockedClick" },
+    ),
+};
+
+export const selectKeyboardOnlyActive = (state: KeyboardOnlyState) =>
+  state.isActive;
+
+export const selectKeyboardOnlyPulse = (state: KeyboardOnlyState) =>
+  state.blockedClickPulse;

--- a/packages/web/src/shortcuts/keyboard-only/useKeyboardOnlyMode.test.tsx
+++ b/packages/web/src/shortcuts/keyboard-only/useKeyboardOnlyMode.test.tsx
@@ -1,0 +1,101 @@
+import { act, renderHook } from "@testing-library/react";
+import { clearAppLockReasons, setAppLockReason } from "@web/shortcuts/app-lock";
+import {
+  initialKeyboardOnlyState,
+  useKeyboardOnlyStore,
+} from "@web/shortcuts/keyboard-only/keyboard-only.store";
+import { useKeyboardOnlyMode } from "@web/shortcuts/keyboard-only/useKeyboardOnlyMode";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+
+const dispatchKey = (
+  type: "keydown" | "keyup",
+  key: string,
+  init: KeyboardEventInit = {},
+) => {
+  const event = new KeyboardEvent(type, {
+    key,
+    code: key === "Shift" ? "ShiftLeft" : key,
+    bubbles: true,
+    cancelable: true,
+    ...init,
+  });
+  document.dispatchEvent(event);
+  return event;
+};
+
+const tapShift = () => {
+  dispatchKey("keydown", "Shift");
+  dispatchKey("keyup", "Shift", { shiftKey: false });
+};
+
+describe("useKeyboardOnlyMode", () => {
+  beforeEach(() => {
+    useKeyboardOnlyStore.setState(initialKeyboardOnlyState);
+    clearAppLockReasons();
+    document.body.innerHTML = `<div id="root"></div>`;
+  });
+
+  afterEach(() => {
+    useKeyboardOnlyStore.setState(initialKeyboardOnlyState);
+    clearAppLockReasons();
+    document.body.innerHTML = "";
+  });
+
+  it("enters on SHIFT-SHIFT and suppresses clicks until Escape", () => {
+    renderHook(() => useKeyboardOnlyMode());
+
+    act(() => {
+      tapShift();
+      tapShift();
+    });
+
+    expect(useKeyboardOnlyStore.getState().isActive).toBe(true);
+
+    const root = document.getElementById("root")!;
+    const button = document.createElement("button");
+    button.textContent = "Click me";
+    root.appendChild(button);
+
+    let clicked = false;
+    button.addEventListener("click", () => {
+      clicked = true;
+    });
+
+    act(() => {
+      window.dispatchEvent(
+        new MouseEvent("click", { bubbles: true, cancelable: true }),
+      );
+    });
+
+    expect(clicked).toBe(false);
+    expect(useKeyboardOnlyStore.getState().blockedClickPulse).toBeGreaterThan(
+      0,
+    );
+
+    act(() => {
+      dispatchKey("keydown", "Escape");
+    });
+
+    expect(useKeyboardOnlyStore.getState().isActive).toBe(false);
+
+    clicked = false;
+    act(() => {
+      button.dispatchEvent(
+        new MouseEvent("click", { bubbles: true, cancelable: true }),
+      );
+    });
+    expect(clicked).toBe(true);
+  });
+
+  it("does not enter while app-locked", () => {
+    setAppLockReason("commandPalette", true);
+    renderHook(() => useKeyboardOnlyMode());
+
+    act(() => {
+      tapShift();
+      tapShift();
+    });
+
+    expect(useKeyboardOnlyStore.getState().isActive).toBe(false);
+  });
+});

--- a/packages/web/src/shortcuts/keyboard-only/useKeyboardOnlyMode.ts
+++ b/packages/web/src/shortcuts/keyboard-only/useKeyboardOnlyMode.ts
@@ -1,0 +1,139 @@
+import { useEffect, useRef } from "react";
+import { isEditableKeyboardTarget } from "@web/common/utils/form/form.util";
+import { isEventFormOpen } from "@web/events/stores/draft.store";
+import { isFloatingLayerOpen } from "@web/shortcuts/floating-layer";
+import {
+  keyboardOnlyActions,
+  useKeyboardOnlyStore,
+} from "@web/shortcuts/keyboard-only/keyboard-only.store";
+import {
+  createKeyboardOnlyDetectorState,
+  type KeyboardOnlyDetectorState,
+  reduceKeyboardOnlyDetector,
+} from "@web/shortcuts/keyboard-only/keyboard-only-detector";
+
+const isAppLocked = () => document.body.dataset.appLocked === "true";
+
+const isShiftKey = (event: KeyboardEvent) =>
+  event.key === "Shift" ||
+  event.code === "ShiftLeft" ||
+  event.code === "ShiftRight";
+
+/**
+ * SHIFT-SHIFT (two quick taps) enters keyboard-only mode. Clicks are inert;
+ * ESC / refresh exits. Mode is not persisted.
+ *
+ * ESC stands down while app lock, floating layers, or the event form own Escape
+ * so those dismiss first; a later ESC exits this mode.
+ */
+export function useKeyboardOnlyMode() {
+  const isActive = useKeyboardOnlyStore((state) => state.isActive);
+  const stateRef = useRef<KeyboardOnlyDetectorState>(
+    createKeyboardOnlyDetectorState(),
+  );
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.defaultPrevented) return;
+
+      if (isShiftKey(event)) {
+        if (event.repeat) return;
+        const blocked = isAppLocked() || isEditableKeyboardTarget(event);
+        const result = reduceKeyboardOnlyDetector(stateRef.current, {
+          type: "shiftDown",
+          now: Date.now(),
+          blocked,
+        });
+        stateRef.current = result.state;
+        return;
+      }
+
+      if (stateRef.current.phase === "down") {
+        const result = reduceKeyboardOnlyDetector(stateRef.current, {
+          type: "chordKeyDown",
+        });
+        stateRef.current = result.state;
+      }
+    };
+
+    const onKeyUp = (event: KeyboardEvent) => {
+      if (!isShiftKey(event)) return;
+      // Keep counting a hold if the other Shift key is still down.
+      if (event.shiftKey) return;
+
+      const result = reduceKeyboardOnlyDetector(stateRef.current, {
+        type: "shiftUp",
+        now: Date.now(),
+      });
+      stateRef.current = result.state;
+      if (result.entered && !useKeyboardOnlyStore.getState().isActive) {
+        keyboardOnlyActions.enter();
+      }
+    };
+
+    const onBlur = () => {
+      const result = reduceKeyboardOnlyDetector(stateRef.current, {
+        type: "reset",
+      });
+      stateRef.current = result.state;
+    };
+
+    document.addEventListener("keydown", onKeyDown, true);
+    document.addEventListener("keyup", onKeyUp, true);
+    window.addEventListener("blur", onBlur);
+
+    return () => {
+      document.removeEventListener("keydown", onKeyDown, true);
+      document.removeEventListener("keyup", onKeyUp, true);
+      window.removeEventListener("blur", onBlur);
+    };
+  }, []);
+
+  // Click suppression while active. Window capture runs before React's
+  // delegated root listeners (and grid PointerCaptureBoundary), so clicks
+  // never reach event open handlers. Scroll and hover stay live.
+  useEffect(() => {
+    if (!isActive) return;
+
+    const blockPointer = (event: Event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      keyboardOnlyActions.pulseBlockedClick();
+    };
+
+    window.addEventListener("pointerdown", blockPointer, true);
+    window.addEventListener("mousedown", blockPointer, true);
+    window.addEventListener("click", blockPointer, true);
+    window.addEventListener("auxclick", blockPointer, true);
+
+    return () => {
+      window.removeEventListener("pointerdown", blockPointer, true);
+      window.removeEventListener("mousedown", blockPointer, true);
+      window.removeEventListener("click", blockPointer, true);
+      window.removeEventListener("auxclick", blockPointer, true);
+    };
+  }, [isActive]);
+
+  // ESC exits when nothing higher owns Escape.
+  useEffect(() => {
+    if (!isActive) return;
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      if (event.defaultPrevented) return;
+      if (isAppLocked()) return;
+      if (isFloatingLayerOpen()) return;
+      if (isEventFormOpen()) return;
+
+      event.preventDefault();
+      event.stopPropagation();
+      keyboardOnlyActions.exit();
+      stateRef.current = createKeyboardOnlyDetectorState();
+    };
+
+    document.addEventListener("keydown", onKeyDown, true);
+    return () => {
+      document.removeEventListener("keydown", onKeyDown, true);
+    };
+  }, [isActive]);
+}

--- a/packages/web/src/shortcuts/shift-hint/shift-hold-detector.test.ts
+++ b/packages/web/src/shortcuts/shift-hint/shift-hold-detector.test.ts
@@ -2,6 +2,7 @@ import {
   createShiftHoldState,
   isShiftDoubleTapCandidate,
   reduceShiftHold,
+  SHIFT_DOUBLE_TAP_MAX_GAP_MS,
   SHIFT_HOLD_HINT_THRESHOLD_MS,
 } from "@web/shortcuts/shift-hint/shift-hold-detector";
 import { describe, expect, it } from "bun:test";
@@ -86,7 +87,7 @@ describe("hold vs double-tap coordination", () => {
       isShiftDoubleTapCandidate({
         lastShiftReleaseAt: state.lastShiftReleaseAt,
         now: 1050 + 100,
-        maxGapMs: 300,
+        maxGapMs: SHIFT_DOUBLE_TAP_MAX_GAP_MS,
       }),
     ).toBe(true);
 
@@ -108,7 +109,7 @@ describe("hold vs double-tap coordination", () => {
       isShiftDoubleTapCandidate({
         lastShiftReleaseAt: 1000,
         now: 1000 + 1000,
-        maxGapMs: 300,
+        maxGapMs: SHIFT_DOUBLE_TAP_MAX_GAP_MS,
       }),
     ).toBe(false);
   });

--- a/packages/web/src/shortcuts/shift-hint/shift-hold-detector.ts
+++ b/packages/web/src/shortcuts/shift-hint/shift-hold-detector.ts
@@ -8,6 +8,9 @@
 
 export const SHIFT_HOLD_HINT_THRESHOLD_MS = 200;
 
+/** Max gap between two quick Shift taps to enter keyboard-only mode. */
+export const SHIFT_DOUBLE_TAP_MAX_GAP_MS = 400;
+
 export type ShiftHoldPhase = "idle" | "pending" | "active";
 
 export type ShiftHoldState = {

--- a/packages/web/src/shortcuts/shortcuts.registry.test.ts
+++ b/packages/web/src/shortcuts/shortcuts.registry.test.ts
@@ -80,6 +80,16 @@ describe("shortcuts.registry", () => {
       expect(life).not.toContain("focus-shift-hold");
     });
 
+    it("lists SHIFT-SHIFT keyboard-only mode in every view's other section", () => {
+      for (const view of ["day", "week", "life"] as const) {
+        const ids = filterShortcutsByContext({
+          view,
+          isViewingCurrentPeriod: true,
+        }).map((shortcut) => shortcut.id);
+        expect(ids).toContain("other-keyboard-only");
+      }
+    });
+
     it("hides event-focused edit sequences until an event is focused", () => {
       const idle = filterShortcutsByContext({
         view: "day",

--- a/packages/web/src/shortcuts/shortcuts.registry.ts
+++ b/packages/web/src/shortcuts/shortcuts.registry.ts
@@ -296,6 +296,12 @@ export const SHORTCUTS_REGISTRY: Shortcut[] = [
     label: "Redo last change",
     section: "other",
   },
+  {
+    id: "other-keyboard-only",
+    keys: ["Shift", "Shift"],
+    label: "Enter keyboard-only mode",
+    section: "other",
+  },
 ];
 
 interface FilterOptions {


### PR DESCRIPTION
## Summary
- Two quick Shift taps enter keyboard-only mode; hold-Shift event jump hints are unchanged
- While active, pointer clicks are suppressed (scroll and hover still work); a sidebar badge shows the mode and pulses on blocked clicks
- ESC exits when no higher Escape owner is open; refresh also clears the mode (not persisted)
- Shortcut legend documents Shift Shift; unit + Playwright coverage included

## Test plan
- [x] `bun test:web` on keyboard-only + related shortcut registry/legend tests
- [x] `bunx playwright test e2e/timed/keyboard-only-mode.spec.ts`
- [ ] Manual: Shift Shift → badge appears → click an event (inert) → ESC → click works again
- [ ] Manual: hold Shift still flashes jump keys without entering the mode