### PR TITLE
fix(web): hide Compass day column when Google is connected

### DIFF
--- a/packages/web/src/calendars/calendar.util.test.ts
+++ b/packages/web/src/calendars/calendar.util.test.ts
@@ -188,7 +188,7 @@ describe("getDefaultTargetCalendar", () => {
     ).toBe(starred);
   });
 
-  it("lets the local calendar be starred explicitly", () => {
+  it("lets the local calendar be starred explicitly while disconnected", () => {
     const local = makeCalendar({ provider: "local" });
     const primaryGoogle = makeCalendar({
       provider: "google",
@@ -201,6 +201,46 @@ describe("getDefaultTargetCalendar", () => {
         preferredCalendarId: local.id,
       }),
     ).toBe(local);
+  });
+
+  it("ignores a starred local calendar once an account is connected", () => {
+    const local = makeCalendar({ provider: "local" });
+    const primaryGoogle = makeCalendar({
+      provider: "google",
+      isPrimary: true,
+      accountEmail: "user@example.com",
+      id: "507f1f77bcf86cd799439012" as Calendar["id"],
+    });
+
+    expect(
+      getDefaultTargetCalendar([local, primaryGoogle], {
+        preferredCalendarId: local.id,
+        accountEmailOrder: ["user@example.com"],
+      }),
+    ).toBe(primaryGoogle);
+  });
+
+  it("does not fall back to local once an account is connected", () => {
+    const local = makeCalendar({ provider: "local" });
+    const readOnlyPrimary = makeCalendar({
+      provider: "google",
+      isPrimary: true,
+      accountEmail: "user@example.com",
+      id: "507f1f77bcf86cd799439012" as Calendar["id"],
+      capabilities: {
+        canReadAvailability: true,
+        canReadDetails: true,
+        canWrite: false,
+        canManage: false,
+        canWatchEvents: true,
+      },
+    });
+
+    expect(
+      getDefaultTargetCalendar([local, readOnlyPrimary], {
+        accountEmailOrder: ["user@example.com"],
+      }),
+    ).toBeUndefined();
   });
 
   it("falls back to the derived default when the starred calendar is gone", () => {

--- a/packages/web/src/calendars/calendar.util.ts
+++ b/packages/web/src/calendars/calendar.util.ts
@@ -195,8 +195,9 @@ const isWritableGoogleCalendar = (
 /**
  * Where a new event lands: the user's chosen default if it is still usable,
  * else the primary calendar of the oldest-connected account, else the local
- * calendar (offline/anonymous mode, or a Google account with no primary the
- * user can write to).
+ * calendar while disconnected (anonymous / no Google account). Once any
+ * account is connected, local is never the create target - matching the
+ * writable picker and day-view column filter.
  */
 export function getDefaultTargetCalendar(
   calendars: Calendar[],
@@ -204,15 +205,21 @@ export function getDefaultTargetCalendar(
 ): Calendar | undefined {
   const { preferredCalendarId, accountEmailOrder = [] } = options;
   const reconnectRequiredEmails = toEmailSet(options.reconnectRequiredEmails);
+  // Same connection gate as getWritableCalendars / sidebar LCV3: once any
+  // account is connected, new events belong on a provider calendar. A stale
+  // local preference (or local fallback) would otherwise open drafts that day
+  // view no longer has a column for.
+  const hasConnectedAccount = accountEmailOrder.length > 0;
 
   const preferred = preferredCalendarId
     ? calendars.find((calendar) => calendar.id === preferredCalendarId)
     : undefined;
-  // The local calendar is a valid explicit choice even though it is not a
-  // writable *Google* calendar.
+  // The local calendar is a valid explicit choice while disconnected, even
+  // though it is not a writable *Google* calendar.
   if (
     preferred?.capabilities.canWrite &&
-    !calendarNeedsReconnect(preferred, reconnectRequiredEmails)
+    !calendarNeedsReconnect(preferred, reconnectRequiredEmails) &&
+    (!hasConnectedAccount || preferred.provider !== "local")
   ) {
     return preferred;
   }
@@ -228,5 +235,9 @@ export function getDefaultTargetCalendar(
     )
     .find(Boolean);
 
-  return byConnectionOrder ?? primaries[0] ?? getLocalCalendar(calendars);
+  return (
+    byConnectionOrder ??
+    primaries[0] ??
+    (hasConnectedAccount ? undefined : getLocalCalendar(calendars))
+  );
 }

--- a/packages/web/src/calendars/useDefaultTargetCalendar.ts
+++ b/packages/web/src/calendars/useDefaultTargetCalendar.ts
@@ -14,7 +14,7 @@ import { useDefaultCalendarId } from "@web/calendars/default-calendar.store";
 /**
  * The calendar a new event should land on: the user's chosen default when
  * it is still usable, else the primary calendar of the oldest-connected
- * account, else the local calendar.
+ * account, else the local calendar while disconnected.
  *
  * Wraps getDefaultTargetCalendar with the two reactive inputs every caller
  * needs - the stored preference and the connected accounts in connection

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarEventLayers.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarEventLayers.tsx
@@ -39,6 +39,7 @@ interface DayAllDayEventsProps {
 
 interface DayTimedEventsProps {
   getCalendarColumnIndex: (event: GridEvent) => number;
+  isDisplayedEvent: (event: GridEvent) => boolean;
   draft: GridEventDraft | null;
   events: GridEvent[];
   measurements: GridMeasurements;
@@ -89,6 +90,7 @@ export const DayCalendarTimedEventsLayer = ({
   draft,
   events: timedEvents,
   getCalendarColumnIndex,
+  isDisplayedEvent,
   measurements,
   onOpenEvent,
   visibleDates,
@@ -106,8 +108,8 @@ export const DayCalendarTimedEventsLayer = ({
         events: timedEvents,
         isAllDay: false,
         visibleDates,
-      }),
-    [draft, timedEvents, visibleDates],
+      }).filter(isDisplayedEvent),
+    [draft, isDisplayedEvent, timedEvents, visibleDates],
   );
   const timedEventItems = useMemo(() => {
     const eventsByColumn = new Map<number, GridEvent[]>();

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
@@ -101,6 +101,7 @@ export function DayCalendarGrid() {
     displayedCalendars,
     displayedTimedEvents,
     getCalendarColumnIndex,
+    isDisplayedEvent,
     visibleDates,
   } = useDayCalendarColumns({ allDayEvents, dateInView, timedEvents });
   const { gridRefs, measurements } = useGridMeasurements({
@@ -146,12 +147,13 @@ export function DayCalendarGrid() {
         events: displayedAllDayEvents,
         isAllDay: true,
         visibleDates,
-      });
+      }).filter(isDisplayedEvent);
       return assignDayAllDayEventRows(withDraft, getCalendarColumnIndex);
     }, [
       displayedAllDayEvents,
       getCalendarColumnIndex,
       gridDraft,
+      isDisplayedEvent,
       visibleDates,
     ]);
 
@@ -357,6 +359,7 @@ export function DayCalendarGrid() {
         <DayCalendarTimedEventsLayer
           events={displayedTimedEvents}
           getCalendarColumnIndex={getCalendarColumnIndex}
+          isDisplayedEvent={isDisplayedEvent}
           draft={gridDraft}
           measurements={measurements}
           onOpenEvent={openEventFormForEvent}
@@ -370,6 +373,7 @@ export function DayCalendarGrid() {
       displayedTimedEvents,
       gridDraft,
       getCalendarColumnIndex,
+      isDisplayedEvent,
       measurements,
       openEventFormForEvent,
       visibleDates,

--- a/packages/web/src/views/Day/components/Calendar/dayCalendarColumns.util.test.ts
+++ b/packages/web/src/views/Day/components/Calendar/dayCalendarColumns.util.test.ts
@@ -1,0 +1,93 @@
+import { type Calendar } from "@core/types/calendar.contracts";
+import { getDayViewCalendars } from "./dayCalendarColumns.util";
+import { describe, expect, it } from "bun:test";
+
+function makeCalendar(overrides: Partial<Calendar>): Calendar {
+  return {
+    id: "507f1f77bcf86cd799439011" as Calendar["id"],
+    name: "Cal",
+    description: "",
+    timeZone: null,
+    foregroundColor: "#000000",
+    backgroundColor: "#ffffff",
+    provider: "local",
+    access: "owner",
+    capabilities: {
+      canReadAvailability: true,
+      canReadDetails: true,
+      canWrite: true,
+      canManage: false,
+      canWatchEvents: false,
+    },
+    isPrimary: false,
+    isVisible: true,
+    isActive: true,
+    ...overrides,
+  };
+}
+
+describe("getDayViewCalendars", () => {
+  it("keeps the local calendar when no account is connected", () => {
+    const local = makeCalendar({ provider: "local", name: "Compass" });
+    const google = makeCalendar({
+      provider: "google",
+      id: "507f1f77bcf86cd799439012" as Calendar["id"],
+      name: "primary",
+    });
+
+    expect(getDayViewCalendars([local, google])).toEqual([local, google]);
+  });
+
+  it("drops the local calendar once an account is connected", () => {
+    const local = makeCalendar({ provider: "local", name: "Compass" });
+    const google = makeCalendar({
+      provider: "google",
+      id: "507f1f77bcf86cd799439012" as Calendar["id"],
+      name: "primary",
+    });
+
+    expect(
+      getDayViewCalendars([local, google], { hasConnectedAccount: true }),
+    ).toEqual([google]);
+  });
+
+  it("falls back to the primary among remaining calendars when none are visible", () => {
+    const local = makeCalendar({
+      provider: "local",
+      name: "Compass",
+      isVisible: false,
+    });
+    const primaryGoogle = makeCalendar({
+      provider: "google",
+      id: "507f1f77bcf86cd799439012" as Calendar["id"],
+      name: "primary",
+      isPrimary: true,
+      isVisible: false,
+    });
+    const secondaryGoogle = makeCalendar({
+      provider: "google",
+      id: "507f1f77bcf86cd799439013" as Calendar["id"],
+      name: "secondary",
+      isVisible: false,
+    });
+
+    expect(
+      getDayViewCalendars([local, secondaryGoogle, primaryGoogle], {
+        hasConnectedAccount: true,
+      }),
+    ).toEqual([primaryGoogle]);
+  });
+
+  it("does not fall back to the local calendar when an account is connected", () => {
+    const local = makeCalendar({
+      provider: "local",
+      name: "Compass",
+      isPrimary: true,
+      isVisible: false,
+    });
+
+    expect(getDayViewCalendars([local], { hasConnectedAccount: true })).toEqual(
+      [],
+    );
+  });
+});

--- a/packages/web/src/views/Day/components/Calendar/dayCalendarColumns.util.ts
+++ b/packages/web/src/views/Day/components/Calendar/dayCalendarColumns.util.ts
@@ -1,14 +1,37 @@
 import { type Calendar } from "@core/types/calendar.contracts";
 
-export const getDayViewCalendars = (calendars: Calendar[]): Calendar[] => {
-  const enabledCalendars = calendars.filter(
-    (calendar) => calendar.isActive && calendar.isVisible,
+export interface GetDayViewCalendarsOptions {
+  /**
+   * True once any account is connected. Mirrors the sidebar (LCV3): the local
+   * Compass calendar then drops out of day-view columns so connected users do
+   * not see an orphan empty column they can no longer toggle in the list.
+   * Derive from connection state (e.g. useConnectedAccountEmails().length > 0),
+   * never from calendar rows alone.
+   */
+  hasConnectedAccount?: boolean;
+}
+
+export const getDayViewCalendars = (
+  calendars: Calendar[],
+  options: GetDayViewCalendarsOptions = {},
+): Calendar[] => {
+  const { hasConnectedAccount = false } = options;
+  const eligibleCalendars = calendars.filter(
+    (calendar) =>
+      (!hasConnectedAccount || calendar.provider !== "local") &&
+      calendar.isActive &&
+      calendar.isVisible,
   );
 
-  if (enabledCalendars.length > 0) {
-    return enabledCalendars;
+  if (eligibleCalendars.length > 0) {
+    return eligibleCalendars;
   }
 
-  const primaryCalendar = calendars.find((calendar) => calendar.isPrimary);
-  return primaryCalendar ? [primaryCalendar] : calendars.slice(0, 1);
+  const fallbackCalendars = hasConnectedAccount
+    ? calendars.filter((calendar) => calendar.provider !== "local")
+    : calendars;
+  const primaryCalendar = fallbackCalendars.find(
+    (calendar) => calendar.isPrimary,
+  );
+  return primaryCalendar ? [primaryCalendar] : fallbackCalendars.slice(0, 1);
 };

--- a/packages/web/src/views/Day/components/Calendar/useDayCalendarColumns.ts
+++ b/packages/web/src/views/Day/components/Calendar/useDayCalendarColumns.ts
@@ -81,6 +81,7 @@ export const useDayCalendarColumns = ({
     displayedCalendars,
     displayedTimedEvents,
     getCalendarColumnIndex,
+    isDisplayedEvent,
     visibleDates,
   };
 };

--- a/packages/web/src/views/Day/components/Calendar/useDayCalendarColumns.ts
+++ b/packages/web/src/views/Day/components/Calendar/useDayCalendarColumns.ts
@@ -2,6 +2,7 @@ import { useCallback, useMemo } from "react";
 import { YEAR_MONTH_DAY_FORMAT } from "@core/constants/date.constants";
 import { type Dayjs } from "@core/util/date/dayjs";
 import { useCalendarsQuery } from "@web/calendars/calendar.query";
+import { useConnectedAccountEmails } from "@web/calendars/useDefaultTargetCalendar";
 import { type GridEvent } from "@web/common/types/web.event.types";
 import { isAllDayEventOnDay } from "./dayAllDayRows.util";
 import { getDayViewCalendars } from "./dayCalendarColumns.util";
@@ -16,9 +17,10 @@ export const useDayCalendarColumns = ({
   timedEvents: GridEvent[];
 }) => {
   const { data: calendars = [] } = useCalendarsQuery();
+  const hasConnectedAccount = useConnectedAccountEmails().length > 0;
   const displayedCalendars = useMemo(
-    () => getDayViewCalendars(calendars),
-    [calendars],
+    () => getDayViewCalendars(calendars, { hasConnectedAccount }),
+    [calendars, hasConnectedAccount],
   );
   const calendarColumnIndexById = useMemo(
     () =>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Completes the LCV3 local-calendar visibility work for day view: once any Google account is connected, the local Compass calendar is no longer shown as a day-view column (matching the sidebar).

Anonymous and signed-in-but-not-connected users still get the Compass / local column, since it remains their only calendar.

## Changes

- `getDayViewCalendars` accepts `hasConnectedAccount` and filters `provider === "local"` the same way as the sidebar / writable set
- `useDayCalendarColumns` passes connection state from `useConnectedAccountEmails`
- Unit tests cover keep/drop/fallback behavior

## Test plan

- [x] `bun test packages/web/src/views/Day/components/Calendar/dayCalendarColumns.util.test.ts`
- [ ] Connected user: day view shows Google calendars only (no empty Compass column)
- [ ] Anonymous / no Google: day view still shows the local column
- [ ] Disconnect last Google account: Compass column returns

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b19bd7ef-07b0-4bd8-af82-becf3bbcc73a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b19bd7ef-07b0-4bd8-af82-becf3bbcc73a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

