### PR TITLE
fix(web): thicken onboarding tour liquid glass contrast

### DIFF
--- a/packages/web/src/components/OnboardingTour/OnboardingTour.test.tsx
+++ b/packages/web/src/components/OnboardingTour/OnboardingTour.test.tsx
@@ -34,8 +34,8 @@ describe("OnboardingTour", () => {
     const card = screen.getByRole("region", { name: "Onboarding tour" })
       .firstElementChild as HTMLElement;
 
-    expect(card).toHaveClass("bg-surface/90");
-    expect(card).toHaveClass("backdrop-blur-xl");
+    expect(card).toHaveClass("bg-surface/95");
+    expect(card).toHaveClass("backdrop-blur-2xl");
     expect(card).toHaveClass("backdrop-saturate-150");
     expect(card).not.toHaveClass("bg-surface-overlay");
   });

--- a/packages/web/src/components/OnboardingTour/OnboardingTour.test.tsx
+++ b/packages/web/src/components/OnboardingTour/OnboardingTour.test.tsx
@@ -1,0 +1,42 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import { type ReactNode } from "react";
+import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
+import { persistentBrowserStore } from "@web/common/storage/browser-key-value.store";
+import { OnboardingTour } from "@web/components/OnboardingTour/OnboardingTour";
+import {
+  initialOnboardingTourState,
+  onboardingTourActions,
+  useOnboardingTourStore,
+} from "@web/components/OnboardingTour/onboarding.tour.store";
+import { beforeEach, describe, expect, it } from "bun:test";
+
+function renderTour(ui: ReactNode) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
+  );
+}
+
+describe("OnboardingTour", () => {
+  beforeEach(() => {
+    useOnboardingTourStore.setState(initialOnboardingTourState);
+    persistentBrowserStore.set(STORAGE_KEYS.HAS_SEEN_ONBOARDING_TOUR, "");
+    persistentBrowserStore.set(STORAGE_KEYS.HAS_SEEN_CMD_PALETTE_HINT, "");
+  });
+
+  it("uses a thick liquid-glass surface so copy stays readable over events", () => {
+    onboardingTourActions.start();
+    renderTour(<OnboardingTour />);
+
+    const card = screen.getByRole("region", { name: "Onboarding tour" })
+      .firstElementChild as HTMLElement;
+
+    expect(card).toHaveClass("bg-surface/90");
+    expect(card).toHaveClass("backdrop-blur-xl");
+    expect(card).toHaveClass("backdrop-saturate-150");
+    expect(card).not.toHaveClass("bg-surface-overlay");
+  });
+});

--- a/packages/web/src/components/OnboardingTour/OnboardingTour.tsx
+++ b/packages/web/src/components/OnboardingTour/OnboardingTour.tsx
@@ -37,7 +37,7 @@ export const OnboardingTour: FC = () => {
       data-onboarding-tour=""
       style={{ zIndex: Z_INDEX_TOOLTIP }}
     >
-      <div className="pointer-events-auto w-full max-w-md rounded-xl border border-border bg-surface-overlay px-5 py-4 text-text shadow-lg">
+      <div className="pointer-events-auto w-full max-w-md rounded-xl border border-border bg-surface/90 px-5 py-4 text-text shadow-xl backdrop-blur-xl backdrop-saturate-150">
         <div className="mb-1 flex items-center justify-between gap-3">
           <p className="font-medium text-sm">{step.title}</p>
           <p className="shrink-0 text-text-muted text-xs">

--- a/packages/web/src/components/OnboardingTour/OnboardingTour.tsx
+++ b/packages/web/src/components/OnboardingTour/OnboardingTour.tsx
@@ -37,7 +37,7 @@ export const OnboardingTour: FC = () => {
       data-onboarding-tour=""
       style={{ zIndex: Z_INDEX_TOOLTIP }}
     >
-      <div className="pointer-events-auto w-full max-w-md rounded-xl border border-border bg-surface/90 px-5 py-4 text-text shadow-xl backdrop-blur-xl backdrop-saturate-150">
+      <div className="pointer-events-auto w-full max-w-md rounded-xl border border-border bg-surface/95 px-5 py-4 text-text shadow-xl backdrop-blur-2xl backdrop-saturate-150">
         <div className="mb-1 flex items-center justify-between gap-3">
           <p className="font-medium text-sm">{step.title}</p>
           <p className="shrink-0 text-text-muted text-xs">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The onboarding tour coachmark used `bg-surface-overlay` (≈6–7% opacity) with no backdrop blur, so title/body copy washed out over calendar events—especially on light-beach.

Swap the card to a thicker liquid-glass surface: `bg-surface/95`, `backdrop-blur-2xl`, and `backdrop-saturate-150`, keeping a translucent frosted look while keeping text readable.

## Simplicity

Single class-list change on the existing coachmark; no new components or tokens. Closest peer is `ShortcutsOverlay` (`bg-surface/95` + blur).

## Automated validation

- `bun test:web -- packages/web/src/components/OnboardingTour/` — pass (6 tests)
- `bun run lint` — pass (pre-existing warnings only)
- Browser (localhost:9080):
  - dark-abyss: tour over colored events — readable frosted card
  - light-beach: tour over events with `bg-surface/95` + `backdrop-blur-2xl` confirmed in DevTools; card fill stayed ~opaque cream over events

![Onboarding tour liquid glass on light-beach](https://cursor.com/artifacts/c/art-8ed9af81-6282-41e6-b853-7ff95659592d)

## Independent review

Fresh explore review: no blockers. Medium note was unpushed `/95` recipe — now committed. Low note on class-token test coupling accepted as intentional regression guard against `bg-surface-overlay`.

## Test plan

- `bun test:web -- packages/web/src/components/OnboardingTour/`
- `bun run lint`
- Browser: Restart onboarding tour with events behind the card (dark-abyss + light-beach)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-03b64db6-76e3-4727-8d5e-76750e224277?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-03b64db6-76e3-4727-8d5e-76750e224277&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

