### PR TITLE
fix(web): focus Cancel and add Shift+Esc discard

### DIFF
--- a/packages/web/src/components/OverlayPanel/OverlayPanel.test.tsx
+++ b/packages/web/src/components/OverlayPanel/OverlayPanel.test.tsx
@@ -128,4 +128,60 @@ describe("OverlayPanel", () => {
     expect(outside).toHaveFocus();
     outside.remove();
   });
+
+  it("focuses initialFocusRef instead of the first focusable", () => {
+    const initialFocusRef = { current: null as HTMLButtonElement | null };
+    render(
+      <OverlayPanel
+        title="Confirm"
+        onDismiss={() => {}}
+        initialFocusRef={initialFocusRef}
+      >
+        <button type="button">First</button>
+        <button
+          type="button"
+          ref={(node) => {
+            initialFocusRef.current = node;
+          }}
+        >
+          Preferred
+        </button>
+      </OverlayPanel>,
+    );
+
+    expect(screen.getByRole("button", { name: "Preferred" })).toHaveFocus();
+  });
+
+  it("calls onShiftEscape for Shift+Escape and onDismiss for Escape", async () => {
+    const user = userEvent.setup();
+    let dismissed = 0;
+    let shifted = 0;
+    const onDismiss = () => {
+      dismissed += 1;
+    };
+    const onShiftEscape = () => {
+      shifted += 1;
+    };
+
+    render(
+      <OverlayPanel
+        title="Confirm"
+        onDismiss={onDismiss}
+        onShiftEscape={onShiftEscape}
+      >
+        <button type="button">Inside</button>
+      </OverlayPanel>,
+    );
+
+    const inside = screen.getByRole("button", { name: "Inside" });
+    inside.focus();
+
+    await user.keyboard("{Escape}");
+    expect(dismissed).toBe(1);
+    expect(shifted).toBe(0);
+
+    await user.keyboard("{Shift>}{Escape}{/Shift}");
+    expect(shifted).toBe(1);
+    expect(dismissed).toBe(1);
+  });
 });

