### PR TITLE
fix(web): sequence onboarding palette before shortcuts tip

### DIFF
--- a/e2e/onboarding/interactive-tour.spec.ts
+++ b/e2e/onboarding/interactive-tour.spec.ts
@@ -31,10 +31,12 @@ test("Start Now runs the interactive tour happy path", async ({ page }) => {
   // Linux CI uses Ctrl; macOS local runs use Meta. Press both modifiers' chord
   // via ControlOrMeta through Playwright's platform-aware ControlOrMeta token.
   await page.keyboard.press("ControlOrMeta+k");
-  await expect(card).toContainText("Browse every shortcut");
+  // Palette stays open with search focused; the tour must not advance to "?" yet.
+  await expect(card).toContainText("Open the command palette");
   await page.keyboard.press("Escape");
+  await expect(card).toContainText("Browse every shortcut");
 
-  // Shift+/ opens the legend (same as ? on US keyboards).
+  // Shift+/ opens the legend (same as ? on US keyboards) once the calendar has focus.
   await page.keyboard.press("Shift+/");
   await expect(card).toContainText("You are ready");
 

--- a/packages/web/src/components/OnboardingTour/onboarding.tour.steps.test.ts
+++ b/packages/web/src/components/OnboardingTour/onboarding.tour.steps.test.ts
@@ -22,4 +22,15 @@ describe("onboarding tour steps", () => {
     expect(getNextOnboardingStepId("shortcuts")).toBe("done");
     expect(getNextOnboardingStepId("done")).toBeNull();
   });
+
+  it("keeps palette and shortcuts lessons non-contradictory", () => {
+    const steps = getOnboardingTourSteps();
+    const palette = steps.find((step) => step.id === "palette");
+    const shortcuts = steps.find((step) => step.id === "shortcuts");
+
+    expect(palette?.body).toMatch(/close with Escape/i);
+    expect(palette?.body).not.toMatch(/Show keyboard shortcuts/i);
+    expect(shortcuts?.body).toMatch(/from the calendar/i);
+    expect(shortcuts?.shortcutHint).toBe("?");
+  });
 });

--- a/packages/web/src/components/OnboardingTour/onboarding.tour.steps.ts
+++ b/packages/web/src/components/OnboardingTour/onboarding.tour.steps.ts
@@ -41,13 +41,13 @@ export function getOnboardingTourSteps(): OnboardingTourStep[] {
     {
       id: "palette",
       title: "Open the command palette",
-      body: `Press ${mod}+K for commands. Try "Show keyboard shortcuts", then close with Escape.`,
+      body: `Press ${mod}+K for commands. Browse or search, then close with Escape.`,
       shortcutHint: `${mod}+K`,
     },
     {
       id: "shortcuts",
       title: "Browse every shortcut",
-      body: "Press ? to open the shortcut legend. Search it anytime you forget a key.",
+      body: "Press ? from the calendar to open the shortcut legend. Search it anytime you forget a key.",
       shortcutHint: "?",
     },
     {

--- a/packages/web/src/components/OnboardingTour/useOnboardingTourProgress.test.ts
+++ b/packages/web/src/components/OnboardingTour/useOnboardingTourProgress.test.ts
@@ -63,6 +63,16 @@ describe("shouldAdvancePaletteStep", () => {
       }),
     ).toBe(true);
   });
+
+  it("does not advance on shortcuts alone before the palette opened", () => {
+    expect(
+      shouldAdvancePaletteStep({
+        paletteOpened: false,
+        isPaletteOpen: false,
+        isShortcutsOpen: true,
+      }),
+    ).toBe(false);
+  });
 });
 
 describe("useOnboardingTourProgress palette step", () => {
@@ -120,5 +130,18 @@ describe("useOnboardingTourProgress palette step", () => {
       // Palette advance + shortcuts already-open cascade lands on done.
       expect(useOnboardingTourStore.getState().stepId).toBe("done");
     });
+  });
+
+  it("does not skip the palette lesson when shortcuts open alone", async () => {
+    renderHook(() => useOnboardingTourProgress(), { wrapper });
+
+    act(() => {
+      viewActions.toggleShortcuts();
+    });
+
+    await waitFor(() => {
+      expect(useViewStore.getState().shortcuts.isOpen).toBe(true);
+    });
+    expect(useOnboardingTourStore.getState().stepId).toBe("palette");
   });
 });

