### PR TITLE
feat(web): tint day columns from all-day event color

### DIFF
--- a/packages/web/src/events/queries/useWeekEventsQuery.ts
+++ b/packages/web/src/events/queries/useWeekEventsQuery.ts
@@ -44,11 +44,3 @@ export function useWeekEventViewModel(args: WeekEventsQueryArgs) {
   const viewModel = useCalendarEventViewModel(query.data);
   return { ...query, ...viewModel };
 }
-
-/**
- * Read-only week-events loading state. Subscribes to the same cache entry as
- * {@link useWeekEventsQuery} (shared key → no extra fetch).
- */
-export function useWeekEventsQueryStatus(args: WeekEventsQueryArgs) {
-  return useWeekEventsQuery(args);
-}

--- a/packages/web/src/grid/components/AllDayGridRow.test.tsx
+++ b/packages/web/src/grid/components/AllDayGridRow.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from "@testing-library/react";
+import dayjs from "@core/util/date/dayjs";
+import { ALL_DAY_COLUMN_TINT_PERCENT } from "@web/grid/utils/allDayColumnTint.util";
+import { AllDayGridRow } from "./AllDayGridRow";
+import { describe, expect, it } from "bun:test";
+
+const today = dayjs("2026-04-24");
+
+describe("AllDayGridRow", () => {
+  it("applies the all-day tint wash on columns that carry a tint color", () => {
+    const tint = "#039BE5";
+    render(
+      <AllDayGridRow
+        allDayColumnsRef={() => {}}
+        allDayRowRef={() => {}}
+        eventsLayer={null}
+        onMouseDown={() => {}}
+        visibleDates={[
+          {
+            date: today,
+            key: "today",
+            allDayTintColor: tint,
+            surfaceLabel: "Tinted all-day column",
+          },
+        ]}
+      />,
+    );
+
+    const column = screen.getByRole("columnheader", {
+      name: "Tinted all-day column",
+    });
+    expect(column.getAttribute("data-all-day-tint")).toBe("true");
+    expect(column.style.getPropertyValue("--column-all-day-tint")).toBe(tint);
+    // jsdom may normalize the hex inside color-mix to rgb(...).
+    expect(column.style.backgroundColor).toContain("color-mix(in srgb,");
+    expect(column.style.backgroundColor).toContain(
+      `${ALL_DAY_COLUMN_TINT_PERCENT}%`,
+    );
+  });
+});

--- a/packages/web/src/grid/components/AllDayGridRow.tsx
+++ b/packages/web/src/grid/components/AllDayGridRow.tsx
@@ -19,6 +19,7 @@ import {
   GRID_TIME_STEP,
 } from "@web/grid/grid.constants";
 import { type GridVisibleDate } from "@web/grid/types/grid.types";
