### PR TITLE
feat(web): toggle day-prefix event jump with Shift

### DIFF
--- a/docs/acceptance/shortcuts.md
+++ b/docs/acceptance/shortcuts.md
@@ -54,7 +54,7 @@ Helpful notes:
 | `T`                         | Day view  | Go to today                       |
 | `I`                         | Day view  | Focus sidebar                     |
 | `U`                         | Day view  | Focus first calendar event        |
-| Hold `Shift`                | Day view  | Show event jump keys on visible events |
+| `Shift`                     | Day view  | Toggle event jump keys                 |
 | `C`                         | Day view  | Create timed event                |
 | `A`                         | Day view  | Create all-day event              |
 | `Delete`                    | Day view  | Delete focused event              |
@@ -78,7 +78,7 @@ Helpful notes:
 | `A`                         | Week view | Create all-day event              |
 | `I`                         | Week view | Focus sidebar                     |
 | `U`                         | Week view | Focus first calendar event        |
-| Hold `Shift`                | Week view | Show event jump keys on visible events |
+| `Shift`                     | Week view | Toggle event jump keys                 |
 | `Delete`                    | Week view | Delete focused event              |
 | `ArrowUp` / `ArrowDown`     | Week view | Focus previous/next event         |
 | `Arrow keys`                | Week view | Move open draft event             |
