### PR TITLE
fix(web): restore grid focus after event form closes

### DIFF
--- a/packages/web/src/common/utils/event/event.util.test.ts
+++ b/packages/web/src/common/utils/event/event.util.test.ts
@@ -7,6 +7,7 @@ import { GENERIC_ERROR_TOAST_ID } from "@web/common/constants/toast.constants";
 import { type GridEvent } from "@web/common/types/web.event.types";
 import {
   addId,
+  focusCalendarEventElement,
   isEventInRange,
   refocusEventElement,
 } from "@web/common/utils/event/event.util";
@@ -203,6 +204,58 @@ describe("addId", () => {
     expect(result._id).toBeDefined();
     expect(ObjectId.isValid(result._id)).toBe(true);
     expect(result._id).toMatch(/^[a-f0-9]{24}$/);
+  });
+});
+
+describe("focusCalendarEventElement", () => {
+  const EVENT_ID = "507f1f77bcf86cd799439011";
+  let pendingFrames: FrameRequestCallback[];
+  let originalRequestAnimationFrame: typeof requestAnimationFrame;
+
+  const addEventElement = () => {
+    const element = document.createElement("div");
+    element.setAttribute(WEEK_INTERACTION_EVENT_ID_ATTRIBUTE, EVENT_ID);
+    element.tabIndex = 0;
+    document.body.appendChild(element);
+    return element;
+  };
+
+  const flushFrame = () => {
+    const frames = pendingFrames.splice(0);
+    frames.forEach((frame) => frame(performance.now()));
+  };
+
+  beforeEach(() => {
+    pendingFrames = [];
+    originalRequestAnimationFrame = globalThis.requestAnimationFrame;
+    globalThis.requestAnimationFrame = ((frame: FrameRequestCallback) =>
+      pendingFrames.push(frame)) as typeof requestAnimationFrame;
+  });
+
+  afterEach(() => {
+    globalThis.requestAnimationFrame = originalRequestAnimationFrame;
+    document.body.innerHTML = "";
+  });
+
+  it("focuses the event element when it already exists", () => {
+    const element = addEventElement();
+
+    focusCalendarEventElement(EVENT_ID);
+
+    expect(document.activeElement).toBe(element);
+    expect(pendingFrames).toHaveLength(0);
+  });
+
+  it("retries until the event element appears", () => {
+    focusCalendarEventElement(EVENT_ID);
+    flushFrame();
+
+    expect(document.activeElement).not.toBeInstanceOf(HTMLDivElement);
+
+    const element = addEventElement();
+    flushFrame();
+
+    expect(document.activeElement).toBe(element);
   });
 });
 

--- a/packages/web/src/common/utils/event/event.util.test.ts
+++ b/packages/web/src/common/utils/event/event.util.test.ts
@@ -8,6 +8,7 @@ import { type GridEvent } from "@web/common/types/web.event.types";
 import {
   addId,
   focusCalendarEventElement,
+  focusCalendarEventElementAfterDiscard,
   isEventInRange,
   refocusEventElement,
 } from "@web/common/utils/event/event.util";
@@ -256,6 +257,64 @@ describe("focusCalendarEventElement", () => {
     flushFrame();
 
     expect(document.activeElement).toBe(element);
+  });
+});
+
+describe("focusCalendarEventElementAfterDiscard", () => {
+  const EVENT_ID = "507f1f77bcf86cd799439011";
+  let pendingFrames: FrameRequestCallback[];
+  let originalRequestAnimationFrame: typeof requestAnimationFrame;
+
+  const addEventElement = () => {
+    const element = document.createElement("div");
+    element.setAttribute(WEEK_INTERACTION_EVENT_ID_ATTRIBUTE, EVENT_ID);
+    element.tabIndex = 0;
+    document.body.appendChild(element);
+    return element;
+  };
+
+  const flushFrame = () => {
+    const frames = pendingFrames.splice(0);
+    frames.forEach((frame) => frame(performance.now()));
+  };
+
+  beforeEach(() => {
+    pendingFrames = [];
+    originalRequestAnimationFrame = globalThis.requestAnimationFrame;
+    globalThis.requestAnimationFrame = ((frame: FrameRequestCallback) =>
+      pendingFrames.push(frame)) as typeof requestAnimationFrame;
+  });
+
+  afterEach(() => {
+    globalThis.requestAnimationFrame = originalRequestAnimationFrame;
+    document.body.innerHTML = "";
+  });
+
+  it("skips a draft portal and focuses the saved card", () => {
+    const draftPortal = addEventElement();
+    draftPortal.setAttribute("data-grid-event-surface", "draft");
+    const savedCard = addEventElement();
+
+    focusCalendarEventElementAfterDiscard(EVENT_ID);
+    flushFrame();
+
+    expect(document.activeElement).toBe(savedCard);
+  });
+
+  it("waits for a remounted card when only a draft portal is present", () => {
+    const draftPortal = addEventElement();
+    draftPortal.setAttribute("data-grid-event-surface", "draft");
+
+    focusCalendarEventElementAfterDiscard(EVENT_ID);
+    flushFrame();
+
+    expect(document.activeElement).not.toBe(draftPortal);
+
+    draftPortal.remove();
+    const savedCard = addEventElement();
+    flushFrame();
+
+    expect(document.activeElement).toBe(savedCard);
   });
 });
 