--- a/packages/web/src/components/OnboardingTour/useOnboardingTourProgress.test.ts
+++ b/packages/web/src/components/OnboardingTour/useOnboardingTourProgress.test.ts
@@ -1,0 +1,124 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
+import { persistentBrowserStore } from "@web/common/storage/browser-key-value.store";
+import {
+  initialOnboardingTourState,
+  useOnboardingTourStore,
+} from "@web/components/OnboardingTour/onboarding.tour.store";
+import {
+  shouldAdvancePaletteStep,
+  useOnboardingTourProgress,
+} from "@web/components/OnboardingTour/useOnboardingTourProgress";
+import {
+  initialViewState,
+  useViewStore,
+  viewActions,
+} from "@web/events/stores/view.store";
+import {
+  initialSettingsState,
+  settingsActions,
+  useSettingsStore,
+} from "@web/settings/settings.store";
+import { beforeEach, describe, expect, it } from "bun:test";
+
+describe("shouldAdvancePaletteStep", () => {
+  it("does not advance when the palette has only opened", () => {
+    expect(
+      shouldAdvancePaletteStep({
+        paletteOpened: true,
+        isPaletteOpen: true,
+        isShortcutsOpen: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("advances after the palette was opened and then closed", () => {
+    expect(
+      shouldAdvancePaletteStep({
+        paletteOpened: true,
+        isPaletteOpen: false,
+        isShortcutsOpen: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not advance before the palette has ever opened", () => {
+    expect(
+      shouldAdvancePaletteStep({
+        paletteOpened: false,
+        isPaletteOpen: false,
+        isShortcutsOpen: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("advances when shortcuts open from inside the palette", () => {
+    expect(
+      shouldAdvancePaletteStep({
+        paletteOpened: true,
+        isPaletteOpen: true,
+        isShortcutsOpen: true,
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("useOnboardingTourProgress palette step", () => {
+  beforeEach(() => {
+    useOnboardingTourStore.setState({
+      ...initialOnboardingTourState,
+      isActive: true,
+      stepId: "palette",
+    });
+    useSettingsStore.setState(initialSettingsState);
+    useViewStore.setState(initialViewState);
+    persistentBrowserStore.set(STORAGE_KEYS.HAS_SEEN_ONBOARDING_TOUR, "");
+  });
+
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: new QueryClient() }, children);
+
+  it("stays on palette while the command palette is open", async () => {
+    renderHook(() => useOnboardingTourProgress(), { wrapper });
+
+    act(() => {
+      settingsActions.openCmdPalette();
+    });
+
+    await waitFor(() => {
+      expect(useSettingsStore.getState().isCmdPaletteOpen).toBe(true);
+    });
+    expect(useOnboardingTourStore.getState().stepId).toBe("palette");
+  });
+
+  it("advances to shortcuts after the palette opens then closes", async () => {
+    renderHook(() => useOnboardingTourProgress(), { wrapper });
+
+    act(() => {
+      settingsActions.openCmdPalette();
+    });
+    act(() => {
+      settingsActions.closeCmdPalette();
+    });
+
+    await waitFor(() => {
+      expect(useOnboardingTourStore.getState().stepId).toBe("shortcuts");
+    });
+  });
+
+  it("skips ahead when shortcuts open from the palette", async () => {
+    renderHook(() => useOnboardingTourProgress(), { wrapper });
+
+    act(() => {
+      settingsActions.openCmdPalette();
+      viewActions.toggleShortcuts();
+    });
+
+    await waitFor(() => {
+      // Palette advance + shortcuts already-open cascade lands on done.
+      expect(useOnboardingTourStore.getState().stepId).toBe("done");
+    });
+  });
+});

--- a/packages/web/src/components/OnboardingTour/useOnboardingTourProgress.ts
+++ b/packages/web/src/components/OnboardingTour/useOnboardingTourProgress.ts
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import {
   onboardingTourActions,
   selectOnboardingTourActive,
@@ -20,6 +20,19 @@ import {
 } from "@web/settings/settings.store";
 import { isHigherEscapeOwner } from "@web/shortcuts/escape-ownership";
 
+/** Palette step completes after open→close, or if shortcuts open from inside it. */
+export function shouldAdvancePaletteStep({
+  paletteOpened,
+  isPaletteOpen,
+  isShortcutsOpen,
+}: {
+  paletteOpened: boolean;
+  isPaletteOpen: boolean;
+  isShortcutsOpen: boolean;
+}): boolean {
+  return (paletteOpened && !isPaletteOpen) || isShortcutsOpen;
+}
+
 /**
  * Advances tour steps when the user performs the prompted action.
  * Does not take the app lock; coachmarks stay out of the modal Escape stack
@@ -32,6 +45,29 @@ export function useOnboardingTourProgress() {
   const isSaving = useHasPendingEventMutations();
   const isPaletteOpen = useSettingsStore(selectIsCmdPaletteOpen);
   const isShortcutsOpen = useViewStore(selectIsShortcutsOpen);
+  const paletteOpenedRef = useRef(false);
+
+  useEffect(() => {
+    if (!isActive || stepId !== "palette") {
+      paletteOpenedRef.current = false;
+      return;
+    }
+
+    if (isPaletteOpen) {
+      paletteOpenedRef.current = true;
+    }
+
+    if (
+      shouldAdvancePaletteStep({
+        paletteOpened: paletteOpenedRef.current,
+        isPaletteOpen,
+        isShortcutsOpen,
+      })
+    ) {
+      paletteOpenedRef.current = false;
+      onboardingTourActions.advance();
+    }
+  }, [isActive, stepId, isPaletteOpen, isShortcutsOpen]);
 
   useEffect(() => {
     if (!isActive) return;
@@ -47,15 +83,10 @@ export function useOnboardingTourProgress() {
       return;
     }
 
-    if (stepId === "palette" && isPaletteOpen) {
-      onboardingTourActions.advance();
-      return;
-    }
-
     if (stepId === "shortcuts" && isShortcutsOpen) {
       onboardingTourActions.advance();
     }
-  }, [isActive, stepId, isFormOpen, isSaving, isPaletteOpen, isShortcutsOpen]);
+  }, [isActive, stepId, isFormOpen, isSaving, isShortcutsOpen]);
 
   // ESC skips the tour when nothing higher owns Escape. Capture + stand down
   // for app lock / form / floating layers so we never trap the user.

--- a/packages/web/src/components/OnboardingTour/useOnboardingTourProgress.ts
+++ b/packages/web/src/components/OnboardingTour/useOnboardingTourProgress.ts
@@ -30,7 +30,9 @@ export function shouldAdvancePaletteStep({
   isPaletteOpen: boolean;
   isShortcutsOpen: boolean;
 }): boolean {
-  return (paletteOpened && !isPaletteOpen) || isShortcutsOpen;
+  // Require the palette to have opened first so a bare "?" / sidebar toggle
+  // cannot skip the Mod+K lesson.
+  return paletteOpened && (!isPaletteOpen || isShortcutsOpen);
 }
 
 /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The onboarding tour advanced from the command-palette step as soon as Mod+K opened the palette, then immediately asked users to press `?`. With palette search focused, `?` is ignored as a hotkey and only types into the input — a contradictory stuck state.

The palette step now advances only after the palette has been opened and closed (Escape), or if the user opens the shortcuts overlay from inside the palette. The shortcuts step copy clarifies that `?` works from the calendar. Palette advance also requires the palette to have opened first, so a bare `?` cannot skip the Mod+K lesson.

## Simplicity

Kept the existing five-step tour and coachmark UI. Only changed copy, the palette advance condition (tracked with a ref + small pure helper), and tests. No hotkey/`ignoreInputs` changes. Retained `useRef` to record open→close across renders (cannot derive from a single snapshot of `isPaletteOpen`).

## Automated validation

- OnboardingTour unit tests with web preload: 15 pass
- `bun test:web`: 1946 pass (pre-follow-up)
- `bun run lint`: pass (pre-existing warnings only)
- `bunx playwright test e2e/onboarding/interactive-tour.spec.ts`: 2 pass

## Independent review

Confirmed finding fixed: shortcuts-without-palette no longer skips the palette lesson. Residual low risks (batched open+close in one commit; Escape ownership covered by e2e only) accepted.

## Test plan

- `bun test --preload ./packages/web/src/__tests__/web.preload.ts packages/web/src/components/OnboardingTour/`
- `bun test:web`
- `bun run lint`
- `bunx playwright test e2e/onboarding/interactive-tour.spec.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0ff4ab7e-2044-4eb1-8f8c-19a72d7978e3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0ff4ab7e-2044-4eb1-8f8c-19a72d7978e3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

