### PR TITLE
fix(web): show event jump labels on Shift press

### DIFF
--- a/docs/acceptance/shortcuts.md
+++ b/docs/acceptance/shortcuts.md
@@ -331,19 +331,19 @@ After deleting or moving an event, pressing Cmd+Z (Mac) or Ctrl+Z (Windows/Linux
 
 ### UX
 
-Tapping `Shift` toggles event-jump mode (activation waits briefly so Shift-Shift can still enter keyboard-only without a jump flash). Week view chips use day prefixes (`SU`/`M`/`T`/`W`/`R`/`F`/`SA`) plus a per-day index (`W4`, `SU1`). Day view uses numeric chips (`1`, `2`, …). Pressing a day letter highlights that column and focuses its first event; a following digit focuses that index. `Esc` or another Shift tap exits. Quick chords such as Shift+J or Shift+Arrow do not toggle the mode.
+Pressing `Shift` shows event-jump chips immediately; releasing a quick tap keeps the mode on. Week view chips use day prefixes (`SU`/`M`/`T`/`W`/`R`/`F`/`SA`) plus a per-day index (`W4`, `SU1`). Day view uses numeric chips (`1`, `2`, …). Pressing a day letter highlights that column and focuses its first event; a following digit focuses that index. `Esc` or another Shift tap exits. Long holds and quick chords such as Shift+J or Shift+Arrow cancel the press so jump mode does not stay on. A following Shift-Shift still enters keyboard-only without leaving jump chips up.
 
 ### Steps
 
 1. Navigate to `/week` with timed events on at least two different days.
-2. Tap `Shift` once (do not hold for a chord).
+2. Press `Shift` once (do not hold for a chord); chips should appear on key down.
 3. Press the day letter on a chip (for example `W` for Wednesday), then optionally a digit (`2`) or use arrow keys.
 4. Press `Esc` (or tap `Shift` again) to exit.
 5. Repeat with a fast Shift+J chord and confirm jump mode does not activate.
 
 ### Expected Results
 
-- Chips appear on events after a Shift tap and stay until Esc / another Shift tap.
+- Chips appear on events as soon as Shift is pressed and stay after a quick release until Esc / another Shift tap.
 - A day letter highlights that column and focuses the first event; digits refine to `Wn`.
 - Arrow keys keep jump mode on so letter-then-arrows works.
 - Fast Shift+J / Shift+Arrow do not toggle jump mode.
@@ -391,4 +391,4 @@ If time is limited, run these checks before shipping shortcut-related changes:
 12. With a focused event and no draft open, ArrowUp/ArrowDown move focus to the previous/next event chronologically.
 13. Cmd+D / Ctrl+D duplicates a focused event in Day and Week view.
 14. With a focused event, `E` then `T` opens the form with the title focused; bare `E` alone does nothing.
-15. Tapping Shift toggles event jump chips; a day letter + digit focuses that event; fast Shift+J does not toggle the mode.
+15. Pressing Shift shows event jump chips immediately; a day letter + digit focuses that event; fast Shift+J does not leave the mode on.

--- a/packages/web/src/shortcuts/shift-hint/shift-hold-detector.test.ts
+++ b/packages/web/src/shortcuts/shift-hint/shift-hold-detector.test.ts
@@ -8,7 +8,7 @@ import {
 import { describe, expect, it } from "bun:test";
 
 describe("reduceShiftJumpGesture", () => {
-  it("emits toggle on a quick Shift tap", () => {
+  it("emits press on Shift down and toggle on a quick release", () => {
     const state = createShiftJumpGestureState();
     let result = reduceShiftJumpGesture(state, {
       type: "shiftDown",
@@ -16,6 +16,7 @@ describe("reduceShiftJumpGesture", () => {
       blocked: false,
     });
     expect(result.state.phase).toBe("armed");
+    expect(result.press).toBe(true);
     expect(result.toggle).toBe(false);
 
     result = reduceShiftJumpGesture(result.state, {
@@ -24,11 +25,12 @@ describe("reduceShiftJumpGesture", () => {
     });
     expect(result.toggle).toBe(true);
     expect(result.forceOff).toBe(false);
+    expect(result.cancel).toBe(false);
     expect(result.state.phase).toBe("idle");
     expect(result.state.lastShiftReleaseAt).toBe(1100);
   });
 
-  it("does not toggle on a long press", () => {
+  it("cancels on a long press release", () => {
     let state = createShiftJumpGestureState();
     state = reduceShiftJumpGesture(state, {
       type: "shiftDown",
@@ -41,24 +43,41 @@ describe("reduceShiftJumpGesture", () => {
     });
     expect(result.toggle).toBe(false);
     expect(result.forceOff).toBe(false);
+    expect(result.cancel).toBe(true);
     expect(result.state.lastShiftReleaseAt).toBeNull();
   });
 
   it("cancels armed on chord key so Shift+J never toggles", () => {
+    const state = createShiftJumpGestureState();
+    let result = reduceShiftJumpGesture(state, {
+      type: "shiftDown",
+      now: 1000,
+      blocked: false,
+    });
+    expect(result.press).toBe(true);
+    result = reduceShiftJumpGesture(result.state, { type: "chordKeyDown" });
+    expect(result.state.phase).toBe("idle");
+    expect(result.cancel).toBe(true);
+
+    result = reduceShiftJumpGesture(result.state, {
+      type: "shiftUp",
+      now: 1100,
+    });
+    expect(result.toggle).toBe(false);
+    expect(result.cancel).toBe(false);
+  });
+
+  it("cancels via holdExpired while still armed", () => {
     let state = createShiftJumpGestureState();
     state = reduceShiftJumpGesture(state, {
       type: "shiftDown",
       now: 1000,
       blocked: false,
     }).state;
-    state = reduceShiftJumpGesture(state, { type: "chordKeyDown" }).state;
-    expect(state.phase).toBe("idle");
-
-    const result = reduceShiftJumpGesture(state, {
-      type: "shiftUp",
-      now: 1100,
-    });
-    expect(result.toggle).toBe(false);
+    const result = reduceShiftJumpGesture(state, { type: "holdExpired" });
+    expect(result.cancel).toBe(true);
+    expect(result.state.phase).toBe("idle");
+    expect(result.state.lastShiftReleaseAt).toBeNull();
   });
 
   it("does not arm when blocked (editable / app lock)", () => {
@@ -68,10 +87,11 @@ describe("reduceShiftJumpGesture", () => {
       blocked: true,
     });
     expect(result.state.phase).toBe("idle");
+    expect(result.press).toBe(false);
     expect(result.toggle).toBe(false);
   });
 
-  it("forceOff on the second quick tap (Shift-Shift)", () => {
+  it("forceOff on the second quick tap (Shift-Shift) without a second press", () => {
     let state = createShiftJumpGestureState();
     state = reduceShiftJumpGesture(state, {
       type: "shiftDown",
@@ -84,12 +104,13 @@ describe("reduceShiftJumpGesture", () => {
     }).state;
     expect(state.lastShiftReleaseAt).toBe(1050);
 
-    state = reduceShiftJumpGesture(state, {
+    let result = reduceShiftJumpGesture(state, {
       type: "shiftDown",
       now: 1100,
       blocked: false,
-    }).state;
-    const result = reduceShiftJumpGesture(state, {
+    });
+    expect(result.press).toBe(false);
+    result = reduceShiftJumpGesture(result.state, {
       type: "shiftUp",
       now: 1150,
     });

--- a/packages/web/src/shortcuts/shift-hint/shift-hold-detector.ts
+++ b/packages/web/src/shortcuts/shift-hint/shift-hold-detector.ts
@@ -1,10 +1,12 @@
 /**
  * Pure Shift gesture state for event-jump mode.
  *
- * Quick Shift tap → toggle (hook applies). Chord while armed cancels so
- * Shift+J / Shift+Arrow never toggle. Long press (≥ threshold) is not a tap.
- * A second quick tap within {@link SHIFT_DOUBLE_TAP_MAX_GAP_MS} is a
- * Shift-Shift candidate: force jump mode off so keyboard-only can win.
+ * Shift down → optional optimistic `press` (hints can show immediately).
+ * Quick Shift up → `toggle` (hook confirms or toggles off). Chord while
+ * armed, or hold past {@link SHIFT_TAP_MAX_HOLD_MS}, cancels so Shift+J /
+ * long holds never leave jump mode on. A second quick tap within
+ * {@link SHIFT_DOUBLE_TAP_MAX_GAP_MS} is a Shift-Shift candidate: force jump
+ * mode off so keyboard-only can win.
  */
 
 export const SHIFT_TAP_MAX_HOLD_MS = 200;
@@ -39,15 +41,32 @@ export type ShiftJumpGestureEvent =
   | { type: "shiftDown"; now: number; blocked: boolean }
   | { type: "shiftUp"; now: number }
   | { type: "chordKeyDown" }
+  | { type: "holdExpired" }
   | { type: "reset" };
 
 export type ShiftJumpGestureResult = {
   state: ShiftJumpGestureState;
-  /** Quick tap that should toggle jump mode (not a Shift-Shift second tap). */
+  /** Shift down that may show jump hints before release. */
+  press: boolean;
+  /** Quick tap up: confirm optimistic press, or toggle off if already on. */
   toggle: boolean;
   /** Second quick tap: force jump mode off for keyboard-only coexistence. */
   forceOff: boolean;
+  /** Chord or hold timeout: undo an optimistic press. */
+  cancel: boolean;
 };
+
+const idleResult = (
+  state: ShiftJumpGestureState,
+  overrides: Partial<ShiftJumpGestureResult> = {},
+): ShiftJumpGestureResult => ({
+  state,
+  press: false,
+  toggle: false,
+  forceOff: false,
+  cancel: false,
+  ...overrides,
+});
 
 export function reduceShiftJumpGesture(
   state: ShiftJumpGestureState,
@@ -56,46 +75,46 @@ export function reduceShiftJumpGesture(
   switch (event.type) {
     case "shiftDown": {
       if (event.blocked) {
-        return {
-          state: {
-            phase: "idle",
-            armedAt: null,
-            lastShiftReleaseAt: state.lastShiftReleaseAt,
-          },
-          toggle: false,
-          forceOff: false,
-        };
+        return idleResult({
+          phase: "idle",
+          armedAt: null,
+          lastShiftReleaseAt: state.lastShiftReleaseAt,
+        });
       }
       if (state.phase === "armed") {
-        return { state, toggle: false, forceOff: false };
+        return idleResult(state);
       }
-      return {
-        state: {
+      const isSecondTap = isShiftDoubleTapCandidate({
+        lastShiftReleaseAt: state.lastShiftReleaseAt,
+        now: event.now,
+        maxGapMs: SHIFT_DOUBLE_TAP_MAX_GAP_MS,
+      });
+      return idleResult(
+        {
           ...state,
           phase: "armed",
           armedAt: event.now,
         },
-        toggle: false,
-        forceOff: false,
-      };
+        // Second tap of Shift-Shift must not flash hints before forceOff.
+        { press: !isSecondTap },
+      );
     }
     case "shiftUp": {
       if (state.phase !== "armed" || state.armedAt === null) {
-        return { state, toggle: false, forceOff: false };
+        return idleResult(state);
       }
 
       const heldMs = event.now - state.armedAt;
       // Long press: not a tap (also keeps Shift-Shift keyboard-only clean).
       if (heldMs >= SHIFT_TAP_MAX_HOLD_MS) {
-        return {
-          state: {
+        return idleResult(
+          {
             phase: "idle",
             armedAt: null,
             lastShiftReleaseAt: null,
           },
-          toggle: false,
-          forceOff: false,
-        };
+          { cancel: true },
+        );
       }
 
       const isDoubleTap = isShiftDoubleTapCandidate({
@@ -105,48 +124,54 @@ export function reduceShiftJumpGesture(
       });
 
       if (isDoubleTap) {
-        return {
-          state: {
+        return idleResult(
+          {
             phase: "idle",
             armedAt: null,
             lastShiftReleaseAt: null,
           },
-          toggle: false,
-          forceOff: true,
-        };
+          { forceOff: true },
+        );
       }
 
-      return {
-        state: {
+      return idleResult(
+        {
           phase: "idle",
           armedAt: null,
           lastShiftReleaseAt: event.now,
         },
-        toggle: true,
-        forceOff: false,
-      };
+        { toggle: true },
+      );
     }
     case "chordKeyDown": {
       if (state.phase !== "armed") {
-        return { state, toggle: false, forceOff: false };
+        return idleResult(state);
       }
-      return {
-        state: {
+      return idleResult(
+        {
           phase: "idle",
           armedAt: null,
           // Chord cancels the tap; do not seed a double-tap gap.
           lastShiftReleaseAt: null,
         },
-        toggle: false,
-        forceOff: false,
-      };
+        { cancel: true },
+      );
+    }
+    case "holdExpired": {
+      if (state.phase !== "armed") {
+        return idleResult(state);
+      }
+      return idleResult(
+        {
+          phase: "idle",
+          armedAt: null,
+          lastShiftReleaseAt: null,
+        },
+        { cancel: true },
+      );
     }
     case "reset": {
-      return {
-        state: createShiftJumpGestureState(),
-        toggle: false,
-        forceOff: false,
-      };
+      return idleResult(createShiftJumpGestureState());
     }
   }
 }

--- a/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.test.tsx
+++ b/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.test.tsx
@@ -10,7 +10,10 @@ import {
   eventJumpActions,
   useEventJumpStore,
 } from "@web/shortcuts/shift-hint/event-jump.store";
-import { SHIFT_DOUBLE_TAP_MAX_GAP_MS } from "@web/shortcuts/shift-hint/shift-hold-detector";
+import {
+  SHIFT_DOUBLE_TAP_MAX_GAP_MS,
+  SHIFT_TAP_MAX_HOLD_MS,
+} from "@web/shortcuts/shift-hint/shift-hold-detector";
 import { useShiftHoldEventHints } from "@web/shortcuts/shift-hint/useShiftHoldEventHints";
 import { resetSharedShiftTapGesture } from "@web/shortcuts/shift-tap-gesture";
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
@@ -150,6 +153,44 @@ describe("useShiftHoldEventHints", () => {
       expect.objectContaining({ eventId: EVENT_B, element: elements[1] }),
     );
     expect(useEventJumpStore.getState().isActive).toBe(true);
+  });
+
+  it("shows hints on Shift keydown before release", () => {
+    const { result } = mountHints();
+
+    act(() => {
+      dispatch("keydown", "Shift");
+    });
+
+    expect(useEventJumpStore.getState().isActive).toBe(true);
+    expect(result.current.hints).toHaveLength(3);
+
+    act(() => {
+      dispatch("keyup", "Shift");
+    });
+
+    expect(useEventJumpStore.getState().isActive).toBe(true);
+    expect(result.current.hints).toHaveLength(3);
+  });
+
+  it("cancels optimistic hints when Shift is held past the tap threshold", async () => {
+    const { result } = mountHints();
+
+    act(() => {
+      dispatch("keydown", "Shift");
+    });
+    expect(result.current.hints).toHaveLength(3);
+
+    await act(async () => {
+      await Bun.sleep(SHIFT_TAP_MAX_HOLD_MS + 20);
+    });
+    expect(useEventJumpStore.getState().isActive).toBe(false);
+    expect(result.current.hints).toEqual([]);
+
+    act(() => {
+      dispatch("keyup", "Shift");
+    });
+    expect(useEventJumpStore.getState().isActive).toBe(false);
   });
 
   it("does not toggle on a quick Shift chord (Shift+J)", () => {

--- a/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.ts
+++ b/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.ts
@@ -353,6 +353,7 @@ export function useShiftHoldEventHints({
     };
 
     const onBlur = () => {
+      openedByPressRef.current = false;
       if (isActiveRef.current) deactivate();
     };
 
@@ -388,8 +389,10 @@ export function useShiftHoldEventHints({
         }
         return;
       }
-      openedByPressRef.current = false;
-      if (isActiveRef.current) deactivate(false);
+      if (event.type === "doubleTap") {
+        openedByPressRef.current = false;
+        if (isActiveRef.current) deactivate(false);
+      }
     });
 
     document.addEventListener("keydown", onKeyDown, true);

--- a/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.ts
+++ b/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.ts
@@ -112,10 +112,10 @@ const buildDayJumpAssignments = (
 };
 
 /**
- * Tap Shift to toggle day-prefix jump labels on grid events. Esc or another
- * Shift tap exits. Day letters (and digits after a day) win over global
- * shortcuts while active. Shift+chords never toggle; Shift-Shift forces off
- * so keyboard-only mode can enter.
+ * Press Shift to show day-prefix jump labels immediately; release confirms.
+ * Esc or another Shift tap exits. Day letters (and digits after a day) win
+ * over global shortcuts while active. Shift+chords and long holds cancel the
+ * optimistic press; Shift-Shift forces off so keyboard-only mode can enter.
  */
 export function useShiftHoldEventHints({
   allDayEvents = [],
@@ -138,6 +138,8 @@ export function useShiftHoldEventHints({
   const assignmentsRef = useRef<DayJumpAssignment[]>([]);
   const visibleByIdRef = useRef<Map<string, ShiftHintFocusTarget>>(new Map());
   const suppressKeyUpRef = useRef(new Set<string>());
+  /** True when the current Shift press opened jump mode before keyup. */
+  const openedByPressRef = useRef(false);
   const ambiguousCommitTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
     null,
   );
@@ -354,10 +356,31 @@ export function useShiftHoldEventHints({
       if (isActiveRef.current) deactivate();
     };
 
-    // Single tap toggles hints on/off; a following second tap (double tap)
-    // cancels whatever the first tap just did, so keyboard-only mode can win.
+    // Press shows hints before release; quick release confirms (or toggles
+    // off when mode was already on). Chord / hold-timeout cancel an
+    // optimistic press. Double tap cancels and hands off to keyboard-only.
     const unsubscribeShiftGesture = subscribeToShiftTapGesture((event) => {
+      if (event.type === "press") {
+        if (isActiveRef.current) {
+          openedByPressRef.current = false;
+          return;
+        }
+        activate();
+        openedByPressRef.current = isActiveRef.current;
+        return;
+      }
+      if (event.type === "cancel") {
+        if (openedByPressRef.current) {
+          openedByPressRef.current = false;
+          deactivate(false);
+        }
+        return;
+      }
       if (event.type === "singleTap") {
+        if (openedByPressRef.current) {
+          openedByPressRef.current = false;
+          return;
+        }
         if (isActiveRef.current) {
           deactivate();
         } else {
@@ -365,6 +388,7 @@ export function useShiftHoldEventHints({
         }
         return;
       }
+      openedByPressRef.current = false;
       if (isActiveRef.current) deactivate(false);
     });
 
@@ -375,6 +399,7 @@ export function useShiftHoldEventHints({
     return () => {
       clearAmbiguousCommitTimer();
       suppressKeyUpRef.current.clear();
+      openedByPressRef.current = false;
       unsubscribeShiftGesture();
       document.removeEventListener("keydown", onKeyDown, true);
       document.removeEventListener("keyup", onKeyUp, true);

--- a/packages/web/src/shortcuts/shift-tap-gesture.test.ts
+++ b/packages/web/src/shortcuts/shift-tap-gesture.test.ts
@@ -1,4 +1,5 @@
 import { clearAppLockReasons } from "@web/shortcuts/app-lock";
+import { SHIFT_TAP_MAX_HOLD_MS } from "@web/shortcuts/shift-hint/shift-hold-detector";
 import {
   resetSharedShiftTapGesture,
   subscribeToShiftTapGesture,
@@ -37,7 +38,7 @@ describe("shift-tap-gesture", () => {
     resetSharedShiftTapGesture();
   });
 
-  it("notifies every subscriber of a single tap", () => {
+  it("notifies every subscriber of press then single tap", () => {
     const events: string[] = [];
     const unsubscribeA = subscribeToShiftTapGesture((event) =>
       events.push(`a:${event.type}`),
@@ -48,7 +49,12 @@ describe("shift-tap-gesture", () => {
 
     tapShift();
 
-    expect(events).toEqual(["a:singleTap", "b:singleTap"]);
+    expect(events).toEqual([
+      "a:press",
+      "b:press",
+      "a:singleTap",
+      "b:singleTap",
+    ]);
 
     unsubscribeA();
     unsubscribeB();
@@ -63,12 +69,12 @@ describe("shift-tap-gesture", () => {
     tapShift();
     tapShift();
 
-    expect(events).toEqual(["singleTap", "doubleTap"]);
+    expect(events).toEqual(["press", "singleTap", "doubleTap"]);
 
     unsubscribe();
   });
 
-  it("never toggles on a Shift chord", () => {
+  it("cancels an optimistic press on a Shift chord", () => {
     const events: string[] = [];
     const unsubscribe = subscribeToShiftTapGesture((event) =>
       events.push(event.type),
@@ -79,7 +85,22 @@ describe("shift-tap-gesture", () => {
     dispatch("keyup", "j", { shiftKey: true });
     dispatch("keyup", "Shift");
 
-    expect(events).toEqual([]);
+    expect(events).toEqual(["press", "cancel"]);
+
+    unsubscribe();
+  });
+
+  it("cancels an optimistic press once the hold threshold elapses", async () => {
+    const events: string[] = [];
+    const unsubscribe = subscribeToShiftTapGesture((event) =>
+      events.push(event.type),
+    );
+
+    dispatch("keydown", "Shift");
+    await Bun.sleep(SHIFT_TAP_MAX_HOLD_MS + 20);
+    dispatch("keyup", "Shift");
+
+    expect(events).toEqual(["press", "cancel"]);
 
     unsubscribe();
   });

--- a/packages/web/src/shortcuts/shift-tap-gesture.ts
+++ b/packages/web/src/shortcuts/shift-tap-gesture.ts
@@ -1,14 +1,14 @@
 /**
  * One shared document-level listener for the Shift-tap gesture, driving both
- * shift-hint (single tap toggles day-jump hints) and keyboard-only mode
- * (double tap toggles it). Previously each feature ran its own independent
- * listener + reducer instance and coordinated only by timing (shift-hint
- * deferred its activation past the double-tap window so a following second
- * tap could retroactively cancel it). One listener means the two can no
- * longer race: a single tap always fires `singleTap` immediately, and a
- * following second tap within the window fires `doubleTap` instead - which
- * cancels whatever the first tap just started (shift-hint listens for this
- * and turns hints back off).
+ * shift-hint (press shows day-jump hints; quick release confirms) and
+ * keyboard-only mode (double tap toggles it). Previously each feature ran
+ * its own independent listener + reducer instance and coordinated only by
+ * timing. One listener means the two can no longer race: Shift down can
+ * `press` immediately so hints appear before release; a following second
+ * tap within the window fires `doubleTap` instead — which cancels whatever
+ * the first tap just started (shift-hint listens for this and turns hints
+ * back off). Chord or hold-past-threshold fires `cancel` so Shift+J and
+ * long holds do not leave jump mode on.
  */
 
 import { isEditableKeyboardTarget } from "@web/common/utils/form/form.util";
@@ -17,17 +17,39 @@ import {
   createShiftJumpGestureState,
   isShiftKey,
   reduceShiftJumpGesture,
+  SHIFT_TAP_MAX_HOLD_MS,
   type ShiftJumpGestureState,
 } from "@web/shortcuts/shift-hint/shift-hold-detector";
 
-export type ShiftTapGestureEvent = { type: "singleTap" | "doubleTap" };
+export type ShiftTapGestureEvent = {
+  type: "press" | "singleTap" | "doubleTap" | "cancel";
+};
 export type ShiftTapGestureListener = (event: ShiftTapGestureEvent) => void;
 
 let gestureState: ShiftJumpGestureState = createShiftJumpGestureState();
 const listeners = new Set<ShiftTapGestureListener>();
+let holdTimer: ReturnType<typeof setTimeout> | null = null;
 
 const notify = (type: ShiftTapGestureEvent["type"]) => {
   for (const listener of listeners) listener({ type });
+};
+
+const clearHoldTimer = () => {
+  if (holdTimer === null) return;
+  clearTimeout(holdTimer);
+  holdTimer = null;
+};
+
+const armHoldExpiry = () => {
+  clearHoldTimer();
+  holdTimer = setTimeout(() => {
+    holdTimer = null;
+    const result = reduceShiftJumpGesture(gestureState, {
+      type: "holdExpired",
+    });
+    gestureState = result.state;
+    if (result.cancel) notify("cancel");
+  }, SHIFT_TAP_MAX_HOLD_MS);
 };
 
 const onKeyDown = (event: KeyboardEvent) => {
@@ -36,19 +58,27 @@ const onKeyDown = (event: KeyboardEvent) => {
   if (isShiftKey(event)) {
     if (event.repeat) return;
     const blocked = isAppLocked() || isEditableKeyboardTarget(event);
-    gestureState = reduceShiftJumpGesture(gestureState, {
+    const result = reduceShiftJumpGesture(gestureState, {
       type: "shiftDown",
       now: Date.now(),
       blocked,
-    }).state;
+    });
+    gestureState = result.state;
+    if (result.press) {
+      notify("press");
+      armHoldExpiry();
+    }
     return;
   }
 
   // Chord while Shift is down (Shift+J, Shift+Arrow, …): never toggle.
   if (gestureState.phase === "armed") {
-    gestureState = reduceShiftJumpGesture(gestureState, {
+    clearHoldTimer();
+    const result = reduceShiftJumpGesture(gestureState, {
       type: "chordKeyDown",
-    }).state;
+    });
+    gestureState = result.state;
+    if (result.cancel) notify("cancel");
   }
 };
 
@@ -57,6 +87,7 @@ const onKeyUp = (event: KeyboardEvent) => {
   // Keep counting a hold if the other Shift key is still down.
   if (event.shiftKey) return;
 
+  clearHoldTimer();
   const result = reduceShiftJumpGesture(gestureState, {
     type: "shiftUp",
     now: Date.now(),
@@ -65,6 +96,8 @@ const onKeyUp = (event: KeyboardEvent) => {
 
   if (result.forceOff) {
     notify("doubleTap");
+  } else if (result.cancel) {
+    notify("cancel");
   } else if (result.toggle) {
     if (isAppLocked() || isEditableKeyboardTarget(event)) return;
     notify("singleTap");
@@ -72,6 +105,7 @@ const onKeyUp = (event: KeyboardEvent) => {
 };
 
 const onBlur = () => {
+  clearHoldTimer();
   gestureState = reduceShiftJumpGesture(gestureState, { type: "reset" }).state;
 };
 
@@ -87,6 +121,7 @@ const attach = () => {
 
 const detach = () => {
   attached = false;
+  clearHoldTimer();
   document.removeEventListener("keydown", onKeyDown, true);
   document.removeEventListener("keyup", onKeyUp, true);
   window.removeEventListener("blur", onBlur);
@@ -112,5 +147,6 @@ export function subscribeToShiftTapGesture(
  * and by tests resetting between cases.
  */
 export function resetSharedShiftTapGesture(): void {
+  clearHoldTimer();
   gestureState = createShiftJumpGestureState();
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Event-jump chips used to appear only after Shift **keyup**, so a normal tap felt delayed. They now show on **keydown** and stay after a quick release.

- Optimistic `press` on Shift down shows day-prefix labels immediately
- Quick release confirms (mode stays on); another Shift tap still toggles off
- Chord (Shift+J / arrows) or hold past the tap threshold cancels the optimistic press
- Shift-Shift still cancels hints and enters keyboard-only without a second press flash

## Simplicity

Kept the shared gesture reducer as the single source of truth and only added `press` / `cancel` / `holdExpired` signals. Retained `openedByPressRef` so a confirming keyup does not immediately toggle mode back off. Clarified the double-tap branch and clear the optimistic-press ref on blur.

## Automated validation

- `bun test:web` on shift-hint / shift-tap / keyboard-only unit + integration tests — 27 pass
- `bun run lint` — pass (pre-existing warnings only)
- Browser at `http://localhost:9080`: Shift press shows chips immediately; quick release keeps them; Esc clears; Shift+J leaves no chips; long hold leaves no chips; second Shift tap toggles off
- GitHub CI on the PR: lint, type-check, knip, unit suites, e2e, CodeQL — success

## Independent review

Fresh diff-first review: **APPROVE**, no confirmed findings.

## Test plan

- `bun test:web` focused shift-hint / shift-tap / keyboard-only suites — 27 pass
- `bun run lint`
- Manual week-view Shift press / chord / long-hold / toggle-off on localhost:9080
- CI e2e / unit / lint / type-check green on PR #2723

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7a645e3a-4925-40c0-a170-83d5b9285b54?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7a645e3a-4925-40c0-a170-83d5b9285b54&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