@@ -327,26 +327,27 @@ After deleting or moving an event, pressing Cmd+Z (Mac) or Ctrl+Z (Windows/Linux
 
 ---
 
-## Scenario 12: Hold Shift To Jump Focus To A Visible Event
+## Scenario 12: Tap Shift To Jump Focus To An Event By Day Prefix
 
 ### UX
 
-Holding `Shift` for a short beat (~200ms) assigns home-row jump keys to viewport-visible Week/Day events and paints a keycap chip on each. Pressing an assigned key focuses that event and clears the chips. Releasing `Shift` clears them. Quick chords such as Shift+J or Shift+Arrow do not flash hints. `j`/`k` are never assigned as jump keys.
+Tapping `Shift` toggles event-jump mode. Week view chips use day prefixes (`SU`/`M`/`T`/`W`/`R`/`F`/`SA`) plus a per-day index (`W4`, `SU1`). Day view uses numeric chips (`1`, `2`, …). Pressing a day letter highlights that column and focuses its first event; a following digit focuses that index. `Esc` or another Shift tap exits. Quick chords such as Shift+J or Shift+Arrow do not toggle the mode. Shift-Shift still enters keyboard-only mode.
 
 ### Steps
 
-1. Navigate to `/week` with at least three timed events visible on the same day.
-2. Hold `Shift` for about a quarter second (do not tap quickly).
-3. Press the key shown on the middle event's chip (commonly `S` for the second event in chronological order).
-4. Repeat with a fast Shift+J chord and confirm no chips appear.
+1. Navigate to `/week` with timed events on at least two different days.
+2. Tap `Shift` once (do not hold for a chord).
+3. Press the day letter on a chip (for example `W` for Wednesday), then optionally a digit (`2`) or use arrow keys.
+4. Press `Esc` (or tap `Shift` again) to exit.
+5. Repeat with a fast Shift+J chord and confirm jump mode does not activate.
 
 ### Expected Results
 
-- Distinct chips appear on the visible events while Shift is held past the threshold.
-- The assigned key focuses that event; chips disappear.
-- Releasing Shift without pressing a jump key also clears chips.
-- Fast Shift+J / Shift+Arrow do not flash chips.
-- While a modal holds the app lock, or focus is in an editable field, holding Shift does nothing.
+- Chips appear on events after a Shift tap and stay until Esc / another Shift tap.
+- A day letter highlights that column and focuses the first event; digits refine to `Wn`.
+- Arrow keys keep jump mode on so letter-then-arrows works.
+- Fast Shift+J / Shift+Arrow do not toggle jump mode.
+- While a modal holds the app lock, or focus is in an editable field, Shift does not toggle jump mode.
 
 ---
 
@@ -390,4 +391,4 @@ If time is limited, run these checks before shipping shortcut-related changes:
 12. With a focused event and no draft open, ArrowUp/ArrowDown move focus to the previous/next event chronologically.
 13. Cmd+D / Ctrl+D duplicates a focused event in Day and Week view.
 14. With a focused event, `E` then `T` opens the form with the title focused; bare `E` alone does nothing.
-15. Holding Shift shows event jump chips; an assigned key focuses that event; fast Shift+J does not flash chips.
+15. Tapping Shift toggles event jump chips; a day letter + digit focuses that event; fast Shift+J does not toggle the mode.

--- a/docs/acceptance/shortcuts.md
+++ b/docs/acceptance/shortcuts.md
@@ -331,7 +331,7 @@ After deleting or moving an event, pressing Cmd+Z (Mac) or Ctrl+Z (Windows/Linux
 
 ### UX
 
-Tapping `Shift` toggles event-jump mode. Week view chips use day prefixes (`SU`/`M`/`T`/`W`/`R`/`F`/`SA`) plus a per-day index (`W4`, `SU1`). Day view uses numeric chips (`1`, `2`, …). Pressing a day letter highlights that column and focuses its first event; a following digit focuses that index. `Esc` or another Shift tap exits. Quick chords such as Shift+J or Shift+Arrow do not toggle the mode. Shift-Shift still enters keyboard-only mode.
+Tapping `Shift` toggles event-jump mode (activation waits briefly so Shift-Shift can still enter keyboard-only without a jump flash). Week view chips use day prefixes (`SU`/`M`/`T`/`W`/`R`/`F`/`SA`) plus a per-day index (`W4`, `SU1`). Day view uses numeric chips (`1`, `2`, …). Pressing a day letter highlights that column and focuses its first event; a following digit focuses that index. `Esc` or another Shift tap exits. Quick chords such as Shift+J or Shift+Arrow do not toggle the mode.
 
 ### Steps
 

--- a/e2e/timed/keyboard-only-mode.spec.ts
+++ b/e2e/timed/keyboard-only-mode.spec.ts
@@ -79,7 +79,7 @@ test("SHIFT-SHIFT exits keyboard-only mode and restores clicks", async ({
   await expect(page.getByLabel("Title")).toBeVisible();
 });
 
-test("hold Shift still flashes jump keys and does not enter keyboard-only mode", async ({
+test("hold Shift does not enter keyboard-only or event jump", async ({
   page,
 }) => {
   await prepareCalendarPage(page);
@@ -87,7 +87,7 @@ test("hold Shift still flashes jump keys and does not enter keyboard-only mode",
 
   await page.keyboard.down("Shift");
   await page.waitForTimeout(250);
-  await expect(page.locator("[data-shift-event-hints]")).toHaveCount(1);
+  await expect(page.locator("[data-shift-event-hints]")).toHaveCount(0);
   await expect(keyboardOnlyIndicator(page)).toHaveCount(0);
   await page.keyboard.up("Shift");
   await expect(page.locator("[data-shift-event-hints]")).toHaveCount(0);

--- a/e2e/timed/shift-hold-event-hints.spec.ts
+++ b/e2e/timed/shift-hold-event-hints.spec.ts
@@ -21,7 +21,12 @@ const createTimedEventAt = async (
 const shiftHintOverlay = (page: Parameters<typeof prepareCalendarPage>[0]) =>
   page.locator("[data-shift-event-hints]");
 
-test("hold Shift shows jump keys and focuses the assigned event", async ({
+const tapShift = async (page: Parameters<typeof prepareCalendarPage>[0]) => {
+  await page.keyboard.down("Shift");
+  await page.keyboard.up("Shift");
+};
+
+test("tap Shift shows day-prefix jump keys and focuses the assigned event", async ({
   page,
 }) => {
   await prepareCalendarPage(page);
@@ -30,7 +35,7 @@ test("hold Shift shows jump keys and focuses the assigned event", async ({
   const middleTitle = createEventTitle("Middle Flash");
   const lateTitle = createEventTitle("Late Flash");
 
-  // Same weekday column; earlier y ≈ earlier start for chronological hints.
+  // Wednesday column at xRatio 0.42; earlier y ≈ earlier start for indices.
   await createTimedEventAt(page, earlyTitle, { xRatio: 0.42, yRatio: 0.25 });
   await createTimedEventAt(page, middleTitle, { xRatio: 0.42, yRatio: 0.4 });
   await createTimedEventAt(page, lateTitle, { xRatio: 0.42, yRatio: 0.55 });
@@ -39,24 +44,28 @@ test("hold Shift shows jump keys and focuses the assigned event", async ({
     .locator("#mainGrid")
     .getByRole("button", { name: middleTitle });
 
-  await page.keyboard.down("Shift");
-  await page.waitForTimeout(250);
+  await tapShift(page);
 
   const overlay = shiftHintOverlay(page);
-  await expect(overlay.getByText("A", { exact: true })).toHaveCount(1);
-  await expect(overlay.getByText("S", { exact: true })).toHaveCount(1);
-  await expect(overlay.getByText("D", { exact: true })).toHaveCount(1);
+  await expect(overlay.getByText("W1", { exact: true })).toHaveCount(1);
+  await expect(overlay.getByText("W2", { exact: true })).toHaveCount(1);
+  await expect(overlay.getByText("W3", { exact: true })).toHaveCount(1);
 
-  await page.keyboard.down("s");
-  await page.keyboard.up("s");
+  await page.keyboard.down("w");
+  await page.keyboard.up("w");
+  await page.keyboard.down("2");
+  await page.keyboard.up("2");
 
   await expect(middleButton).toBeFocused();
-  await expect(shiftHintOverlay(page)).toHaveCount(0);
+  // Mode stays on after a digit focus so another index can be typed.
+  await expect(shiftHintOverlay(page)).toHaveCount(1);
 
-  await page.keyboard.up("Shift");
+  await page.keyboard.down("Escape");
+  await page.keyboard.up("Escape");
+  await expect(shiftHintOverlay(page)).toHaveCount(0);
 });
 
-test("fast Shift+J does not flash event jump keys", async ({ page }) => {
+test("fast Shift+J does not toggle event jump keys", async ({ page }) => {
   await prepareCalendarPage(page);
 
   const title = createEventTitle("Chord Quiet");

--- a/e2e/timed/shift-hold-event-hints.spec.ts
+++ b/e2e/timed/shift-hold-event-hints.spec.ts
@@ -7,8 +7,20 @@ import {
   prepareCalendarPage,
 } from "../utils/event-test-utils";
 
+type CalendarPage = Parameters<typeof prepareCalendarPage>[0];
+
+const DAY_PREFIX_KEYS: Record<string, string[]> = {
+  SU: ["s", "u"],
+  M: ["m"],
+  T: ["t"],
+  W: ["w"],
+  R: ["r"],
+  F: ["f"],
+  SA: ["s", "a"],
+};
+
 const createTimedEventAt = async (
-  page: Parameters<typeof prepareCalendarPage>[0],
+  page: CalendarPage,
   title: string,
   { xRatio, yRatio }: { xRatio: number; yRatio: number },
 ) => {
@@ -18,10 +30,10 @@ const createTimedEventAt = async (
   await expectTimedEventVisible(page, title);
 };
 
-const shiftHintOverlay = (page: Parameters<typeof prepareCalendarPage>[0]) =>
+const shiftHintOverlay = (page: CalendarPage) =>
   page.locator("[data-shift-event-hints]");
 
-const tapShift = async (page: Parameters<typeof prepareCalendarPage>[0]) => {
+const tapShift = async (page: CalendarPage) => {
   await page.keyboard.down("Shift");
   await page.keyboard.up("Shift");
 };
@@ -35,7 +47,7 @@ test("tap Shift shows day-prefix jump keys and focuses the assigned event", asyn
   const middleTitle = createEventTitle("Middle Flash");
   const lateTitle = createEventTitle("Late Flash");
 
-  // Wednesday column at xRatio 0.42; earlier y ≈ earlier start for indices.
+  // Same timed column; earlier y ≈ earlier start for chronological indices.
   await createTimedEventAt(page, earlyTitle, { xRatio: 0.42, yRatio: 0.25 });
   await createTimedEventAt(page, middleTitle, { xRatio: 0.42, yRatio: 0.4 });
   await createTimedEventAt(page, lateTitle, { xRatio: 0.42, yRatio: 0.55 });
@@ -44,15 +56,31 @@ test("tap Shift shows day-prefix jump keys and focuses the assigned event", asyn
     .locator("#mainGrid")
     .getByRole("button", { name: middleTitle });
 
+  await page.evaluate(() => {
+    if (document.activeElement instanceof HTMLElement) {
+      document.activeElement.blur();
+    }
+  });
   await tapShift(page);
 
   const overlay = shiftHintOverlay(page);
-  await expect(overlay.getByText("W1", { exact: true })).toHaveCount(1);
-  await expect(overlay.getByText("W2", { exact: true })).toHaveCount(1);
-  await expect(overlay.getByText("W3", { exact: true })).toHaveCount(1);
+  await expect(overlay.locator(":scope > span")).toHaveCount(3);
 
-  await page.keyboard.down("w");
-  await page.keyboard.up("w");
+  const labels = await overlay.evaluate((root) =>
+    [...root.querySelectorAll(":scope > span")].map(
+      (node) => node.textContent?.trim() ?? "",
+    ),
+  );
+  const dayPrefix = labels[0]?.replace(/\d+$/, "") ?? "";
+  expect(DAY_PREFIX_KEYS[dayPrefix]).toBeTruthy();
+  expect([...labels].sort()).toEqual(
+    [`${dayPrefix}1`, `${dayPrefix}2`, `${dayPrefix}3`].sort(),
+  );
+
+  for (const key of DAY_PREFIX_KEYS[dayPrefix] ?? []) {
+    await page.keyboard.down(key);
+    await page.keyboard.up(key);
+  }
   await page.keyboard.down("2");
   await page.keyboard.up("2");
 

--- a/packages/web/src/components/Sidebar/SidebarStatusBar.tsx
+++ b/packages/web/src/components/Sidebar/SidebarStatusBar.tsx
@@ -10,6 +10,11 @@ import {
   selectKeyboardOnlyActive,
   useKeyboardOnlyStore,
 } from "@web/shortcuts/keyboard-only/keyboard-only.store";
+import { EventJumpIndicator } from "@web/shortcuts/shift-hint/EventJumpIndicator";
+import {
+  selectEventJumpActive,
+  useEventJumpStore,
+} from "@web/shortcuts/shift-hint/event-jump.store";
 
 /**
  * Pinned status bar at the bottom of the sidebar, just above the actions bar.
@@ -24,6 +29,7 @@ import {
  */
 export const SidebarStatusBar: FC = () => {
   const isKeyboardOnly = useKeyboardOnlyStore(selectKeyboardOnlyActive);
+  const isEventJump = useEventJumpStore(selectEventJumpActive);
   const isSaving = useHasPendingEventMutations();
   // The unscoped hook's `connection` is the primary connection (the one
   // whose own state matches the aggregate) - without it, an account's
@@ -50,6 +56,10 @@ export const SidebarStatusBar: FC = () => {
       {isKeyboardOnly ? (
         <div className="flex h-full min-w-0 flex-1 items-center">
           <KeyboardOnlyIndicator />
+        </div>
+      ) : isEventJump ? (
+        <div className="flex h-full min-w-0 flex-1 items-center">
+          <EventJumpIndicator />
         </div>
       ) : (
         <button

--- a/packages/web/src/components/Sidebar/SidebarStatusBar.tsx
+++ b/packages/web/src/components/Sidebar/SidebarStatusBar.tsx
@@ -13,6 +13,7 @@ import {
 import { EventJumpIndicator } from "@web/shortcuts/shift-hint/EventJumpIndicator";
 import {
   selectEventJumpActive,
+  selectEventJumpAnnouncement,
   useEventJumpStore,
 } from "@web/shortcuts/shift-hint/event-jump.store";
 
@@ -30,6 +31,8 @@ import {
 export const SidebarStatusBar: FC = () => {
   const isKeyboardOnly = useKeyboardOnlyStore(selectKeyboardOnlyActive);
   const isEventJump = useEventJumpStore(selectEventJumpActive);
+  const eventJumpAnnouncement = useEventJumpStore(selectEventJumpAnnouncement);
+  const showEventJump = isEventJump || Boolean(eventJumpAnnouncement);
   const isSaving = useHasPendingEventMutations();
   // The unscoped hook's `connection` is the primary connection (the one
   // whose own state matches the aggregate) - without it, an account's
@@ -57,7 +60,7 @@ export const SidebarStatusBar: FC = () => {
         <div className="flex h-full min-w-0 flex-1 items-center">
           <KeyboardOnlyIndicator />
         </div>
-      ) : isEventJump ? (
+      ) : showEventJump ? (
         <div className="flex h-full min-w-0 flex-1 items-center">
           <EventJumpIndicator />
         </div>

--- a/packages/web/src/grid/components/AllDayGridRow.tsx
+++ b/packages/web/src/grid/components/AllDayGridRow.tsx
@@ -4,6 +4,7 @@ import {
   type ReactNode,
   type RefCallback,
 } from "react";
+import { YEAR_MONTH_DAY_FORMAT } from "@core/constants/date.constants";
 import {
   ID_ALLDAY_COLUMNS,
   ID_GRID_ALLDAY_ROW,
@@ -18,6 +19,10 @@ import {
   GRID_TIME_STEP,
 } from "@web/grid/grid.constants";
 import { type GridVisibleDate } from "@web/grid/types/grid.types";
+import {
+  selectEventJumpActiveDayKeys,
+  useEventJumpStore,
+} from "@web/shortcuts/shift-hint/event-jump.store";
 
 interface AllDayRowProps {
   allDayColumnsRef: RefCallback<HTMLDivElement>;
@@ -56,45 +61,56 @@ export const AllDayGridRow: FC<AllDayRowProps> = ({
   rowsCount = 0,
   rowId = ID_GRID_ALLDAY_ROW,
   visibleDates,
-}) => (
-  <section
-    className="relative flex w-full shrink-0 items-start bg-background"
-    aria-label="All-day events"
-    id={rowId}
-    ref={allDayRowRef}
-    onMouseDown={onMouseDown}
-    style={{
-      height: `calc(${getAllDayRowHeight(gridOffsetTopPx)} * 2 + ${rowsCount * 2 || 1} * ${getAllDayRowHeight(gridOffsetTopPx)})`,
-      minHeight: `${getAllDayRowMinHeightPx(rowsCount)}px`,
-    }}
-  >
-    <div
-      className="absolute top-0 left-[var(--calendar-grid-margin-left)] grid h-full w-[calc(100%_-_var(--calendar-grid-margin-left))] grid-cols-[repeat(var(--calendar-column-count),minmax(var(--calendar-column-min-width),1fr))] before:pointer-events-none before:absolute before:inset-x-0 before:bottom-0 before:h-0.5 before:bg-border before:content-['']"
-      id={columnsId}
-      ref={allDayColumnsRef}
-      style={
-        {
-          "--calendar-column-count": visibleDates.length,
-          "--calendar-column-min-width": `${EVENT_WIDTH_MINIMUM}px`,
-          "--calendar-grid-margin-left": `${GRID_MARGIN_LEFT}px`,
-        } as CSSVariables
-      }
+}) => {
+  const activeDayKeys = useEventJumpStore(selectEventJumpActiveDayKeys);
+
+  return (
+    <section
+      className="relative flex w-full shrink-0 items-start bg-background"
+      aria-label="All-day events"
+      id={rowId}
+      ref={allDayRowRef}
+      onMouseDown={onMouseDown}
+      style={{
+        height: `calc(${getAllDayRowHeight(gridOffsetTopPx)} * 2 + ${rowsCount * 2 || 1} * ${getAllDayRowHeight(gridOffsetTopPx)})`,
+        minHeight: `${getAllDayRowMinHeightPx(rowsCount)}px`,
+      }}
     >
-      <table className="contents">
-        <thead className="contents">
-          <tr className="contents">
-            {visibleDates.map(({ date, key, surfaceLabel }) => (
-              <th
-                className="relative box-border block h-full min-w-[var(--calendar-column-min-width)] border-border border-l"
-                aria-label={surfaceLabel ?? date.format("dddd, MMMM D, YYYY")}
-                key={key}
-                scope="col"
-              />
-            ))}
-          </tr>
-        </thead>
-      </table>
-    </div>
-    {eventsLayer}
-  </section>
-);
+      <div
+        className="absolute top-0 left-[var(--calendar-grid-margin-left)] grid h-full w-[calc(100%_-_var(--calendar-grid-margin-left))] grid-cols-[repeat(var(--calendar-column-count),minmax(var(--calendar-column-min-width),1fr))] before:pointer-events-none before:absolute before:inset-x-0 before:bottom-0 before:h-0.5 before:bg-border before:content-['']"
+        id={columnsId}
+        ref={allDayColumnsRef}
+        style={
+          {
+            "--calendar-column-count": visibleDates.length,
+            "--calendar-column-min-width": `${EVENT_WIDTH_MINIMUM}px`,
+            "--calendar-grid-margin-left": `${GRID_MARGIN_LEFT}px`,
+          } as CSSVariables
+        }
+      >
+        <table className="contents">
+          <thead className="contents">
+            <tr className="contents">
+              {visibleDates.map(({ date, key, surfaceLabel }) => {
+                const dayKey = date.format(YEAR_MONTH_DAY_FORMAT);
+                const isJumpDay = activeDayKeys.includes(dayKey);
+                return (
+                  <th
+                    className="relative box-border block h-full min-w-[var(--calendar-column-min-width)] border-border border-l transition-colors duration-150 data-[jump-day=true]:bg-accent/10 motion-reduce:transition-none"
+                    data-jump-day={isJumpDay ? "true" : undefined}
+                    aria-label={
+                      surfaceLabel ?? date.format("dddd, MMMM D, YYYY")
+                    }
+                    key={key}
+                    scope="col"
+                  />
+                );
+              })}
+            </tr>
+          </thead>
+        </table>
+      </div>
+      {eventsLayer}
+    </section>
+  );
+};

--- a/packages/web/src/grid/components/TimedGrid.tsx
+++ b/packages/web/src/grid/components/TimedGrid.tsx
@@ -5,6 +5,7 @@ import {
   type RefCallback,
   useMemo,
 } from "react";
+import { YEAR_MONTH_DAY_FORMAT } from "@core/constants/date.constants";
 import { type Dayjs } from "@core/util/date/dayjs";
 import {
   DATA_TIMED_GRID_ROW,
@@ -27,6 +28,10 @@ import {
   TIMED_VISIBLE_HOURS,
 } from "@web/grid/grid.constants";
 import { type GridVisibleDate } from "@web/grid/types/grid.types";
+import {
+  selectEventJumpActiveDayKeys,
+  useEventJumpStore,
+} from "@web/shortcuts/shift-hint/event-jump.store";
 
 interface TimedGridProps {
   columnsId?: string;
@@ -49,6 +54,7 @@ export const TimedGrid: FC<TimedGridProps> = ({
   today,
   visibleDates,
 }) => {
+  const activeDayKeys = useEventJumpStore(selectEventJumpActiveDayKeys);
   const todayColumnIndexes = visibleDates.flatMap(({ date }, index) =>
     date.isSame(today, "day") ? [index] : [],
   );
@@ -87,15 +93,22 @@ export const TimedGrid: FC<TimedGridProps> = ({
         <table className="contents">
           <thead className="contents">
             <tr className="contents">
-              {visibleDates.map(({ date, key, surfaceLabel }) => (
-                <th
-                  className="relative box-border block h-full min-w-[var(--calendar-column-min-width)] border-border border-l data-[past=true]:bg-surface"
-                  data-past={date.isBefore(today, "day")}
-                  aria-label={surfaceLabel ?? date.format("dddd, MMMM D, YYYY")}
-                  key={key}
-                  scope="col"
-                />
-              ))}
+              {visibleDates.map(({ date, key, surfaceLabel }) => {
+                const dayKey = date.format(YEAR_MONTH_DAY_FORMAT);
+                const isJumpDay = activeDayKeys.includes(dayKey);
+                return (
+                  <th
+                    className="relative box-border block h-full min-w-[var(--calendar-column-min-width)] border-border border-l transition-colors duration-150 data-[past=true]:data-[jump-day=true]:bg-accent/10 data-[jump-day=true]:bg-accent/10 data-[past=true]:bg-surface motion-reduce:transition-none"
+                    data-jump-day={isJumpDay ? "true" : undefined}
+                    data-past={date.isBefore(today, "day")}
+                    aria-label={
+                      surfaceLabel ?? date.format("dddd, MMMM D, YYYY")
+                    }
+                    key={key}
+                    scope="col"
+                  />
+                );
+              })}
             </tr>
           </thead>
         </table>

--- a/packages/web/src/grid/shortcuts/focus-adjacent-grid-event.test.ts
+++ b/packages/web/src/grid/shortcuts/focus-adjacent-grid-event.test.ts
@@ -4,7 +4,6 @@ import { type GridEvent } from "@web/common/types/web.event.types";
 import { gridEventDefaultPosition } from "@web/common/utils/event/event.util";
 import {
   getChronologicallyAdjacentTarget,
-  getFirstEventOnWeekdayColumn,
   getSpatiallyAdjacentTarget,
 } from "@web/grid/shortcuts/focus-adjacent-grid-event";
 import { describe, expect, it } from "bun:test";
@@ -184,39 +183,5 @@ describe("getSpatiallyAdjacentTarget", () => {
     });
 
     expect(next?.eventId).toBe("wed-noon");
-  });
-});
-
-describe("getFirstEventOnWeekdayColumn", () => {
-  it("returns the first chronological event on the leftmost column for digit 1", () => {
-    const mondayAllDay = target("mon-all", "all-day");
-    const mondayTimed = target("mon-am", "timed");
-    const wednesday = target("wed-noon", "timed");
-
-    const first = getFirstEventOnWeekdayColumn({
-      allDayEvents: [event("mon-all", "2026-05-18", true)],
-      columnIndex: 0,
-      timedEvents: [
-        event("mon-am", "2026-05-18T09:00:00.000"),
-        event("wed-noon", "2026-05-20T12:00:00.000"),
-      ],
-      visible: [mondayTimed, wednesday, mondayAllDay],
-      weekDays,
-    });
-
-    expect(first?.eventId).toBe("mon-all");
-  });
-
-  it("returns null when the column has no visible events", () => {
-    const wednesday = target("wed-noon", "timed");
-    expect(
-      getFirstEventOnWeekdayColumn({
-        allDayEvents: [],
-        columnIndex: 0,
-        timedEvents: [event("wed-noon", "2026-05-20T12:00:00.000")],
-        visible: [wednesday],
-        weekDays,
-      }),
-    ).toBeNull();
   });
 });

--- a/packages/web/src/grid/shortcuts/focus-adjacent-grid-event.ts
+++ b/packages/web/src/grid/shortcuts/focus-adjacent-grid-event.ts
@@ -180,34 +180,3 @@ export function getSpatiallyAdjacentTarget({
   }
   return nearest;
 }
-
-/**
- * Week-view digit targeting: `1`–`7` map to leftmost→rightmost visible columns.
- * Returns the chronologically first event on that day (all-day before timed),
- * or null when the column has no visible events.
- */
-export function getFirstEventOnWeekdayColumn({
-  allDayEvents,
-  columnIndex,
-  timedEvents,
-  visible,
-  weekDays,
-}: {
-  allDayEvents: GridEvent[];
-  /** 0-based index into `weekDays` (digit `1` → 0). */
-  columnIndex: number;
-  timedEvents: GridEvent[];
-  visible: FocusableGridEventTarget[];
-  weekDays: Dayjs[];
-}): FocusableGridEventTarget | null {
-  if (columnIndex < 0 || columnIndex >= weekDays.length) return null;
-
-  const dayKey = weekDays[columnIndex]!.format("YYYY-MM-DD");
-  const scheduleById = buildScheduleById(allDayEvents, timedEvents);
-  const dayTargets = visible.filter(
-    (target) => scheduleById.get(target.eventId)?.dayKey === dayKey,
-  );
-  if (dayTargets.length === 0) return null;
-
-  return sortVisibleChronologically(dayTargets, scheduleById)[0] ?? null;
-}

--- a/packages/web/src/shortcuts/data/shortcuts.data.test.ts
+++ b/packages/web/src/shortcuts/data/shortcuts.data.test.ts
@@ -139,26 +139,22 @@ describe("shortcuts.data", () => {
       expect(stripMetadata(findFocus("day")?.shortcuts ?? [])).toEqual([
         { keys: ["i"], label: "Focus sidebar" },
         { keys: ["u"], label: "Focus calendar event" },
-        { keys: ["Hold", "Shift"], label: "Show event jump keys" },
+        { keys: ["Shift"], label: "Toggle event jump keys" },
       ]);
       expect(stripMetadata(findFocus("week")?.shortcuts ?? [])).toEqual([
         { keys: ["i"], label: "Focus sidebar" },
         { keys: ["u"], label: "Focus calendar event" },
-        { keys: ["Hold", "Shift"], label: "Show event jump keys" },
+        { keys: ["Shift"], label: "Toggle event jump keys" },
       ]);
       expect(stripMetadata(findFocus("week", true)?.shortcuts ?? [])).toEqual([
         { keys: ["i"], label: "Focus sidebar" },
         { keys: ["u"], label: "Focus calendar event" },
-        {
-          keys: ["1-7"],
-          label: "Focus first event on weekday column",
-        },
-        { keys: ["Hold", "Shift"], label: "Show event jump keys" },
+        { keys: ["Shift"], label: "Toggle event jump keys" },
       ]);
       expect(stripMetadata(findFocus("day", true)?.shortcuts ?? [])).toEqual([
         { keys: ["i"], label: "Focus sidebar" },
         { keys: ["u"], label: "Focus calendar event" },
-        { keys: ["Hold", "Shift"], label: "Show event jump keys" },
+        { keys: ["Shift"], label: "Toggle event jump keys" },
       ]);
     });
 

--- a/packages/web/src/shortcuts/shift-hint/EventJumpIndicator.tsx
+++ b/packages/web/src/shortcuts/shift-hint/EventJumpIndicator.tsx
@@ -1,16 +1,30 @@
-import { type FC } from "react";
+import { type FC, useEffect } from "react";
 import {
+  eventJumpActions,
   selectEventJumpActive,
   selectEventJumpAnnouncement,
   useEventJumpStore,
 } from "@web/shortcuts/shift-hint/event-jump.store";
 
+const EXIT_ANNOUNCEMENT_LINGER_MS = 1200;
+
 /**
- * Persistent badge + live region while event-jump mode is on.
+ * Persistent badge + live region while event-jump mode is on. Stays mounted
+ * briefly after exit so "Event jump off" can be spoken.
  */
 export const EventJumpIndicator: FC = () => {
   const isActive = useEventJumpStore(selectEventJumpActive);
   const announcement = useEventJumpStore(selectEventJumpAnnouncement);
+
+  useEffect(() => {
+    if (isActive || announcement !== "Event jump off") return;
+    const timer = window.setTimeout(() => {
+      if (useEventJumpStore.getState().announcement === "Event jump off") {
+        eventJumpActions.clearAnnouncement();
+      }
+    }, EXIT_ANNOUNCEMENT_LINGER_MS);
+    return () => window.clearTimeout(timer);
+  }, [isActive, announcement]);
 
   if (!isActive && !announcement) return null;
 

--- a/packages/web/src/shortcuts/shift-hint/EventJumpIndicator.tsx
+++ b/packages/web/src/shortcuts/shift-hint/EventJumpIndicator.tsx
@@ -28,6 +28,12 @@ export const EventJumpIndicator: FC = () => {
 
   if (!isActive && !announcement) return null;
 
+  const statusText = !isActive
+    ? announcement
+    : announcement && announcement !== "Event jump on"
+      ? `Jump · ${announcement} · Esc`
+      : "Event jump · Esc or Shift";
+
   return (
     <span
       aria-live="polite"
@@ -35,11 +41,7 @@ export const EventJumpIndicator: FC = () => {
       data-event-jump-indicator=""
       role="status"
     >
-      {isActive
-        ? announcement && announcement !== "Event jump on"
-          ? `Jump · ${announcement} · Esc`
-          : "Event jump · Esc or Shift"
-        : announcement}
+      {statusText}
     </span>
   );
 };

--- a/packages/web/src/shortcuts/shift-hint/EventJumpIndicator.tsx
+++ b/packages/web/src/shortcuts/shift-hint/EventJumpIndicator.tsx
@@ -1,0 +1,31 @@
+import { type FC } from "react";
+import {
+  selectEventJumpActive,
+  selectEventJumpAnnouncement,
+  useEventJumpStore,
+} from "@web/shortcuts/shift-hint/event-jump.store";
+
+/**
+ * Persistent badge + live region while event-jump mode is on.
+ */
+export const EventJumpIndicator: FC = () => {
+  const isActive = useEventJumpStore(selectEventJumpActive);
+  const announcement = useEventJumpStore(selectEventJumpAnnouncement);
+
+  if (!isActive && !announcement) return null;
+
+  return (
+    <span
+      aria-live="polite"
+      className="truncate text-text-muted text-xs opacity-80"
+      data-event-jump-indicator=""
+      role="status"
+    >
+      {isActive
+        ? announcement && announcement !== "Event jump on"
+          ? `Jump · ${announcement} · Esc`
+          : "Event jump · Esc or Shift"
+        : announcement}
+    </span>
+  );
+};

--- a/packages/web/src/shortcuts/shift-hint/ShiftHintOverlay.tsx
+++ b/packages/web/src/shortcuts/shift-hint/ShiftHintOverlay.tsx
@@ -5,8 +5,8 @@ import { ShortcutHint } from "@web/components/Shortcuts/ShortcutHint";
 import { type ActiveShiftHint } from "@web/shortcuts/shift-hint/useShiftHoldEventHints";
 
 /**
- * Fixed-position keycap chips anchored to visible event cards while SHIFT is
- * held. Portaled so overflow-hidden cards do not clip the hints.
+ * Fixed-position keycap chips anchored to event cards while event-jump mode
+ * is on. Portaled so overflow-hidden cards do not clip the hints.
  */
 export function ShiftHintOverlay({ hints }: { hints: ActiveShiftHint[] }) {
   const [, setLayoutTick] = useState(0);
@@ -49,13 +49,20 @@ export function ShiftHintOverlay({ hints }: { hints: ActiveShiftHint[] }) {
           return null;
         }
 
+        const label = hint.hint.toUpperCase();
+        // Longer labels (SU1, F10) need more room than the old AA chips.
+        const chipWidth = Math.max(22, 10 + label.length * 8);
+
         return (
           <span
             key={`${hint.eventId}:${hint.hint}`}
             className="absolute"
-            style={{ top: rect.top + 4, left: rect.right - 22 }}
+            style={{
+              top: rect.top + 4,
+              left: Math.max(4, rect.right - chipWidth),
+            }}
           >
-            <ShortcutHint>{hint.hint.toUpperCase()}</ShortcutHint>
+            <ShortcutHint>{label}</ShortcutHint>
           </span>
         );
       })}

--- a/packages/web/src/shortcuts/shift-hint/assign-shift-hint-keys.test.ts
+++ b/packages/web/src/shortcuts/shift-hint/assign-shift-hint-keys.test.ts
@@ -314,6 +314,7 @@ describe("matchDayJumpKeystroke", () => {
       kind: "prefix",
       buffer: "f1",
       dayKeys: ["2026-08-07"],
+      pendingExactEventId: "fri-1",
     });
 
     expect(
@@ -327,6 +328,22 @@ describe("matchDayJumpKeystroke", () => {
       eventId: "fri-10",
       dayKey: "2026-08-07",
       buffer: "f10",
+    });
+  });
+
+  it("abandons an unresolved weekend S when another day letter is typed", () => {
+    expect(
+      matchDayJumpKeystroke({
+        assignments: weekAssignments,
+        key: "w",
+        buffer: "s",
+      }),
+    ).toEqual({
+      kind: "selectDay",
+      dayPrefix: "w",
+      dayKey: "2026-08-05",
+      firstEventId: "wed-1",
+      buffer: "w",
     });
   });
 

--- a/packages/web/src/shortcuts/shift-hint/assign-shift-hint-keys.test.ts
+++ b/packages/web/src/shortcuts/shift-hint/assign-shift-hint-keys.test.ts
@@ -1,111 +1,374 @@
 import {
-  assignShiftHintKeys,
+  assignDayJumpKeys,
+  DAY_JUMP_PREFIX_BY_WEEKDAY,
   filterHintsByPrefix,
-  generateHintKeys,
-  matchShiftHintKeystroke,
-  SHIFT_HINT_ALPHABET,
+  matchDayJumpKeystroke,
 } from "@web/shortcuts/shift-hint/assign-shift-hint-keys";
 import { describe, expect, it } from "bun:test";
 
-describe("assignShiftHintKeys", () => {
-  it("assigns home-row singles in chronological order", () => {
-    const assignments = assignShiftHintKeys([
-      { eventId: "c", startMs: 300, eventType: "timed" },
-      { eventId: "a", startMs: 100, eventType: "timed" },
-      { eventId: "b", startMs: 200, eventType: "timed" },
-    ]);
+describe("assignDayJumpKeys", () => {
+  it("assigns weekday prefixes and per-day indices chronologically", () => {
+    const assignments = assignDayJumpKeys(
+      [
+        {
+          eventId: "wed-2",
+          startMs: 200,
+          eventType: "timed",
+          dayKey: "2026-08-05",
+          weekday: 3,
+        },
+        {
+          eventId: "wed-1",
+          startMs: 100,
+          eventType: "timed",
+          dayKey: "2026-08-05",
+          weekday: 3,
+        },
+        {
+          eventId: "mon-1",
+          startMs: 50,
+          eventType: "timed",
+          dayKey: "2026-08-03",
+          weekday: 1,
+        },
+      ],
+      "week",
+    );
 
     expect(assignments).toEqual([
-      { eventId: "a", hint: "a" },
-      { eventId: "b", hint: "s" },
-      { eventId: "c", hint: "d" },
+      {
+        eventId: "mon-1",
+        hint: "m1",
+        dayKey: "2026-08-03",
+        dayPrefix: "m",
+        index: 1,
+      },
+      {
+        eventId: "wed-1",
+        hint: "w1",
+        dayKey: "2026-08-05",
+        dayPrefix: "w",
+        index: 1,
+      },
+      {
+        eventId: "wed-2",
+        hint: "w2",
+        dayKey: "2026-08-05",
+        dayPrefix: "w",
+        index: 2,
+      },
     ]);
   });
 
-  it("excludes j and k from the alphabet", () => {
-    expect(SHIFT_HINT_ALPHABET).not.toContain("j");
-    expect(SHIFT_HINT_ALPHABET).not.toContain("k");
-    expect(generateHintKeys(SHIFT_HINT_ALPHABET.length)).toEqual([
-      ...SHIFT_HINT_ALPHABET,
-    ]);
-  });
+  it("uses SU / SA / R / F prefixes from the weekday map", () => {
+    expect(DAY_JUMP_PREFIX_BY_WEEKDAY[0]).toBe("su");
+    expect(DAY_JUMP_PREFIX_BY_WEEKDAY[4]).toBe("r");
+    expect(DAY_JUMP_PREFIX_BY_WEEKDAY[5]).toBe("f");
+    expect(DAY_JUMP_PREFIX_BY_WEEKDAY[6]).toBe("sa");
 
-  it("switches to two-letter-only keys once singles cannot cover the set", () => {
-    const count = SHIFT_HINT_ALPHABET.length + 3;
-    const keys = generateHintKeys(count);
-    expect(keys.every((key) => key.length === 2)).toBe(true);
-    expect(keys.slice(0, 3)).toEqual(["aa", "as", "ad"]);
-  });
-
-  it("caps assignments when the alphabet cannot cover every target", () => {
-    const overflow =
-      SHIFT_HINT_ALPHABET.length * SHIFT_HINT_ALPHABET.length + 5;
-    const targets = Array.from({ length: overflow }, (_, index) => ({
-      eventId: `e${index}`,
-      startMs: index,
-      eventType: "timed" as const,
-    }));
-    const assignments = assignShiftHintKeys(targets);
-    expect(assignments).toHaveLength(
-      SHIFT_HINT_ALPHABET.length * SHIFT_HINT_ALPHABET.length,
+    const assignments = assignDayJumpKeys(
+      [
+        {
+          eventId: "sun",
+          startMs: 1,
+          eventType: "timed",
+          dayKey: "2026-08-02",
+          weekday: 0,
+        },
+        {
+          eventId: "sat",
+          startMs: 1,
+          eventType: "timed",
+          dayKey: "2026-08-08",
+          weekday: 6,
+        },
+        {
+          eventId: "fri-10",
+          startMs: 10,
+          eventType: "timed",
+          dayKey: "2026-08-07",
+          weekday: 5,
+        },
+      ],
+      "week",
     );
-    expect(assignments.every((item) => item.hint.length > 0)).toBe(true);
+
+    expect(assignments.map((item) => item.hint)).toEqual(["su1", "f1", "sa1"]);
   });
 
-  it("prefers all-day before timed on equal start", () => {
-    const assignments = assignShiftHintKeys([
-      { eventId: "timed", startMs: 100, eventType: "timed" },
-      { eventId: "allday", startMs: 100, eventType: "all-day" },
-    ]);
+  it("prefers all-day before timed on equal start within a day", () => {
+    const assignments = assignDayJumpKeys(
+      [
+        {
+          eventId: "timed",
+          startMs: 100,
+          eventType: "timed",
+          dayKey: "2026-08-03",
+          weekday: 1,
+        },
+        {
+          eventId: "allday",
+          startMs: 100,
+          eventType: "all-day",
+          dayKey: "2026-08-03",
+          weekday: 1,
+        },
+      ],
+      "week",
+    );
+    expect(assignments.map((item) => item.hint)).toEqual(["m1", "m2"]);
     expect(assignments.map((item) => item.eventId)).toEqual([
       "allday",
       "timed",
     ]);
   });
 
-  it("is stable for the same visible set", () => {
-    const targets = [
-      { eventId: "2", startMs: 2, eventType: "timed" as const },
-      { eventId: "1", startMs: 1, eventType: "timed" as const },
-    ];
-    expect(assignShiftHintKeys(targets)).toEqual(assignShiftHintKeys(targets));
-  });
-});
-
-describe("matchShiftHintKeystroke", () => {
-  const assignments = [
-    { eventId: "1", hint: "a" },
-    { eventId: "2", hint: "s" },
-    { eventId: "3", hint: "aa" },
-  ];
-
-  it("focuses an exact single-key match", () => {
-    expect(
-      matchShiftHintKeystroke({ assignments, key: "s", prefix: "" }),
-    ).toEqual({ kind: "focus", eventId: "2" });
-  });
-
-  it("narrows on the first letter of a two-letter combo", () => {
-    const many = [
-      { eventId: "1", hint: "aa" },
-      { eventId: "2", hint: "as" },
-      { eventId: "3", hint: "s" },
-    ];
-    expect(
-      matchShiftHintKeystroke({ assignments: many, key: "a", prefix: "" }),
-    ).toEqual({ kind: "prefix", prefix: "a" });
-    expect(filterHintsByPrefix(many, "a")).toEqual([
-      { eventId: "1", hint: "aa" },
-      { eventId: "2", hint: "as" },
+  it("uses bare numeric hints in day mode", () => {
+    const assignments = assignDayJumpKeys(
+      [
+        {
+          eventId: "b",
+          startMs: 200,
+          eventType: "timed",
+          dayKey: "2026-08-05",
+          weekday: 3,
+        },
+        {
+          eventId: "a",
+          startMs: 100,
+          eventType: "timed",
+          dayKey: "2026-08-05",
+          weekday: 3,
+        },
+      ],
+      "day",
+    );
+    expect(assignments).toEqual([
+      {
+        eventId: "a",
+        hint: "1",
+        dayKey: "2026-08-05",
+        dayPrefix: "",
+        index: 1,
+      },
+      {
+        eventId: "b",
+        hint: "2",
+        dayKey: "2026-08-05",
+        dayPrefix: "",
+        index: 2,
+      },
     ]);
   });
 
-  it("ignores j and k", () => {
+  it("supports double-digit indices", () => {
+    const targets = Array.from({ length: 10 }, (_, index) => ({
+      eventId: `e${index}`,
+      startMs: index,
+      eventType: "timed" as const,
+      dayKey: "2026-08-07",
+      weekday: 5,
+    }));
+    const assignments = assignDayJumpKeys(targets, "week");
+    expect(assignments[9]?.hint).toBe("f10");
+  });
+});
+
+describe("matchDayJumpKeystroke", () => {
+  const weekAssignments = assignDayJumpKeys(
+    [
+      {
+        eventId: "sun-event",
+        startMs: 1,
+        eventType: "timed",
+        dayKey: "2026-08-02",
+        weekday: 0,
+      },
+      {
+        eventId: "wed-1",
+        startMs: 1,
+        eventType: "timed",
+        dayKey: "2026-08-05",
+        weekday: 3,
+      },
+      {
+        eventId: "wed-2",
+        startMs: 2,
+        eventType: "timed",
+        dayKey: "2026-08-05",
+        weekday: 3,
+      },
+      {
+        eventId: "wed-3",
+        startMs: 3,
+        eventType: "timed",
+        dayKey: "2026-08-05",
+        weekday: 3,
+      },
+      {
+        eventId: "wed-4",
+        startMs: 4,
+        eventType: "timed",
+        dayKey: "2026-08-05",
+        weekday: 3,
+      },
+      {
+        eventId: "sat-event",
+        startMs: 1,
+        eventType: "timed",
+        dayKey: "2026-08-08",
+        weekday: 6,
+      },
+      ...Array.from({ length: 10 }, (_, index) => ({
+        eventId: `fri-${index + 1}`,
+        startMs: index + 1,
+        eventType: "timed" as const,
+        dayKey: "2026-08-07",
+        weekday: 5,
+      })),
+    ],
+    "week",
+  );
+
+  it("selects a unique day and focuses its first event", () => {
     expect(
-      matchShiftHintKeystroke({ assignments, key: "j", prefix: "" }),
-    ).toBeNull();
+      matchDayJumpKeystroke({
+        assignments: weekAssignments,
+        key: "w",
+        buffer: "",
+      }),
+    ).toEqual({
+      kind: "selectDay",
+      dayPrefix: "w",
+      dayKey: "2026-08-05",
+      firstEventId: "wed-1",
+      buffer: "w",
+    });
+  });
+
+  it("narrows weekend on S then resolves SU / SA", () => {
     expect(
-      matchShiftHintKeystroke({ assignments, key: "k", prefix: "" }),
-    ).toBeNull();
+      matchDayJumpKeystroke({
+        assignments: weekAssignments,
+        key: "s",
+        buffer: "",
+      }),
+    ).toEqual({
+      kind: "prefix",
+      buffer: "s",
+      dayKeys: ["2026-08-02", "2026-08-08"],
+    });
+
+    expect(
+      matchDayJumpKeystroke({
+        assignments: weekAssignments,
+        key: "u",
+        buffer: "s",
+      }),
+    ).toEqual({
+      kind: "selectDay",
+      dayPrefix: "su",
+      dayKey: "2026-08-02",
+      firstEventId: "sun-event",
+      buffer: "su",
+    });
+
+    expect(
+      matchDayJumpKeystroke({
+        assignments: weekAssignments,
+        key: "a",
+        buffer: "s",
+      }),
+    ).toEqual({
+      kind: "selectDay",
+      dayPrefix: "sa",
+      dayKey: "2026-08-08",
+      firstEventId: "sat-event",
+      buffer: "sa",
+    });
+  });
+
+  it("focuses W4 after day selection", () => {
+    expect(
+      matchDayJumpKeystroke({
+        assignments: weekAssignments,
+        key: "4",
+        buffer: "w",
+      }),
+    ).toEqual({
+      kind: "focus",
+      eventId: "wed-4",
+      dayKey: "2026-08-05",
+      buffer: "w4",
+    });
+  });
+
+  it("waits on F1 when F10 also exists, then focuses F10", () => {
+    expect(
+      matchDayJumpKeystroke({
+        assignments: weekAssignments,
+        key: "1",
+        buffer: "f",
+      }),
+    ).toEqual({
+      kind: "prefix",
+      buffer: "f1",
+      dayKeys: ["2026-08-07"],
+    });
+
+    expect(
+      matchDayJumpKeystroke({
+        assignments: weekAssignments,
+        key: "0",
+        buffer: "f1",
+      }),
+    ).toEqual({
+      kind: "focus",
+      eventId: "fri-10",
+      dayKey: "2026-08-07",
+      buffer: "f10",
+    });
+  });
+
+  it("filters chips by prefix", () => {
+    expect(
+      filterHintsByPrefix(weekAssignments, "w").map((a) => a.hint),
+    ).toEqual(["w1", "w2", "w3", "w4"]);
+  });
+
+  it("matches day-mode digits", () => {
+    const dayAssignments = assignDayJumpKeys(
+      [
+        {
+          eventId: "a",
+          startMs: 1,
+          eventType: "timed",
+          dayKey: "2026-08-05",
+          weekday: 3,
+        },
+        {
+          eventId: "b",
+          startMs: 2,
+          eventType: "timed",
+          dayKey: "2026-08-05",
+          weekday: 3,
+        },
+      ],
+      "day",
+    );
+
+    expect(
+      matchDayJumpKeystroke({
+        assignments: dayAssignments,
+        key: "2",
+        buffer: "",
+        mode: "day",
+      }),
+    ).toEqual({
+      kind: "focus",
+      eventId: "b",
+      dayKey: "2026-08-05",
+      buffer: "2",
+    });
   });
 });

--- a/packages/web/src/shortcuts/shift-hint/assign-shift-hint-keys.ts
+++ b/packages/web/src/shortcuts/shift-hint/assign-shift-hint-keys.ts
@@ -39,10 +39,10 @@ export type DayJumpAssignment = {
   index: number;
 };
 
-/** @deprecated Prefer {@link DayJumpAssignment}. */
-export type ShiftHintAssignment = DayJumpAssignment;
-
 export type DayJumpLabelMode = "week" | "day";
+
+/** Wait before committing a digit that could still grow (F1 vs F10). */
+export const DIGIT_AMBIGUOUS_COMMIT_MS = 400;
 
 const compareTargets = (a: DayJumpTarget, b: DayJumpTarget) => {
   if (a.dayKey !== b.dayKey) return a.dayKey.localeCompare(b.dayKey);
@@ -108,28 +108,6 @@ export function assignDayJumpKeys(
   return assignments;
 }
 
-/** @deprecated Use {@link assignDayJumpKeys}. */
-export function assignShiftHintKeys(
-  targets: Array<{
-    eventId: string;
-    startMs: number;
-    eventType: "all-day" | "timed";
-    dayKey?: string;
-    weekday?: number;
-  }>,
-): DayJumpAssignment[] {
-  return assignDayJumpKeys(
-    targets.map((target) => ({
-      eventId: target.eventId,
-      startMs: target.startMs,
-      eventType: target.eventType,
-      dayKey: target.dayKey ?? "1970-01-01",
-      weekday: target.weekday ?? 0,
-    })),
-    "week",
-  );
-}
-
 /** Narrow assignments whose hint starts with `prefix`. */
 export function filterHintsByPrefix(
   assignments: DayJumpAssignment[],
@@ -147,7 +125,13 @@ export type DayJumpMatchResult =
       firstEventId: string;
       buffer: string;
     }
-  | { kind: "prefix"; buffer: string; dayKeys: string[] }
+  | {
+      kind: "prefix";
+      buffer: string;
+      dayKeys: string[];
+      /** Exact hint match that is still ambiguous with a longer sibling. */
+      pendingExactEventId?: string;
+    }
   | { kind: "focus"; eventId: string; dayKey: string; buffer: string }
   | null;
 
@@ -204,7 +188,8 @@ export function matchDayJumpKeystroke({
       return selectDayPrefix(assignments, dayPrefix);
     }
 
-    if (buffer === "" && UNIQUE_DAY_LETTERS.has(lower)) {
+    // Abandon an unresolved weekend "s" when another day letter is typed.
+    if (UNIQUE_DAY_LETTERS.has(lower)) {
       return selectDayPrefix(assignments, lower);
     }
 
@@ -222,35 +207,6 @@ export function matchDayJumpKeystroke({
   }
 
   return null;
-}
-
-/** @deprecated Use {@link matchDayJumpKeystroke}. */
-export function matchShiftHintKeystroke({
-  assignments,
-  key,
-  prefix,
-}: {
-  assignments: DayJumpAssignment[];
-  key: string;
-  prefix: string;
-}):
-  | { kind: "focus"; eventId: string }
-  | { kind: "prefix"; prefix: string }
-  | null {
-  const match = matchDayJumpKeystroke({
-    assignments,
-    key,
-    buffer: prefix,
-    mode: "week",
-  });
-  if (!match) return null;
-  if (match.kind === "focus") {
-    return { kind: "focus", eventId: match.eventId };
-  }
-  if (match.kind === "selectDay") {
-    return { kind: "prefix", prefix: match.dayPrefix };
-  }
-  return { kind: "prefix", prefix: match.buffer };
 }
 
 function selectDayPrefix(
@@ -298,6 +254,7 @@ function matchDigitBuffer(
     kind: "prefix",
     buffer: next,
     dayKeys: uniqueDayKeys(narrowed),
+    ...(exact ? { pendingExactEventId: exact.eventId } : {}),
   };
 }
 

--- a/packages/web/src/shortcuts/shift-hint/assign-shift-hint-keys.ts
+++ b/packages/web/src/shortcuts/shift-hint/assign-shift-hint-keys.ts
@@ -1,111 +1,306 @@
 /**
- * Home-row-first hint alphabet. `j`/`k` are excluded so Shift+J/K week-window
- * navigation stays unambiguous while hints are armed or pending.
+ * Day-prefix event jump labels.
+ *
+ * Week: SU/M/T/W/R/F/SA + per-day chronological index (W4, SU1, F10).
+ * Day view: numeric index only (1, 2, …).
  */
-export const SHIFT_HINT_ALPHABET = ["a", "s", "d", "f", "g", "h", "l"] as const;
 
-export type ShiftHintTarget = {
+export const DAY_JUMP_PREFIX_BY_WEEKDAY = {
+  0: "su",
+  1: "m",
+  2: "t",
+  3: "w",
+  4: "r",
+  5: "f",
+  6: "sa",
+} as const;
+
+export type DayJumpWeekday = keyof typeof DAY_JUMP_PREFIX_BY_WEEKDAY;
+
+export type DayJumpTarget = {
   eventId: string;
   /** Stable sort key: earlier start first. */
   startMs: number;
   eventType: "all-day" | "timed";
+  /** YYYY-MM-DD column date. */
+  dayKey: string;
+  /** Local weekday 0=Sunday … 6=Saturday. */
+  weekday: number;
 };
 
-export type ShiftHintAssignment = {
+export type DayJumpAssignment = {
   eventId: string;
+  /** Full chip text, lowercase (e.g. "w4", "su1", "10"). */
   hint: string;
+  dayKey: string;
+  /** Letter prefix without index ("w", "su", or "" in day view). */
+  dayPrefix: string;
+  /** 1-based index within the day (or the whole day-view set). */
+  index: number;
 };
+
+/** @deprecated Prefer {@link DayJumpAssignment}. */
+export type ShiftHintAssignment = DayJumpAssignment;
+
+export type DayJumpLabelMode = "week" | "day";
+
+const compareTargets = (a: DayJumpTarget, b: DayJumpTarget) => {
+  if (a.dayKey !== b.dayKey) return a.dayKey.localeCompare(b.dayKey);
+  if (a.startMs !== b.startMs) return a.startMs - b.startMs;
+  if (a.eventType !== b.eventType) {
+    return a.eventType === "all-day" ? -1 : 1;
+  }
+  return a.eventId.localeCompare(b.eventId);
+};
+
+export function dayPrefixForWeekday(weekday: number): string {
+  const prefix =
+    DAY_JUMP_PREFIX_BY_WEEKDAY[weekday as DayJumpWeekday] ?? undefined;
+  return prefix ?? "";
+}
 
 /**
- * Deterministic hint keys for the visible target set. Same targets → same keys
- * across re-renders within a hold. Singles first, then two-letter combos from
- * the same alphabet when more events are visible than single keys.
+ * Assign day-prefix (week) or numeric (day) hints. Same targets → same keys.
  */
-export function assignShiftHintKeys(
-  targets: ShiftHintTarget[],
-): ShiftHintAssignment[] {
+export function assignDayJumpKeys(
+  targets: DayJumpTarget[],
+  mode: DayJumpLabelMode = "week",
+): DayJumpAssignment[] {
   if (targets.length === 0) return [];
 
-  const sorted = [...targets].sort((a, b) => {
-    if (a.startMs !== b.startMs) return a.startMs - b.startMs;
-    if (a.eventType !== b.eventType) {
-      return a.eventType === "all-day" ? -1 : 1;
-    }
-    return a.eventId.localeCompare(b.eventId);
-  });
-
-  const keys = generateHintKeys(sorted.length);
-  return sorted.flatMap((target, index) => {
-    const hint = keys[index];
-    if (!hint) return [];
-    return [{ eventId: target.eventId, hint }];
-  });
-}
-
-export function generateHintKeys(count: number): string[] {
-  if (count <= 0) return [];
-
-  // Stay on singles while they cover the set. Past that, use only two-letter
-  // combos so the first keystroke always narrows instead of colliding with a
-  // single-letter assignment that shares the same prefix.
-  if (count <= SHIFT_HINT_ALPHABET.length) {
-    return SHIFT_HINT_ALPHABET.slice(0, count).map((key) => key);
+  if (mode === "day") {
+    const sorted = [...targets].sort(compareTargets);
+    return sorted.map((target, index) => ({
+      eventId: target.eventId,
+      hint: String(index + 1),
+      dayKey: target.dayKey,
+      dayPrefix: "",
+      index: index + 1,
+    }));
   }
 
-  const keys: string[] = [];
-  for (const first of SHIFT_HINT_ALPHABET) {
-    for (const second of SHIFT_HINT_ALPHABET) {
-      keys.push(`${first}${second}`);
-      if (keys.length >= count) return keys;
-    }
+  const byDay = new Map<string, DayJumpTarget[]>();
+  for (const target of targets) {
+    const list = byDay.get(target.dayKey);
+    if (list) list.push(target);
+    else byDay.set(target.dayKey, [target]);
   }
 
-  return keys.slice(0, count);
+  const assignments: DayJumpAssignment[] = [];
+  const dayKeys = [...byDay.keys()].sort();
+  for (const dayKey of dayKeys) {
+    const dayTargets = byDay.get(dayKey);
+    if (!dayTargets) continue;
+    const sorted = [...dayTargets].sort(compareTargets);
+    const dayPrefix = dayPrefixForWeekday(sorted[0]?.weekday ?? 0);
+    sorted.forEach((target, index) => {
+      const n = index + 1;
+      assignments.push({
+        eventId: target.eventId,
+        hint: `${dayPrefix}${n}`,
+        dayKey,
+        dayPrefix,
+        index: n,
+      });
+    });
+  }
+
+  return assignments;
 }
 
-/** Narrow assignments whose hint starts with `prefix` (two-letter flow). */
+/** @deprecated Use {@link assignDayJumpKeys}. */
+export function assignShiftHintKeys(
+  targets: Array<{
+    eventId: string;
+    startMs: number;
+    eventType: "all-day" | "timed";
+    dayKey?: string;
+    weekday?: number;
+  }>,
+): DayJumpAssignment[] {
+  return assignDayJumpKeys(
+    targets.map((target) => ({
+      eventId: target.eventId,
+      startMs: target.startMs,
+      eventType: target.eventType,
+      dayKey: target.dayKey ?? "1970-01-01",
+      weekday: target.weekday ?? 0,
+    })),
+    "week",
+  );
+}
+
+/** Narrow assignments whose hint starts with `prefix`. */
 export function filterHintsByPrefix(
-  assignments: ShiftHintAssignment[],
+  assignments: DayJumpAssignment[],
   prefix: string,
-): ShiftHintAssignment[] {
+): DayJumpAssignment[] {
   if (!prefix) return assignments;
   return assignments.filter((assignment) => assignment.hint.startsWith(prefix));
 }
 
+export type DayJumpMatchResult =
+  | {
+      kind: "selectDay";
+      dayPrefix: string;
+      dayKey: string;
+      firstEventId: string;
+      buffer: string;
+    }
+  | { kind: "prefix"; buffer: string; dayKeys: string[] }
+  | { kind: "focus"; eventId: string; dayKey: string; buffer: string }
+  | null;
+
+const UNIQUE_DAY_LETTERS = new Set(["m", "t", "w", "r", "f"]);
+
 /**
- * Resolve a keystroke against current assignments + optional prefix buffer.
- * Returns the focused event id, an updated prefix, or null when ignored.
+ * Resolve a keystroke against assignments + buffer.
+ *
+ * Buffer holds the typed prefix so far (`""`, `"s"`, `"su"`, `"w"`, `"w1"`…).
+ * Unique day letters select the day and focus the first event without requiring
+ * a digit. Digits append and focus when the buffer uniquely identifies a hint
+ * (exact match with no longer sibling prefixes).
  */
+export function matchDayJumpKeystroke({
+  assignments,
+  key,
+  buffer,
+  mode = "week",
+}: {
+  assignments: DayJumpAssignment[];
+  key: string;
+  buffer: string;
+  mode?: DayJumpLabelMode;
+}): DayJumpMatchResult {
+  if (key.length !== 1) return null;
+  const lower = key.toLowerCase();
+
+  if (mode === "day") {
+    if (!/^\d$/.test(lower)) return null;
+    return matchDigitBuffer(assignments, `${buffer}${lower}`);
+  }
+
+  // Digit after a day is selected (buffer is day prefix or day+digits).
+  if (/^\d$/.test(lower)) {
+    if (!buffer) return null;
+    // Still resolving weekend: "s" alone is not a selected day.
+    if (buffer === "s") return null;
+    return matchDigitBuffer(assignments, `${buffer}${lower}`);
+  }
+
+  if (!/^[a-z]$/.test(lower)) return null;
+
+  // Starting a new day selection (or continuing weekend).
+  if (!buffer || buffer === "s") {
+    if (buffer === "" && lower === "s") {
+      const weekend = filterHintsByPrefix(assignments, "s");
+      if (weekend.length === 0) return null;
+      const dayKeys = uniqueDayKeys(weekend);
+      return { kind: "prefix", buffer: "s", dayKeys };
+    }
+
+    if (buffer === "s" && (lower === "u" || lower === "a")) {
+      const dayPrefix = lower === "u" ? "su" : "sa";
+      return selectDayPrefix(assignments, dayPrefix);
+    }
+
+    if (buffer === "" && UNIQUE_DAY_LETTERS.has(lower)) {
+      return selectDayPrefix(assignments, lower);
+    }
+
+    return null;
+  }
+
+  // Day already selected (or digits in progress): letter starts a new day pick.
+  if (lower === "s") {
+    const weekend = filterHintsByPrefix(assignments, "s");
+    if (weekend.length === 0) return null;
+    return { kind: "prefix", buffer: "s", dayKeys: uniqueDayKeys(weekend) };
+  }
+  if (UNIQUE_DAY_LETTERS.has(lower)) {
+    return selectDayPrefix(assignments, lower);
+  }
+
+  return null;
+}
+
+/** @deprecated Use {@link matchDayJumpKeystroke}. */
 export function matchShiftHintKeystroke({
   assignments,
   key,
   prefix,
 }: {
-  assignments: ShiftHintAssignment[];
+  assignments: DayJumpAssignment[];
   key: string;
   prefix: string;
 }):
   | { kind: "focus"; eventId: string }
   | { kind: "prefix"; prefix: string }
   | null {
-  if (key.length !== 1) return null;
-  const lower = key.toLowerCase();
-  if (
-    !SHIFT_HINT_ALPHABET.includes(lower as (typeof SHIFT_HINT_ALPHABET)[number])
-  ) {
-    return null;
+  const match = matchDayJumpKeystroke({
+    assignments,
+    key,
+    buffer: prefix,
+    mode: "week",
+  });
+  if (!match) return null;
+  if (match.kind === "focus") {
+    return { kind: "focus", eventId: match.eventId };
   }
-
-  const next = `${prefix}${lower}`;
-  const exact = assignments.find((assignment) => assignment.hint === next);
-  if (exact) {
-    return { kind: "focus", eventId: exact.eventId };
+  if (match.kind === "selectDay") {
+    return { kind: "prefix", prefix: match.dayPrefix };
   }
+  return { kind: "prefix", prefix: match.buffer };
+}
 
+function selectDayPrefix(
+  assignments: DayJumpAssignment[],
+  dayPrefix: string,
+): DayJumpMatchResult {
+  const forDay = assignments.filter(
+    (assignment) => assignment.dayPrefix === dayPrefix,
+  );
+  if (forDay.length === 0) return null;
+  const first = forDay.reduce((best, item) =>
+    item.index < best.index ? item : best,
+  );
+  return {
+    kind: "selectDay",
+    dayPrefix,
+    dayKey: first.dayKey,
+    firstEventId: first.eventId,
+    buffer: dayPrefix,
+  };
+}
+
+function matchDigitBuffer(
+  assignments: DayJumpAssignment[],
+  next: string,
+): DayJumpMatchResult {
   const narrowed = filterHintsByPrefix(assignments, next);
-  if (narrowed.length === 0) {
-    return null;
+  if (narrowed.length === 0) return null;
+
+  const exact = narrowed.find((assignment) => assignment.hint === next);
+  const hasLonger = narrowed.some(
+    (assignment) => assignment.hint.length > next.length,
+  );
+
+  if (exact && !hasLonger) {
+    return {
+      kind: "focus",
+      eventId: exact.eventId,
+      dayKey: exact.dayKey,
+      buffer: next,
+    };
   }
 
-  return { kind: "prefix", prefix: next };
+  return {
+    kind: "prefix",
+    buffer: next,
+    dayKeys: uniqueDayKeys(narrowed),
+  };
+}
+
+function uniqueDayKeys(assignments: DayJumpAssignment[]): string[] {
+  return [...new Set(assignments.map((item) => item.dayKey))];
 }

--- a/packages/web/src/shortcuts/shift-hint/assign-shift-hint-keys.ts
+++ b/packages/web/src/shortcuts/shift-hint/assign-shift-hint-keys.ts
@@ -53,12 +53,6 @@ const compareTargets = (a: DayJumpTarget, b: DayJumpTarget) => {
   return a.eventId.localeCompare(b.eventId);
 };
 
-export function dayPrefixForWeekday(weekday: number): string {
-  const prefix =
-    DAY_JUMP_PREFIX_BY_WEEKDAY[weekday as DayJumpWeekday] ?? undefined;
-  return prefix ?? "";
-}
-
 /**
  * Assign day-prefix (week) or numeric (day) hints. Same targets → same keys.
  */
@@ -87,12 +81,11 @@ export function assignDayJumpKeys(
   }
 
   const assignments: DayJumpAssignment[] = [];
-  const dayKeys = [...byDay.keys()].sort();
-  for (const dayKey of dayKeys) {
-    const dayTargets = byDay.get(dayKey);
-    if (!dayTargets) continue;
+  const days = [...byDay.entries()].sort(([a], [b]) => a.localeCompare(b));
+  for (const [dayKey, dayTargets] of days) {
     const sorted = [...dayTargets].sort(compareTargets);
-    const dayPrefix = dayPrefixForWeekday(sorted[0]?.weekday ?? 0);
+    const weekday = (sorted[0]?.weekday ?? 0) as DayJumpWeekday;
+    const dayPrefix = DAY_JUMP_PREFIX_BY_WEEKDAY[weekday] ?? "";
     sorted.forEach((target, index) => {
       const n = index + 1;
       assignments.push({

--- a/packages/web/src/shortcuts/shift-hint/event-jump.store.ts
+++ b/packages/web/src/shortcuts/shift-hint/event-jump.store.ts
@@ -43,6 +43,11 @@ export const eventJumpActions = {
       false,
       { type: "silenceOff" },
     ),
+  /** Clear a lingering exit announcement after the live region has spoken. */
+  clearAnnouncement: () =>
+    useEventJumpStore.setState({ announcement: "" }, false, {
+      type: "clearAnnouncement",
+    }),
   setActiveDayKeys: (activeDayKeys: string[], announcement?: string) =>
     useEventJumpStore.setState(
       {

--- a/packages/web/src/shortcuts/shift-hint/event-jump.store.ts
+++ b/packages/web/src/shortcuts/shift-hint/event-jump.store.ts
@@ -1,0 +1,65 @@
+import { create } from "zustand";
+import { devtools } from "zustand/middleware";
+import { IS_DEV } from "@web/common/constants/env.constants";
+
+export type EventJumpState = {
+  isActive: boolean;
+  /** YYYY-MM-DD keys for highlighted day column(s). */
+  activeDayKeys: string[];
+  /** Polite live-region message for mode / day selection. */
+  announcement: string;
+};
+
+export const initialEventJumpState: EventJumpState = {
+  isActive: false,
+  activeDayKeys: [],
+  announcement: "",
+};
+
+export const useEventJumpStore = create<EventJumpState>()(
+  devtools(() => initialEventJumpState, {
+    name: "compass/event-jump",
+    enabled: IS_DEV,
+  }),
+);
+
+export const eventJumpActions = {
+  setActive: (isActive: boolean) =>
+    useEventJumpStore.setState(
+      {
+        isActive,
+        activeDayKeys: isActive
+          ? useEventJumpStore.getState().activeDayKeys
+          : [],
+        announcement: isActive ? "Event jump on" : "Event jump off",
+      },
+      false,
+      { type: "setActive" },
+    ),
+  /** Exit without announcing (e.g. Shift-Shift handing off to keyboard-only). */
+  silenceOff: () =>
+    useEventJumpStore.setState(
+      { isActive: false, activeDayKeys: [], announcement: "" },
+      false,
+      { type: "silenceOff" },
+    ),
+  setActiveDayKeys: (activeDayKeys: string[], announcement?: string) =>
+    useEventJumpStore.setState(
+      {
+        activeDayKeys,
+        ...(announcement !== undefined ? { announcement } : {}),
+      },
+      false,
+      { type: "setActiveDayKeys" },
+    ),
+  reset: () =>
+    useEventJumpStore.setState(initialEventJumpState, false, { type: "reset" }),
+};
+
+export const selectEventJumpActive = (state: EventJumpState) => state.isActive;
+
+export const selectEventJumpActiveDayKeys = (state: EventJumpState) =>
+  state.activeDayKeys;
+
+export const selectEventJumpAnnouncement = (state: EventJumpState) =>
+  state.announcement;

--- a/packages/web/src/shortcuts/shift-hint/shift-hold-detector.test.ts
+++ b/packages/web/src/shortcuts/shift-hint/shift-hold-detector.test.ts
@@ -1,88 +1,116 @@
 import {
-  createShiftHoldState,
+  createShiftJumpGestureState,
   isShiftDoubleTapCandidate,
-  reduceShiftHold,
+  reduceShiftJumpGesture,
   SHIFT_DOUBLE_TAP_MAX_GAP_MS,
   SHIFT_HOLD_HINT_THRESHOLD_MS,
 } from "@web/shortcuts/shift-hint/shift-hold-detector";
 import { describe, expect, it } from "bun:test";
 
-describe("reduceShiftHold", () => {
-  it("activates only after the hold threshold", () => {
-    let state = createShiftHoldState();
-    state = reduceShiftHold(state, {
+describe("reduceShiftJumpGesture", () => {
+  it("emits toggle on a quick Shift tap", () => {
+    const state = createShiftJumpGestureState();
+    let result = reduceShiftJumpGesture(state, {
       type: "shiftDown",
       now: 1000,
       blocked: false,
     });
-    expect(state.phase).toBe("pending");
-    expect(state.pendingStartedAt).toBe(1000);
+    expect(result.state.phase).toBe("armed");
+    expect(result.toggle).toBe(false);
 
-    state = reduceShiftHold(state, { type: "thresholdReached" });
-    expect(state.phase).toBe("active");
+    result = reduceShiftJumpGesture(result.state, {
+      type: "shiftUp",
+      now: 1100,
+    });
+    expect(result.toggle).toBe(true);
+    expect(result.forceOff).toBe(false);
+    expect(result.state.phase).toBe("idle");
+    expect(result.state.lastShiftReleaseAt).toBe(1100);
   });
 
-  it("treats a quick Shift tap as idle and records release time", () => {
-    let state = createShiftHoldState();
-    state = reduceShiftHold(state, {
+  it("does not toggle on a long press", () => {
+    let state = createShiftJumpGestureState();
+    state = reduceShiftJumpGesture(state, {
       type: "shiftDown",
       now: 1000,
       blocked: false,
+    }).state;
+    const result = reduceShiftJumpGesture(state, {
+      type: "shiftUp",
+      now: 1000 + SHIFT_HOLD_HINT_THRESHOLD_MS,
     });
-    state = reduceShiftHold(state, { type: "shiftUp", now: 1100 });
-
-    expect(state.phase).toBe("idle");
-    expect(state.lastShiftReleaseAt).toBe(1100);
-    expect(state.pendingStartedAt).toBeNull();
+    expect(result.toggle).toBe(false);
+    expect(result.forceOff).toBe(false);
+    expect(result.state.lastShiftReleaseAt).toBeNull();
   });
 
-  it("cancels pending on chord key so Shift+J never flashes hints", () => {
-    let state = createShiftHoldState();
-    state = reduceShiftHold(state, {
+  it("cancels armed on chord key so Shift+J never toggles", () => {
+    let state = createShiftJumpGestureState();
+    state = reduceShiftJumpGesture(state, {
       type: "shiftDown",
       now: 1000,
       blocked: false,
-    });
-    state = reduceShiftHold(state, { type: "chordKeyDown" });
+    }).state;
+    state = reduceShiftJumpGesture(state, { type: "chordKeyDown" }).state;
     expect(state.phase).toBe("idle");
 
-    state = reduceShiftHold(state, { type: "thresholdReached" });
-    expect(state.phase).toBe("idle");
+    const result = reduceShiftJumpGesture(state, {
+      type: "shiftUp",
+      now: 1100,
+    });
+    expect(result.toggle).toBe(false);
   });
 
-  it("does not start pending when blocked (editable / app lock)", () => {
-    let state = createShiftHoldState();
-    state = reduceShiftHold(state, {
+  it("does not arm when blocked (editable / app lock)", () => {
+    const result = reduceShiftJumpGesture(createShiftJumpGestureState(), {
       type: "shiftDown",
       now: 1000,
       blocked: true,
     });
-    expect(state.phase).toBe("idle");
+    expect(result.state.phase).toBe("idle");
+    expect(result.toggle).toBe(false);
   });
 
-  it("dismisses active hints on Shift release without stamping a tap", () => {
-    let state = createShiftHoldState();
-    state = reduceShiftHold(state, {
+  it("forceOff on the second quick tap (Shift-Shift)", () => {
+    let state = createShiftJumpGestureState();
+    state = reduceShiftJumpGesture(state, {
       type: "shiftDown",
       now: 1000,
       blocked: false,
+    }).state;
+    state = reduceShiftJumpGesture(state, {
+      type: "shiftUp",
+      now: 1050,
+    }).state;
+    expect(state.lastShiftReleaseAt).toBe(1050);
+
+    state = reduceShiftJumpGesture(state, {
+      type: "shiftDown",
+      now: 1100,
+      blocked: false,
+    }).state;
+    const result = reduceShiftJumpGesture(state, {
+      type: "shiftUp",
+      now: 1150,
     });
-    state = reduceShiftHold(state, { type: "thresholdReached" });
-    state = reduceShiftHold(state, { type: "shiftUp", now: 1300 });
-    expect(state.phase).toBe("idle");
-    expect(state.lastShiftReleaseAt).toBeNull();
+    expect(result.toggle).toBe(false);
+    expect(result.forceOff).toBe(true);
+    expect(result.state.lastShiftReleaseAt).toBeNull();
   });
 });
 
 describe("hold vs double-tap coordination", () => {
   it("records release times so a future SHIFT-SHIFT detector can use them", () => {
-    let state = createShiftHoldState();
-    state = reduceShiftHold(state, {
+    let state = createShiftJumpGestureState();
+    state = reduceShiftJumpGesture(state, {
       type: "shiftDown",
       now: 1000,
       blocked: false,
-    });
-    state = reduceShiftHold(state, { type: "shiftUp", now: 1050 });
+    }).state;
+    state = reduceShiftJumpGesture(state, {
+      type: "shiftUp",
+      now: 1050,
+    }).state;
     expect(
       isShiftDoubleTapCandidate({
         lastShiftReleaseAt: state.lastShiftReleaseAt,
@@ -90,20 +118,9 @@ describe("hold vs double-tap coordination", () => {
         maxGapMs: SHIFT_DOUBLE_TAP_MAX_GAP_MS,
       }),
     ).toBe(true);
-
-    // A completed hold also releases, but pending never became active on a
-    // double-tap path: two quick taps stay idle.
-    state = reduceShiftHold(state, {
-      type: "shiftDown",
-      now: 1150,
-      blocked: false,
-    });
-    state = reduceShiftHold(state, { type: "shiftUp", now: 1200 });
-    expect(state.phase).toBe("idle");
-    expect(state.lastShiftReleaseAt).toBe(1200);
   });
 
-  it("does not treat a long hold release as a double-tap candidate gap start only", () => {
+  it("does not treat a long hold release as a double-tap candidate", () => {
     expect(SHIFT_HOLD_HINT_THRESHOLD_MS).toBeGreaterThan(100);
     expect(
       isShiftDoubleTapCandidate({

--- a/packages/web/src/shortcuts/shift-hint/shift-hold-detector.ts
+++ b/packages/web/src/shortcuts/shift-hint/shift-hold-detector.ts
@@ -35,9 +35,6 @@ export const createShiftJumpGestureState = (): ShiftJumpGestureState => ({
   lastShiftReleaseAt: null,
 });
 
-/** @deprecated Use {@link createShiftJumpGestureState}. */
-export const createShiftHoldState = createShiftJumpGestureState;
-
 export type ShiftJumpGestureEvent =
   | { type: "shiftDown"; now: number; blocked: boolean }
   | { type: "shiftUp"; now: number }
@@ -152,14 +149,6 @@ export function reduceShiftJumpGesture(
       };
     }
   }
-}
-
-/** @deprecated Use {@link reduceShiftJumpGesture}. */
-export function reduceShiftHold(
-  state: ShiftJumpGestureState,
-  event: ShiftJumpGestureEvent,
-): ShiftJumpGestureState {
-  return reduceShiftJumpGesture(state, event).state;
 }
 
 /** True when a second Shift tap would count as double-tap, not a hold. */

--- a/packages/web/src/shortcuts/shift-hint/shift-hold-detector.ts
+++ b/packages/web/src/shortcuts/shift-hint/shift-hold-detector.ts
@@ -1,9 +1,10 @@
 /**
- * Pure SHIFT-hold state for event flash hints.
+ * Pure Shift gesture state for event-jump mode.
  *
- * Hold (≥ threshold) → active. Quick tap → idle (records release time for a
- * future SHIFT-SHIFT detector). A chord key while pending cancels before
- * hints appear, so Shift+J / Shift+Arrow never flash.
+ * Quick Shift tap → toggle (hook applies). Chord while armed cancels so
+ * Shift+J / Shift+Arrow never toggle. Long press (≥ threshold) is not a tap.
+ * A second quick tap within {@link SHIFT_DOUBLE_TAP_MAX_GAP_MS} is a
+ * Shift-Shift candidate: force jump mode off so keyboard-only can win.
  */
 
 export const SHIFT_HOLD_HINT_THRESHOLD_MS = 200;
@@ -16,112 +17,149 @@ export const isShiftKey = (event: Pick<KeyboardEvent, "key" | "code">) =>
   event.code === "ShiftLeft" ||
   event.code === "ShiftRight";
 
-export type ShiftHoldPhase = "idle" | "pending" | "active";
+export type ShiftJumpGesturePhase = "idle" | "armed";
 
-export type ShiftHoldState = {
-  phase: ShiftHoldPhase;
-  pendingStartedAt: number | null;
+export type ShiftJumpGestureState = {
+  phase: ShiftJumpGesturePhase;
+  armedAt: number | null;
   /**
-   * Timestamp of the last completed Shift keyup. Keyboard-only mode (double
-   * Shift) can read this without sharing the hold timer.
+   * Timestamp of the last completed quick Shift tap. Used to detect the
+   * second tap of Shift-Shift (force jump off; keyboard-only owns that).
    */
   lastShiftReleaseAt: number | null;
-  hintPrefix: string;
 };
 
-export const createShiftHoldState = (): ShiftHoldState => ({
+export const createShiftJumpGestureState = (): ShiftJumpGestureState => ({
   phase: "idle",
-  pendingStartedAt: null,
+  armedAt: null,
   lastShiftReleaseAt: null,
-  hintPrefix: "",
 });
 
-export type ShiftHoldEvent =
+/** @deprecated Use {@link createShiftJumpGestureState}. */
+export const createShiftHoldState = createShiftJumpGestureState;
+
+export type ShiftJumpGestureEvent =
   | { type: "shiftDown"; now: number; blocked: boolean }
   | { type: "shiftUp"; now: number }
-  | { type: "thresholdReached" }
   | { type: "chordKeyDown" }
-  | { type: "setPrefix"; prefix: string }
-  | { type: "dismiss" };
+  | { type: "reset" };
 
-export function reduceShiftHold(
-  state: ShiftHoldState,
-  event: ShiftHoldEvent,
-): ShiftHoldState {
+export type ShiftJumpGestureResult = {
+  state: ShiftJumpGestureState;
+  /** Quick tap that should toggle jump mode (not a Shift-Shift second tap). */
+  toggle: boolean;
+  /** Second quick tap: force jump mode off for keyboard-only coexistence. */
+  forceOff: boolean;
+};
+
+export function reduceShiftJumpGesture(
+  state: ShiftJumpGestureState,
+  event: ShiftJumpGestureEvent,
+): ShiftJumpGestureResult {
   switch (event.type) {
     case "shiftDown": {
       if (event.blocked) {
         return {
-          ...state,
-          phase: "idle",
-          pendingStartedAt: null,
-          hintPrefix: "",
+          state: {
+            phase: "idle",
+            armedAt: null,
+            lastShiftReleaseAt: state.lastShiftReleaseAt,
+          },
+          toggle: false,
+          forceOff: false,
         };
       }
-      if (state.phase === "active") {
-        return state;
+      if (state.phase === "armed") {
+        return { state, toggle: false, forceOff: false };
       }
       return {
-        ...state,
-        phase: "pending",
-        pendingStartedAt: event.now,
-        hintPrefix: "",
+        state: {
+          ...state,
+          phase: "armed",
+          armedAt: event.now,
+        },
+        toggle: false,
+        forceOff: false,
       };
     }
     case "shiftUp": {
-      // Only short taps (pending → idle without activating) stamp
-      // lastShiftReleaseAt for a future SHIFT-SHIFT detector. Completed holds
-      // and idle/blocked ups must not look like double-tap candidates.
-      if (state.phase === "pending") {
+      if (state.phase !== "armed" || state.armedAt === null) {
+        return { state, toggle: false, forceOff: false };
+      }
+
+      const heldMs = event.now - state.armedAt;
+      // Long press: not a tap (also keeps Shift-Shift keyboard-only clean).
+      if (heldMs >= SHIFT_HOLD_HINT_THRESHOLD_MS) {
         return {
-          ...state,
-          phase: "idle",
-          pendingStartedAt: null,
-          lastShiftReleaseAt: event.now,
-          hintPrefix: "",
+          state: {
+            phase: "idle",
+            armedAt: null,
+            lastShiftReleaseAt: null,
+          },
+          toggle: false,
+          forceOff: false,
         };
       }
-      if (state.phase === "active") {
+
+      const isDoubleTap = isShiftDoubleTapCandidate({
+        lastShiftReleaseAt: state.lastShiftReleaseAt,
+        now: event.now,
+        maxGapMs: SHIFT_DOUBLE_TAP_MAX_GAP_MS,
+      });
+
+      if (isDoubleTap) {
         return {
-          ...state,
-          phase: "idle",
-          pendingStartedAt: null,
-          hintPrefix: "",
+          state: {
+            phase: "idle",
+            armedAt: null,
+            lastShiftReleaseAt: null,
+          },
+          toggle: false,
+          forceOff: true,
         };
       }
-      return state;
-    }
-    case "thresholdReached": {
-      if (state.phase !== "pending") return state;
+
       return {
-        ...state,
-        phase: "active",
-        pendingStartedAt: null,
-        hintPrefix: "",
+        state: {
+          phase: "idle",
+          armedAt: null,
+          lastShiftReleaseAt: event.now,
+        },
+        toggle: true,
+        forceOff: false,
       };
     }
     case "chordKeyDown": {
-      if (state.phase !== "pending") return state;
+      if (state.phase !== "armed") {
+        return { state, toggle: false, forceOff: false };
+      }
       return {
-        ...state,
-        phase: "idle",
-        pendingStartedAt: null,
-        hintPrefix: "",
+        state: {
+          phase: "idle",
+          armedAt: null,
+          // Chord cancels the tap; do not seed a double-tap gap.
+          lastShiftReleaseAt: null,
+        },
+        toggle: false,
+        forceOff: false,
       };
     }
-    case "setPrefix": {
-      if (state.phase !== "active") return state;
-      return { ...state, hintPrefix: event.prefix };
-    }
-    case "dismiss": {
+    case "reset": {
       return {
-        ...state,
-        phase: "idle",
-        pendingStartedAt: null,
-        hintPrefix: "",
+        state: createShiftJumpGestureState(),
+        toggle: false,
+        forceOff: false,
       };
     }
   }
+}
+
+/** @deprecated Use {@link reduceShiftJumpGesture}. */
+export function reduceShiftHold(
+  state: ShiftJumpGestureState,
+  event: ShiftJumpGestureEvent,
+): ShiftJumpGestureState {
+  return reduceShiftJumpGesture(state, event).state;
 }
 
 /** True when a second Shift tap would count as double-tap, not a hold. */

--- a/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.test.tsx
+++ b/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.test.tsx
@@ -3,9 +3,14 @@ import { EventIdSchema } from "@core/types/domain-primitives";
 import { type GridEvent } from "@web/common/types/web.event.types";
 import { clearAppLockReasons, setAppLockReason } from "@web/shortcuts/app-lock";
 import {
+  keyboardOnlyActions,
+  useKeyboardOnlyStore,
+} from "@web/shortcuts/keyboard-only/keyboard-only.store";
+import {
   eventJumpActions,
   useEventJumpStore,
 } from "@web/shortcuts/shift-hint/event-jump.store";
+import { SHIFT_DOUBLE_TAP_MAX_GAP_MS } from "@web/shortcuts/shift-hint/shift-hold-detector";
 import { useShiftHoldEventHints } from "@web/shortcuts/shift-hint/useShiftHoldEventHints";
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 
@@ -34,6 +39,12 @@ const tapShift = () => {
   dispatch("keyup", "Shift");
 };
 
+const flushActivate = async () => {
+  await act(async () => {
+    await Bun.sleep(SHIFT_DOUBLE_TAP_MAX_GAP_MS + 5);
+  });
+};
+
 const timedFixture = (id: string, startDate: string): GridEvent =>
   ({
     _id: id,
@@ -47,12 +58,14 @@ describe("useShiftHoldEventHints", () => {
   beforeEach(() => {
     clearAppLockReasons();
     eventJumpActions.reset();
+    keyboardOnlyActions.exit();
   });
 
   afterEach(() => {
     cleanup();
     clearAppLockReasons();
     eventJumpActions.reset();
+    keyboardOnlyActions.exit();
     document.body.innerHTML = "";
   });
 
@@ -100,12 +113,15 @@ describe("useShiftHoldEventHints", () => {
     return { focus, result, elements };
   };
 
-  it("toggles hints on a quick Shift tap and focuses via day prefix", () => {
+  it("toggles hints on a quick Shift tap and focuses via day prefix", async () => {
     const { focus, result, elements } = mountHints();
 
     act(() => {
       tapShift();
     });
+    expect(result.current.isActive).toBe(false);
+
+    await flushActivate();
 
     expect(result.current.isActive).toBe(true);
     expect(result.current.hints.map((hint) => hint.hint)).toEqual([
@@ -135,7 +151,7 @@ describe("useShiftHoldEventHints", () => {
     expect(result.current.isActive).toBe(true);
   });
 
-  it("does not toggle on a quick Shift chord (Shift+J)", () => {
+  it("does not toggle on a quick Shift chord (Shift+J)", async () => {
     const { result } = mountHints();
 
     act(() => {
@@ -145,39 +161,64 @@ describe("useShiftHoldEventHints", () => {
       dispatch("keyup", "Shift");
     });
 
+    await flushActivate();
     expect(result.current.isActive).toBe(false);
     expect(result.current.hints).toEqual([]);
   });
 
-  it("stays inert while app-locked", () => {
+  it("stays inert while app-locked", async () => {
     setAppLockReason("test-modal", true);
     const { result } = mountHints();
 
     act(() => {
       tapShift();
     });
+    await flushActivate();
 
     expect(result.current.isActive).toBe(false);
     expect(result.current.hints).toEqual([]);
   });
 
-  it("clears hints when Shift is tapped again or Escape is pressed", () => {
+  it("does not activate while keyboard-only mode is on", async () => {
+    keyboardOnlyActions.enter();
     const { result } = mountHints();
 
     act(() => {
       tapShift();
     });
+    await flushActivate();
+
+    expect(result.current.isActive).toBe(false);
+    expect(useKeyboardOnlyStore.getState().isActive).toBe(true);
+  });
+
+  it("clears hints when Shift is tapped again or Escape is pressed", async () => {
+    const { result } = mountHints();
+
+    act(() => {
+      tapShift();
+    });
+    await flushActivate();
     expect(result.current.hints).toHaveLength(3);
 
+    // Wait past the double-tap window so the next Shift is a toggle-off.
+    await act(async () => {
+      await Bun.sleep(SHIFT_DOUBLE_TAP_MAX_GAP_MS + 5);
+    });
     act(() => {
       tapShift();
     });
     expect(result.current.isActive).toBe(false);
     expect(result.current.hints).toEqual([]);
 
+    // Wait so re-entry is a fresh tap, not Shift-Shift forceOff.
+    await act(async () => {
+      await Bun.sleep(SHIFT_DOUBLE_TAP_MAX_GAP_MS + 5);
+    });
     act(() => {
       tapShift();
     });
+    await flushActivate();
     expect(result.current.isActive).toBe(true);
 
     act(() => {
@@ -187,11 +228,14 @@ describe("useShiftHoldEventHints", () => {
     expect(result.current.hints).toEqual([]);
   });
 
-  it("keeps mode on when arrows are pressed after selecting a day", () => {
+  it("keeps mode on when arrows are pressed after selecting a day", async () => {
     const { focus, result } = mountHints();
 
     act(() => {
       tapShift();
+    });
+    await flushActivate();
+    act(() => {
       dispatch("keydown", "w");
     });
     expect(focus).toHaveBeenCalled();
@@ -203,20 +247,16 @@ describe("useShiftHoldEventHints", () => {
     expect(result.current.isActive).toBe(true);
   });
 
-  it("force-off on Shift-Shift without leaving jump announcement", () => {
+  it("cancels deferred activate on Shift-Shift without flashing jump", async () => {
     const { result } = mountHints();
 
     act(() => {
       tapShift();
-    });
-    expect(result.current.isActive).toBe(true);
-
-    act(() => {
-      // Second tap within double-tap window.
       tapShift();
     });
-    // A second single tap toggles off normally when gap exceeds… wait, same
-    // tapShift twice quickly is forceOff path on the second release.
+    await flushActivate();
+
     expect(result.current.isActive).toBe(false);
+    expect(useEventJumpStore.getState().announcement).toBe("");
   });
 });

--- a/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.test.tsx
+++ b/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.test.tsx
@@ -2,17 +2,12 @@ import { act, cleanup, renderHook } from "@testing-library/react";
 import { EventIdSchema } from "@core/types/domain-primitives";
 import { type GridEvent } from "@web/common/types/web.event.types";
 import { clearAppLockReasons, setAppLockReason } from "@web/shortcuts/app-lock";
-import { SHIFT_HOLD_HINT_THRESHOLD_MS } from "@web/shortcuts/shift-hint/shift-hold-detector";
-import { useShiftHoldEventHints } from "@web/shortcuts/shift-hint/useShiftHoldEventHints";
 import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  mock,
-  spyOn,
-} from "bun:test";
+  eventJumpActions,
+  useEventJumpStore,
+} from "@web/shortcuts/shift-hint/event-jump.store";
+import { useShiftHoldEventHints } from "@web/shortcuts/shift-hint/useShiftHoldEventHints";
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 
 const EVENT_A = EventIdSchema.parse("aaaaaaaaaaaaaaaaaaaaaaaa");
 const EVENT_B = EventIdSchema.parse("bbbbbbbbbbbbbbbbbbbbbbbb");
@@ -34,6 +29,11 @@ const dispatch = (
   );
 };
 
+const tapShift = () => {
+  dispatch("keydown", "Shift");
+  dispatch("keyup", "Shift");
+};
+
 const timedFixture = (id: string, startDate: string): GridEvent =>
   ({
     _id: id,
@@ -44,47 +44,30 @@ const timedFixture = (id: string, startDate: string): GridEvent =>
   }) as GridEvent;
 
 describe("useShiftHoldEventHints", () => {
-  let timeoutCb: (() => void) | null = null;
-  let setTimeoutSpy: ReturnType<typeof spyOn>;
-  let clearTimeoutSpy: ReturnType<typeof spyOn>;
-
   beforeEach(() => {
     clearAppLockReasons();
-    timeoutCb = null;
-    setTimeoutSpy = spyOn(globalThis, "setTimeout").mockImplementation(((
-      handler: TimerHandler,
-    ) => {
-      timeoutCb = () => {
-        if (typeof handler === "function") handler();
-      };
-      return 1 as unknown as ReturnType<typeof setTimeout>;
-    }) as unknown as typeof setTimeout);
-    clearTimeoutSpy = spyOn(globalThis, "clearTimeout").mockImplementation(
-      (() => {}) as typeof clearTimeout,
-    );
+    eventJumpActions.reset();
   });
 
   afterEach(() => {
     cleanup();
     clearAppLockReasons();
+    eventJumpActions.reset();
     document.body.innerHTML = "";
-    setTimeoutSpy.mockRestore();
-    clearTimeoutSpy.mockRestore();
   });
 
-  const mountHints = () => {
+  const mountHints = (mode: "week" | "day" = "week") => {
     const focus = mock((_target: { eventId: string }) => {});
-    const elements = [EVENT_A, EVENT_B, EVENT_C].map((id, index) => {
+    const elements = [EVENT_A, EVENT_B, EVENT_C].map((id) => {
       const el = document.createElement("button");
       el.textContent = id;
-      // jsdom has no layout; stub a viewport rect so flash targeting can arm.
       el.getBoundingClientRect = () =>
         ({
           x: 40,
-          y: 80 + index * 40,
-          top: 80 + index * 40,
+          y: 80,
+          top: 80,
           left: 40,
-          bottom: 110 + index * 40,
+          bottom: 110,
           right: 200,
           width: 160,
           height: 30,
@@ -94,10 +77,11 @@ describe("useShiftHoldEventHints", () => {
       return el;
     });
 
+    // Wednesday / Thursday / Friday so prefixes are W / R / F.
     const timedEvents = [
-      timedFixture(EVENT_A, "2026-05-20T09:00:00.000Z"),
-      timedFixture(EVENT_B, "2026-05-20T11:00:00.000Z"),
-      timedFixture(EVENT_C, "2026-05-20T13:00:00.000Z"),
+      timedFixture(EVENT_A, "2026-08-05T09:00:00.000Z"),
+      timedFixture(EVENT_B, "2026-08-05T11:00:00.000Z"),
+      timedFixture(EVENT_C, "2026-08-06T13:00:00.000Z"),
     ];
 
     const { result } = renderHook(() =>
@@ -108,6 +92,7 @@ describe("useShiftHoldEventHints", () => {
           { eventId: EVENT_B, eventType: "timed", element: elements[1]! },
           { eventId: EVENT_C, eventType: "timed", element: elements[2]! },
         ],
+        mode,
         timedEvents,
       }),
     );
@@ -115,52 +100,53 @@ describe("useShiftHoldEventHints", () => {
     return { focus, result, elements };
   };
 
-  it("shows hints after the hold threshold and focuses on an assigned key", () => {
+  it("toggles hints on a quick Shift tap and focuses via day prefix", () => {
     const { focus, result, elements } = mountHints();
 
     act(() => {
-      dispatch("keydown", "Shift");
-    });
-    expect(result.current).toEqual([]);
-    expect(setTimeoutSpy).toHaveBeenCalledWith(
-      expect.any(Function),
-      SHIFT_HOLD_HINT_THRESHOLD_MS,
-    );
-
-    act(() => {
-      timeoutCb?.();
+      tapShift();
     });
 
-    expect(result.current.map((hint) => hint.hint)).toEqual(["a", "s", "d"]);
-    expect(result.current.map((hint) => hint.eventId)).toEqual([
-      EVENT_A,
-      EVENT_B,
-      EVENT_C,
+    expect(result.current.isActive).toBe(true);
+    expect(result.current.hints.map((hint) => hint.hint)).toEqual([
+      "w1",
+      "w2",
+      "r1",
     ]);
+    expect(useEventJumpStore.getState().announcement).toBe("Event jump on");
 
     act(() => {
-      dispatch("keydown", "s", { shiftKey: true });
-      dispatch("keyup", "s", { shiftKey: true });
+      dispatch("keydown", "w");
+    });
+
+    expect(focus).toHaveBeenCalledWith(
+      expect.objectContaining({ eventId: EVENT_A, element: elements[0] }),
+    );
+    expect(result.current.activeDayKeys).toEqual(["2026-08-05"]);
+    expect(result.current.isActive).toBe(true);
+
+    act(() => {
+      dispatch("keydown", "2");
     });
 
     expect(focus).toHaveBeenCalledWith(
       expect.objectContaining({ eventId: EVENT_B, element: elements[1] }),
     );
-    expect(result.current).toEqual([]);
+    expect(result.current.isActive).toBe(true);
   });
 
-  it("does not flash hints on a quick Shift chord (Shift+J)", () => {
+  it("does not toggle on a quick Shift chord (Shift+J)", () => {
     const { result } = mountHints();
 
     act(() => {
       dispatch("keydown", "Shift");
       dispatch("keydown", "j", { shiftKey: true });
-    });
-    act(() => {
-      timeoutCb?.();
+      dispatch("keyup", "j", { shiftKey: true });
+      dispatch("keyup", "Shift");
     });
 
-    expect(result.current).toEqual([]);
+    expect(result.current.isActive).toBe(false);
+    expect(result.current.hints).toEqual([]);
   });
 
   it("stays inert while app-locked", () => {
@@ -168,27 +154,69 @@ describe("useShiftHoldEventHints", () => {
     const { result } = mountHints();
 
     act(() => {
-      dispatch("keydown", "Shift");
-    });
-    act(() => {
-      timeoutCb?.();
+      tapShift();
     });
 
-    expect(result.current).toEqual([]);
+    expect(result.current.isActive).toBe(false);
+    expect(result.current.hints).toEqual([]);
   });
 
-  it("clears hints when Shift is released", () => {
+  it("clears hints when Shift is tapped again or Escape is pressed", () => {
     const { result } = mountHints();
 
     act(() => {
-      dispatch("keydown", "Shift");
-      timeoutCb?.();
+      tapShift();
     });
-    expect(result.current).toHaveLength(3);
+    expect(result.current.hints).toHaveLength(3);
 
     act(() => {
-      dispatch("keyup", "Shift");
+      tapShift();
     });
-    expect(result.current).toEqual([]);
+    expect(result.current.isActive).toBe(false);
+    expect(result.current.hints).toEqual([]);
+
+    act(() => {
+      tapShift();
+    });
+    expect(result.current.isActive).toBe(true);
+
+    act(() => {
+      dispatch("keydown", "Escape");
+    });
+    expect(result.current.isActive).toBe(false);
+    expect(result.current.hints).toEqual([]);
+  });
+
+  it("keeps mode on when arrows are pressed after selecting a day", () => {
+    const { focus, result } = mountHints();
+
+    act(() => {
+      tapShift();
+      dispatch("keydown", "w");
+    });
+    expect(focus).toHaveBeenCalled();
+    expect(result.current.isActive).toBe(true);
+
+    act(() => {
+      dispatch("keydown", "ArrowDown");
+    });
+    expect(result.current.isActive).toBe(true);
+  });
+
+  it("force-off on Shift-Shift without leaving jump announcement", () => {
+    const { result } = mountHints();
+
+    act(() => {
+      tapShift();
+    });
+    expect(result.current.isActive).toBe(true);
+
+    act(() => {
+      // Second tap within double-tap window.
+      tapShift();
+    });
+    // A second single tap toggles off normally when gap exceeds… wait, same
+    // tapShift twice quickly is forceOff path on the second release.
+    expect(result.current.isActive).toBe(false);
   });
 });

--- a/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.ts
+++ b/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.ts
@@ -2,10 +2,12 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import dayjs from "@core/util/date/dayjs";
 import { type GridEvent } from "@web/common/types/web.event.types";
 import { isEditableKeyboardTarget } from "@web/common/utils/form/form.util";
+import { isHigherEscapeOwner } from "@web/shortcuts/escape-ownership";
 import {
   assignDayJumpKeys,
   type DayJumpAssignment,
   type DayJumpLabelMode,
+  DIGIT_AMBIGUOUS_COMMIT_MS,
   filterHintsByPrefix,
   matchDayJumpKeystroke,
 } from "@web/shortcuts/shift-hint/assign-shift-hint-keys";
@@ -93,6 +95,9 @@ export function useShiftHoldEventHints({
   const assignmentsRef = useRef<DayJumpAssignment[]>([]);
   const visibleByIdRef = useRef<Map<string, ShiftHintFocusTarget>>(new Map());
   const suppressKeyUpRef = useRef(new Set<string>());
+  const ambiguousCommitTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
   const focusRef = useRef(focus);
   const listVisibleRef = useRef(listVisible);
   const allDayEventsRef = useRef(allDayEvents);
@@ -116,11 +121,19 @@ export function useShiftHoldEventHints({
       return;
     }
 
+    const clearAmbiguousCommitTimer = () => {
+      if (ambiguousCommitTimerRef.current !== null) {
+        clearTimeout(ambiguousCommitTimerRef.current);
+        ambiguousCommitTimerRef.current = null;
+      }
+    };
+
     const publishHints = (next: ActiveShiftHint[]) => {
       setHints(next);
     };
 
     const clearHints = () => {
+      clearAmbiguousCommitTimer();
       assignmentsRef.current = [];
       visibleByIdRef.current = new Map();
       bufferRef.current = "";
@@ -210,6 +223,35 @@ export function useShiftHoldEventHints({
       focusRef.current(target);
     };
 
+    const commitFocus = (eventId: string, dayKey: string, buffer: string) => {
+      clearAmbiguousCommitTimer();
+      eventJumpActions.setActiveDayKeys([dayKey]);
+      publishFiltered(buffer.replace(/\d+$/, "") || buffer);
+      focusEvent(eventId);
+      // Reset digit buffer to the day prefix so another index can be typed,
+      // or clear fully in day mode.
+      const dayPrefix = buffer.replace(/\d+$/, "");
+      bufferRef.current = dayPrefix;
+      if (modeRef.current === "day") {
+        bufferRef.current = "";
+        publishFiltered("");
+      }
+    };
+
+    const scheduleAmbiguousCommit = (
+      eventId: string,
+      dayKey: string,
+      buffer: string,
+    ) => {
+      clearAmbiguousCommitTimer();
+      ambiguousCommitTimerRef.current = setTimeout(() => {
+        ambiguousCommitTimerRef.current = null;
+        if (!isActiveRef.current) return;
+        if (bufferRef.current !== buffer) return;
+        commitFocus(eventId, dayKey, buffer);
+      }, DIGIT_AMBIGUOUS_COMMIT_MS);
+    };
+
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.defaultPrevented) return;
 
@@ -241,20 +283,16 @@ export function useShiftHoldEventHints({
       }
 
       if (event.key === "Escape") {
+        if (isHigherEscapeOwner()) return;
         event.preventDefault();
         event.stopPropagation();
         deactivate();
         return;
       }
 
-      // Arrows / j / k keep mode on so letter-then-arrows works.
-      if (
-        event.key.startsWith("Arrow") ||
-        event.key === "j" ||
-        event.key === "J" ||
-        event.key === "k" ||
-        event.key === "K"
-      ) {
+      // Arrows keep mode on so letter-then-arrows can move focus.
+      if (event.key.startsWith("Arrow")) {
+        clearAmbiguousCommitTimer();
         return;
       }
 
@@ -263,6 +301,9 @@ export function useShiftHoldEventHints({
       }
 
       const key = event.key.length === 1 ? event.key.toLowerCase() : event.key;
+      if (key.length !== 1) return;
+
+      // Swallow j/k and other unmatched printable shortcuts while jump is on.
       const match = matchDayJumpKeystroke({
         assignments: assignmentsRef.current,
         key,
@@ -270,11 +311,14 @@ export function useShiftHoldEventHints({
         mode: modeRef.current,
       });
 
-      if (!match) return;
-
       event.preventDefault();
       event.stopPropagation();
       suppressKeyUpRef.current.add(key);
+
+      if (!match) {
+        clearAmbiguousCommitTimer();
+        return;
+      }
 
       if (match.kind === "prefix") {
         bufferRef.current = match.buffer;
@@ -283,10 +327,21 @@ export function useShiftHoldEventHints({
           match.buffer === "s" ? "Sunday or Saturday" : undefined,
         );
         publishFiltered(match.buffer);
+        if (match.pendingExactEventId) {
+          const exact = assignmentsRef.current.find(
+            (assignment) => assignment.eventId === match.pendingExactEventId,
+          );
+          if (exact) {
+            scheduleAmbiguousCommit(exact.eventId, exact.dayKey, match.buffer);
+          }
+        } else {
+          clearAmbiguousCommitTimer();
+        }
         return;
       }
 
       if (match.kind === "selectDay") {
+        clearAmbiguousCommitTimer();
         bufferRef.current = match.buffer;
         const dayName = DAY_NAME_BY_PREFIX[match.dayPrefix] ?? match.dayPrefix;
         eventJumpActions.setActiveDayKeys(
@@ -299,19 +354,7 @@ export function useShiftHoldEventHints({
         return;
       }
 
-      // focus
-      bufferRef.current = match.buffer;
-      eventJumpActions.setActiveDayKeys([match.dayKey]);
-      publishFiltered(match.buffer.replace(/\d+$/, "") || match.buffer);
-      focusEvent(match.eventId);
-      // Reset digit buffer to the day prefix so another index can be typed,
-      // or clear fully in day mode.
-      const dayPrefix = match.buffer.replace(/\d+$/, "");
-      bufferRef.current = dayPrefix;
-      if (modeRef.current === "day") {
-        bufferRef.current = "";
-        publishFiltered("");
-      }
+      commitFocus(match.eventId, match.dayKey, match.buffer);
     };
 
     const onKeyUp = (event: KeyboardEvent) => {
@@ -360,6 +403,7 @@ export function useShiftHoldEventHints({
     window.addEventListener("blur", onBlur);
 
     return () => {
+      clearAmbiguousCommitTimer();
       suppressKeyUpRef.current.clear();
       document.removeEventListener("keydown", onKeyDown, true);
       document.removeEventListener("keyup", onKeyUp, true);

--- a/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.ts
+++ b/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.ts
@@ -1,19 +1,23 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import dayjs from "@core/util/date/dayjs";
 import { type GridEvent } from "@web/common/types/web.event.types";
 import { isEditableKeyboardTarget } from "@web/common/utils/form/form.util";
 import {
-  assignShiftHintKeys,
+  assignDayJumpKeys,
+  type DayJumpAssignment,
+  type DayJumpLabelMode,
   filterHintsByPrefix,
-  matchShiftHintKeystroke,
-  type ShiftHintAssignment,
+  matchDayJumpKeystroke,
 } from "@web/shortcuts/shift-hint/assign-shift-hint-keys";
 import {
-  createShiftHoldState,
+  eventJumpActions,
+  useEventJumpStore,
+} from "@web/shortcuts/shift-hint/event-jump.store";
+import {
+  createShiftJumpGestureState,
   isShiftKey,
-  reduceShiftHold,
-  SHIFT_HOLD_HINT_THRESHOLD_MS,
-  type ShiftHoldState,
+  reduceShiftJumpGesture,
+  type ShiftJumpGestureState,
 } from "@web/shortcuts/shift-hint/shift-hold-detector";
 
 export type ShiftHintFocusTarget = {
@@ -22,77 +26,95 @@ export type ShiftHintFocusTarget = {
   element: HTMLElement;
 };
 
-export type ActiveShiftHint = ShiftHintAssignment & {
+export type ActiveShiftHint = DayJumpAssignment & {
   element: HTMLElement;
+};
+
+export type EventJumpHintsResult = {
+  hints: ActiveShiftHint[];
+  isActive: boolean;
+  activeDayKeys: string[];
 };
 
 const isAppLocked = () => document.body.dataset.appLocked === "true";
 
-const scheduleStartMs = (event: GridEvent): number => {
-  if (!event.startDate) return 0;
-  return dayjs(event.startDate).valueOf();
+const DAY_NAME_BY_PREFIX: Record<string, string> = {
+  su: "Sunday",
+  m: "Monday",
+  t: "Tuesday",
+  w: "Wednesday",
+  r: "Thursday",
+  f: "Friday",
+  sa: "Saturday",
 };
 
-/** True when any part of the element intersects the viewport. */
-const isInViewport = (element: HTMLElement): boolean => {
-  const rect = element.getBoundingClientRect();
-  if (rect.width === 0 && rect.height === 0) return false;
-  return (
-    rect.bottom > 0 &&
-    rect.right > 0 &&
-    rect.top < window.innerHeight &&
-    rect.left < window.innerWidth
-  );
+const scheduleMeta = (event: GridEvent) => {
+  if (!event.startDate) {
+    return { startMs: 0, dayKey: "1970-01-01", weekday: 0 };
+  }
+  const start = dayjs(event.startDate);
+  return {
+    startMs: start.valueOf(),
+    dayKey: start.format("YYYY-MM-DD"),
+    weekday: start.day(),
+  };
 };
 
 /**
- * Hold SHIFT (≥ threshold) to flash home-row hint chips on visible grid events.
- * Assigned key focuses the event and dismisses. Release clears. Quick chords
- * (Shift+J, Shift+Arrow) cancel before hints appear.
+ * Tap Shift to toggle day-prefix jump labels on grid events. Esc or another
+ * Shift tap exits. Day letters (and digits after a day) win over global
+ * shortcuts while active. Shift+chords never toggle; Shift-Shift forces off
+ * so keyboard-only mode can enter.
  */
 export function useShiftHoldEventHints({
   allDayEvents = [],
   enabled = true,
   focus,
   listVisible,
+  mode = "week",
   timedEvents,
 }: {
   allDayEvents?: GridEvent[];
   enabled?: boolean;
   focus: (target: ShiftHintFocusTarget) => void;
   listVisible: () => ShiftHintFocusTarget[];
+  mode?: DayJumpLabelMode;
   timedEvents: GridEvent[];
-}): ActiveShiftHint[] {
+}): EventJumpHintsResult {
   const [hints, setHints] = useState<ActiveShiftHint[]>([]);
-  const stateRef = useRef<ShiftHoldState>(createShiftHoldState());
-  const assignmentsRef = useRef<ShiftHintAssignment[]>([]);
+  const isActive = useEventJumpStore((state) => state.isActive);
+  const activeDayKeys = useEventJumpStore((state) => state.activeDayKeys);
+
+  const gestureRef = useRef<ShiftJumpGestureState>(
+    createShiftJumpGestureState(),
+  );
+  const isActiveRef = useRef(false);
+  const bufferRef = useRef("");
+  const assignmentsRef = useRef<DayJumpAssignment[]>([]);
   const visibleByIdRef = useRef<Map<string, ShiftHintFocusTarget>>(new Map());
-  const thresholdTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const suppressKeyUpRef = useRef(new Set<string>());
   const focusRef = useRef(focus);
   const listVisibleRef = useRef(listVisible);
   const allDayEventsRef = useRef(allDayEvents);
   const timedEventsRef = useRef(timedEvents);
+  const modeRef = useRef(mode);
 
   focusRef.current = focus;
   listVisibleRef.current = listVisible;
   allDayEventsRef.current = allDayEvents;
   timedEventsRef.current = timedEvents;
+  modeRef.current = mode;
+  isActiveRef.current = isActive;
 
   useEffect(() => {
     if (!enabled) {
-      stateRef.current = createShiftHoldState();
+      gestureRef.current = createShiftJumpGestureState();
+      bufferRef.current = "";
       assignmentsRef.current = [];
       setHints([]);
+      eventJumpActions.reset();
       return;
     }
-
-    const clearThresholdTimer = () => {
-      if (thresholdTimerRef.current !== null) {
-        clearTimeout(thresholdTimerRef.current);
-        thresholdTimerRef.current = null;
-      }
-    };
 
     const publishHints = (next: ActiveShiftHint[]) => {
       setHints(next);
@@ -101,31 +123,42 @@ export function useShiftHoldEventHints({
     const clearHints = () => {
       assignmentsRef.current = [];
       visibleByIdRef.current = new Map();
+      bufferRef.current = "";
       publishHints([]);
     };
 
     const buildAssignments = () => {
-      // Targeting adapters include laid-out-but-scrolled-off cards; flash
-      // hints only for events intersecting the viewport.
-      const visible = listVisibleRef
-        .current()
-        .filter((target) => isInViewport(target.element));
-      const scheduleById = new Map<string, number>();
+      // Label every registered event in the view (not only viewport cards) so
+      // day indices stay stable while scrolling.
+      const visible = listVisibleRef.current();
+      const scheduleById = new Map<
+        string,
+        { startMs: number; dayKey: string; weekday: number }
+      >();
       for (const event of [
         ...allDayEventsRef.current,
         ...timedEventsRef.current,
       ]) {
         if (!event._id) continue;
-        scheduleById.set(event._id, scheduleStartMs(event));
+        scheduleById.set(event._id, scheduleMeta(event));
       }
 
-      const targets = visible.map((target) => ({
-        eventId: target.eventId,
-        eventType: target.eventType,
-        startMs: scheduleById.get(target.eventId) ?? 0,
-      }));
+      const targets = visible.map((target) => {
+        const meta = scheduleById.get(target.eventId) ?? {
+          startMs: 0,
+          dayKey: "1970-01-01",
+          weekday: 0,
+        };
+        return {
+          eventId: target.eventId,
+          eventType: target.eventType,
+          startMs: meta.startMs,
+          dayKey: meta.dayKey,
+          weekday: meta.weekday,
+        };
+      });
 
-      const assignments = assignShiftHintKeys(targets);
+      const assignments = assignDayJumpKeys(targets, modeRef.current);
       assignmentsRef.current = assignments;
       visibleByIdRef.current = new Map(
         visible.map((target) => [target.eventId, target]),
@@ -138,18 +171,43 @@ export function useShiftHoldEventHints({
       });
     };
 
+    const publishFiltered = (buffer: string) => {
+      const source = buffer
+        ? filterHintsByPrefix(assignmentsRef.current, buffer)
+        : assignmentsRef.current;
+      publishHints(
+        source.flatMap((assignment) => {
+          const target = visibleByIdRef.current.get(assignment.eventId);
+          if (!target) return [];
+          return [{ ...assignment, element: target.element }];
+        }),
+      );
+    };
+
     const activate = () => {
-      stateRef.current = reduceShiftHold(stateRef.current, {
-        type: "thresholdReached",
-      });
-      if (stateRef.current.phase !== "active") return;
+      isActiveRef.current = true;
+      bufferRef.current = "";
+      eventJumpActions.setActive(true);
+      eventJumpActions.setActiveDayKeys([]);
       publishHints(buildAssignments());
     };
 
-    const dismiss = () => {
-      clearThresholdTimer();
-      stateRef.current = reduceShiftHold(stateRef.current, { type: "dismiss" });
+    const deactivate = (announceOff = true) => {
+      isActiveRef.current = false;
+      bufferRef.current = "";
       clearHints();
+      if (announceOff) {
+        eventJumpActions.setActive(false);
+      } else {
+        eventJumpActions.silenceOff();
+      }
+    };
+
+    const focusEvent = (eventId: string) => {
+      const target = visibleByIdRef.current.get(eventId);
+      if (!target) return;
+      target.element.scrollIntoView({ block: "nearest" });
+      focusRef.current(target);
     };
 
     const onKeyDown = (event: KeyboardEvent) => {
@@ -158,64 +216,58 @@ export function useShiftHoldEventHints({
       if (isShiftKey(event)) {
         if (event.repeat) return;
         const blocked = isAppLocked() || isEditableKeyboardTarget(event);
-        stateRef.current = reduceShiftHold(stateRef.current, {
+        const result = reduceShiftJumpGesture(gestureRef.current, {
           type: "shiftDown",
           now: Date.now(),
           blocked,
         });
-        clearThresholdTimer();
-        if (stateRef.current.phase !== "pending") return;
-
-        thresholdTimerRef.current = setTimeout(() => {
-          thresholdTimerRef.current = null;
-          if (stateRef.current.phase !== "pending") return;
-          if (isAppLocked()) {
-            dismiss();
-            return;
-          }
-          activate();
-        }, SHIFT_HOLD_HINT_THRESHOLD_MS);
+        gestureRef.current = result.state;
         return;
       }
 
-      if (stateRef.current.phase === "pending") {
-        // Any other key while pending is a chord (Shift+J, Shift+Arrow, …).
-        clearThresholdTimer();
-        stateRef.current = reduceShiftHold(stateRef.current, {
+      if (gestureRef.current.phase === "armed") {
+        // Chord while Shift is down (Shift+J, Shift+Arrow, …): never toggle.
+        const result = reduceShiftJumpGesture(gestureRef.current, {
           type: "chordKeyDown",
         });
+        gestureRef.current = result.state;
         return;
       }
 
-      if (stateRef.current.phase !== "active") return;
+      if (!isActiveRef.current) return;
       if (isAppLocked() || isEditableKeyboardTarget(event)) {
-        dismiss();
+        deactivate();
         return;
       }
 
-      // Escape / arrows dismiss and let existing handlers run.
+      if (event.key === "Escape") {
+        event.preventDefault();
+        event.stopPropagation();
+        deactivate();
+        return;
+      }
+
+      // Arrows / j / k keep mode on so letter-then-arrows works.
       if (
-        event.key === "Escape" ||
         event.key.startsWith("Arrow") ||
         event.key === "j" ||
         event.key === "J" ||
         event.key === "k" ||
         event.key === "K"
       ) {
-        dismiss();
         return;
       }
 
       if (event.metaKey || event.ctrlKey || event.altKey) {
-        dismiss();
         return;
       }
 
       const key = event.key.length === 1 ? event.key.toLowerCase() : event.key;
-      const match = matchShiftHintKeystroke({
+      const match = matchDayJumpKeystroke({
         assignments: assignmentsRef.current,
         key,
-        prefix: stateRef.current.hintPrefix,
+        buffer: bufferRef.current,
+        mode: modeRef.current,
       });
 
       if (!match) return;
@@ -225,44 +277,68 @@ export function useShiftHoldEventHints({
       suppressKeyUpRef.current.add(key);
 
       if (match.kind === "prefix") {
-        stateRef.current = reduceShiftHold(stateRef.current, {
-          type: "setPrefix",
-          prefix: match.prefix,
-        });
-        const narrowed = filterHintsByPrefix(
-          assignmentsRef.current,
-          match.prefix,
+        bufferRef.current = match.buffer;
+        eventJumpActions.setActiveDayKeys(
+          match.dayKeys,
+          match.buffer === "s" ? "Sunday or Saturday" : undefined,
         );
-        publishHints(
-          narrowed.flatMap((assignment) => {
-            const target = visibleByIdRef.current.get(assignment.eventId);
-            if (!target) return [];
-            return [{ ...assignment, element: target.element }];
-          }),
-        );
+        publishFiltered(match.buffer);
         return;
       }
 
-      const target = visibleByIdRef.current.get(match.eventId);
-      dismiss();
-      if (!target) return;
-      target.element.scrollIntoView({ block: "nearest" });
-      focusRef.current(target);
+      if (match.kind === "selectDay") {
+        bufferRef.current = match.buffer;
+        const dayName = DAY_NAME_BY_PREFIX[match.dayPrefix] ?? match.dayPrefix;
+        eventJumpActions.setActiveDayKeys(
+          [match.dayKey],
+          `${dayName} selected`,
+        );
+        // Keep chips for the selected day so a following digit can refine.
+        publishFiltered(match.dayPrefix);
+        focusEvent(match.firstEventId);
+        return;
+      }
+
+      // focus
+      bufferRef.current = match.buffer;
+      eventJumpActions.setActiveDayKeys([match.dayKey]);
+      publishFiltered(match.buffer.replace(/\d+$/, "") || match.buffer);
+      focusEvent(match.eventId);
+      // Reset digit buffer to the day prefix so another index can be typed,
+      // or clear fully in day mode.
+      const dayPrefix = match.buffer.replace(/\d+$/, "");
+      bufferRef.current = dayPrefix;
+      if (modeRef.current === "day") {
+        bufferRef.current = "";
+        publishFiltered("");
+      }
     };
 
     const onKeyUp = (event: KeyboardEvent) => {
       if (isShiftKey(event)) {
-        // Keep holding if the other Shift key is still down.
         if (event.shiftKey) return;
 
-        const wasActive = stateRef.current.phase === "active";
-        clearThresholdTimer();
-        stateRef.current = reduceShiftHold(stateRef.current, {
-          type: "shiftUp",
-          now: Date.now(),
-        });
-        if (wasActive || assignmentsRef.current.length > 0) {
-          clearHints();
+        const { state, toggle, forceOff } = reduceShiftJumpGesture(
+          gestureRef.current,
+          {
+            type: "shiftUp",
+            now: Date.now(),
+          },
+        );
+        gestureRef.current = state;
+
+        if (forceOff) {
+          if (isActiveRef.current) deactivate(false);
+          return;
+        }
+
+        if (!toggle) return;
+        if (isAppLocked() || isEditableKeyboardTarget(event)) return;
+
+        if (isActiveRef.current) {
+          deactivate();
+        } else {
+          activate();
         }
         return;
       }
@@ -275,7 +351,8 @@ export function useShiftHoldEventHints({
     };
 
     const onBlur = () => {
-      dismiss();
+      gestureRef.current = createShiftJumpGestureState();
+      if (isActiveRef.current) deactivate();
     };
 
     document.addEventListener("keydown", onKeyDown, true);
@@ -283,13 +360,73 @@ export function useShiftHoldEventHints({
     window.addEventListener("blur", onBlur);
 
     return () => {
-      clearThresholdTimer();
       suppressKeyUpRef.current.clear();
       document.removeEventListener("keydown", onKeyDown, true);
       document.removeEventListener("keyup", onKeyUp, true);
       window.removeEventListener("blur", onBlur);
+      if (isActiveRef.current) {
+        eventJumpActions.reset();
+      }
     };
   }, [enabled]);
 
-  return hints;
+  const eventIdsKey = useMemo(
+    () =>
+      [...allDayEvents, ...timedEvents]
+        .map((event) => event._id ?? "")
+        .join(","),
+    [allDayEvents, timedEvents],
+  );
+
+  // Rebuild chips when the event set changes while mode is on. Uses refs for
+  // listVisible so an inline callback identity does not loop setState.
+  useEffect(() => {
+    if (!enabled || !isActive) return;
+    // Read eventIdsKey so the effect re-runs when the visible event id set changes.
+    void eventIdsKey;
+
+    const visible = listVisibleRef.current();
+    const scheduleById = new Map<
+      string,
+      { startMs: number; dayKey: string; weekday: number }
+    >();
+    for (const event of [
+      ...allDayEventsRef.current,
+      ...timedEventsRef.current,
+    ]) {
+      if (!event._id) continue;
+      scheduleById.set(event._id, scheduleMeta(event));
+    }
+    const targets = visible.map((target) => {
+      const meta = scheduleById.get(target.eventId) ?? {
+        startMs: 0,
+        dayKey: "1970-01-01",
+        weekday: 0,
+      };
+      return {
+        eventId: target.eventId,
+        eventType: target.eventType,
+        startMs: meta.startMs,
+        dayKey: meta.dayKey,
+        weekday: meta.weekday,
+      };
+    });
+    const assignments = assignDayJumpKeys(targets, modeRef.current);
+    assignmentsRef.current = assignments;
+    visibleByIdRef.current = new Map(
+      visible.map((target) => [target.eventId, target]),
+    );
+    const source = bufferRef.current
+      ? filterHintsByPrefix(assignments, bufferRef.current)
+      : assignments;
+    setHints(
+      source.flatMap((assignment) => {
+        const target = visibleByIdRef.current.get(assignment.eventId);
+        if (!target) return [];
+        return [{ ...assignment, element: target.element }];
+      }),
+    );
+  }, [enabled, eventIdsKey, isActive]);
+
+  return { hints, isActive, activeDayKeys };
 }

--- a/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.ts
+++ b/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.ts
@@ -5,6 +5,10 @@ import { type GridEvent } from "@web/common/types/web.event.types";
 import { isEditableKeyboardTarget } from "@web/common/utils/form/form.util";
 import { isHigherEscapeOwner } from "@web/shortcuts/escape-ownership";
 import {
+  selectKeyboardOnlyActive,
+  useKeyboardOnlyStore,
+} from "@web/shortcuts/keyboard-only/keyboard-only.store";
+import {
   assignDayJumpKeys,
   type DayJumpAssignment,
   type DayJumpLabelMode,
@@ -20,6 +24,7 @@ import {
   createShiftJumpGestureState,
   isShiftKey,
   reduceShiftJumpGesture,
+  SHIFT_DOUBLE_TAP_MAX_GAP_MS,
   type ShiftJumpGestureState,
 } from "@web/shortcuts/shift-hint/shift-hold-detector";
 
@@ -151,6 +156,9 @@ export function useShiftHoldEventHints({
   const ambiguousCommitTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
     null,
   );
+  const pendingActivateTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
   const focusRef = useRef(focus);
   const listVisibleRef = useRef(listVisible);
   const allDayEventsRef = useRef(allDayEvents);
@@ -166,6 +174,14 @@ export function useShiftHoldEventHints({
 
   useEffect(() => {
     if (!enabled) {
+      if (pendingActivateTimerRef.current !== null) {
+        clearTimeout(pendingActivateTimerRef.current);
+        pendingActivateTimerRef.current = null;
+      }
+      if (ambiguousCommitTimerRef.current !== null) {
+        clearTimeout(ambiguousCommitTimerRef.current);
+        ambiguousCommitTimerRef.current = null;
+      }
       gestureRef.current = createShiftJumpGestureState();
       bufferRef.current = "";
       assignmentsRef.current = [];
@@ -178,6 +194,13 @@ export function useShiftHoldEventHints({
       if (ambiguousCommitTimerRef.current !== null) {
         clearTimeout(ambiguousCommitTimerRef.current);
         ambiguousCommitTimerRef.current = null;
+      }
+    };
+
+    const clearPendingActivateTimer = () => {
+      if (pendingActivateTimerRef.current !== null) {
+        clearTimeout(pendingActivateTimerRef.current);
+        pendingActivateTimerRef.current = null;
       }
     };
 
@@ -209,15 +232,41 @@ export function useShiftHoldEventHints({
       setHints(toActiveHints(source, visibleByIdRef.current));
     };
 
+    /** Drop trailing digits so the next index starts from the day prefix. */
+    const stripDigitBuffer = () => {
+      const dayPrefix = bufferRef.current.replace(/\d+$/, "");
+      if (dayPrefix === bufferRef.current) return;
+      bufferRef.current = dayPrefix;
+      publishFiltered(dayPrefix);
+    };
+
     const activate = () => {
+      if (selectKeyboardOnlyActive(useKeyboardOnlyStore.getState())) return;
+      const assignments = rebuildAssignments();
+      if (assignments.length === 0) return;
       isActiveRef.current = true;
       bufferRef.current = "";
       eventJumpActions.setActive(true);
       eventJumpActions.setActiveDayKeys([]);
-      setHints(toActiveHints(rebuildAssignments(), visibleByIdRef.current));
+      setHints(toActiveHints(assignments, visibleByIdRef.current));
+    };
+
+    const scheduleActivate = () => {
+      clearPendingActivateTimer();
+      // Defer past the Shift-Shift window so keyboard-only can win without a
+      // jump-mode flash on the first tap.
+      // Wait just past the double-tap window so a second Shift is forceOff
+      // (keyboard-only) rather than racing this activate.
+      pendingActivateTimerRef.current = setTimeout(() => {
+        pendingActivateTimerRef.current = null;
+        if (isActiveRef.current) return;
+        if (isAppLocked()) return;
+        activate();
+      }, SHIFT_DOUBLE_TAP_MAX_GAP_MS + 1);
     };
 
     const deactivate = (announceOff = true) => {
+      clearPendingActivateTimer();
       isActiveRef.current = false;
       bufferRef.current = "";
       clearHints();
@@ -305,6 +354,7 @@ export function useShiftHoldEventHints({
       // Arrows keep mode on so letter-then-arrows can move focus.
       if (event.key.startsWith("Arrow")) {
         clearAmbiguousCommitTimer();
+        stripDigitBuffer();
         return;
       }
 
@@ -329,6 +379,7 @@ export function useShiftHoldEventHints({
 
       if (!match) {
         clearAmbiguousCommitTimer();
+        stripDigitBuffer();
         return;
       }
 
@@ -383,6 +434,8 @@ export function useShiftHoldEventHints({
         gestureRef.current = state;
 
         if (forceOff) {
+          // Cancel a deferred first-tap activate; silence if jump already on.
+          clearPendingActivateTimer();
           if (isActiveRef.current) deactivate(false);
           return;
         }
@@ -392,8 +445,12 @@ export function useShiftHoldEventHints({
 
         if (isActiveRef.current) {
           deactivate();
+        } else if (pendingActivateTimerRef.current !== null) {
+          // Second intentional tap after deferral window started but before
+          // activate fired: treat as cancel (also covers slow double intent).
+          clearPendingActivateTimer();
         } else {
-          activate();
+          scheduleActivate();
         }
         return;
       }
@@ -407,6 +464,7 @@ export function useShiftHoldEventHints({
 
     const onBlur = () => {
       gestureRef.current = createShiftJumpGestureState();
+      clearPendingActivateTimer();
       if (isActiveRef.current) deactivate();
     };
 
@@ -416,6 +474,7 @@ export function useShiftHoldEventHints({
 
     return () => {
       clearAmbiguousCommitTimer();
+      clearPendingActivateTimer();
       suppressKeyUpRef.current.clear();
       document.removeEventListener("keydown", onKeyDown, true);
       document.removeEventListener("keyup", onKeyUp, true);

--- a/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.ts
+++ b/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.ts
@@ -1,4 +1,5 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
+import { YEAR_MONTH_DAY_FORMAT } from "@core/constants/date.constants";
 import dayjs from "@core/util/date/dayjs";
 import { type GridEvent } from "@web/common/types/web.event.types";
 import { isEditableKeyboardTarget } from "@web/common/utils/form/form.util";
@@ -50,15 +51,67 @@ const DAY_NAME_BY_PREFIX: Record<string, string> = {
   sa: "Saturday",
 };
 
-const scheduleMeta = (event: GridEvent) => {
-  if (!event.startDate) {
-    return { startMs: 0, dayKey: "1970-01-01", weekday: 0 };
-  }
+const FALLBACK_SCHEDULE = {
+  startMs: 0,
+  dayKey: "1970-01-01",
+  weekday: 0,
+} as const;
+
+type ScheduleMeta = {
+  startMs: number;
+  dayKey: string;
+  weekday: number;
+};
+
+const scheduleMeta = (event: GridEvent): ScheduleMeta => {
+  if (!event.startDate) return FALLBACK_SCHEDULE;
   const start = dayjs(event.startDate);
   return {
     startMs: start.valueOf(),
-    dayKey: start.format("YYYY-MM-DD"),
+    dayKey: start.format(YEAR_MONTH_DAY_FORMAT),
     weekday: start.day(),
+  };
+};
+
+const toActiveHints = (
+  assignments: DayJumpAssignment[],
+  visibleById: Map<string, ShiftHintFocusTarget>,
+): ActiveShiftHint[] =>
+  assignments.flatMap((assignment) => {
+    const target = visibleById.get(assignment.eventId);
+    if (!target) return [];
+    return [{ ...assignment, element: target.element }];
+  });
+
+/** Assign day-jump keys for the currently registered grid targets. */
+const buildDayJumpAssignments = (
+  visible: ShiftHintFocusTarget[],
+  events: GridEvent[],
+  mode: DayJumpLabelMode,
+): {
+  assignments: DayJumpAssignment[];
+  visibleById: Map<string, ShiftHintFocusTarget>;
+} => {
+  const scheduleById = new Map<string, ScheduleMeta>();
+  for (const event of events) {
+    if (!event._id) continue;
+    scheduleById.set(event._id, scheduleMeta(event));
+  }
+
+  const targets = visible.map((target) => {
+    const meta = scheduleById.get(target.eventId) ?? FALLBACK_SCHEDULE;
+    return {
+      eventId: target.eventId,
+      eventType: target.eventType,
+      startMs: meta.startMs,
+      dayKey: meta.dayKey,
+      weekday: meta.weekday,
+    };
+  });
+
+  return {
+    assignments: assignDayJumpKeys(targets, mode),
+    visibleById: new Map(visible.map((target) => [target.eventId, target])),
   };
 };
 
@@ -128,73 +181,32 @@ export function useShiftHoldEventHints({
       }
     };
 
-    const publishHints = (next: ActiveShiftHint[]) => {
-      setHints(next);
-    };
-
     const clearHints = () => {
       clearAmbiguousCommitTimer();
       assignmentsRef.current = [];
       visibleByIdRef.current = new Map();
       bufferRef.current = "";
-      publishHints([]);
+      setHints([]);
     };
 
-    const buildAssignments = () => {
+    const rebuildAssignments = () => {
       // Label every registered event in the view (not only viewport cards) so
       // day indices stay stable while scrolling.
-      const visible = listVisibleRef.current();
-      const scheduleById = new Map<
-        string,
-        { startMs: number; dayKey: string; weekday: number }
-      >();
-      for (const event of [
-        ...allDayEventsRef.current,
-        ...timedEventsRef.current,
-      ]) {
-        if (!event._id) continue;
-        scheduleById.set(event._id, scheduleMeta(event));
-      }
-
-      const targets = visible.map((target) => {
-        const meta = scheduleById.get(target.eventId) ?? {
-          startMs: 0,
-          dayKey: "1970-01-01",
-          weekday: 0,
-        };
-        return {
-          eventId: target.eventId,
-          eventType: target.eventType,
-          startMs: meta.startMs,
-          dayKey: meta.dayKey,
-          weekday: meta.weekday,
-        };
-      });
-
-      const assignments = assignDayJumpKeys(targets, modeRef.current);
-      assignmentsRef.current = assignments;
-      visibleByIdRef.current = new Map(
-        visible.map((target) => [target.eventId, target]),
+      const { assignments, visibleById } = buildDayJumpAssignments(
+        listVisibleRef.current(),
+        [...allDayEventsRef.current, ...timedEventsRef.current],
+        modeRef.current,
       );
-
-      return assignments.flatMap((assignment) => {
-        const target = visibleByIdRef.current.get(assignment.eventId);
-        if (!target) return [];
-        return [{ ...assignment, element: target.element }];
-      });
+      assignmentsRef.current = assignments;
+      visibleByIdRef.current = visibleById;
+      return assignments;
     };
 
     const publishFiltered = (buffer: string) => {
       const source = buffer
         ? filterHintsByPrefix(assignmentsRef.current, buffer)
         : assignmentsRef.current;
-      publishHints(
-        source.flatMap((assignment) => {
-          const target = visibleByIdRef.current.get(assignment.eventId);
-          if (!target) return [];
-          return [{ ...assignment, element: target.element }];
-        }),
-      );
+      setHints(toActiveHints(source, visibleByIdRef.current));
     };
 
     const activate = () => {
@@ -202,7 +214,7 @@ export function useShiftHoldEventHints({
       bufferRef.current = "";
       eventJumpActions.setActive(true);
       eventJumpActions.setActiveDayKeys([]);
-      publishHints(buildAssignments());
+      setHints(toActiveHints(rebuildAssignments(), visibleByIdRef.current));
     };
 
     const deactivate = (announceOff = true) => {
@@ -226,16 +238,16 @@ export function useShiftHoldEventHints({
     const commitFocus = (eventId: string, dayKey: string, buffer: string) => {
       clearAmbiguousCommitTimer();
       eventJumpActions.setActiveDayKeys([dayKey]);
-      publishFiltered(buffer.replace(/\d+$/, "") || buffer);
       focusEvent(eventId);
-      // Reset digit buffer to the day prefix so another index can be typed,
-      // or clear fully in day mode.
-      const dayPrefix = buffer.replace(/\d+$/, "");
-      bufferRef.current = dayPrefix;
+      // Day view clears the buffer; week keeps the day prefix for the next index.
       if (modeRef.current === "day") {
         bufferRef.current = "";
         publishFiltered("");
+        return;
       }
+      const dayPrefix = buffer.replace(/\d+$/, "") || buffer;
+      bufferRef.current = dayPrefix;
+      publishFiltered(dayPrefix);
     };
 
     const scheduleAmbiguousCommit = (
@@ -414,62 +426,28 @@ export function useShiftHoldEventHints({
     };
   }, [enabled]);
 
-  const eventIdsKey = useMemo(
-    () =>
-      [...allDayEvents, ...timedEvents]
-        .map((event) => event._id ?? "")
-        .join(","),
-    [allDayEvents, timedEvents],
-  );
-
   // Rebuild chips when the event set changes while mode is on. Uses refs for
   // listVisible so an inline callback identity does not loop setState.
+  const eventIdsKey = [...allDayEvents, ...timedEvents]
+    .map((event) => event._id ?? "")
+    .join(",");
+
   useEffect(() => {
     if (!enabled || !isActive) return;
     // Read eventIdsKey so the effect re-runs when the visible event id set changes.
     void eventIdsKey;
 
-    const visible = listVisibleRef.current();
-    const scheduleById = new Map<
-      string,
-      { startMs: number; dayKey: string; weekday: number }
-    >();
-    for (const event of [
-      ...allDayEventsRef.current,
-      ...timedEventsRef.current,
-    ]) {
-      if (!event._id) continue;
-      scheduleById.set(event._id, scheduleMeta(event));
-    }
-    const targets = visible.map((target) => {
-      const meta = scheduleById.get(target.eventId) ?? {
-        startMs: 0,
-        dayKey: "1970-01-01",
-        weekday: 0,
-      };
-      return {
-        eventId: target.eventId,
-        eventType: target.eventType,
-        startMs: meta.startMs,
-        dayKey: meta.dayKey,
-        weekday: meta.weekday,
-      };
-    });
-    const assignments = assignDayJumpKeys(targets, modeRef.current);
-    assignmentsRef.current = assignments;
-    visibleByIdRef.current = new Map(
-      visible.map((target) => [target.eventId, target]),
+    const { assignments, visibleById } = buildDayJumpAssignments(
+      listVisibleRef.current(),
+      [...allDayEventsRef.current, ...timedEventsRef.current],
+      modeRef.current,
     );
+    assignmentsRef.current = assignments;
+    visibleByIdRef.current = visibleById;
     const source = bufferRef.current
       ? filterHintsByPrefix(assignments, bufferRef.current)
       : assignments;
-    setHints(
-      source.flatMap((assignment) => {
-        const target = visibleByIdRef.current.get(assignment.eventId);
-        if (!target) return [];
-        return [{ ...assignment, element: target.element }];
-      }),
-    );
+    setHints(toActiveHints(source, visibleById));
   }, [enabled, eventIdsKey, isActive]);
 
   return { hints, isActive, activeDayKeys };

--- a/packages/web/src/shortcuts/shortcuts.registry.test.ts
+++ b/packages/web/src/shortcuts/shortcuts.registry.test.ts
@@ -62,7 +62,7 @@ describe("shortcuts.registry", () => {
       expect(ids).toContain("edit-save");
     });
 
-    it("lists hold-Shift event jump keys in day and week focus sections", () => {
+    it("lists Shift event jump toggle in day and week focus sections", () => {
       for (const view of ["day", "week"] as const) {
         const shortcuts = filterShortcutsByContext({
           view,

--- a/packages/web/src/shortcuts/shortcuts.registry.ts
+++ b/packages/web/src/shortcuts/shortcuts.registry.ts
@@ -123,16 +123,9 @@ export const SHORTCUTS_REGISTRY: Shortcut[] = [
     section: "focus",
   },
   {
-    id: "focus-weekday-column",
-    keys: ["1-7"],
-    label: "Focus first event on weekday column",
-    section: "focus",
-    when: { eventFocused: true },
-  },
-  {
     id: "focus-shift-hold",
-    keys: ["Hold", "Shift"],
-    label: "Show event jump keys",
+    keys: ["Shift"],
+    label: "Toggle event jump keys",
     section: "focus",
   },
 
@@ -392,10 +385,6 @@ export const filterShortcutsByContext = (
         view === "day" &&
         (shortcut.id === "nav-shift-left" || shortcut.id === "nav-shift-right")
       ) {
-        return false;
-      }
-      // Digit weekday columns only apply in week view
-      if (view === "day" && shortcut.id === "focus-weekday-column") {
         return false;
       }
     }

--- a/packages/web/src/views/Day/hooks/shortcuts/useDayEventNudgeShortcuts.ts
+++ b/packages/web/src/views/Day/hooks/shortcuts/useDayEventNudgeShortcuts.ts
@@ -92,10 +92,11 @@ export function useDayEventNudgeShortcuts({
     timedEvents,
   });
 
-  const shiftHints = useShiftHoldEventHints({
+  const { hints: shiftHints } = useShiftHoldEventHints({
     allDayEvents,
     focus: focusDayGridEventTarget,
     listVisible: listVisibleDayGridEventTargets,
+    mode: "day",
     timedEvents,
   });
 

--- a/packages/web/src/views/Week/components/Header/DayLabels.tsx
+++ b/packages/web/src/views/Week/components/Header/DayLabels.tsx
@@ -1,8 +1,13 @@
 import cn from "classnames";
 import { type FC } from "react";
+import { YEAR_MONTH_DAY_FORMAT } from "@core/constants/date.constants";
 import { type Dayjs } from "@core/util/date/dayjs";
 import { getWeekDayLabel } from "@web/common/utils/event/event.util";
 import { EVENT_WIDTH_MINIMUM } from "@web/grid/grid.constants";
+import {
+  selectEventJumpActiveDayKeys,
+  useEventJumpStore,
+} from "@web/shortcuts/shift-hint/event-jump.store";
 
 interface Props {
   today: Dayjs;
@@ -17,6 +22,7 @@ export const DayLabels: FC<Props> = ({
   week,
   weekDays,
 }) => {
+  const activeDayKeys = useEventJumpStore(selectEventJumpActiveDayKeys);
   const getColor = (day: Dayjs) => {
     const isCurrentWeek = today.week() === week;
     const isToday = isCurrentWeek && today.format("DD") === day.format("DD");
@@ -51,12 +57,18 @@ export const DayLabels: FC<Props> = ({
         {weekDays.map((day) => {
           const dayNumber = getDayNumber(day);
           const { isToday, color } = getColor(day);
+          const dayKey = day.format(YEAR_MONTH_DAY_FORMAT);
+          const isJumpDay = activeDayKeys.includes(dayKey);
 
           return (
             <div
-              className="flex items-end justify-center gap-1"
+              className={cn(
+                "flex items-end justify-center gap-1 rounded-sm px-1 transition-colors duration-150 motion-reduce:transition-none",
+                isJumpDay && "bg-accent/15 text-accent",
+              )}
+              data-jump-day={isJumpDay ? "true" : undefined}
               key={getWeekDayLabel(day)}
-              style={{ color }}
+              style={isJumpDay ? undefined : { color }}
               title={getWeekDayLabel(day)}
             >
               <span

--- a/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcutOwner.test.tsx
+++ b/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcutOwner.test.tsx
@@ -27,7 +27,6 @@ import { DraftContext } from "@web/views/Week/components/Draft/context/DraftCont
 import { weekEventRegistry } from "@web/views/Week/interaction/registry/week-event.registry";
 import {
   clearHoveredWeekGridEventTarget,
-  getFocusedWeekGridEventTarget,
   setHoveredWeekGridEventTarget,
 } from "@web/views/Week/interaction/targeting/week-event.targeting";
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
@@ -431,28 +430,6 @@ describe("useWeekShortcutOwner calendar event targeting", () => {
     pressKey("ArrowLeft");
 
     expect(document.activeElement).toBe(monday);
-  });
-
-  it("focuses the first event on the leftmost column with digit 1", () => {
-    const monday = addCalendarTarget(leftmostEvent.id);
-    const wednesday = addCalendarTarget(editableEvent.id);
-    wednesday.focus();
-    renderShortcuts({ includeLeftmostEvent: true });
-
-    pressKey("1");
-
-    expect(document.activeElement).toBe(monday);
-  });
-
-  it("does not change focus with digit 1 when nothing is focused", () => {
-    addCalendarTarget(leftmostEvent.id);
-    const wednesday = addCalendarTarget(editableEvent.id);
-    renderShortcuts({ includeLeftmostEvent: true });
-
-    pressKey("1");
-
-    expect(document.activeElement).not.toBe(wednesday);
-    expect(getFocusedWeekGridEventTarget()).toBeNull();
   });
 
   it("deletes pending calendar events with Delete", () => {

--- a/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcutOwner.ts
+++ b/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcutOwner.ts
@@ -10,12 +10,9 @@ import {
   createAlldayDraft,
   createTimedDraft,
 } from "@web/common/utils/draft/draft.util";
-import { isEditableKeyboardTarget } from "@web/common/utils/form/form.util";
 import { useFocusSidebarShortcut } from "@web/components/Sidebar/useFocusSidebarShortcut";
 import { useWeekEventViewModel } from "@web/events/queries/useWeekEventsQuery";
-import { useRecurrenceScopeOpportunityStore } from "@web/events/recurrence/recurrence-scope-opportunity.store";
 import { draftActions, isEventFormOpen } from "@web/events/stores/draft.store";
-import { getFirstEventOnWeekdayColumn } from "@web/grid/shortcuts/focus-adjacent-grid-event";
 import { useGridEventEditShortcuts } from "@web/grid/shortcuts/useGridEventEditShortcuts";
 import { useGridEventFormFieldSequences } from "@web/grid/shortcuts/useGridEventFormFieldSequences";
 import {
@@ -58,7 +55,10 @@ export const useWeekShortcutOwner = ({
   weekDays,
   util,
   scrollUtil,
-}: ShortcutProps): { shiftHints: ActiveShiftHint[] } => {
+}: ShortcutProps): {
+  shiftHints: ActiveShiftHint[];
+  activeDayKeys: string[];
+} => {
   const { data: calendars = [], isPending: isCalendarsPending } =
     useCalendarsQuery();
   const defaultTargetCalendarId =
@@ -177,33 +177,6 @@ export const useWeekShortcutOwner = ({
     listVisible: listVisibleWeekGridEventTargets,
   };
 
-  const focusWeekdayColumn = useCallback(
-    (columnIndex: number, keyboardEvent: KeyboardEvent) => {
-      // Recurrence toast owns digits 1/2 while ready; don't steal them.
-      const opportunity =
-        useRecurrenceScopeOpportunityStore.getState().opportunity;
-      if (opportunity?.status === "ready") return false;
-
-      if (isEventFormOpen()) return false;
-      if (isEditableKeyboardTarget(keyboardEvent)) return false;
-      if (!getFocusedWeekGridEventTarget()) return false;
-
-      const target = getFirstEventOnWeekdayColumn({
-        allDayEvents,
-        columnIndex,
-        timedEvents,
-        visible: listVisibleWeekGridEventTargets(),
-        weekDays,
-      });
-      if (!target) return false;
-
-      target.element.scrollIntoView({ block: "nearest" });
-      focusWeekGridEventTarget(target);
-      return true;
-    },
-    [allDayEvents, timedEvents, weekDays],
-  );
-
   useGridEventEditShortcuts({
     allDayEvents,
     timedEvents,
@@ -227,15 +200,15 @@ export const useWeekShortcutOwner = ({
     onCreateAllDayDraft: emitCreateAllDayDraft,
     onCreateTimedDraft: emitCreateTimedDraft,
     onFocusCalendar: focusFirstCalendarEvent,
-    onFocusWeekdayColumn: focusWeekdayColumn,
   });
 
-  const shiftHints = useShiftHoldEventHints({
+  const { hints: shiftHints, activeDayKeys } = useShiftHoldEventHints({
     allDayEvents,
     focus: focusWeekGridEventTarget,
     listVisible: listVisibleWeekGridEventTargets,
+    mode: "week",
     timedEvents,
   });
 
-  return { shiftHints };
+  return { shiftHints, activeDayKeys };
 };

--- a/packages/web/src/views/Week/hooks/shortcuts/useWeekViewShortcuts.ts
+++ b/packages/web/src/views/Week/hooks/shortcuts/useWeekViewShortcuts.ts
@@ -1,7 +1,4 @@
-import {
-  useAppShortcut,
-  useAppShortcutUp,
-} from "@web/shortcuts/useAppShortcut";
+import { useAppShortcutUp } from "@web/shortcuts/useAppShortcut";
 
 export interface WeekViewShortcutsConfig {
   onPreviousWeek?: () => void;
@@ -12,22 +9,7 @@ export interface WeekViewShortcutsConfig {
   onCreateAllDayDraft?: () => void;
   onCreateTimedDraft?: () => void;
   onFocusCalendar?: () => void;
-  /**
-   * Digit `1`–`7` → focus first event on that leftmost→rightmost week column.
-   * Return true when the digit was handled so the key event can be consumed.
-   */
-  onFocusWeekdayColumn?: (
-    columnIndex: number,
-    keyboardEvent: KeyboardEvent,
-  ) => boolean;
 }
-
-const DIGIT_HOTKEY_OPTIONS = {
-  ignoreInputs: false,
-  preventDefault: false,
-  stopPropagation: false,
-  conflictBehavior: "allow" as const,
-};
 
 /**
  * Registers Week view keyboard shortcuts only. Behavior lives in the owner
@@ -43,7 +25,6 @@ export function useWeekViewShortcuts(config: WeekViewShortcutsConfig) {
     onCreateAllDayDraft,
     onCreateTimedDraft,
     onFocusCalendar,
-    onFocusWeekdayColumn,
   } = config;
 
   useAppShortcutUp("J", () => {
@@ -70,68 +51,4 @@ export function useWeekViewShortcuts(config: WeekViewShortcutsConfig) {
   useAppShortcutUp("U", () => {
     onFocusCalendar?.();
   });
-
-  useAppShortcut(
-    "1",
-    (keyboardEvent) => {
-      if (!onFocusWeekdayColumn?.(0, keyboardEvent)) return;
-      keyboardEvent.preventDefault();
-      keyboardEvent.stopPropagation();
-    },
-    DIGIT_HOTKEY_OPTIONS,
-  );
-  useAppShortcut(
-    "2",
-    (keyboardEvent) => {
-      if (!onFocusWeekdayColumn?.(1, keyboardEvent)) return;
-      keyboardEvent.preventDefault();
-      keyboardEvent.stopPropagation();
-    },
-    DIGIT_HOTKEY_OPTIONS,
-  );
-  useAppShortcut(
-    "3",
-    (keyboardEvent) => {
-      if (!onFocusWeekdayColumn?.(2, keyboardEvent)) return;
-      keyboardEvent.preventDefault();
-      keyboardEvent.stopPropagation();
-    },
-    DIGIT_HOTKEY_OPTIONS,
-  );
-  useAppShortcut(
-    "4",
-    (keyboardEvent) => {
-      if (!onFocusWeekdayColumn?.(3, keyboardEvent)) return;
-      keyboardEvent.preventDefault();
-      keyboardEvent.stopPropagation();
-    },
-    DIGIT_HOTKEY_OPTIONS,
-  );
-  useAppShortcut(
-    "5",
-    (keyboardEvent) => {
-      if (!onFocusWeekdayColumn?.(4, keyboardEvent)) return;
-      keyboardEvent.preventDefault();
-      keyboardEvent.stopPropagation();
-    },
-    DIGIT_HOTKEY_OPTIONS,
-  );
-  useAppShortcut(
-    "6",
-    (keyboardEvent) => {
-      if (!onFocusWeekdayColumn?.(5, keyboardEvent)) return;
-      keyboardEvent.preventDefault();
-      keyboardEvent.stopPropagation();
-    },
-    DIGIT_HOTKEY_OPTIONS,
-  );
-  useAppShortcut(
-    "7",
-    (keyboardEvent) => {
-      if (!onFocusWeekdayColumn?.(6, keyboardEvent)) return;
-      keyboardEvent.preventDefault();
-      keyboardEvent.stopPropagation();
-    },
-    DIGIT_HOTKEY_OPTIONS,
-  );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Replace hold-Shift home-row jump chips with a Shift-tap toggle for day-prefix event jump. Week chips use `SU`/`M`/`T`/`W`/`R`/`F`/`SA` plus a per-day index; Day view uses numeric chips. Day letters highlight the column and focus the first event; digits refine. Esc or another Shift tap exits. Shift+chords never toggle; Shift-Shift still enters keyboard-only without a jump flash (activation is deferred past the double-tap window). Week `1`–`7` column shortcuts removed.

## Simplicity

Extracted shared assignment/hint builders in `useShiftHoldEventHints`, inlined one-use day-prefix helper, and flattened EventJumpIndicator copy. Retained document-level gesture refs/effects and the rebuild-on-event-set effect for stable chips.

## Automated validation

- Focused shift-hint + keyboard-only unit tests: pass
- `bun run knip` / `bun run lint`: pass
- Playwright shift-hint + keyboard-only specs: 5/5 pass (CI e2e green)
- Browser `/week`: chips, day letter + digits, Esc, Shift+J, Shift-Shift — all pass

## Independent review

Confirmed findings fixed (Escape ownership, weekend `S` abandon, ambiguous digit commit + buffer reset, shortcut swallowing, exit announcement linger, deferred activate for Shift-Shift, no activate under keyboard-only / empty targets).

## Test plan

- `bun packages/scripts/src/testing/test-parallel.ts web -- packages/web/src/shortcuts/shift-hint/ packages/web/src/shortcuts/keyboard-only/`
- `bun run knip` · `bun run lint`
- `bunx playwright test e2e/timed/shift-hold-event-hints.spec.ts e2e/timed/keyboard-only-mode.spec.ts`

**Shipped:** merged as `576d8993` → tag `v1.1.151`; staging-cloud and staging-selfhosted health checks green.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8e3a5f9d-4de8-49bc-bc0f-a84bed3fd4d4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8e3a5f9d-4de8-49bc-bc0f-a84bed3fd4d4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

