### PR TITLE
fix(web): keep drag placeholder dim across week navigation

### DIFF
--- a/packages/web/src/interaction/dom/source-element.visibility.ts
+++ b/packages/web/src/interaction/dom/source-element.visibility.ts
@@ -60,3 +60,16 @@ export const restoreSourceElement = (source: PreparedSourceElement) => {
 
   source.element.style.visibility = source.visibility;
 };
+
+/** Re-apply dim/hide without rewriting the stored pre-interaction styles. */
+export const reapplyPreparedSourceStyles = (source: PreparedSourceElement) => {
+  source.element.setAttribute(SOURCE_ELEMENT_INTERACTION_ATTRIBUTE, "true");
+
+  if (source.draftEventMode === "dim-source") {
+    source.element.style.opacity = "0.5";
+    source.element.style.pointerEvents = "none";
+    return;
+  }
+
+  source.element.style.visibility = "hidden";
+};

--- a/packages/web/src/interaction/interaction.engine.test.ts
+++ b/packages/web/src/interaction/interaction.engine.test.ts
@@ -316,6 +316,39 @@ describe("InteractionEngine", () => {
     expect(source).not.toHaveAttribute(SOURCE_ELEMENT_INTERACTION_ATTRIBUTE);
   });
 
+  it("rebinds dimmed placeholder styles onto a remounted source element", () => {
+    const { engine, fireCommitTeardownDeadline, flushFrame, source } =
+      createHarness({
+        sourceDraftEventMode: "dim-source",
+      });
+
+    engine.handlePointerDown(makePointerEvent("pointerdown", { x: 10, y: 10 }));
+    engine.handlePointerMove(makePointerEvent("pointermove", { x: 36, y: 10 }));
+
+    // Simulate edge-nav remount: old node disconnects, a fresh card mounts.
+    source.remove();
+    const remounted = document.createElement("div");
+    document.body.append(remounted);
+
+    engine.rebindPreparedSource(remounted);
+
+    expect(remounted.style.opacity).toBe("0.5");
+    expect(remounted.style.pointerEvents).toBe("none");
+    expect(remounted).toHaveAttribute(SOURCE_ELEMENT_INTERACTION_ATTRIBUTE);
+    expect(engine.getSession()).toMatchObject({
+      phase: "motion",
+      sourceElement: remounted,
+    });
+
+    flushFrame();
+    engine.handlePointerUp(makePointerEvent("pointerup"));
+    fireCommitTeardownDeadline();
+
+    expect(remounted.style.opacity).toBe("");
+    expect(remounted.style.pointerEvents).toBe("");
+    remounted.remove();
+  });
+
   it("restores only the styles changed by the source draft event mode", () => {
     const { engine, fireCommitTeardownDeadline, flushFrame, source } =
       createHarness();

--- a/packages/web/src/interaction/interaction.engine.ts
+++ b/packages/web/src/interaction/interaction.engine.ts
@@ -2,6 +2,7 @@ import { FloatingDraftEvent } from "./dom/draft-event";
 import {
   type PreparedSourceElement,
   prepareSourceElementForInteraction,
+  reapplyPreparedSourceStyles,
   restoreSourceElement,
 } from "./dom/source-element.visibility";
 import {
@@ -63,6 +64,12 @@ export interface InteractionEngine<TTarget, TVisual, TResult> {
     event: PointerEvent,
   ): InteractionPointerUpResult<TTarget, TResult>;
   ownsPointer(event: Pick<PointerEvent, "pointerId">): boolean;
+  /**
+   * After edge-nav remounts the grid, the original source node is gone and
+   * its dim/hide styles die with it. Rebind the prepared source to the
+   * event's new DOM node so placeholder styling survives multi-week drags.
+   */
+  rebindPreparedSource(nextElement: HTMLElement): void;
 }
 
 const defaultOptions = {
@@ -535,6 +542,29 @@ export const createInteractionEngine = <TTarget, TVisual, TResult>(
     metrics.phase = phase;
   }
 
+  function rebindPreparedSource(nextElement: HTMLElement) {
+    if (!preparedSource) return;
+
+    if (preparedSource.element === nextElement && nextElement.isConnected) {
+      // React may have cleared inline styles on reconcile; re-apply without
+      // overwriting the stored pre-interaction values used on restore.
+      reapplyPreparedSourceStyles(preparedSource);
+      return;
+    }
+
+    const mode = preparedSource.draftEventMode;
+
+    if (preparedSource.element.isConnected) {
+      restoreSourceElement(preparedSource);
+    }
+
+    preparedSource = prepareSourceElementForInteraction(nextElement, mode);
+
+    if (session.phase === "pending" || session.phase === "motion") {
+      session = { ...session, sourceElement: nextElement };
+    }
+  }
+
   return {
     cancel,
     connectCancellationEvents,
@@ -545,6 +575,7 @@ export const createInteractionEngine = <TTarget, TVisual, TResult>(
     handlePointerMove,
     handlePointerUp,
     ownsPointer,
+    rebindPreparedSource,
   };
 };
 

--- a/packages/web/src/views/Week/interaction/adapter/week-interaction.adapter.ts
+++ b/packages/web/src/views/Week/interaction/adapter/week-interaction.adapter.ts
@@ -19,6 +19,7 @@ import {
   type VisualPoint,
   type VisualRect,
 } from "@web/grid/interaction/types/timed-drag.types";
+import { calendarEventIdValueSelector } from "@web/grid/interaction/view-event-registry";
 import { type InteractionAdapter } from "@web/interaction/interaction.adapter.types";
 import {
   createInteractionEngine,
@@ -137,6 +138,20 @@ export const createWeekInteractionAdapter = ({
     }
 
     rebuildLayoutIfNeeded(session.target);
+
+    // Edge-nav remounts event cards; re-dim/hide the source on the new node
+    // so the placeholder style survives dragging across weeks.
+    if (session.phase === "pending" || session.phase === "motion") {
+      const { eventId, eventType } = session.target.registered;
+      const nextElement =
+        weekEventRegistry.resolve(eventId, eventType) ??
+        document.querySelector<HTMLElement>(
+          calendarEventIdValueSelector(eventId),
+        );
+      if (nextElement) {
+        engine.rebindPreparedSource(nextElement);
+      }
+    }
   }
 
   function handlePointerDown(


### PR DESCRIPTION
## Summary
- After mid-drag week edge navigation remounts event cards, re-apply the dimmed/hidden source styles on the event's new DOM node
- Fixes duplicate full-opacity cards when dragging to another week and back

Closes #1784

## Test plan
- [x] Unit: engine rebind after remount restores dim and cleans up on commit
- [x] Existing timed-drag edge-nav commit tests
- [ ] Manual: drag event to previous week (without release) then back; source card stays transparent/dimmed