### PR TITLE
refactor(web): remove Week's create-draft emit-then-subscribe round-trip

### DIFF
--- a/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcutOwner.ts
+++ b/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcutOwner.ts
@@ -2,10 +2,7 @@ import { useCallback, useEffect } from "react";
 import { type Dayjs } from "@core/util/date/dayjs";
 import { useCalendarsQuery } from "@web/calendars/calendar.query";
 import { useDefaultTargetCalendar } from "@web/calendars/useDefaultTargetCalendar";
-import {
-  emitViewCommand,
-  onViewCommand,
-} from "@web/common/utils/dom/view-command-bus";
+import { onViewCommand } from "@web/common/utils/dom/view-command-bus";
 import {
   createAlldayDraft,
   createTimedDraft,
@@ -131,19 +128,9 @@ export const useWeekShortcutOwner = ({
     );
   }, [defaultTargetCalendarId, isCalendarsPending, isCurrentWeek, startOfView]);
 
-  const emitCreateAllDayDraft = useCallback(
-    () => emitViewCommand("CREATE_ALLDAY_DRAFT"),
-    [],
-  );
-  const emitCreateTimedDraft = useCallback(
-    () => emitViewCommand("CREATE_TIMED_DRAFT"),
-    [],
-  );
-
-  // The "C"/"A" keys and the command palette's create-event rows
-  // (event.cmd.constants.ts) both just emit these commands; this effect is
-  // the one place that turns them into a draft, so every trigger runs
-  // identical code. Resubscribes when the create handlers change (week in
+  // The command palette's create-event rows (event.cmd.constants.ts) can only
+  // reach this view through the bus; the "C"/"A" keys below call the create
+  // functions directly. Resubscribes when the create handlers change (week in
   // view or default target calendar).
   useEffect(() => {
     const unsubscribeCreateAllDayDraft = onViewCommand(
@@ -196,8 +183,8 @@ export const useWeekShortcutOwner = ({
     onShiftViewBackward: shiftViewBackward,
     onShiftViewForward: shiftViewForward,
     onGoToToday: toToday,
-    onCreateAllDayDraft: emitCreateAllDayDraft,
-    onCreateTimedDraft: emitCreateTimedDraft,
+    onCreateAllDayDraft: createAllDayDraftEvent,
+    onCreateTimedDraft: createTimedDraftEvent,
     onFocusCalendar: focusFirstCalendarEvent,
   });
 


### PR DESCRIPTION
## Summary
- Week's "C"/"A" keys emitted a `view-command-bus` event that the same hook immediately subscribed to and turned into a draft — pure indirection, since the create functions were already in scope where the keys are registered.
- Keys now call `createTimedDraftEvent`/`createAllDayDraftEvent` directly. The bus subscription stays, scoped to what actually needs it: the command palette's create-event rows, which have no other way to reach the mounted Week view.

Stacked on #2715 (PR 1). Note: the plan for this slot originally called for deleting `day-event.registry.ts`/`week-event.registry.ts`/their targeting pairs as "pure re-export aliases." On inspection they're not — each is the single instantiation point for that view's registry singleton, and deleting them would make every importer construct its own instance. Skipped as unsafe; noted in the working plan.

## Test plan
- [x] `bun run type-check` passes
- [x] `bun test src/views src/grid src/shortcuts src/components/CommandPalette` — 576 + 161 pass
- [x] `biome check` clean