### PR TITLE
feat(web): add redo last change to the command palette

### DIFF
--- a/packages/web/src/components/CommandPalette/CommandPalette.test.tsx
+++ b/packages/web/src/components/CommandPalette/CommandPalette.test.tsx
@@ -267,14 +267,19 @@ describe("CommandPalette", () => {
     expect(isOpen()).toBe(false);
   });
 
-  it("renders a disabled Undo row with keycaps when there is no history", () => {
+  it("renders disabled Undo and Redo rows with keycaps when there is no history", () => {
     renderPalette();
 
-    const row = screen.getByText("Undo last change").closest("button");
-    expect(row).toBeDisabled();
+    const undoRow = screen.getByText("Undo last change").closest("button");
+    expect(undoRow).toBeDisabled();
     // Two keycap chips: the platform modifier and Z (see the aria-hidden
     // note in the Show Shortcuts test below).
-    expect(row?.querySelectorAll("[aria-hidden='true']")).toHaveLength(2);
+    expect(undoRow?.querySelectorAll("[aria-hidden='true']")).toHaveLength(2);
+
+    const redoRow = screen.getByText("Redo last change").closest("button");
+    expect(redoRow).toBeDisabled();
+    // Mod + Shift + Z → three keycap chips.
+    expect(redoRow?.querySelectorAll("[aria-hidden='true']")).toHaveLength(3);
   });
 
   it("undoes the last change and closes when the Undo row is clicked", async () => {
@@ -317,6 +322,51 @@ describe("CommandPalette", () => {
     await waitFor(() => {
       expect(useUndoHistoryStore.getState().past).toHaveLength(0);
       expect(useUndoHistoryStore.getState().future).toHaveLength(1);
+    });
+    expect(isOpen()).toBe(false);
+  });
+
+  it("redoes the last change and closes when the Redo row is clicked", async () => {
+    const before = createMockEvent({
+      content: { kind: "details", title: "Before", description: "" },
+    });
+    undoHistoryActions.record({
+      kind: "edit",
+      id: before.id,
+      before,
+      after: {
+        ...before,
+        content: { kind: "details", title: "After", description: "" },
+      },
+    });
+    // Move the edit into the future stack so Redo is enabled.
+    undoHistoryActions.commitUndo();
+    const repository: EventRepository = {
+      list: async () => [],
+      create: async () => before,
+      replace: async (id, input) => ({
+        ...before,
+        id,
+        content: input.content,
+        schedule: input.schedule,
+      }),
+      delete: async () => {},
+    };
+    renderPalette({
+      source: "local",
+      repository,
+      markWrite: async () => {},
+      reportError: () => {},
+    });
+
+    const row = screen.getByText("Redo last change").closest("button");
+    expect(row).not.toBeDisabled();
+
+    fireEvent.click(row as HTMLButtonElement);
+
+    await waitFor(() => {
+      expect(useUndoHistoryStore.getState().past).toHaveLength(1);
+      expect(useUndoHistoryStore.getState().future).toHaveLength(0);
     });
     expect(isOpen()).toBe(false);
   });

--- a/packages/web/src/components/CommandPalette/CommandPalette.tsx
+++ b/packages/web/src/components/CommandPalette/CommandPalette.tsx
@@ -7,7 +7,10 @@ import {
   useListNavigation,
   useRole,
 } from "@floating-ui/react";
-import { ArrowCounterClockwiseIcon } from "@phosphor-icons/react";
+import {
+  ArrowClockwiseIcon,
+  ArrowCounterClockwiseIcon,
+} from "@phosphor-icons/react";
 import { useNavigate } from "@tanstack/react-router";
 import { useCallback, useRef, useState } from "react";
 import { Z_INDEX_MODAL } from "@web/common/constants/web.constants";
@@ -287,7 +290,7 @@ export const CommandPalette = ({
   const showAccountsCmdItems = useShowAccountsCmdItems();
   const logoutCmdItems = useLogoutCmdItems();
   const themeCmdItems = useThemeCmdItems();
-  const { undo, canUndo } = useUndoRedo(mutationDependencies);
+  const { undo, redo, canUndo, canRedo } = useUndoRedo(mutationDependencies);
   const recentCommandIds = useRecentCommandIds();
 
   const sections: CommandSection[] = [
@@ -320,6 +323,15 @@ export const CommandPalette = ({
           // Defer so the palette unmounts before undo's refocusEventElement
           // starts hunting for the restored event element.
           onClick: () => queueMicrotask(undo),
+        },
+        {
+          id: "redo-last-change",
+          label: "Redo last change",
+          icon: ArrowClockwiseIcon,
+          shortcut: ["Mod", "Shift", "Z"],
+          keywords: ["forward", "history", "repeat"],
+          disabled: !canRedo,
+          onClick: () => queueMicrotask(redo),
         },
       ],
     },


### PR DESCRIPTION
## Summary
- Command palette exposes Redo last change next to Undo, disabled when the redo stack is empty
- Activating the row replays optimistically (same path as Mod+Shift+Z) and closes the palette

## Test plan
- [x] Palette unit tests for disabled keycaps + redo click path
- [ ] Manual: edit an event → Undo from palette → Redo from palette restores the edit