--- a/packages/web/src/common/utils/event/event.util.ts
+++ b/packages/web/src/common/utils/event/event.util.ts
@@ -145,6 +145,33 @@ export const focusCalendarEventElement = (eventId: string) => {
   tryFocus();
 };
 
+const isGridDraftEventSurface = (element: HTMLElement) =>
+  element.getAttribute("data-grid-event-surface") === "draft";
+
+/**
+ * Focuses the grid event after the form draft is discarded. Skips `GridDraft`
+ * portal nodes (same interaction id, unmounts on the next commit) and retries
+ * across animation frames until a saved/placeholder card is available.
+ */
+export const focusCalendarEventElementAfterDiscard = (eventId: string) => {
+  const selector = calendarEventIdValueSelector(eventId);
+  let attempts = 0;
+
+  const tryFocus = () => {
+    attempts += 1;
+    const element = [...document.querySelectorAll<HTMLElement>(selector)].find(
+      (candidate) => !isGridDraftEventSurface(candidate),
+    );
+    if (element) {
+      element.focus();
+      return;
+    }
+    if (attempts < 30) requestAnimationFrame(tryFocus);
+  };
+
+  requestAnimationFrame(tryFocus);
+};
+
 /**
  * Refocuses an event's element after React replaces it. Retries across
  * animation frames until the new element appears, then focuses it.

--- a/packages/web/src/common/utils/event/event.util.ts
+++ b/packages/web/src/common/utils/event/event.util.ts
@@ -124,6 +124,28 @@ export const getCalendarEventIdFromElement = (element: HTMLElement) =>
   readCalendarEventIdFromElement(element);
 
 /**
+ * Focuses a calendar event's DOM node as soon as it exists. Retries across
+ * animation frames when the card is not mounted yet (e.g. after form close or
+ * undo restore). Unlike `refocusEventElement`, this focuses an in-place node
+ * and does not wait for React to replace it.
+ */
+export const focusCalendarEventElement = (eventId: string) => {
+  const selector = calendarEventIdValueSelector(eventId);
+  let attempts = 0;
+
+  const tryFocus = () => {
+    const element = document.querySelector<HTMLElement>(selector);
+    if (element) {
+      element.focus();
+      return;
+    }
+    if (++attempts < 30) requestAnimationFrame(tryFocus);
+  };
+
+  tryFocus();
+};
+
+/**
  * Refocuses an event's element after React replaces it. Retries across
  * animation frames until the new element appears, then focuses it.
  */

--- a/packages/web/src/events/mutations/useUndoRedo.ts
+++ b/packages/web/src/events/mutations/useUndoRedo.ts
@@ -3,6 +3,7 @@ import { useCallback } from "react";
 import { type EventId } from "@core/types/domain-primitives";
 import { type Event } from "@core/types/event.contracts";
 import { UNDO_DECLINED_TOAST_ID } from "@web/common/constants/toast.constants";
