### PR TITLE
refactor(web): share escape ownership and shift-key helpers

### DIFF
--- a/packages/web/src/components/OnboardingTour/useOnboardingTourProgress.ts
+++ b/packages/web/src/components/OnboardingTour/useOnboardingTourProgress.ts
@@ -7,7 +7,6 @@ import {
 } from "@web/components/OnboardingTour/onboarding.tour.store";
 import { useHasPendingEventMutations } from "@web/events/mutations/useEventPending";
 import {
-  isEventFormOpen,
   selectIsEventFormOpen,
   useDraftStore,
 } from "@web/events/stores/draft.store";
@@ -19,7 +18,7 @@ import {
   selectIsCmdPaletteOpen,
   useSettingsStore,
 } from "@web/settings/settings.store";
-import { isFloatingLayerOpen } from "@web/shortcuts/floating-layer";
+import { isHigherEscapeOwner } from "@web/shortcuts/escape-ownership";
 
 /**
  * Advances tour steps when the user performs the prompted action.
@@ -66,9 +65,7 @@ export function useOnboardingTourProgress() {
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key !== "Escape") return;
       if (event.defaultPrevented) return;
-      if (document.body.dataset.appLocked === "true") return;
-      if (isFloatingLayerOpen()) return;
-      if (isEventFormOpen()) return;
+      if (isHigherEscapeOwner()) return;
 
       event.preventDefault();
       event.stopPropagation();

--- a/packages/web/src/shortcuts/escape-ownership.ts
+++ b/packages/web/src/shortcuts/escape-ownership.ts
@@ -1,0 +1,11 @@
+import { isEventFormOpen } from "@web/events/stores/draft.store";
+import { isFloatingLayerOpen } from "@web/shortcuts/floating-layer";
+
+/** True when Escape should dismiss a modal/form/layer before lower-priority handlers. */
+export function isHigherEscapeOwner(): boolean {
+  return (
+    document.body.dataset.appLocked === "true" ||
+    isFloatingLayerOpen() ||
+    isEventFormOpen()
+  );
+}

--- a/packages/web/src/shortcuts/keyboard-only/useKeyboardOnlyMode.test.tsx
+++ b/packages/web/src/shortcuts/keyboard-only/useKeyboardOnlyMode.test.tsx
@@ -63,14 +63,15 @@ describe("useKeyboardOnlyMode", () => {
 
     act(() => {
       window.dispatchEvent(
+        new PointerEvent("pointerdown", { bubbles: true, cancelable: true }),
+      );
+      window.dispatchEvent(
         new MouseEvent("click", { bubbles: true, cancelable: true }),
       );
     });
 
     expect(clicked).toBe(false);
-    expect(useKeyboardOnlyStore.getState().blockedClickPulse).toBeGreaterThan(
-      0,
-    );
+    expect(useKeyboardOnlyStore.getState().blockedClickPulse).toBe(1);
 
     act(() => {
       dispatchKey("keydown", "Escape");

--- a/packages/web/src/shortcuts/keyboard-only/useKeyboardOnlyMode.ts
+++ b/packages/web/src/shortcuts/keyboard-only/useKeyboardOnlyMode.ts
@@ -1,7 +1,6 @@
 import { useEffect, useRef } from "react";
 import { isEditableKeyboardTarget } from "@web/common/utils/form/form.util";
-import { isEventFormOpen } from "@web/events/stores/draft.store";
-import { isFloatingLayerOpen } from "@web/shortcuts/floating-layer";
+import { isHigherEscapeOwner } from "@web/shortcuts/escape-ownership";
 import {
   keyboardOnlyActions,
   useKeyboardOnlyStore,
@@ -11,13 +10,9 @@ import {
   type KeyboardOnlyDetectorState,
   reduceKeyboardOnlyDetector,
 } from "@web/shortcuts/keyboard-only/keyboard-only-detector";
+import { isShiftKey } from "@web/shortcuts/shift-hint/shift-hold-detector";
 
 const isAppLocked = () => document.body.dataset.appLocked === "true";
-
-const isShiftKey = (event: KeyboardEvent) =>
-  event.key === "Shift" ||
-  event.code === "ShiftLeft" ||
-  event.code === "ShiftRight";
 
 /**
  * SHIFT-SHIFT (two quick taps) enters keyboard-only mode. Clicks are inert;
@@ -98,7 +93,10 @@ export function useKeyboardOnlyMode() {
     const blockPointer = (event: Event) => {
       event.preventDefault();
       event.stopPropagation();
-      keyboardOnlyActions.pulseBlockedClick();
+      // Pulse once per gesture (pointerdown), not again on click/mousedown.
+      if (event.type === "pointerdown") {
+        keyboardOnlyActions.pulseBlockedClick();
+      }
     };
 
     window.addEventListener("pointerdown", blockPointer, true);
@@ -121,9 +119,7 @@ export function useKeyboardOnlyMode() {
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key !== "Escape") return;
       if (event.defaultPrevented) return;
-      if (isAppLocked()) return;
-      if (isFloatingLayerOpen()) return;
-      if (isEventFormOpen()) return;
+      if (isHigherEscapeOwner()) return;
 
       event.preventDefault();
       event.stopPropagation();

--- a/packages/web/src/shortcuts/shift-hint/shift-hold-detector.ts
+++ b/packages/web/src/shortcuts/shift-hint/shift-hold-detector.ts
@@ -11,6 +11,11 @@ export const SHIFT_HOLD_HINT_THRESHOLD_MS = 200;
 /** Max gap between two quick Shift taps to enter keyboard-only mode. */
 export const SHIFT_DOUBLE_TAP_MAX_GAP_MS = 400;
 
+export const isShiftKey = (event: Pick<KeyboardEvent, "key" | "code">) =>
+  event.key === "Shift" ||
+  event.code === "ShiftLeft" ||
+  event.code === "ShiftRight";
+
 export type ShiftHoldPhase = "idle" | "pending" | "active";
 
 export type ShiftHoldState = {

--- a/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.ts
+++ b/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.ts
@@ -10,6 +10,7 @@ import {
 } from "@web/shortcuts/shift-hint/assign-shift-hint-keys";
 import {
   createShiftHoldState,
+  isShiftKey,
   reduceShiftHold,
   SHIFT_HOLD_HINT_THRESHOLD_MS,
   type ShiftHoldState,
@@ -26,11 +27,6 @@ export type ActiveShiftHint = ShiftHintAssignment & {
 };
 
 const isAppLocked = () => document.body.dataset.appLocked === "true";
-
-const isShiftKey = (event: KeyboardEvent) =>
-  event.key === "Shift" ||
-  event.code === "ShiftLeft" ||
-  event.code === "ShiftRight";
 
 const scheduleStartMs = (event: GridEvent): number => {
   if (!event.startDate) return 0;


### PR DESCRIPTION
## Summary
- Shared `isHigherEscapeOwner` for keyboard-only mode and onboarding Escape handling
- Shared `isShiftKey` between hold-Shift hints and SHIFT-SHIFT keyboard-only detection
- Blocked-click indicator pulses once per pointerdown gesture

## Test plan
- [x] Focused web unit tests for keyboard-only, shift-hold hints, and onboarding store
- [x] `bun run lint`