### PR TITLE
feat(web): polish keyboard-only discovery and palette enter

### DIFF
--- a/e2e/timed/keyboard-only-mode.spec.ts
+++ b/e2e/timed/keyboard-only-mode.spec.ts
@@ -38,7 +38,7 @@ test("SHIFT-SHIFT enters keyboard-only mode; clicks are inert until Escape", asy
   await tapShift(page);
 
   await expect(keyboardOnlyIndicator(page)).toContainText("Keyboard only");
-  await expect(keyboardOnlyIndicator(page)).toContainText("ESC to exit");
+  await expect(keyboardOnlyIndicator(page)).toContainText("Esc or Shift Shift");
 
   // Shortcuts overlay stays mounted with role=dialog even when closed, so
   // assert the event form did not open rather than dialog count.
@@ -48,6 +48,36 @@ test("SHIFT-SHIFT enters keyboard-only mode; clicks are inert until Escape", asy
   await expect(eventButton).not.toBeFocused();
 
   await page.keyboard.press("Escape");
+  await expect(keyboardOnlyIndicator(page)).toHaveCount(0);
+
+  await eventButton.click();
+  await expect(page.getByLabel("Title")).toBeVisible();
+});
+
+test("SHIFT-SHIFT exits keyboard-only mode and restores clicks", async ({
+  page,
+}) => {
+  await prepareCalendarPage(page);
+
+  const title = createEventTitle("Keyboard Only Toggle Exit");
+  const { x, y } = await getMainGridPoint(page, {
+    xRatio: 0.42,
+    yRatio: 0.35,
+  });
+  await page.mouse.click(x, y);
+  await fillTitleAndSaveEventForm(page, title);
+  await expectTimedEventVisible(page, title);
+
+  const eventButton = page
+    .locator("#mainGrid")
+    .getByRole("button", { name: title });
+
+  await tapShift(page);
+  await tapShift(page);
+  await expect(keyboardOnlyIndicator(page)).toBeVisible();
+
+  await tapShift(page);
+  await tapShift(page);
   await expect(keyboardOnlyIndicator(page)).toHaveCount(0);
 
   await eventButton.click();

--- a/e2e/timed/keyboard-only-mode.spec.ts
+++ b/e2e/timed/keyboard-only-mode.spec.ts
@@ -7,21 +7,18 @@ import {
   prepareCalendarPage,
 } from "../utils/event-test-utils";
 
-const keyboardOnlyIndicator = (
-  page: Parameters<typeof prepareCalendarPage>[0],
-) => page.locator("[data-keyboard-only-indicator]");
+type CalendarPage = Parameters<typeof prepareCalendarPage>[0];
 
-const tapShift = async (page: Parameters<typeof prepareCalendarPage>[0]) => {
+const keyboardOnlyIndicator = (page: CalendarPage) =>
+  page.locator("[data-keyboard-only-indicator]");
+
+const tapShift = async (page: CalendarPage) => {
   await page.keyboard.down("Shift");
   await page.keyboard.up("Shift");
 };
 
-test("SHIFT-SHIFT enters keyboard-only mode; clicks are inert until Escape", async ({
-  page,
-}) => {
-  await prepareCalendarPage(page);
-
-  const title = createEventTitle("Keyboard Only Target");
+const createTimedEventOnGrid = async (page: CalendarPage, label: string) => {
+  const title = createEventTitle(label);
   const { x, y } = await getMainGridPoint(page, {
     xRatio: 0.42,
     yRatio: 0.35,
@@ -29,10 +26,17 @@ test("SHIFT-SHIFT enters keyboard-only mode; clicks are inert until Escape", asy
   await page.mouse.click(x, y);
   await fillTitleAndSaveEventForm(page, title);
   await expectTimedEventVisible(page, title);
+  return page.locator("#mainGrid").getByRole("button", { name: title });
+};
 
-  const eventButton = page
-    .locator("#mainGrid")
-    .getByRole("button", { name: title });
+test("SHIFT-SHIFT enters keyboard-only mode; clicks are inert until Escape", async ({
+  page,
+}) => {
+  await prepareCalendarPage(page);
+  const eventButton = await createTimedEventOnGrid(
+    page,
+    "Keyboard Only Target",
+  );
 
   await tapShift(page);
   await tapShift(page);
@@ -58,19 +62,10 @@ test("SHIFT-SHIFT exits keyboard-only mode and restores clicks", async ({
   page,
 }) => {
   await prepareCalendarPage(page);
-
-  const title = createEventTitle("Keyboard Only Toggle Exit");
-  const { x, y } = await getMainGridPoint(page, {
-    xRatio: 0.42,
-    yRatio: 0.35,
-  });
-  await page.mouse.click(x, y);
-  await fillTitleAndSaveEventForm(page, title);
-  await expectTimedEventVisible(page, title);
-
-  const eventButton = page
-    .locator("#mainGrid")
-    .getByRole("button", { name: title });
+  const eventButton = await createTimedEventOnGrid(
+    page,
+    "Keyboard Only Toggle Exit",
+  );
 
   await tapShift(page);
   await tapShift(page);
@@ -88,15 +83,7 @@ test("hold Shift still flashes jump keys and does not enter keyboard-only mode",
   page,
 }) => {
   await prepareCalendarPage(page);
-
-  const title = createEventTitle("Hold Not Double");
-  const { x, y } = await getMainGridPoint(page, {
-    xRatio: 0.42,
-    yRatio: 0.35,
-  });
-  await page.mouse.click(x, y);
-  await fillTitleAndSaveEventForm(page, title);
-  await expectTimedEventVisible(page, title);
+  await createTimedEventOnGrid(page, "Hold Not Double");
 
   await page.keyboard.down("Shift");
   await page.waitForTimeout(250);

--- a/packages/web/src/components/CommandPalette/CommandPalette.test.tsx
+++ b/packages/web/src/components/CommandPalette/CommandPalette.test.tsx
@@ -28,15 +28,7 @@ import {
 } from "@web/shortcuts/keyboard-only/keyboard-only.store";
 import { useKeyboardOnlyMode } from "@web/shortcuts/keyboard-only/useKeyboardOnlyMode";
 import { recordRecentCommand } from "./recent-commands.store";
-import {
-  afterAll,
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  mock,
-} from "bun:test";
+import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
 
 const mockNavigate = mock();
 // Bun's mock.module is process-wide, so mock the router's useNavigate directly
@@ -111,10 +103,6 @@ describe("CommandPalette", () => {
     mockNavigate.mockClear();
     onGoToToday.mockClear();
     onShowShortcuts.mockClear();
-    useKeyboardOnlyStore.setState(initialKeyboardOnlyState);
-  });
-
-  afterEach(() => {
     useKeyboardOnlyStore.setState(initialKeyboardOnlyState);
   });
 

--- a/packages/web/src/components/CommandPalette/CommandPalette.test.tsx
+++ b/packages/web/src/components/CommandPalette/CommandPalette.test.tsx
@@ -2,6 +2,7 @@ import "@testing-library/jest-dom";
 import {
   act,
   fireEvent,
+  renderHook,
   screen,
   waitFor,
   within,
@@ -20,8 +21,22 @@ import {
   settingsActions,
   useSettingsStore,
 } from "@web/settings/settings.store";
+import {
+  initialKeyboardOnlyState,
+  keyboardOnlyActions,
+  useKeyboardOnlyStore,
+} from "@web/shortcuts/keyboard-only/keyboard-only.store";
+import { useKeyboardOnlyMode } from "@web/shortcuts/keyboard-only/useKeyboardOnlyMode";
 import { recordRecentCommand } from "./recent-commands.store";
-import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  mock,
+} from "bun:test";
 
 const mockNavigate = mock();
 // Bun's mock.module is process-wide, so mock the router's useNavigate directly
@@ -96,6 +111,11 @@ describe("CommandPalette", () => {
     mockNavigate.mockClear();
     onGoToToday.mockClear();
     onShowShortcuts.mockClear();
+    useKeyboardOnlyStore.setState(initialKeyboardOnlyState);
+  });
+
+  afterEach(() => {
+    useKeyboardOnlyStore.setState(initialKeyboardOnlyState);
   });
 
   it("renders all sections with items and focuses the input on mount", () => {
@@ -194,7 +214,8 @@ describe("CommandPalette", () => {
     // disabled Undo row and lands on the Appearance section's theme toggle.
     fireEvent.keyDown(input, { key: "ArrowDown" }); // Go to Day
     fireEvent.keyDown(input, { key: "ArrowDown" }); // Go to Life
-    fireEvent.keyDown(input, { key: "ArrowDown" }); // Show Shortcuts
+    fireEvent.keyDown(input, { key: "ArrowDown" }); // Show shortcuts
+    fireEvent.keyDown(input, { key: "ArrowDown" }); // Enter keyboard-only mode
     fireEvent.keyDown(input, { key: "ArrowDown" }); // Restart onboarding tour
     fireEvent.keyDown(input, { key: "ArrowDown" }); // Create event
     fireEvent.keyDown(input, { key: "ArrowDown" }); // Create all-day event
@@ -220,6 +241,26 @@ describe("CommandPalette", () => {
     });
     expect(isOpen()).toBe(false);
     unsubscribe();
+  });
+
+  it("runs Enter selection while keyboard-only mode blocks clicks", () => {
+    // Mount the same capture-phase click blocker RootShell uses in production.
+    const { unmount: unmountMode } = renderHook(() => useKeyboardOnlyMode());
+
+    act(() => {
+      keyboardOnlyActions.enter();
+    });
+    expect(useKeyboardOnlyStore.getState().isActive).toBe(true);
+
+    renderPalette();
+    const input = getInput();
+    fireEvent.change(input, { target: { value: "Show shortcuts" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(onShowShortcuts).toHaveBeenCalledTimes(1);
+    expect(isOpen()).toBe(false);
+
+    unmountMode();
   });
 
   it("resets the active option to the first after typing", () => {
@@ -377,7 +418,7 @@ describe("CommandPalette", () => {
     // `[aria-hidden='true']` (not `.c-keycap`) because SelectView.test.tsx
     // mocks ShortcutHint process-wide (bun's mock.module leaks across
     // files); its stub keeps aria-hidden but drops the real class.
-    const row = screen.getByText("Show keyboard shortcuts").closest("button");
+    const row = screen.getByText("Show shortcuts").closest("button");
     expect(row?.querySelector("[aria-hidden='true']")?.textContent).toBe("?");
 
     fireEvent.click(row as HTMLButtonElement);
@@ -443,7 +484,7 @@ describe("CommandPalette", () => {
   it("records a command as recent when it's selected", () => {
     renderPalette();
 
-    fireEvent.click(screen.getByText("Show keyboard shortcuts"));
+    fireEvent.click(screen.getByText("Show shortcuts"));
     expect(isOpen()).toBe(false);
 
     // Same reopen pattern as "clears the search query when reopened after
@@ -455,7 +496,7 @@ describe("CommandPalette", () => {
     const recentHeading = screen.getByText("Recent");
     const recentSection = recentHeading.closest("div.mb-1") as HTMLElement;
     expect(
-      within(recentSection).getByText("Show keyboard shortcuts"),
+      within(recentSection).getByText("Show shortcuts"),
     ).toBeInTheDocument();
   });
 });

--- a/packages/web/src/components/CommandPalette/CommandPalette.test.tsx
+++ b/packages/web/src/components/CommandPalette/CommandPalette.test.tsx
@@ -203,7 +203,7 @@ describe("CommandPalette", () => {
     fireEvent.keyDown(input, { key: "ArrowDown" }); // Go to Day
     fireEvent.keyDown(input, { key: "ArrowDown" }); // Go to Life
     fireEvent.keyDown(input, { key: "ArrowDown" }); // Show shortcuts
-    fireEvent.keyDown(input, { key: "ArrowDown" }); // Enter keyboard-only mode
+    fireEvent.keyDown(input, { key: "ArrowDown" }); // Toggle keyboard-only mode
     fireEvent.keyDown(input, { key: "ArrowDown" }); // Restart onboarding tour
     fireEvent.keyDown(input, { key: "ArrowDown" }); // Create event
     fireEvent.keyDown(input, { key: "ArrowDown" }); // Create all-day event

--- a/packages/web/src/components/CommandPalette/CommandPalette.tsx
+++ b/packages/web/src/components/CommandPalette/CommandPalette.tsx
@@ -116,6 +116,15 @@ const CommandPaletteContent = ({
       ? `No results for “${search}”`
       : `${resultCount} result${resultCount === 1 ? "" : "s"}`;
 
+  // Invoke the item action directly — not via HTMLElement.click() — so
+  // keyboard-only mode's capture-phase click blocker cannot swallow Enter.
+  const activateItem = (item: CommandItem) => {
+    if (item.disabled) return;
+    recordRecentCommand(item.id);
+    item.onClick?.();
+    close();
+  };
+
   const dismiss = useDismiss(context);
   const role = useRole(context, { role: "listbox" });
   const listNav = useListNavigation(context, {
@@ -153,7 +162,8 @@ const CommandPaletteContent = ({
               onKeyDown(event) {
                 if (event.key === "Enter" && activeIndex != null) {
                   event.preventDefault();
-                  listRef.current[activeIndex]?.click();
+                  const item = flatItems[activeIndex];
+                  if (item) activateItem(item);
                 }
               },
             })}
@@ -232,10 +242,7 @@ const CommandPaletteContent = ({
                             setActiveIndex(index);
                           },
                           onClick() {
-                            if (item.disabled) return;
-                            recordRecentCommand(item.id);
-                            item.onClick?.();
-                            close();
+                            activateItem(item);
                           },
                         })}
                         type="button"

--- a/packages/web/src/components/CommandPalette/navigation.cmd.constants.test.ts
+++ b/packages/web/src/components/CommandPalette/navigation.cmd.constants.test.ts
@@ -25,7 +25,7 @@ describe("getNavigationCommandItems", () => {
       "Go to Week",
       "Go to Life",
       "Show shortcuts",
-      "Enter keyboard-only mode",
+      "Toggle keyboard-only mode",
     ]);
   });
 
@@ -52,7 +52,7 @@ describe("getNavigationCommandItems", () => {
       "Go to Day",
       "Go to Week",
       "Go to Life",
-      "Enter keyboard-only mode",
+      "Toggle keyboard-only mode",
     ]);
   });
 
@@ -80,7 +80,7 @@ describe("getNavigationCommandItems", () => {
     expect(labels).toEqual([
       "Go to Day",
       "Go to Week",
-      "Enter keyboard-only mode",
+      "Toggle keyboard-only mode",
     ]);
   });
 
@@ -116,15 +116,20 @@ describe("getNavigationCommandItems", () => {
       useKeyboardOnlyStore.setState(initialKeyboardOnlyState);
     });
 
-    it("enters keyboard-only mode on the next microtask", async () => {
+    it("toggles keyboard-only mode on the next microtask", async () => {
       const items = getNavigationCommandItems({
         onNavigateToView: () => {},
       });
-      items.find((item) => item.id === "enter-keyboard-only")?.onClick?.();
+      const toggle = items.find((item) => item.id === "enter-keyboard-only");
 
+      toggle?.onClick?.();
       expect(useKeyboardOnlyStore.getState().isActive).toBe(false);
       await Promise.resolve();
       expect(useKeyboardOnlyStore.getState().isActive).toBe(true);
+
+      toggle?.onClick?.();
+      await Promise.resolve();
+      expect(useKeyboardOnlyStore.getState().isActive).toBe(false);
     });
 
     it("advertises Shift Shift as the shortcut", () => {
@@ -132,6 +137,7 @@ describe("getNavigationCommandItems", () => {
         onNavigateToView: () => {},
       }).find((entry) => entry.id === "enter-keyboard-only");
 
+      expect(item?.label).toBe("Toggle keyboard-only mode");
       expect(item?.shortcut).toEqual(["Shift", "Shift"]);
     });
   });

--- a/packages/web/src/components/CommandPalette/navigation.cmd.constants.test.ts
+++ b/packages/web/src/components/CommandPalette/navigation.cmd.constants.test.ts
@@ -2,7 +2,11 @@ import {
   type CommandPaletteViewName,
   getNavigationCommandItems,
 } from "@web/components/CommandPalette/navigation.cmd.constants";
-import { describe, expect, it } from "bun:test";
+import {
+  initialKeyboardOnlyState,
+  useKeyboardOnlyStore,
+} from "@web/shortcuts/keyboard-only/keyboard-only.store";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 
 describe("getNavigationCommandItems", () => {
   const noopHandlers = {
@@ -11,7 +15,7 @@ describe("getNavigationCommandItems", () => {
     onShowShortcuts: () => {},
   };
 
-  it("lists Today first, then Day, Week, Life, then shortcuts", () => {
+  it("lists Today first, then Day, Week, Life, then shortcuts and keyboard-only", () => {
     const labels = getNavigationCommandItems(noopHandlers).map(
       (item) => item.label,
     );
@@ -20,7 +24,8 @@ describe("getNavigationCommandItems", () => {
       "Go to Day",
       "Go to Week",
       "Go to Life",
-      "Show keyboard shortcuts",
+      "Show shortcuts",
+      "Enter keyboard-only mode",
     ]);
   });
 
@@ -43,7 +48,12 @@ describe("getNavigationCommandItems", () => {
       onNavigateToView: () => {},
     }).map((item) => item.label);
 
-    expect(labels).toEqual(["Go to Day", "Go to Week", "Go to Life"]);
+    expect(labels).toEqual([
+      "Go to Day",
+      "Go to Week",
+      "Go to Life",
+      "Enter keyboard-only mode",
+    ]);
   });
 
   it("advertises every view shortcut in the command palette", () => {
@@ -67,7 +77,11 @@ describe("getNavigationCommandItems", () => {
       onNavigateToView: () => {},
     }).map((item) => item.label);
 
-    expect(labels).toEqual(["Go to Day", "Go to Week"]);
+    expect(labels).toEqual([
+      "Go to Day",
+      "Go to Week",
+      "Enter keyboard-only mode",
+    ]);
   });
 
   it("runs the matching navigation callbacks", () => {
@@ -95,5 +109,34 @@ describe("getNavigationCommandItems", () => {
     expect(navigatedViews).toEqual(["day", "week", "life"]);
     expect(didGoToToday).toBe(true);
     expect(didShowShortcuts).toBe(true);
+  });
+
+  describe("enter-keyboard-only", () => {
+    beforeEach(() => {
+      useKeyboardOnlyStore.setState(initialKeyboardOnlyState);
+    });
+
+    afterEach(() => {
+      useKeyboardOnlyStore.setState(initialKeyboardOnlyState);
+    });
+
+    it("enters keyboard-only mode on the next microtask", async () => {
+      const items = getNavigationCommandItems({
+        onNavigateToView: () => {},
+      });
+      items.find((item) => item.id === "enter-keyboard-only")?.onClick?.();
+
+      expect(useKeyboardOnlyStore.getState().isActive).toBe(false);
+      await Promise.resolve();
+      expect(useKeyboardOnlyStore.getState().isActive).toBe(true);
+    });
+
+    it("advertises Shift Shift as the shortcut", () => {
+      const item = getNavigationCommandItems({
+        onNavigateToView: () => {},
+      }).find((entry) => entry.id === "enter-keyboard-only");
+
+      expect(item?.shortcut).toEqual(["Shift", "Shift"]);
+    });
   });
 });

--- a/packages/web/src/components/CommandPalette/navigation.cmd.constants.test.ts
+++ b/packages/web/src/components/CommandPalette/navigation.cmd.constants.test.ts
@@ -6,7 +6,7 @@ import {
   initialKeyboardOnlyState,
   useKeyboardOnlyStore,
 } from "@web/shortcuts/keyboard-only/keyboard-only.store";
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { beforeEach, describe, expect, it } from "bun:test";
 
 describe("getNavigationCommandItems", () => {
   const noopHandlers = {
@@ -113,10 +113,6 @@ describe("getNavigationCommandItems", () => {
 
   describe("enter-keyboard-only", () => {
     beforeEach(() => {
-      useKeyboardOnlyStore.setState(initialKeyboardOnlyState);
-    });
-
-    afterEach(() => {
       useKeyboardOnlyStore.setState(initialKeyboardOnlyState);
     });
 

--- a/packages/web/src/components/CommandPalette/navigation.cmd.constants.ts
+++ b/packages/web/src/components/CommandPalette/navigation.cmd.constants.ts
@@ -8,7 +8,10 @@ import {
   KeyboardIcon,
 } from "@phosphor-icons/react";
 import { type CommandItem } from "@web/components/CommandPalette/command-palette.types";
-import { keyboardOnlyActions } from "@web/shortcuts/keyboard-only/keyboard-only.store";
+import {
+  keyboardOnlyActions,
+  useKeyboardOnlyStore,
+} from "@web/shortcuts/keyboard-only/keyboard-only.store";
 import {
   LIFE_SHORTCUT,
   VIEW_SHORTCUTS,
@@ -107,19 +110,33 @@ export const getNavigationCommandItems = ({
       label: "Show shortcuts",
       icon: KeyboardIcon,
       shortcut: "?",
-      keywords: ["hotkeys", "keys", "help", "keybindings"],
+      keywords: [
+        "keyboard",
+        "keyboard shortcuts",
+        "hotkeys",
+        "keys",
+        "help",
+        "keybindings",
+      ],
       onClick: onShowShortcuts,
     });
   }
 
   calendarItems.push({
     id: "enter-keyboard-only",
-    label: "Enter keyboard-only mode",
+    label: "Toggle keyboard-only mode",
     icon: KeyboardIcon,
     shortcut: ["Shift", "Shift"],
     keywords: ["keyboard", "clicks", "pointer", "mouseless", "hotkeys"],
     // Defer so the palette closes before click-blocking installs.
-    onClick: () => queueMicrotask(() => keyboardOnlyActions.enter()),
+    onClick: () =>
+      queueMicrotask(() => {
+        if (useKeyboardOnlyStore.getState().isActive) {
+          keyboardOnlyActions.exit();
+        } else {
+          keyboardOnlyActions.enter();
+        }
+      }),
   });
 
   if (onShowOnboardingTour) {

--- a/packages/web/src/components/CommandPalette/navigation.cmd.constants.ts
+++ b/packages/web/src/components/CommandPalette/navigation.cmd.constants.ts
@@ -8,6 +8,7 @@ import {
   KeyboardIcon,
 } from "@phosphor-icons/react";
 import { type CommandItem } from "@web/components/CommandPalette/command-palette.types";
+import { keyboardOnlyActions } from "@web/shortcuts/keyboard-only/keyboard-only.store";
 import {
   LIFE_SHORTCUT,
   VIEW_SHORTCUTS,
@@ -103,13 +104,23 @@ export const getNavigationCommandItems = ({
   if (onShowShortcuts) {
     calendarItems.push({
       id: "show-shortcuts",
-      label: "Show keyboard shortcuts",
+      label: "Show shortcuts",
       icon: KeyboardIcon,
       shortcut: "?",
       keywords: ["hotkeys", "keys", "help", "keybindings"],
       onClick: onShowShortcuts,
     });
   }
+
+  calendarItems.push({
+    id: "enter-keyboard-only",
+    label: "Enter keyboard-only mode",
+    icon: KeyboardIcon,
+    shortcut: ["Shift", "Shift"],
+    keywords: ["keyboard", "clicks", "pointer", "mouseless", "hotkeys"],
+    // Defer so the palette closes before click-blocking installs.
+    onClick: () => queueMicrotask(() => keyboardOnlyActions.enter()),
+  });
 
   if (onShowOnboardingTour) {
     calendarItems.push({

--- a/packages/web/src/components/OnboardingTour/onboarding.tour.steps.test.ts
+++ b/packages/web/src/components/OnboardingTour/onboarding.tour.steps.test.ts
@@ -33,4 +33,14 @@ describe("onboarding tour steps", () => {
     expect(shortcuts?.body).toMatch(/from the calendar/i);
     expect(shortcuts?.shortcutHint).toBe("?");
   });
+
+  it("points the finale at keyboard-only practice", () => {
+    const done = getOnboardingTourSteps().find((step) => step.id === "done");
+
+    expect(done?.body).toMatch(/anything with the keyboard/i);
+    expect(done?.body).toMatch(/Shift Shift/i);
+    expect(done?.body).toMatch(/clicks/i);
+    expect(done?.body).toMatch(/command palette/i);
+    expect(done?.shortcutHint).toBe("Shift Shift");
+  });
 });

--- a/packages/web/src/components/OnboardingTour/onboarding.tour.steps.ts
+++ b/packages/web/src/components/OnboardingTour/onboarding.tour.steps.ts
@@ -53,7 +53,8 @@ export function getOnboardingTourSteps(): OnboardingTourStep[] {
     {
       id: "done",
       title: "You are ready",
-      body: "Sample events are already on your calendar. Reopen this tour from the command palette anytime.",
+      body: "You can do anything with the keyboard. Try Shift Shift to practice; clicks stay off until you exit. Sample events are already on your calendar. Reopen this tour from the command palette anytime.",
+      shortcutHint: "Shift Shift",
     },
   ];
 }

--- a/packages/web/src/shortcuts/data/shortcuts.data.test.ts
+++ b/packages/web/src/shortcuts/data/shortcuts.data.test.ts
@@ -274,7 +274,7 @@ describe("shortcuts.data", () => {
       });
       expect(stripMetadata(other?.shortcuts ?? [])).toContainEqual({
         keys: ["Shift", "Shift"],
-        label: "Enter keyboard-only mode",
+        label: "Toggle keyboard-only mode",
       });
       expect(stripMetadata(other?.shortcuts ?? [])).toContainEqual({
         keys: ["Mod", "Shift", "Z"],

--- a/packages/web/src/shortcuts/keyboard-only/KeyboardOnlyIndicator.tsx
+++ b/packages/web/src/shortcuts/keyboard-only/KeyboardOnlyIndicator.tsx
@@ -26,11 +26,11 @@ export const KeyboardOnlyIndicator: FC = () => {
   return (
     <span
       aria-live="polite"
-      className={`truncate text-text text-xs ${isPulsing ? "font-semibold opacity-100" : "opacity-80"}`}
+      className={`c-sync-text-wave truncate text-xs ${isPulsing ? "font-semibold opacity-100" : "opacity-80"}`}
       data-keyboard-only-indicator=""
       role="status"
     >
-      Keyboard only · ESC to exit
+      Keyboard only · Esc or Shift Shift
     </span>
   );
 };

--- a/packages/web/src/shortcuts/keyboard-only/useKeyboardOnlyMode.test.tsx
+++ b/packages/web/src/shortcuts/keyboard-only/useKeyboardOnlyMode.test.tsx
@@ -88,6 +88,22 @@ describe("useKeyboardOnlyMode", () => {
     expect(clicked).toBe(true);
   });
 
+  it("exits on a second SHIFT-SHIFT", () => {
+    renderHook(() => useKeyboardOnlyMode());
+
+    act(() => {
+      tapShift();
+      tapShift();
+    });
+    expect(useKeyboardOnlyStore.getState().isActive).toBe(true);
+
+    act(() => {
+      tapShift();
+      tapShift();
+    });
+    expect(useKeyboardOnlyStore.getState().isActive).toBe(false);
+  });
+
   it("does not enter while app-locked", () => {
     setAppLockReason("commandPalette", true);
     renderHook(() => useKeyboardOnlyMode());

--- a/packages/web/src/shortcuts/keyboard-only/useKeyboardOnlyMode.ts
+++ b/packages/web/src/shortcuts/keyboard-only/useKeyboardOnlyMode.ts
@@ -56,17 +56,19 @@ export function useKeyboardOnlyMode() {
       // Keep counting a hold if the other Shift key is still down.
       if (event.shiftKey) return;
 
-      const result = reduceKeyboardOnlyDetector(stateRef.current, {
-        type: "shiftUp",
-        now: Date.now(),
-      });
-      stateRef.current = result.state;
-      if (result.entered) {
-        if (useKeyboardOnlyStore.getState().isActive) {
-          keyboardOnlyActions.exit();
-        } else {
-          keyboardOnlyActions.enter();
-        }
+      const { state, entered: doubleTapped } = reduceKeyboardOnlyDetector(
+        stateRef.current,
+        {
+          type: "shiftUp",
+          now: Date.now(),
+        },
+      );
+      stateRef.current = state;
+      if (!doubleTapped) return;
+      if (useKeyboardOnlyStore.getState().isActive) {
+        keyboardOnlyActions.exit();
+      } else {
+        keyboardOnlyActions.enter();
       }
     };
 

--- a/packages/web/src/shortcuts/keyboard-only/useKeyboardOnlyMode.ts
+++ b/packages/web/src/shortcuts/keyboard-only/useKeyboardOnlyMode.ts
@@ -15,8 +15,8 @@ import { isShiftKey } from "@web/shortcuts/shift-hint/shift-hold-detector";
 const isAppLocked = () => document.body.dataset.appLocked === "true";
 
 /**
- * SHIFT-SHIFT (two quick taps) enters keyboard-only mode. Clicks are inert;
- * ESC / refresh exits. Mode is not persisted.
+ * SHIFT-SHIFT (two quick taps) toggles keyboard-only mode. Clicks are inert;
+ * ESC, SHIFT-SHIFT again, or refresh exits. Mode is not persisted.
  *
  * ESC stands down while app lock, floating layers, or the event form own Escape
  * so those dismiss first; a later ESC exits this mode.
@@ -61,8 +61,12 @@ export function useKeyboardOnlyMode() {
         now: Date.now(),
       });
       stateRef.current = result.state;
-      if (result.entered && !useKeyboardOnlyStore.getState().isActive) {
-        keyboardOnlyActions.enter();
+      if (result.entered) {
+        if (useKeyboardOnlyStore.getState().isActive) {
+          keyboardOnlyActions.exit();
+        } else {
+          keyboardOnlyActions.enter();
+        }
       }
     };
 

--- a/packages/web/src/shortcuts/shortcuts.registry.ts
+++ b/packages/web/src/shortcuts/shortcuts.registry.ts
@@ -299,7 +299,7 @@ export const SHORTCUTS_REGISTRY: Shortcut[] = [
   {
     id: "other-keyboard-only",
     keys: ["Shift", "Shift"],
-    label: "Enter keyboard-only mode",
+    label: "Toggle keyboard-only mode",
     section: "other",
   },
 ];


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Rename the command palette item to **Show shortcuts**, add a **Toggle keyboard-only mode** command, teach Shift Shift as a toggle exit, shimmer the sidebar keyboard-only indicator, mention keyboard-only practice at the end of onboarding, and fix Enter selection in the command palette while keyboard-only mode blocks clicks.

## Simplicity

Reuse existing pieces: `keyboardOnlyActions`, the sync sidebar shimmer (`c-sync-text-wave`), and a shared `activateItem` helper so Enter no longer depends on a synthetic DOM click. Follow-up refactor extracted shared e2e setup and clarified the Shift Shift toggle branch without adding a store `toggle()` API.

## Automated validation

Browser (http://localhost:9080, anonymous):
- Shift Shift enters keyboard-only; clicks blocked; indicator shows shimmer + "Esc or Shift Shift"
- Shift Shift again exits and restores clicks
- Esc exits keyboard-only
- Palette: "Show shortcuts" and "Toggle/Enter keyboard-only" discoverable; palette Enter activates keyboard-only
- While keyboard-only, palette Enter activates "Show shortcuts" (bug fix)
- Onboarding step 5/5 mentions keyboard, Shift Shift, and clicks off

Commands:
- `bun test:web --` CommandPalette, navigation.cmd.constants, onboarding.tour.steps, useKeyboardOnlyMode, shortcuts.data, shortcuts.registry — **61 pass, 0 fail**
- `bun run lint` — exit 0 (pre-existing warnings only)

## Independent review

Fresh read-only review found two important issues; both fixed:
1. Restored `keyboard` / `keyboard shortcuts` keywords on Show shortcuts
2. Relabeled Shift Shift as toggle in the legend and palette

No remaining blockers. Nit about shared KeyboardIcon left as-is.

## Test plan

- `bun test:web -- packages/web/src/components/CommandPalette/navigation.cmd.constants.test.ts packages/web/src/components/CommandPalette/CommandPalette.test.tsx packages/web/src/components/OnboardingTour/onboarding.tour.steps.test.ts packages/web/src/shortcuts/keyboard-only/useKeyboardOnlyMode.test.tsx packages/web/src/shortcuts/data/shortcuts.data.test.ts packages/web/src/shortcuts/shortcuts.registry.test.ts`
- `bun run lint`
- Browser scenarios above on `bun run dev:web`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4d9586b5-386d-4222-8014-dd8c69977a47?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4d9586b5-386d-4222-8014-dd8c69977a47&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