+import { focusCalendarEventElement } from "@web/common/utils/event/event.util";
 import {
   showRestoredToast,
   showRestoreFailedToast,
@@ -33,7 +34,6 @@ import {
   undoHistoryActions,
   useUndoHistoryStore,
 } from "@web/events/stores/undo.store";
-import { calendarEventIdValueSelector } from "@web/grid/interaction/view-event-registry";
 
 const isCreateEntry = (
   entry: UndoHistoryEntry,
@@ -48,26 +48,10 @@ const isDeleteEntry = (
 const entryEventId = (entry: UndoHistoryEntry): string =>
   isDeleteEntry(entry) || isCreateEntry(entry) ? entry.event.id : entry.id;
 
-// Not `refocusEventElement`: that helper waits for the DOM node to be
-// *replaced*, but an edit replay updates the node in place (same React key),
-// so it would never fire. Here we just focus the event's element as soon as
-// it exists — synchronously for edit replays (the node survives the
-// re-render), with a short rAF retry loop for delete-undo, where the element
-// reappears a frame or two after the optimistic insert.
-const refocusAfterReplay = (eventId: string) => {
-  let attempts = 0;
-  const tryFocus = () => {
-    const element = document.querySelector<HTMLElement>(
-      calendarEventIdValueSelector(eventId),
-    );
-    if (element) {
-      element.focus();
-      return;
-    }
-    if (++attempts < 30) requestAnimationFrame(tryFocus);
-  };
-  tryFocus();
-};
+// Edit replays keep the same React key (in-place update); delete-undo may
+// need a frame or two for the card to remount. `focusCalendarEventElement`
+// covers both — unlike `refocusEventElement`, which waits for a replaced node.
+const refocusAfterReplay = focusCalendarEventElement;
 
 const showUndoDeclinedToast = () =>
   showStatusToast(UNDO_DECLINED_TOAST_ID, "Can't undo — event changed since");

--- a/packages/web/src/events/mutations/useUndoRedo.ts
+++ b/packages/web/src/events/mutations/useUndoRedo.ts
@@ -51,7 +51,6 @@ const entryEventId = (entry: UndoHistoryEntry): string =>
 // Edit replays keep the same React key (in-place update); delete-undo may
 // need a frame or two for the card to remount. `focusCalendarEventElement`
 // covers both — unlike `refocusEventElement`, which waits for a replaced node.
-const refocusAfterReplay = focusCalendarEventElement;
 
 const showUndoDeclinedToast = () =>
   showStatusToast(UNDO_DECLINED_TOAST_ID, "Can't undo — event changed since");
@@ -258,7 +257,7 @@ export function useUndoRedo(dependencies: EventMutationDependencies = {}) {
         replaySnapshot(entry.id as EventId, entry.before);
       }
     });
-    if (!isCreateEntry(entry)) refocusAfterReplay(entryEventId(entry));
+    if (!isCreateEntry(entry)) focusCalendarEventElement(entryEventId(entry));
   }, [queryClient, source, undoDelete, undoCreate, replaySnapshot]);
 
   const redo = useCallback(() => {
@@ -300,9 +299,9 @@ export function useUndoRedo(dependencies: EventMutationDependencies = {}) {
       }
     });
     if (isCreateEntry(entry)) {
-      refocusAfterReplay(entry.event.id);
+      focusCalendarEventElement(entry.event.id);
     } else if (!isDeleteEntry(entry)) {
-      refocusAfterReplay(entry.id);
+      focusCalendarEventElement(entry.id);
     }
   }, [queryClient, source, mutations, replaySnapshot]);
 

--- a/packages/web/src/views/Forms/hooks/useCloseEventForm.test.ts
+++ b/packages/web/src/views/Forms/hooks/useCloseEventForm.test.ts
@@ -1,6 +1,5 @@
 import { renderHook } from "@testing-library/react";
 import { EventIdSchema } from "@core/types/domain-primitives";