--- a/packages/web/src/components/OverlayPanel/OverlayPanel.tsx
+++ b/packages/web/src/components/OverlayPanel/OverlayPanel.tsx
@@ -1,8 +1,8 @@
 import classNames from "classnames";
 import {
   type ButtonHTMLAttributes,
+  forwardRef,
   type ReactNode,
-  type Ref,
   type RefObject,
   useEffect,
   useId,
@@ -237,32 +237,38 @@ export const OverlayPanelActions = ({
 interface OverlayPanelActionButtonProps
   extends ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: "primary" | "secondary" | "destructive";
-  ref?: Ref<HTMLButtonElement>;
 }
 
-export const OverlayPanelActionButton = ({
-  children,
-  className,
-  type = "button",
-  variant = "secondary",
+export const OverlayPanelActionButton = forwardRef<
+  HTMLButtonElement,
+  OverlayPanelActionButtonProps
+>(function OverlayPanelActionButton(
+  {
+    children,
+    className,
+    type = "button",
+    variant = "secondary",
+    ...buttonProps
+  },
   ref,
-  ...buttonProps
-}: OverlayPanelActionButtonProps) => (
-  <button
-    ref={ref}
-    className={classNames(
-      "h-11 rounded px-4 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-surface-panel disabled:pointer-events-none disabled:opacity-50",
-      variant === "primary" &&
-        "bg-accent text-on-accent transition hover:brightness-110",
-      variant === "destructive" &&
-        "bg-error text-on-accent transition hover:brightness-110",
-      variant === "secondary" &&
-        "border border-border bg-surface-overlay text-text transition-colors hover:bg-surface-panel",
-      className,
-    )}
-    type={type}
-    {...buttonProps}
-  >
-    {children}
-  </button>
-);
+) {
+  return (
+    <button
+      ref={ref}
+      className={classNames(
+        "h-11 rounded px-4 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-surface-panel disabled:pointer-events-none disabled:opacity-50",
+        variant === "primary" &&
+          "bg-accent text-on-accent transition hover:brightness-110",
+        variant === "destructive" &&
+          "bg-error text-on-accent transition hover:brightness-110",
+        variant === "secondary" &&
+          "border border-border bg-surface-overlay text-text transition-colors hover:bg-surface-panel",
+        className,
+      )}
+      type={type}
+      {...buttonProps}
+    >
+      {children}
+    </button>
+  );
+});

--- a/packages/web/src/components/OverlayPanel/OverlayPanel.tsx
+++ b/packages/web/src/components/OverlayPanel/OverlayPanel.tsx
@@ -2,6 +2,7 @@ import classNames from "classnames";
 import {
   type ButtonHTMLAttributes,
   type ReactNode,
+  type Ref,
   type RefObject,
   useEffect,
   useId,
@@ -31,6 +32,10 @@ interface Props {
   children?: ReactNode;
   /** Called when clicking the backdrop or pressing Escape */
   onDismiss?: () => void;
+  /** Called when pressing Shift+Escape; falls back to onDismiss when omitted. */
+  onShiftEscape?: () => void;
+  /** Focus this element on open instead of the first focusable in the panel. */
+  initialFocusRef?: RefObject<HTMLElement | null>;
   /** Overrides the element that receives focus when the dialog closes. */
   restoreFocus?: () => void;
   /**
@@ -60,6 +65,8 @@ export const OverlayPanel = ({
   message,
   children,
   onDismiss,
+  onShiftEscape,
+  initialFocusRef,
   restoreFocus,
   skipFocusRestoreRef,
   role = "dialog",
@@ -82,7 +89,8 @@ export const OverlayPanel = ({
     if (!panel) return;
     const previouslyFocused = document.activeElement as HTMLElement | null;
     const [firstFocusable] = getFocusableElements(panel);
-    (firstFocusable ?? panel).focus();
+    const initialFocus = initialFocusRef?.current ?? firstFocusable ?? panel;
+    initialFocus.focus();
     return () => {
       // Read at unmount so callers can suppress restore for dialog handoffs.
       if (skipFocusRestoreRef?.current) return;
@@ -92,7 +100,7 @@ export const OverlayPanel = ({
       if (restoreFocus) restoreFocus();
       else previouslyFocused?.focus?.();
     };
-  }, [restoreFocus, role, skipFocusRestoreRef]);
+  }, [initialFocusRef, restoreFocus, role, skipFocusRestoreRef]);
 
   const backdropClasses = classNames(
     "fixed inset-0 flex items-center justify-center bg-background/85 backdrop-blur-sm",
@@ -128,11 +136,19 @@ export const OverlayPanel = ({
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (onDismiss && e.key === "Escape") {
-      e.preventDefault();
-      e.stopPropagation();
-      onDismiss();
-      return;
+    if (e.key === "Escape") {
+      if (e.shiftKey && onShiftEscape) {
+        e.preventDefault();
+        e.stopPropagation();
+        onShiftEscape();
+        return;
+      }
+      if (onDismiss) {
+        e.preventDefault();
+        e.stopPropagation();
+        onDismiss();
+        return;
+      }
     }
     if (e.key !== "Tab" || !panelRef.current) return;
     const focusables = getFocusableElements(panelRef.current);
@@ -221,6 +237,7 @@ export const OverlayPanelActions = ({
 interface OverlayPanelActionButtonProps
   extends ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: "primary" | "secondary" | "destructive";
+  ref?: Ref<HTMLButtonElement>;
 }
 
 export const OverlayPanelActionButton = ({
@@ -228,9 +245,11 @@ export const OverlayPanelActionButton = ({
   className,
   type = "button",
   variant = "secondary",
+  ref,
   ...buttonProps
 }: OverlayPanelActionButtonProps) => (
   <button
+    ref={ref}
     className={classNames(
       "h-11 rounded px-4 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-surface-panel disabled:pointer-events-none disabled:opacity-50",
       variant === "primary" &&

--- a/packages/web/src/components/Sidebar/EventDetails/SidebarEventDetails.test.tsx
+++ b/packages/web/src/components/Sidebar/EventDetails/SidebarEventDetails.test.tsx
@@ -166,6 +166,81 @@ describe("SidebarEventDetails", () => {
     );
   });
 
+  it("discards a dirty existing event on Shift+Escape without prompting", async () => {
+    const existingEvent = createMockEvent({
+      id: EventIdSchema.parse(EXISTING_EVENT_ID),
+      content: {
+        kind: "details",
+        title: "Existing Event",
+        description: "",
+      },
+      schedule: EventScheduleSchema.parse({
+        kind: "timed",
+        start: "2026-05-20T14:00:00.000Z",
+        end: "2026-05-20T15:00:00.000Z",
+        timeZone: "UTC",
+      }),
+    });
+    const draft = editGridEventDraft(existingEvent);
+    if (!draft) throw new Error("expected an edit draft");
+    draft.values.title = "Changed title";
+    draftActions.startGridDraft({ activity: "keyboardEdit", draft });
+    draftActions.setFormOpen(true);
+
+    render(<SidebarEventDetails />);
+
+    const titleField = await screen.findByDisplayValue("Changed title");
+    fireEvent.keyDown(titleField, { key: "Escape", shiftKey: true });
+
+    await waitFor(() =>
+      expect(useDraftStore.getState().status?.isFormOpen).toBe(false),
+    );
+    expect(
+      screen.queryByRole("dialog", { name: "Discard unsaved changes?" }),
+    ).toBeNull();
+  });
+
+  it("discards from the confirm dialog on Shift+Escape", async () => {
+    const existingEvent = createMockEvent({
+      id: EventIdSchema.parse(EXISTING_EVENT_ID),
+      content: {
+        kind: "details",
+        title: "Existing Event",
+        description: "",
+      },
+      schedule: EventScheduleSchema.parse({
+        kind: "timed",
+        start: "2026-05-20T14:00:00.000Z",
+        end: "2026-05-20T15:00:00.000Z",
+        timeZone: "UTC",
+      }),
+    });
+    const draft = editGridEventDraft(existingEvent);
+    if (!draft) throw new Error("expected an edit draft");
+    draft.values.title = "Changed title";
+    draftActions.startGridDraft({ activity: "keyboardEdit", draft });
+    draftActions.setFormOpen(true);
+
+    render(<SidebarEventDetails />);
+
+    const titleField = await screen.findByDisplayValue("Changed title");
+    fireEvent.keyDown(titleField, { key: "Escape" });
+
+    const dialog = await screen.findByRole("dialog", {
+      name: "Discard unsaved changes?",
+    });
+    expect(screen.getByRole("button", { name: "Cancel" })).toHaveFocus();
+
+    fireEvent.keyDown(dialog, { key: "Escape", shiftKey: true });
+
+    await waitFor(() =>
+      expect(useDraftStore.getState().status?.isFormOpen).toBe(false),
+    );
+    expect(
+      screen.queryByRole("dialog", { name: "Discard unsaved changes?" }),
+    ).toBeNull();
+  });
+
   it("deletes an already-saved event on Delete instead of just closing the form", async () => {
     const existingEvent = createMockEvent({
       id: EventIdSchema.parse(EXISTING_EVENT_ID),

--- a/packages/web/src/views/Forms/EventForm/DiscardUnsavedChangesDialog.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/DiscardUnsavedChangesDialog.test.tsx
@@ -40,6 +40,16 @@ describe("DiscardUnsavedChangesDialog", () => {
     expect(screen.getByRole("button", { name: "Close" })).toBeInTheDocument();
   });
 
+  it("focuses Cancel on open and Tabs to Discard", async () => {
+    const user = userEvent.setup();
+    renderDialog(true);
+
+    expect(screen.getByRole("button", { name: "Cancel" })).toHaveFocus();
+
+    await user.tab();
+    expect(screen.getByRole("button", { name: "Discard" })).toHaveFocus();
+  });
+
   it("discards and cancels via the action buttons", async () => {
     const user = userEvent.setup();
     renderDialog(true);
@@ -58,5 +68,23 @@ describe("DiscardUnsavedChangesDialog", () => {
     await user.click(screen.getByRole("button", { name: "Close" }));
     expect(onCancel).toHaveBeenCalledTimes(1);
     expect(onDiscard).not.toHaveBeenCalled();
+  });
+
+  it("cancels on Escape", async () => {
+    const user = userEvent.setup();
+    renderDialog(true);
+
+    await user.keyboard("{Escape}");
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(onDiscard).not.toHaveBeenCalled();
+  });
+
+  it("discards on Shift+Escape", async () => {
+    const user = userEvent.setup();
+    renderDialog(true);
+
+    await user.keyboard("{Shift>}{Escape}{/Shift}");
+    expect(onDiscard).toHaveBeenCalledTimes(1);
+    expect(onCancel).not.toHaveBeenCalled();
   });
 });

--- a/packages/web/src/views/Forms/EventForm/DiscardUnsavedChangesDialog.tsx
+++ b/packages/web/src/views/Forms/EventForm/DiscardUnsavedChangesDialog.tsx
@@ -1,4 +1,5 @@
 import { XIcon } from "@phosphor-icons/react";
+import { useRef } from "react";
 import {
   OverlayPanel,
   OverlayPanelActionButton,
@@ -16,6 +17,8 @@ export function DiscardUnsavedChangesDialog({
   onCancel,
   onDiscard,
 }: DiscardUnsavedChangesDialogProps) {
+  const cancelButtonRef = useRef<HTMLButtonElement>(null);
+
   if (!isOpen) return null;
 
   return (
@@ -32,11 +35,13 @@ export function DiscardUnsavedChangesDialog({
         </button>
       }
       onDismiss={onCancel}
+      onShiftEscape={onDiscard}
+      initialFocusRef={cancelButtonRef}
       align="start"
       variant="modal"
     >
       <OverlayPanelActions align="end">
-        <OverlayPanelActionButton onClick={onCancel}>
+        <OverlayPanelActionButton ref={cancelButtonRef} onClick={onCancel}>
           Cancel
         </OverlayPanelActionButton>
         <OverlayPanelActionButton variant="primary" onClick={onDiscard}>

--- a/packages/web/src/views/Forms/hooks/useEscapeToCloseForm.test.tsx
+++ b/packages/web/src/views/Forms/hooks/useEscapeToCloseForm.test.tsx
@@ -51,4 +51,24 @@ describe("useEscapeToCloseForm", () => {
 
     expect(onClose).toHaveBeenCalledTimes(1);
   });
+
+  it("closes on Shift+Escape without prompting", () => {
+    const onClose = mock(() => {});
+    const { result } = renderHook(() => useEscapeToCloseForm(onClose));
+
+    pressKey("Escape", { keyDownInit: { shiftKey: true } });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(result.current.isConfirmOpen).toBe(false);
+  });
+
+  it("stands Shift+Escape down while a floating layer is open", () => {
+    const onClose = mock(() => {});
+    setFloatingLayerReason("actionsMenu:test", true);
+    renderHook(() => useEscapeToCloseForm(onClose));
+
+    pressKey("Escape", { keyDownInit: { shiftKey: true } });
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
 });

--- a/packages/web/src/views/Forms/hooks/useEscapeToCloseForm.ts
+++ b/packages/web/src/views/Forms/hooks/useEscapeToCloseForm.ts
@@ -7,6 +7,7 @@ import { shouldConfirmDiscardUnsavedChanges } from "@web/views/Forms/hooks/shoul
 /**
  * Escape closes the event-details form. Dirty edits of a persisted event
  * confirm first; create drafts and unchanged edits discard immediately.
+ * Shift+Escape always discards without prompting.
  * Nested floating layers (menus, listboxes, date pickers) register via
  * `useFloatingLayer` so Escape closes them first.
  */
@@ -26,6 +27,18 @@ export const useEscapeToCloseForm = (onClose: () => void) => {
         return;
       }
 
+      onClose();
+    },
+    { ignoreInputs: false },
+  );
+
+  useAppShortcut(
+    "Shift+Escape",
+    (keyboardEvent) => {
+      if (isFloatingLayerOpen()) return;
+
+      keyboardEvent.preventDefault();
+      setIsConfirmOpen(false);
       onClose();
     },
     { ignoreInputs: false },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Improves keyboard UX for the “Discard unsaved changes?” confirm dialog:

- Default focus lands on **Cancel** (not the X); Tab still reaches Discard / Close
- **Shift+Escape** on the open dialog discards immediately
- **Shift+Escape** on a dirty event form closes without showing the confirm prompt (plain Escape still prompts)

## Simplicity

Already minimal: one `useRef` for Cancel initial focus (required by OverlayPanel’s focus effect), optional `initialFocusRef` / `onShiftEscape` on OverlayPanel, and a separate `Shift+Escape` hotkey in `useEscapeToCloseForm`. No further simplification applied.

## Automated validation

Browser at http://localhost:9080/week (anonymous IndexedDB):

- Dirty existing event + Escape → confirm dialog with Cancel focused
- Tab → Discard focused
- Escape on dialog → dialog closes, form stays
- Shift+Escape on dialog → form closes
- Shift+Escape on dirty form (no dialog) → closes with no prompt
- New create draft + Escape → closes without dialog (existing design)
- Console: no errors

## Independent review

Bugbot on branch diff: no confirmed findings.

## Test plan

- `bun test` focused OverlayPanel / DiscardUnsavedChangesDialog / useEscapeToCloseForm / SidebarEventDetails (30 pass)
- `bun run lint` (no new issues; pre-existing warnings only)
- CI Test + CodeQL checks: all SUCCESS

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6b2b9f9e-c822-4f37-94f2-6d389099e94b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6b2b9f9e-c822-4f37-94f2-6d389099e94b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