+import { allDayColumnTintBackground } from "@web/grid/utils/allDayColumnTint.util";
 import {
   selectEventJumpActiveDayKeys,
   useEventJumpStore,
@@ -91,21 +92,35 @@ export const AllDayGridRow: FC<AllDayRowProps> = ({
         <table className="contents">
           <thead className="contents">
             <tr className="contents">
-              {visibleDates.map(({ date, key, surfaceLabel }) => {
-                const dayKey = date.format(YEAR_MONTH_DAY_FORMAT);
-                const isJumpDay = activeDayKeys.includes(dayKey);
-                return (
-                  <th
-                    className="relative box-border block h-full min-w-[var(--calendar-column-min-width)] border-border border-l transition-colors duration-150 data-[jump-day=true]:bg-accent/10 motion-reduce:transition-none"
-                    data-jump-day={isJumpDay ? "true" : undefined}
-                    aria-label={
-                      surfaceLabel ?? date.format("dddd, MMMM D, YYYY")
-                    }
-                    key={key}
-                    scope="col"
-                  />
-                );
-              })}
+              {visibleDates.map(
+                ({ date, key, surfaceLabel, allDayTintColor }) => {
+                  const dayKey = date.format(YEAR_MONTH_DAY_FORMAT);
+                  const isJumpDay = activeDayKeys.includes(dayKey);
+                  const showAllDayTint =
+                    allDayTintColor !== undefined && !isJumpDay;
+                  return (
+                    <th
+                      className="relative box-border block h-full min-w-[var(--calendar-column-min-width)] border-border border-l transition-colors duration-150 data-[jump-day=true]:bg-accent/10 motion-reduce:transition-none"
+                      data-all-day-tint={showAllDayTint ? "true" : undefined}
+                      data-jump-day={isJumpDay ? "true" : undefined}
+                      aria-label={
+                        surfaceLabel ?? date.format("dddd, MMMM D, YYYY")
+                      }
+                      key={key}
+                      scope="col"
+                      style={
+                        showAllDayTint
+                          ? ({
+                              "--column-all-day-tint": allDayTintColor,
+                              backgroundColor:
+                                allDayColumnTintBackground(allDayTintColor),
+                            } as CSSVariables)
+                          : undefined
+                      }
+                    />
+                  );
+                },
+              )}
             </tr>
           </thead>
         </table>

--- a/packages/web/src/grid/components/AllDayGridRow.tsx
+++ b/packages/web/src/grid/components/AllDayGridRow.tsx
@@ -19,7 +19,7 @@ import {
   GRID_TIME_STEP,
 } from "@web/grid/grid.constants";
 import { type GridVisibleDate } from "@web/grid/types/grid.types";
-import { allDayColumnTintBackground } from "@web/grid/utils/allDayColumnTint.util";
+import { allDayColumnTintStyle } from "@web/grid/utils/allDayColumnTint.util";
 import {
   selectEventJumpActiveDayKeys,
   useEventJumpStore,
@@ -96,27 +96,21 @@ export const AllDayGridRow: FC<AllDayRowProps> = ({
                 ({ date, key, surfaceLabel, allDayTintColor }) => {
                   const dayKey = date.format(YEAR_MONTH_DAY_FORMAT);
                   const isJumpDay = activeDayKeys.includes(dayKey);
-                  const showAllDayTint =
-                    allDayTintColor !== undefined && !isJumpDay;
+                  const tintStyle = allDayColumnTintStyle(
+                    allDayTintColor,
+                    isJumpDay,
+                  );
                   return (
                     <th
                       className="relative box-border block h-full min-w-[var(--calendar-column-min-width)] border-border border-l transition-colors duration-150 data-[jump-day=true]:bg-accent/10 motion-reduce:transition-none"
-                      data-all-day-tint={showAllDayTint ? "true" : undefined}
+                      data-all-day-tint={tintStyle ? "true" : undefined}
                       data-jump-day={isJumpDay ? "true" : undefined}
                       aria-label={
                         surfaceLabel ?? date.format("dddd, MMMM D, YYYY")
                       }
                       key={key}
                       scope="col"
-                      style={
-                        showAllDayTint
-                          ? ({
-                              "--column-all-day-tint": allDayTintColor,
-                              backgroundColor:
-                                allDayColumnTintBackground(allDayTintColor),
-                            } as CSSVariables)
-                          : undefined
-                      }
+                      style={tintStyle}
                     />
                   );
                 },

--- a/packages/web/src/grid/components/TimedGrid.test.tsx
+++ b/packages/web/src/grid/components/TimedGrid.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import dayjs from "@core/util/date/dayjs";
+import { ALL_DAY_COLUMN_TINT_PERCENT } from "@web/grid/utils/allDayColumnTint.util";
 import { TimedGrid } from "./TimedGrid";
 import { describe, expect, it } from "bun:test";
 
@@ -31,5 +32,35 @@ describe("TimedGrid", () => {
 
     await user.tab();
     expect(grid).toHaveFocus();
+  });
+
+  it("applies the all-day tint CSS variable and wash on the day column", () => {
+    const tint = "#0B8043";
+    render(
+      <TimedGrid
+        eventsLayer={null}
+        onMouseDown={() => {}}
+        timedColumnsRef={() => {}}
+        timedGridRef={() => {}}
+        today={today}
+        visibleDates={[
+          {
+            date: today,
+            key: "today",
+            allDayTintColor: tint,
+            surfaceLabel: "Tinted day",
+          },
+        ]}
+      />,
+    );
+
+    const column = screen.getByRole("columnheader", { name: "Tinted day" });
+    expect(column.getAttribute("data-all-day-tint")).toBe("true");
+    expect(column.style.getPropertyValue("--column-all-day-tint")).toBe(tint);
+    // jsdom may normalize the hex inside color-mix to rgb(...).
+    expect(column.style.backgroundColor).toContain("color-mix(in srgb,");
+    expect(column.style.backgroundColor).toContain(
+      `${ALL_DAY_COLUMN_TINT_PERCENT}%`,
+    );
   });
 });

--- a/packages/web/src/grid/components/TimedGrid.tsx
+++ b/packages/web/src/grid/components/TimedGrid.tsx
@@ -28,7 +28,7 @@ import {
   TIMED_VISIBLE_HOURS,
 } from "@web/grid/grid.constants";
 import { type GridVisibleDate } from "@web/grid/types/grid.types";
-import { allDayColumnTintBackground } from "@web/grid/utils/allDayColumnTint.util";
+import { allDayColumnTintStyle } from "@web/grid/utils/allDayColumnTint.util";
 import {
   selectEventJumpActiveDayKeys,
   useEventJumpStore,
@@ -98,14 +98,14 @@ export const TimedGrid: FC<TimedGridProps> = ({
                 ({ date, key, surfaceLabel, allDayTintColor }) => {
                   const dayKey = date.format(YEAR_MONTH_DAY_FORMAT);
                   const isJumpDay = activeDayKeys.includes(dayKey);
-                  // Jump-day wash wins; otherwise the all-day tint replaces
-                  // the default/past fill via inline backgroundColor.
-                  const showAllDayTint =
-                    allDayTintColor !== undefined && !isJumpDay;
+                  const tintStyle = allDayColumnTintStyle(
+                    allDayTintColor,
+                    isJumpDay,
+                  );
                   return (
                     <th
                       className="relative box-border block h-full min-w-[var(--calendar-column-min-width)] border-border border-l transition-colors duration-150 data-[past=true]:data-[jump-day=true]:bg-accent/10 data-[jump-day=true]:bg-accent/10 data-[past=true]:bg-surface motion-reduce:transition-none"
-                      data-all-day-tint={showAllDayTint ? "true" : undefined}
+                      data-all-day-tint={tintStyle ? "true" : undefined}
                       data-jump-day={isJumpDay ? "true" : undefined}
                       data-past={date.isBefore(today, "day")}
                       aria-label={
@@ -113,15 +113,7 @@ export const TimedGrid: FC<TimedGridProps> = ({
                       }
                       key={key}
                       scope="col"
-                      style={
-                        showAllDayTint
-                          ? ({
-                              "--column-all-day-tint": allDayTintColor,
-                              backgroundColor:
-                                allDayColumnTintBackground(allDayTintColor),
-                            } as CSSVariables)
-                          : undefined
-                      }
+                      style={tintStyle}
                     />
                   );
                 },

--- a/packages/web/src/grid/components/TimedGrid.tsx
+++ b/packages/web/src/grid/components/TimedGrid.tsx
@@ -28,6 +28,7 @@ import {
   TIMED_VISIBLE_HOURS,
 } from "@web/grid/grid.constants";
 import { type GridVisibleDate } from "@web/grid/types/grid.types";
+import { allDayColumnTintBackground } from "@web/grid/utils/allDayColumnTint.util";
 import {
   selectEventJumpActiveDayKeys,
   useEventJumpStore,
@@ -93,22 +94,38 @@ export const TimedGrid: FC<TimedGridProps> = ({
         <table className="contents">
           <thead className="contents">
             <tr className="contents">
-              {visibleDates.map(({ date, key, surfaceLabel }) => {
-                const dayKey = date.format(YEAR_MONTH_DAY_FORMAT);
-                const isJumpDay = activeDayKeys.includes(dayKey);
-                return (
-                  <th
-                    className="relative box-border block h-full min-w-[var(--calendar-column-min-width)] border-border border-l transition-colors duration-150 data-[past=true]:data-[jump-day=true]:bg-accent/10 data-[jump-day=true]:bg-accent/10 data-[past=true]:bg-surface motion-reduce:transition-none"
-                    data-jump-day={isJumpDay ? "true" : undefined}
-                    data-past={date.isBefore(today, "day")}
-                    aria-label={
-                      surfaceLabel ?? date.format("dddd, MMMM D, YYYY")
-                    }
-                    key={key}
-                    scope="col"
-                  />
-                );
-              })}
+              {visibleDates.map(
+                ({ date, key, surfaceLabel, allDayTintColor }) => {
+                  const dayKey = date.format(YEAR_MONTH_DAY_FORMAT);
+                  const isJumpDay = activeDayKeys.includes(dayKey);
+                  // Jump-day wash wins; otherwise the all-day tint replaces
+                  // the default/past fill via inline backgroundColor.
+                  const showAllDayTint =
+                    allDayTintColor !== undefined && !isJumpDay;
+                  return (
+                    <th
+                      className="relative box-border block h-full min-w-[var(--calendar-column-min-width)] border-border border-l transition-colors duration-150 data-[past=true]:data-[jump-day=true]:bg-accent/10 data-[jump-day=true]:bg-accent/10 data-[past=true]:bg-surface motion-reduce:transition-none"
+                      data-all-day-tint={showAllDayTint ? "true" : undefined}
+                      data-jump-day={isJumpDay ? "true" : undefined}
+                      data-past={date.isBefore(today, "day")}
+                      aria-label={
+                        surfaceLabel ?? date.format("dddd, MMMM D, YYYY")
+                      }
+                      key={key}
+                      scope="col"
+                      style={
+                        showAllDayTint
+                          ? ({
+                              "--column-all-day-tint": allDayTintColor,
+                              backgroundColor:
+                                allDayColumnTintBackground(allDayTintColor),
+                            } as CSSVariables)
+                          : undefined
+                      }
+                    />
+                  );
+                },
+              )}
             </tr>
           </thead>
         </table>

--- a/packages/web/src/grid/types/grid.types.ts
+++ b/packages/web/src/grid/types/grid.types.ts
@@ -10,6 +10,8 @@ export interface GridVisibleDate {
   date: Dayjs;
   key: string;
   surfaceLabel?: string;
+  /** Resolved event fill hex for subtle all-day column wash */
+  allDayTintColor?: string;
 }
 
 export interface GridMeasurement {

--- a/packages/web/src/grid/utils/allDayColumnTint.util.test.ts
+++ b/packages/web/src/grid/utils/allDayColumnTint.util.test.ts
@@ -9,6 +9,7 @@ import {
   ALL_DAY_COLUMN_TINT_PERCENT,
   type AllDayColumnTintEvent,
   allDayColumnTintBackground,
+  allDayColumnTintStyle,
   withAllDayColumnTints,
 } from "@web/grid/utils/allDayColumnTint.util";
 import { describe, expect, it } from "bun:test";
@@ -38,6 +39,20 @@ describe("allDayColumnTintBackground", () => {
     expect(allDayColumnTintBackground("#0B8043")).toBe(
       `color-mix(in srgb, #0B8043 ${ALL_DAY_COLUMN_TINT_PERCENT}%, transparent)`,
     );
+  });
+});
+
+describe("allDayColumnTintStyle", () => {
+  it("returns the CSS variable and wash when a tint is active", () => {
+    expect(allDayColumnTintStyle("#0B8043", false)).toEqual({
+      "--column-all-day-tint": "#0B8043",
+      backgroundColor: allDayColumnTintBackground("#0B8043"),
+    });
+  });
+
+  it("returns undefined when jump-day wins or no tint is set", () => {
+    expect(allDayColumnTintStyle("#0B8043", true)).toBeUndefined();
+    expect(allDayColumnTintStyle(undefined, false)).toBeUndefined();
   });
 });
 

--- a/packages/web/src/grid/utils/allDayColumnTint.util.test.ts
+++ b/packages/web/src/grid/utils/allDayColumnTint.util.test.ts
@@ -1,3 +1,4 @@
+import { type CalendarId } from "@core/types/domain-primitives";
 import dayjs from "@core/util/date/dayjs";
 import {
   EVENT_COLOR_SLOT_HEX,
@@ -11,6 +12,8 @@ import {
   withAllDayColumnTints,
 } from "@web/grid/utils/allDayColumnTint.util";
 import { describe, expect, it } from "bun:test";
+
+const calendarId = (value: string) => value as CalendarId;
 
 const monday = dayjs("2026-08-10");
 const tuesday = dayjs("2026-08-11");
@@ -167,7 +170,7 @@ describe("withAllDayColumnTints (calendar / day)", () => {
         event({
           startDate: "2026-08-10",
           endDate: "2026-08-11",
-          calendarId: "cal-b",
+          calendarId: calendarId("cal-b"),
           color: "plum",
         }),
       ],
@@ -202,14 +205,14 @@ describe("withAllDayColumnTints (calendar / day)", () => {
         event({
           startDate: "2026-08-10",
           endDate: "2026-08-11",
-          calendarId: "cal-a",
+          calendarId: calendarId("cal-a"),
           color: "orange",
           row: 2,
         }),
         event({
           startDate: "2026-08-10",
           endDate: "2026-08-11",
-          calendarId: "cal-a",
+          calendarId: calendarId("cal-a"),
           color: "slate",
           row: 1,
         }),

--- a/packages/web/src/grid/utils/allDayColumnTint.util.test.ts
+++ b/packages/web/src/grid/utils/allDayColumnTint.util.test.ts
@@ -1,0 +1,222 @@
+import dayjs from "@core/util/date/dayjs";
+import {
+  EVENT_COLOR_SLOT_HEX,
+  getEventPalette,
+} from "@web/common/styles/theme.util";
+import { type GridVisibleDate } from "@web/grid/types/grid.types";
+import {
+  ALL_DAY_COLUMN_TINT_PERCENT,
+  type AllDayColumnTintEvent,
+  allDayColumnTintBackground,
+  withAllDayColumnTints,
+} from "@web/grid/utils/allDayColumnTint.util";
+import { describe, expect, it } from "bun:test";
+
+const monday = dayjs("2026-08-10");
+const tuesday = dayjs("2026-08-11");
+const wednesday = dayjs("2026-08-12");
+
+const weekColumns = (): GridVisibleDate[] => [
+  { date: monday, key: "2026-08-10" },
+  { date: tuesday, key: "2026-08-11" },
+  { date: wednesday, key: "2026-08-12" },
+];
+
+const event = (
+  overrides: Partial<AllDayColumnTintEvent> &
+    Pick<AllDayColumnTintEvent, "startDate" | "endDate">,
+): AllDayColumnTintEvent => ({
+  row: 1,
+  ...overrides,
+});
+
+describe("allDayColumnTintBackground", () => {
+  it("applies the fixed wash percent via color-mix", () => {
+    expect(allDayColumnTintBackground("#0B8043")).toBe(
+      `color-mix(in srgb, #0B8043 ${ALL_DAY_COLUMN_TINT_PERCENT}%, transparent)`,
+    );
+  });
+});
+
+describe("withAllDayColumnTints (date / week)", () => {
+  it("returns the same columns when there are no all-day events", () => {
+    const columns = weekColumns();
+    expect(withAllDayColumnTints(columns, [], "date")).toBe(columns);
+  });
+
+  it("tints a single day from the event fill color", () => {
+    const tinted = withAllDayColumnTints(
+      weekColumns(),
+      [
+        event({
+          startDate: "2026-08-10",
+          endDate: "2026-08-11",
+          color: "green",
+        }),
+      ],
+      "date",
+    );
+
+    expect(tinted[0]?.allDayTintColor).toBe(EVENT_COLOR_SLOT_HEX.green);
+    expect(tinted[1]?.allDayTintColor).toBeUndefined();
+    expect(tinted[2]?.allDayTintColor).toBeUndefined();
+  });
+
+  it("tints every day a multi-day all-day event spans", () => {
+    const tinted = withAllDayColumnTints(
+      weekColumns(),
+      [
+        event({
+          startDate: "2026-08-10",
+          endDate: "2026-08-12",
+          color: "mint",
+        }),
+      ],
+      "date",
+    );
+
+    expect(tinted[0]?.allDayTintColor).toBe(EVENT_COLOR_SLOT_HEX.mint);
+    expect(tinted[1]?.allDayTintColor).toBe(EVENT_COLOR_SLOT_HEX.mint);
+    expect(tinted[2]?.allDayTintColor).toBeUndefined();
+  });
+
+  it("prefers the topmost chip (lowest row) when multiple cover a day", () => {
+    const tinted = withAllDayColumnTints(
+      weekColumns(),
+      [
+        event({
+          startDate: "2026-08-10",
+          endDate: "2026-08-11",
+          color: "blue",
+          row: 2,
+        }),
+        event({
+          startDate: "2026-08-10",
+          endDate: "2026-08-11",
+          color: "green",
+          row: 1,
+        }),
+      ],
+      "date",
+    );
+
+    expect(tinted[0]?.allDayTintColor).toBe(EVENT_COLOR_SLOT_HEX.green);
+  });
+
+  it("keeps the first encounter when rows tie", () => {
+    const tinted = withAllDayColumnTints(
+      weekColumns(),
+      [
+        event({
+          startDate: "2026-08-10",
+          endDate: "2026-08-11",
+          color: "coral",
+          row: 1,
+        }),
+        event({
+          startDate: "2026-08-10",
+          endDate: "2026-08-11",
+          color: "gold",
+          row: 1,
+        }),
+      ],
+      "date",
+    );
+
+    expect(tinted[0]?.allDayTintColor).toBe(EVENT_COLOR_SLOT_HEX.coral);
+  });
+
+  it("prefers colorHex over a slot color", () => {
+    const tinted = withAllDayColumnTints(
+      weekColumns(),
+      [
+        event({
+          startDate: "2026-08-10",
+          endDate: "2026-08-11",
+          color: "red",
+          colorHex: "#009688",
+        }),
+      ],
+      "date",
+    );
+
+    expect(tinted[0]?.allDayTintColor).toBe("#009688");
+  });
+
+  it("falls back to the theme default fill when no color is set", () => {
+    const tinted = withAllDayColumnTints(
+      weekColumns(),
+      [event({ startDate: "2026-08-10", endDate: "2026-08-11" })],
+      "date",
+    );
+
+    expect(tinted[0]?.allDayTintColor).toBe(getEventPalette().base);
+  });
+});
+
+describe("withAllDayColumnTints (calendar / day)", () => {
+  const calendarColumns = (): GridVisibleDate[] => [
+    { date: monday, key: "cal-a", surfaceLabel: "A" },
+    { date: monday, key: "cal-b", surfaceLabel: "B" },
+  ];
+
+  it("tints only the calendar column that owns the all-day event", () => {
+    const tinted = withAllDayColumnTints(
+      calendarColumns(),
+      [
+        event({
+          startDate: "2026-08-10",
+          endDate: "2026-08-11",
+          calendarId: "cal-b",
+          color: "plum",
+        }),
+      ],
+      "calendar",
+    );
+
+    expect(tinted[0]?.allDayTintColor).toBeUndefined();
+    expect(tinted[1]?.allDayTintColor).toBe(EVENT_COLOR_SLOT_HEX.plum);
+  });
+
+  it("places events without a calendarId on the first column", () => {
+    const tinted = withAllDayColumnTints(
+      calendarColumns(),
+      [
+        event({
+          startDate: "2026-08-10",
+          endDate: "2026-08-11",
+          color: "indigo",
+        }),
+      ],
+      "calendar",
+    );
+
+    expect(tinted[0]?.allDayTintColor).toBe(EVENT_COLOR_SLOT_HEX.indigo);
+    expect(tinted[1]?.allDayTintColor).toBeUndefined();
+  });
+
+  it("picks the topmost chip within a calendar column", () => {
+    const tinted = withAllDayColumnTints(
+      calendarColumns(),
+      [
+        event({
+          startDate: "2026-08-10",
+          endDate: "2026-08-11",
+          calendarId: "cal-a",
+          color: "orange",
+          row: 2,
+        }),
+        event({
+          startDate: "2026-08-10",
+          endDate: "2026-08-11",
+          calendarId: "cal-a",
+          color: "slate",
+          row: 1,
+        }),
+      ],
+      "calendar",
+    );
+
+    expect(tinted[0]?.allDayTintColor).toBe(EVENT_COLOR_SLOT_HEX.slate);
+  });
+});

--- a/packages/web/src/grid/utils/allDayColumnTint.util.test.ts
+++ b/packages/web/src/grid/utils/allDayColumnTint.util.test.ts
@@ -213,6 +213,24 @@ describe("withAllDayColumnTints (calendar / day)", () => {
     expect(tinted[1]?.allDayTintColor).toBeUndefined();
   });
 
+  it("falls unknown calendarIds back to the first column", () => {
+    const tinted = withAllDayColumnTints(
+      calendarColumns(),
+      [
+        event({
+          startDate: "2026-08-10",
+          endDate: "2026-08-11",
+          calendarId: calendarId("cal-missing"),
+          color: "red",
+        }),
+      ],
+      "calendar",
+    );
+
+    expect(tinted[0]?.allDayTintColor).toBe(EVENT_COLOR_SLOT_HEX.red);
+    expect(tinted[1]?.allDayTintColor).toBeUndefined();
+  });
+
   it("picks the topmost chip within a calendar column", () => {
     const tinted = withAllDayColumnTints(
       calendarColumns(),

--- a/packages/web/src/grid/utils/allDayColumnTint.util.ts
+++ b/packages/web/src/grid/utils/allDayColumnTint.util.ts
@@ -1,4 +1,5 @@
 import { type EventColorSlot } from "@core/types/event-color.contracts";
+import { type CSSVariables } from "@web/common/styles/css.types";
 import { getEventPalette } from "@web/common/styles/theme.util";
 import { type GridEvent } from "@web/common/types/web.event.types";
 import { type GridVisibleDate } from "@web/grid/types/grid.types";
@@ -14,17 +15,29 @@ export type AllDayColumnTintEvent = Pick<
   "startDate" | "endDate" | "row" | "color" | "colorHex" | "calendarId"
 >;
 
-type TintWinner = {
-  event: AllDayColumnTintEvent;
-  row: number;
-};
-
 /**
  * CSS background for a column tinted by an all-day event fill color.
  * Keeps the stored hex opaque; opacity is applied only at paint time.
  */
 export const allDayColumnTintBackground = (hex: string): string =>
   `color-mix(in srgb, ${hex} ${ALL_DAY_COLUMN_TINT_PERCENT}%, transparent)`;
+
+/**
+ * Inline column paint for an all-day tint. Jump-day wash wins, so this returns
+ * undefined when jump-day is active or no tint color is set.
+ */
+export const allDayColumnTintStyle = (
+  tintColor: string | undefined,
+  isJumpDay: boolean,
+): CSSVariables | undefined => {
+  if (tintColor === undefined || isJumpDay) {
+    return undefined;
+  }
+  return {
+    "--column-all-day-tint": tintColor,
+    backgroundColor: allDayColumnTintBackground(tintColor),
+  };
+};
 
 const resolveTintHex = (color?: EventColorSlot, colorHex?: string): string =>
   getEventPalette(color, colorHex).base;
@@ -43,7 +56,7 @@ const eventBelongsToCalendarColumn = (
 };
 
 const considerWinner = (
-  winners: Map<string, TintWinner>,
+  winners: Map<string, AllDayColumnTintEvent>,
   columnKey: string,
   event: AllDayColumnTintEvent,
 ) => {
@@ -51,10 +64,13 @@ const considerWinner = (
   // equal rows keep the first encounter (topmost chip in input order).
   const row = event.row ?? Number.POSITIVE_INFINITY;
   const existing = winners.get(columnKey);
-  if (existing !== undefined && row >= existing.row) {
+  if (
+    existing !== undefined &&
+    row >= (existing.row ?? Number.POSITIVE_INFINITY)
+  ) {
     return;
   }
-  winners.set(columnKey, { event, row });
+  winners.set(columnKey, event);
 };
 
 /**
@@ -71,7 +87,7 @@ export const withAllDayColumnTints = (
     return visibleDates;
   }
 
-  const winners = new Map<string, TintWinner>();
+  const winners = new Map<string, AllDayColumnTintEvent>();
   const fallbackCalendarKey = visibleDates[0]?.key;
 
   for (const [columnIndex, column] of visibleDates.entries()) {
@@ -106,10 +122,7 @@ export const withAllDayColumnTints = (
     }
     return {
       ...column,
-      allDayTintColor: resolveTintHex(
-        winner.event.color,
-        winner.event.colorHex,
-      ),
+      allDayTintColor: resolveTintHex(winner.color, winner.colorHex),
     };
   });
 };

--- a/packages/web/src/grid/utils/allDayColumnTint.util.ts
+++ b/packages/web/src/grid/utils/allDayColumnTint.util.ts
@@ -3,7 +3,7 @@ import { type CSSVariables } from "@web/common/styles/css.types";
 import { getEventPalette } from "@web/common/styles/theme.util";
 import { type GridEvent } from "@web/common/types/web.event.types";
 import { type GridVisibleDate } from "@web/grid/types/grid.types";
-import { isAllDayEventOnDay } from "@web/views/Day/components/Calendar/dayAllDayRows.util";
+import { isAllDayEventOnDay } from "@web/grid/utils/allDayEventOnDay.util";
 
 /** Opacity of the all-day event color wash on day columns (Vimcal-like). */
 export const ALL_DAY_COLUMN_TINT_PERCENT = 8;
@@ -42,17 +42,19 @@ export const allDayColumnTintStyle = (
 const resolveTintHex = (color?: EventColorSlot, colorHex?: string): string =>
   getEventPalette(color, colorHex).base;
 
-const eventBelongsToCalendarColumn = (
+const resolveCalendarColumnKey = (
   event: AllDayColumnTintEvent,
-  column: GridVisibleDate,
-  columnIndex: number,
-  fallbackKey: string | undefined,
-): boolean => {
-  if (event.calendarId !== undefined) {
-    return event.calendarId === column.key;
+  visibleDates: GridVisibleDate[],
+): string | undefined => {
+  // Match Day view's getCalendarColumnIndex: known calendar → that column,
+  // otherwise fall back to column 0 (missing/unknown calendarId).
+  if (
+    event.calendarId !== undefined &&
+    visibleDates.some((column) => column.key === event.calendarId)
+  ) {
+    return event.calendarId;
   }
-  // Untitled / local drafts without a calendar land in the first column.
-  return columnIndex === 0 && column.key === fallbackKey;
+  return visibleDates[0]?.key;
 };
 
 const considerWinner = (
@@ -88,25 +90,21 @@ export const withAllDayColumnTints = (
   }
 
   const winners = new Map<string, AllDayColumnTintEvent>();
-  const fallbackCalendarKey = visibleDates[0]?.key;
 
-  for (const [columnIndex, column] of visibleDates.entries()) {
+  for (const column of visibleDates) {
     for (const event of allDayEvents) {
       if (mode === "date") {
         if (!isAllDayEventOnDay(event, column.date)) {
           continue;
         }
-      } else if (
-        !eventBelongsToCalendarColumn(
-          event,
-          column,
-          columnIndex,
-          fallbackCalendarKey,
-        )
-      ) {
+        considerWinner(winners, column.key, event);
         continue;
       }
 
+      const eventColumnKey = resolveCalendarColumnKey(event, visibleDates);
+      if (eventColumnKey !== column.key) {
+        continue;
+      }
       considerWinner(winners, column.key, event);
     }
   }

--- a/packages/web/src/grid/utils/allDayColumnTint.util.ts
+++ b/packages/web/src/grid/utils/allDayColumnTint.util.ts
@@ -1,0 +1,115 @@
+import { type EventColorSlot } from "@core/types/event-color.contracts";
+import { getEventPalette } from "@web/common/styles/theme.util";
+import { type GridEvent } from "@web/common/types/web.event.types";
+import { type GridVisibleDate } from "@web/grid/types/grid.types";
+import { isAllDayEventOnDay } from "@web/views/Day/components/Calendar/dayAllDayRows.util";
+
+/** Opacity of the all-day event color wash on day columns (Vimcal-like). */
+export const ALL_DAY_COLUMN_TINT_PERCENT = 8;
+
+export type AllDayColumnTintMode = "date" | "calendar";
+
+export type AllDayColumnTintEvent = Pick<
+  GridEvent,
+  "startDate" | "endDate" | "row" | "color" | "colorHex" | "calendarId"
+>;
+
+type TintWinner = {
+  event: AllDayColumnTintEvent;
+  row: number;
+};
+
+/**
+ * CSS background for a column tinted by an all-day event fill color.
+ * Keeps the stored hex opaque; opacity is applied only at paint time.
+ */
+export const allDayColumnTintBackground = (hex: string): string =>
+  `color-mix(in srgb, ${hex} ${ALL_DAY_COLUMN_TINT_PERCENT}%, transparent)`;
+
+const resolveTintHex = (color?: EventColorSlot, colorHex?: string): string =>
+  getEventPalette(color, colorHex).base;
+
+const eventBelongsToCalendarColumn = (
+  event: AllDayColumnTintEvent,
+  column: GridVisibleDate,
+  columnIndex: number,
+  fallbackKey: string | undefined,
+): boolean => {
+  if (event.calendarId !== undefined) {
+    return event.calendarId === column.key;
+  }
+  // Untitled / local drafts without a calendar land in the first column.
+  return columnIndex === 0 && column.key === fallbackKey;
+};
+
+const considerWinner = (
+  winners: Map<string, TintWinner>,
+  columnKey: string,
+  event: AllDayColumnTintEvent,
+) => {
+  // Missing row sorts last so packed chips always beat unassigned ones;
+  // equal rows keep the first encounter (topmost chip in input order).
+  const row = event.row ?? Number.POSITIVE_INFINITY;
+  const existing = winners.get(columnKey);
+  if (existing !== undefined && row >= existing.row) {
+    return;
+  }
+  winners.set(columnKey, { event, row });
+};
+
+/**
+ * Attaches `allDayTintColor` from the topmost all-day chip on each column.
+ * - `date`: week columns — tint every day the event's exclusive span covers.
+ * - `calendar`: day columns — tint only the calendar column that owns the chip.
+ */
+export const withAllDayColumnTints = (
+  visibleDates: GridVisibleDate[],
+  allDayEvents: AllDayColumnTintEvent[],
+  mode: AllDayColumnTintMode,
+): GridVisibleDate[] => {
+  if (visibleDates.length === 0 || allDayEvents.length === 0) {
+    return visibleDates;
+  }
+
+  const winners = new Map<string, TintWinner>();
+  const fallbackCalendarKey = visibleDates[0]?.key;
+
+  for (const [columnIndex, column] of visibleDates.entries()) {
+    for (const event of allDayEvents) {
+      if (mode === "date") {
+        if (!isAllDayEventOnDay(event, column.date)) {
+          continue;
+        }
+      } else if (
+        !eventBelongsToCalendarColumn(
+          event,
+          column,
+          columnIndex,
+          fallbackCalendarKey,
+        )
+      ) {
+        continue;
+      }
+
+      considerWinner(winners, column.key, event);
+    }
+  }
+
+  if (winners.size === 0) {
+    return visibleDates;
+  }
+
+  return visibleDates.map((column) => {
+    const winner = winners.get(column.key);
+    if (winner === undefined) {
+      return column;
+    }
+    return {
+      ...column,
+      allDayTintColor: resolveTintHex(
+        winner.event.color,
+        winner.event.colorHex,
+      ),
+    };
+  });
+};

--- a/packages/web/src/grid/utils/allDayEventOnDay.util.ts
+++ b/packages/web/src/grid/utils/allDayEventOnDay.util.ts
@@ -1,0 +1,23 @@
+import { YEAR_MONTH_DAY_FORMAT } from "@core/constants/date.constants";
+import { type Dayjs } from "@core/util/date/dayjs";
+import { type GridEvent } from "@web/common/types/web.event.types";
+
+/**
+ * Whether an all-day (or all-day-row) event's exclusive date span covers
+ * `date`. Uses calendar-date prefixes so Sync UTC-midnight datetime shapes
+ * and date-only schedules agree with {@link eventMatchesRange} / week
+ * {@link isAllDayEventInVisibleDays}.
+ */
+export const isAllDayEventOnDay = (
+  event: Pick<GridEvent, "startDate" | "endDate">,
+  date: Dayjs,
+): boolean => {
+  const dayStart = date.startOf("day").format(YEAR_MONTH_DAY_FORMAT);
+  const dayEnd = date
+    .startOf("day")
+    .add(1, "day")
+    .format(YEAR_MONTH_DAY_FORMAT);
+  const eventStart = event.startDate.slice(0, 10);
+  const eventEnd = event.endDate.slice(0, 10);
+  return eventStart < dayEnd && eventEnd > dayStart;
+};

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
@@ -30,6 +30,7 @@ import { EventGrid, isEventGridLoading } from "@web/grid/components/EventGrid";
 import { useAllDayDraftCreation } from "@web/grid/hooks/useAllDayDraftCreation";
 import { useGridCoordinates } from "@web/grid/hooks/useGridCoordinates";
 import { useGridMeasurements } from "@web/grid/hooks/useGridMeasurements";
+import { withAllDayColumnTints } from "@web/grid/utils/allDayColumnTint.util";
 import { ShiftHintOverlay } from "@web/shortcuts/shift-hint/ShiftHintOverlay";
 import { dayEventQueryRange } from "@web/views/Day/hooks/events/useDayEvents";
 import { useDateInView } from "@web/views/Day/hooks/navigation/useDateInView";
@@ -154,6 +155,11 @@ export function DayCalendarGrid() {
       gridDraft,
       visibleDates,
     ]);
+
+  const tintedVisibleDates = useMemo(
+    () => withAllDayColumnTints(visibleDates, renderedAllDayEvents, "calendar"),
+    [renderedAllDayEvents, visibleDates],
+  );
 
   const calendarColumnKeys = useMemo(
     () => displayedCalendars.map((calendar) => calendar.id),
@@ -405,7 +411,7 @@ export function DayCalendarGrid() {
           onTimedMouseDown={handleTimedMouseDown}
           timedEventsLayer={timedEventsLayer}
           today={today}
-          visibleDates={visibleDates}
+          visibleDates={tintedVisibleDates}
         />
       </DayInteractionCoordinator>
       {contextMenu}

--- a/packages/web/src/views/Day/components/Calendar/dayAllDayRows.util.ts
+++ b/packages/web/src/views/Day/components/Calendar/dayAllDayRows.util.ts
@@ -1,26 +1,6 @@
-import { YEAR_MONTH_DAY_FORMAT } from "@core/constants/date.constants";
-import { type Dayjs } from "@core/util/date/dayjs";
 import { type GridEvent } from "@web/common/types/web.event.types";
 
-/**
- * Whether an all-day (or all-day-row) event's exclusive date span covers
- * `date`. Uses calendar-date prefixes so Sync UTC-midnight datetime shapes
- * and date-only schedules agree with {@link eventMatchesRange} / week
- * {@link isAllDayEventInVisibleDays}.
- */
-export const isAllDayEventOnDay = (
-  event: Pick<GridEvent, "startDate" | "endDate">,
-  date: Dayjs,
-): boolean => {
-  const dayStart = date.startOf("day").format(YEAR_MONTH_DAY_FORMAT);
-  const dayEnd = date
-    .startOf("day")
-    .add(1, "day")
-    .format(YEAR_MONTH_DAY_FORMAT);
-  const eventStart = event.startDate.slice(0, 10);
-  const eventEnd = event.endDate.slice(0, 10);
-  return eventStart < dayEnd && eventEnd > dayStart;
-};
+export { isAllDayEventOnDay } from "@web/grid/utils/allDayEventOnDay.util";
 
 /**
  * Day view columns are calendars on the same date. Week-style row assignment

--- a/packages/web/src/views/Week/components/Grid/Grid.tsx
+++ b/packages/web/src/views/Week/components/Grid/Grid.tsx
@@ -2,10 +2,7 @@ import { type FC, useMemo } from "react";
 import { YEAR_MONTH_DAY_FORMAT } from "@core/constants/date.constants";
 import { type Dayjs } from "@core/util/date/dayjs";
 import { useGoogleUiState } from "@web/auth/google/hooks/useConnectGoogle/useGoogleUiState";
-import {
-  useWeekEventsQueryStatus,
-  useWeekEventViewModel,
-} from "@web/events/queries/useWeekEventsQuery";
+import { useWeekEventViewModel } from "@web/events/queries/useWeekEventsQuery";
 import { EventGrid, isEventGridLoading } from "@web/grid/components/EventGrid";
 import { withAllDayColumnTints } from "@web/grid/utils/allDayColumnTint.util";
 import { AllDayRow } from "@web/views/Week/components/Grid/AllDayRow/AllDayRow";
@@ -39,17 +36,14 @@ export const Grid: FC<Props> = ({
   // Subscribes to the same cache entry the event layers read, so this reports
   // their load without issuing a second fetch.
   const {
+    allDayEvents,
     isPending,
     isFetching,
     isError: isErrorEvents,
     isSuccess,
     data,
     refetch,
-  } = useWeekEventsQueryStatus({
-    startOfView: weekProps.query.startOfView,
-    endOfView: weekProps.query.endOfView,
-  });
-  const { allDayEvents } = useWeekEventViewModel({
+  } = useWeekEventViewModel({
     startOfView: weekProps.query.startOfView,
     endOfView: weekProps.query.endOfView,
   });

--- a/packages/web/src/views/Week/components/Grid/Grid.tsx
+++ b/packages/web/src/views/Week/components/Grid/Grid.tsx
@@ -1,9 +1,13 @@
-import { type FC } from "react";
+import { type FC, useMemo } from "react";
 import { YEAR_MONTH_DAY_FORMAT } from "@core/constants/date.constants";
 import { type Dayjs } from "@core/util/date/dayjs";
 import { useGoogleUiState } from "@web/auth/google/hooks/useConnectGoogle/useGoogleUiState";
-import { useWeekEventsQueryStatus } from "@web/events/queries/useWeekEventsQuery";
+import {
+  useWeekEventsQueryStatus,
+  useWeekEventViewModel,
+} from "@web/events/queries/useWeekEventsQuery";
 import { EventGrid, isEventGridLoading } from "@web/grid/components/EventGrid";
+import { withAllDayColumnTints } from "@web/grid/utils/allDayColumnTint.util";
 import { AllDayRow } from "@web/views/Week/components/Grid/AllDayRow/AllDayRow";
 import { EdgeNavigationIndicators } from "@web/views/Week/components/Grid/MainGrid/EdgeNavigationIndicators/EdgeNavigationIndicators";
 import { MainGrid } from "@web/views/Week/components/Grid/MainGrid/MainGrid";
@@ -45,6 +49,10 @@ export const Grid: FC<Props> = ({
     startOfView: weekProps.query.startOfView,
     endOfView: weekProps.query.endOfView,
   });
+  const { allDayEvents } = useWeekEventViewModel({
+    startOfView: weekProps.query.startOfView,
+    endOfView: weekProps.query.endOfView,
+  });
   const googleState = useGoogleUiState();
   const isLoadingEvents = isEventGridLoading(
     isPending,
@@ -57,10 +65,19 @@ export const Grid: FC<Props> = ({
 
   useDragEdgeNavigation(mainGridRef, weekProps);
 
-  const visibleDates = weekProps.component.weekDays.map((date) => ({
-    date,
-    key: date.format(YEAR_MONTH_DAY_FORMAT),
-  }));
+  const weekDays = weekProps.component.weekDays;
+  const visibleDates = useMemo(
+    () =>
+      withAllDayColumnTints(
+        weekDays.map((date) => ({
+          date,
+          key: date.format(YEAR_MONTH_DAY_FORMAT),
+        })),
+        allDayEvents,
+        "date",
+      ),
+    [allDayEvents, weekDays],
+  );
 
   return (
     <AllDayRow

--- a/packages/web/src/views/Week/components/Grid/Grid.tsx
+++ b/packages/web/src/views/Week/components/Grid/Grid.tsx
@@ -3,7 +3,9 @@ import { YEAR_MONTH_DAY_FORMAT } from "@core/constants/date.constants";
 import { type Dayjs } from "@core/util/date/dayjs";
 import { useGoogleUiState } from "@web/auth/google/hooks/useConnectGoogle/useGoogleUiState";
 import { useWeekEventViewModel } from "@web/events/queries/useWeekEventsQuery";
+import { selectGridDraft, useDraftStore } from "@web/events/stores/draft.store";
 import { EventGrid, isEventGridLoading } from "@web/grid/components/EventGrid";
+import { positionAllDayDraftEvent } from "@web/grid/layout/all-day-draft.position";
 import { withAllDayColumnTints } from "@web/grid/utils/allDayColumnTint.util";
 import { AllDayRow } from "@web/views/Week/components/Grid/AllDayRow/AllDayRow";
 import { EdgeNavigationIndicators } from "@web/views/Week/components/Grid/MainGrid/EdgeNavigationIndicators/EdgeNavigationIndicators";
@@ -59,6 +61,15 @@ export const Grid: FC<Props> = ({
 
   useDragEdgeNavigation(mainGridRef, weekProps);
 
+  const gridDraft = useDraftStore(selectGridDraft);
+  // Include the live all-day draft so create/edit chips tint columns before save.
+  const allDayEventsForTint = useMemo(
+    () =>
+      positionAllDayDraftEvent({ draft: gridDraft, events: allDayEvents })
+        .events,
+    [allDayEvents, gridDraft],
+  );
+
   const weekDays = weekProps.component.weekDays;
   const visibleDates = useMemo(
     () =>
@@ -67,10 +78,10 @@ export const Grid: FC<Props> = ({
           date,
           key: date.format(YEAR_MONTH_DAY_FORMAT),
         })),
-        allDayEvents,
+        allDayEventsForTint,
         "date",
       ),
-    [allDayEvents, weekDays],
+    [allDayEventsForTint, weekDays],
   );
 
   return (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
When a day has all-day events, its week/day grid column(s) get a subtle wash of the topmost all-day chip’s fill color (Vimcal-style).

## Behavior
- Color comes from the topmost chip (`lowest row`; ties keep first encounter)
- Week: tint each day the all-day span covers
- Day: tint only calendar columns that have an all-day event that day
- Jump-day highlight still wins over the tint while active

## Implementation
- `withAllDayColumnTints` enriches `GridVisibleDate` with `allDayTintColor`
- `TimedGrid` / `AllDayGridRow` paint via `color-mix(..., 8%, transparent)`
- Wired from Week `Grid` and `DayCalendarGrid`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-77ff2243-8aca-4c26-8eca-7626ded6644a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-77ff2243-8aca-4c26-8eca-7626ded6644a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