-import { EventScheduleSchema } from "@core/types/event.contracts";
 import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
 import {
   createGridEventDraft,
@@ -14,11 +13,27 @@ import {
 } from "@web/events/stores/draft.store";
 import { WEEK_INTERACTION_EVENT_ID_ATTRIBUTE } from "@web/views/Week/interaction/registry/week-event.registry";
 import { useCloseEventForm } from "./useCloseEventForm";
-import { afterEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 
 const EXISTING_EVENT_ID = "507f1f77bcf86cd799439011";
 
+let pendingFrames: FrameRequestCallback[];
+let originalRequestAnimationFrame: typeof requestAnimationFrame;
+
+const flushFrame = () => {
+  const frames = pendingFrames.splice(0);
+  frames.forEach((frame) => frame(performance.now()));
+};
+
+beforeEach(() => {
+  pendingFrames = [];
+  originalRequestAnimationFrame = globalThis.requestAnimationFrame;
+  globalThis.requestAnimationFrame = ((frame: FrameRequestCallback) =>
+    pendingFrames.push(frame)) as typeof requestAnimationFrame;
+});
+
 afterEach(() => {
+  globalThis.requestAnimationFrame = originalRequestAnimationFrame;
   draftActions.discard();
   document.body.innerHTML = "";
 });
@@ -44,21 +59,9 @@ describe("useCloseEventForm", () => {
   });
 
   it("restores focus to the grid event for the closed draft", () => {
-    const existingEvent = createMockEvent({
-      id: EventIdSchema.parse(EXISTING_EVENT_ID),
-      content: {
-        kind: "details",
-        title: "Focus me",
-        description: "",
-      },
-      schedule: EventScheduleSchema.parse({
-        kind: "timed",
-        start: "2026-05-20T14:00:00.000Z",
-        end: "2026-05-20T15:00:00.000Z",
-        timeZone: "UTC",
-      }),
-    });
-    const draft = editGridEventDraft(existingEvent);
+    const draft = editGridEventDraft(
+      createMockEvent({ id: EventIdSchema.parse(EXISTING_EVENT_ID) }),
+    );
     if (!draft) throw new Error("expected an edit draft");
 
     const card = document.createElement("button");
@@ -71,8 +74,45 @@ describe("useCloseEventForm", () => {
 
     const { result } = renderHook(() => useCloseEventForm());
     result.current();
+    flushFrame();
 
     expect(useDraftStore.getState()).toEqual(initialDraftState);
     expect(document.activeElement).toBe(card);
+  });
+
+  it("does not leave focus on a draft portal that unmounts after discard", () => {
+    const draft = editGridEventDraft(
+      createMockEvent({ id: EventIdSchema.parse(EXISTING_EVENT_ID) }),
+    );
+    if (!draft) throw new Error("expected an edit draft");
+
+    const draftPortal = document.createElement("button");
+    draftPortal.setAttribute(
+      WEEK_INTERACTION_EVENT_ID_ATTRIBUTE,
+      EXISTING_EVENT_ID,
+    );
+    draftPortal.setAttribute("data-grid-event-surface", "draft");
+    draftPortal.tabIndex = 0;
+    document.body.appendChild(draftPortal);
+
+    draftActions.startGridDraft({ activity: "keyboardEdit", draft });
+    draftActions.setFormOpen(true);
+
+    const { result } = renderHook(() => useCloseEventForm());
+    result.current();
+
+    // Simulate React committing: draft portal gone, saved card remounted.
+    draftPortal.remove();
+    const savedCard = document.createElement("button");
+    savedCard.setAttribute(
+      WEEK_INTERACTION_EVENT_ID_ATTRIBUTE,
+      EXISTING_EVENT_ID,
+    );
+    savedCard.tabIndex = 0;
+    document.body.appendChild(savedCard);
+
+    flushFrame();
+
+    expect(document.activeElement).toBe(savedCard);
   });
 });

--- a/packages/web/src/views/Forms/hooks/useCloseEventForm.test.ts
+++ b/packages/web/src/views/Forms/hooks/useCloseEventForm.test.ts
@@ -1,6 +1,10 @@
 import { renderHook } from "@testing-library/react";
+import { EventIdSchema } from "@core/types/domain-primitives";
+import { EventScheduleSchema } from "@core/types/event.contracts";
+import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
 import {
   createGridEventDraft,
+  editGridEventDraft,
   timedGridSchedule,
 } from "@web/events/grid-event-draft.adapter";
 import {
@@ -8,8 +12,16 @@ import {
   initialDraftState,
   useDraftStore,
 } from "@web/events/stores/draft.store";
+import { WEEK_INTERACTION_EVENT_ID_ATTRIBUTE } from "@web/views/Week/interaction/registry/week-event.registry";
 import { useCloseEventForm } from "./useCloseEventForm";
-import { describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it } from "bun:test";
+
+const EXISTING_EVENT_ID = "507f1f77bcf86cd799439011";
+
+afterEach(() => {
+  draftActions.discard();
+  document.body.innerHTML = "";
+});
 
 describe("useCloseEventForm", () => {
   it("should discard the draft (which closes the form)", () => {
@@ -29,5 +41,38 @@ describe("useCloseEventForm", () => {
     result.current();
 
     expect(useDraftStore.getState()).toEqual(initialDraftState);
+  });
+
+  it("restores focus to the grid event for the closed draft", () => {
+    const existingEvent = createMockEvent({
+      id: EventIdSchema.parse(EXISTING_EVENT_ID),
+      content: {
+        kind: "details",
+        title: "Focus me",
+        description: "",
+      },
+      schedule: EventScheduleSchema.parse({
+        kind: "timed",
+        start: "2026-05-20T14:00:00.000Z",
+        end: "2026-05-20T15:00:00.000Z",
+        timeZone: "UTC",
+      }),
+    });
+    const draft = editGridEventDraft(existingEvent);
+    if (!draft) throw new Error("expected an edit draft");
+
+    const card = document.createElement("button");
+    card.setAttribute(WEEK_INTERACTION_EVENT_ID_ATTRIBUTE, EXISTING_EVENT_ID);
+    card.tabIndex = 0;
+    document.body.appendChild(card);
+
+    draftActions.startGridDraft({ activity: "keyboardEdit", draft });
+    draftActions.setFormOpen(true);
+
+    const { result } = renderHook(() => useCloseEventForm());
+    result.current();
+
+    expect(useDraftStore.getState()).toEqual(initialDraftState);
+    expect(document.activeElement).toBe(card);
   });
 });

--- a/packages/web/src/views/Forms/hooks/useCloseEventForm.ts
+++ b/packages/web/src/views/Forms/hooks/useCloseEventForm.ts
@@ -1,8 +1,17 @@
 import { useCallback } from "react";
-import { draftActions } from "@web/events/stores/draft.store";
+import { focusCalendarEventElement } from "@web/common/utils/event/event.util";
+import {
+  draftActions,
+  selectDraftId,
+  useDraftStore,
+} from "@web/events/stores/draft.store";
 
 export function useCloseEventForm() {
   return useCallback(() => {
+    const eventId = selectDraftId(useDraftStore.getState());
     draftActions.discard();
+    if (eventId) {
+      focusCalendarEventElement(eventId);
+    }
   }, []);
 }

--- a/packages/web/src/views/Forms/hooks/useCloseEventForm.ts
+++ b/packages/web/src/views/Forms/hooks/useCloseEventForm.ts
@@ -1,5 +1,5 @@
 import { useCallback } from "react";
-import { focusCalendarEventElement } from "@web/common/utils/event/event.util";
+import { focusCalendarEventElementAfterDiscard } from "@web/common/utils/event/event.util";
 import {
   draftActions,
   selectDraftId,
@@ -11,7 +11,7 @@ export function useCloseEventForm() {
     const eventId = selectDraftId(useDraftStore.getState());
     draftActions.discard();
     if (eventId) {
-      focusCalendarEventElement(eventId);
+      focusCalendarEventElementAfterDiscard(eventId);
     }
   }, []);
 }

--- a/packages/web/src/views/Week/components/Draft/grid/GridDraft.tsx
+++ b/packages/web/src/views/Week/components/Draft/grid/GridDraft.tsx
@@ -95,11 +95,16 @@ export const GridDraft: FC<Props> = ({
     : draftAsGridEvent;
 
   const draftEventType = rendersInAllDayRow ? "all-day" : "timed";
+  // `data-grid-event-surface` lets post-close focus restore skip this portal
+  // node — it shares the saved event's interaction id but unmounts on discard.
   const draftInteractionAttributes = draftAsGridEvent._id
-    ? getWeekInteractionTargetAttributes({
-        eventId: draftAsGridEvent._id,
-        eventType: draftEventType,
-      })
+    ? {
+        ...getWeekInteractionTargetAttributes({
+          eventId: draftAsGridEvent._id,
+          eventType: draftEventType,
+        }),
+        "data-grid-event-surface": "draft",
+      }
     : undefined;
 
   return (

--- a/packages/web/src/views/Week/components/Grid/MainGrid/keyboardEditForm.test.tsx
+++ b/packages/web/src/views/Week/components/Grid/MainGrid/keyboardEditForm.test.tsx
@@ -168,4 +168,45 @@ describe("Enter on a focused grid event", () => {
 
     expect(await screen.findByDisplayValue("Quarterly review")).toBeVisible();
   });
+
+  it("returns focus to the grid event after the form closes", async () => {
+    seededEvents = [
+      createMockEvent({
+        calendarId: writableCalendar.id,
+        content: {
+          kind: "details",
+          title: "Quarterly review",
+          description: "",
+        },
+        schedule: EventScheduleSchema.parse({
+          kind: "timed",
+          start: "2024-01-15T09:00:00.000Z",
+          end: "2024-01-15T10:00:00.000Z",
+          timeZone: "UTC",
+        }),
+      }),
+    ];
+
+    render(
+      <Harness>
+        <GridWithSidebar />
+      </Harness>,
+    );
+
+    const card = screen.getByRole("button", { name: /quarterly review/i });
+    await act(async () => {
+      card.focus();
+      fireEvent.keyDown(card, { key: "Enter" });
+    });
+
+    const titleField = await screen.findByDisplayValue("Quarterly review");
+    expect(titleField).toHaveFocus();
+
+    await act(async () => {
+      fireEvent.keyDown(titleField, { key: "Escape" });
+    });
+
+    expect(screen.queryByDisplayValue("Quarterly review")).toBeNull();
+    expect(document.activeElement).toBe(card);
+  });
 });

--- a/packages/web/src/views/Week/components/Grid/MainGrid/keyboardEditForm.test.tsx
+++ b/packages/web/src/views/Week/components/Grid/MainGrid/keyboardEditForm.test.tsx
@@ -13,6 +13,7 @@ import {
   fireEvent,
   render,
   screen,
+  waitFor,
 } from "@web/__tests__/__mocks__/mock.render";
 import { seedEventQueries } from "@web/__tests__/utils/event-query-test-data";
 import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
@@ -207,6 +208,8 @@ describe("Enter on a focused grid event", () => {
     });
 
     expect(screen.queryByDisplayValue("Quarterly review")).toBeNull();
-    expect(document.activeElement).toBe(card);
+    await waitFor(() => {
+      expect(document.activeElement).toBe(card);
+    });
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

After saving or discarding the event form, keyboard focus returns to the same grid event so arrow/Enter navigation continues from where the user left off.

Close goes through `useCloseEventForm`, which captures the draft event id, discards, then focuses via `focusCalendarEventElementAfterDiscard`. That helper skips `GridDraft` portal nodes (marked `data-grid-event-surface="draft"`) that share the saved event id but unmount on discard, and retries until a saved/placeholder card is available.

## Simplicity

Extracted shared `focusCalendarEventElement` for undo/redo (in-place focus). Form close uses a separate after-discard helper so we do not treat the draft portal as a successful restore. No extra React state or effects.

## Automated validation

- Browser at http://localhost:9080 (anonymous): focus event → Enter → Escape → Enter reopens form (pass). Edit title → Ctrl+Enter → Enter reopens (pass). No focus-related console errors.
- Focused web tests: `event.util.test.ts`, `useCloseEventForm.test.ts`, `keyboardEditForm.test.tsx`, `GridDraft.test.tsx`, `useUndoRedo.test.tsx` — all pass.
- `bun lint` — pass (pre-existing unrelated warnings only).

## Independent review

Fresh review found a major GridDraft portal race on the first revision; fixed by marking draft surfaces and skipping them in after-discard restore. Re-review: clear to ship after this commit. No remaining blockers.

## Test plan

- `bun test:web -- packages/web/src/common/utils/event/event.util.test.ts packages/web/src/views/Forms/hooks/useCloseEventForm.test.ts packages/web/src/views/Week/components/Grid/MainGrid/keyboardEditForm.test.tsx packages/web/src/views/Week/components/Draft/grid/GridDraft.test.tsx packages/web/src/events/mutations/useUndoRedo.test.tsx`
- `bun lint`
- Browser keyboard Escape and Ctrl+Enter close paths on Week view

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ab5f5559-5e90-4126-b846-83d92efd3c84?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ab5f5559-5e90-4126-b846-83d92efd3c84&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

