### PR TITLE
fix(web): keep day arrow keys on event focus

### DIFF
--- a/packages/web/src/grid/shortcuts/useGridEventEditShortcuts.ts
+++ b/packages/web/src/grid/shortcuts/useGridEventEditShortcuts.ts
@@ -51,11 +51,6 @@ export type GridEventEditDayBoundary =
       kind: "follow";
       /** Day view: navigate so a day-crossing nudge stays on screen. */
       onCrossed: (date: Dayjs) => void;
-      /**
-       * Day view: ArrowLeft/Right page the visible day and focus that day's
-       * first event after the route settles (when provided).
-       */
-      onFocusPageDay?: (direction: "previous" | "next") => void;
     }
   | {
       kind: "clamp";
@@ -220,36 +215,15 @@ export function useGridEventEditShortcuts({
     if (isEventFormOpen()) return;
     if (!isArrowKey(keyboardEvent.key)) return;
 
-    // Day view: Left/Right page the calendar day, then focus its first event.
-    // Require a focused grid event (same as Up/Down) so sidebar focus and
-    // idle grid don't steal the day under the user.
-    if (
-      dayBoundary.kind === "follow" &&
-      (keyboardEvent.key === "ArrowLeft" ||
-        keyboardEvent.key === "ArrowRight") &&
-      dayBoundary.onFocusPageDay
-    ) {
-      if (isFocusInSidebar() || !targeting.getFocused()) return;
-
-      keyboardEvent.preventDefault();
-      keyboardEvent.stopPropagation();
-      dayBoundary.onFocusPageDay(
-        keyboardEvent.key === "ArrowLeft" ? "previous" : "next",
-      );
-      return;
-    }
-
+    // Day view: all four arrows move chronological focus. Period changes stay
+    // on j/k (same split as week view: arrows focus, j/k navigate).
     if (dayBoundary.kind === "follow") {
-      if (
-        keyboardEvent.key !== "ArrowUp" &&
-        keyboardEvent.key !== "ArrowDown"
-      ) {
-        return;
-      }
-
       const adjacent = getChronologicallyAdjacentTarget({
         allDayEvents,
-        direction: keyboardEvent.key === "ArrowUp" ? "previous" : "next",
+        direction:
+          keyboardEvent.key === "ArrowUp" || keyboardEvent.key === "ArrowLeft"
+            ? "previous"
+            : "next",
         focused: targeting.getFocused(),
         timedEvents,
         visible: targeting.listVisible(),

--- a/packages/web/src/shortcuts/data/shortcuts.data.test.ts
+++ b/packages/web/src/shortcuts/data/shortcuts.data.test.ts
@@ -189,15 +189,13 @@ describe("shortcuts.data", () => {
           keys: ["ArrowLeft"],
           label:
             view === "day"
-              ? "Previous day and focus first event"
+              ? "Focus previous event"
               : "Focus event on previous day",
         });
         expect(stripMetadata(edit?.shortcuts ?? [])).toContainEqual({
           keys: ["ArrowRight"],
           label:
-            view === "day"
-              ? "Next day and focus first event"
-              : "Focus event on next day",
+            view === "day" ? "Focus next event" : "Focus event on next day",
         });
         expect(stripMetadata(edit?.shortcuts ?? [])).toContainEqual({
           keys: ["Enter"],

--- a/packages/web/src/shortcuts/shortcuts.registry.ts
+++ b/packages/web/src/shortcuts/shortcuts.registry.ts
@@ -338,14 +338,9 @@ export const filterShortcutsByContext = (
       label = view === "week" ? "Focus next event on day" : "Focus next event";
     } else if (shortcut.id === "edit-focus-left") {
       label =
-        view === "day"
-          ? "Previous day and focus first event"
-          : "Focus event on previous day";
+        view === "day" ? "Focus previous event" : "Focus event on previous day";
     } else if (shortcut.id === "edit-focus-right") {
-      label =
-        view === "day"
-          ? "Next day and focus first event"
-          : "Focus event on next day";
+      label = view === "day" ? "Focus next event" : "Focus event on next day";
     }
 
     return { ...shortcut, label };

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
@@ -37,7 +37,6 @@ import { useDateInView } from "@web/views/Day/hooks/navigation/useDateInView";
 import { useDateNavigation } from "@web/views/Day/hooks/navigation/useDateNavigation";
 import { useDayEventNudgeShortcuts } from "@web/views/Day/hooks/shortcuts/useDayEventNudgeShortcuts";
 import { DayInteractionCoordinator } from "@web/views/Day/interaction/DayInteractionCoordinator";
-import { consumePendingFocusFirstDayCalendarEvent } from "@web/views/Day/interaction/day-event.focus";
 import { DayCalendarBusyPeriodsLayer } from "./DayCalendarBusyPeriods";
 import { DayCalendarColumnHeaders } from "./DayCalendarColumnHeaders";
 import { useDayCalendarContextMenu } from "./DayCalendarContextMenu";
@@ -68,8 +67,7 @@ const isDayInteractionMotionActive = () => false;
 
 export function DayCalendarGrid() {
   const dateInView = useDateInView();
-  const { navigateToDate, navigateToNextDay, navigateToPreviousDay } =
-    useDateNavigation();
+  const { navigateToDate } = useDateNavigation();
   const today = useMemo(() => dayjs(), []);
   const { data: calendars = [], isPending: isCalendarsPending } =
     useCalendarsQuery();
@@ -117,23 +115,8 @@ export function DayCalendarGrid() {
   const { shiftHints } = useDayEventNudgeShortcuts({
     allDayEvents: displayedAllDayEvents,
     navigateToDate,
-    navigateToNextDay,
-    navigateToPreviousDay,
     timedEvents: displayedTimedEvents,
   });
-  // ArrowLeft/Right page the day asynchronously; focus the first event once
-  // the destination day's targets are registered.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: re-run after day navigation and event paint so pending focus can find new targets.
-  useEffect(() => {
-    consumePendingFocusFirstDayCalendarEvent({
-      allowEmpty: !isLoadingEvents,
-    });
-  }, [
-    dateInView,
-    displayedAllDayEvents,
-    displayedTimedEvents,
-    isLoadingEvents,
-  ]);
   const gridDraft = useDraftStore(selectGridDraft);
   // Strip height must include the all-day draft: layer rendering used to
   // re-stack with the draft while EventGrid still sized from saved events only.

--- a/packages/web/src/views/Day/hooks/shortcuts/useDayEventNudgeShortcuts.test.tsx
+++ b/packages/web/src/views/Day/hooks/shortcuts/useDayEventNudgeShortcuts.test.tsx
@@ -101,14 +101,10 @@ const focusCalendarTarget = (
 const renderEditShortcuts = ({
   allDayEvents = [],
   navigateToDate,
-  navigateToNextDay,
-  navigateToPreviousDay,
   timedEvents = [timedEvent],
 }: {
   allDayEvents?: GridEvent[];
   navigateToDate?: (date: Dayjs) => void;
-  navigateToNextDay?: () => void;
-  navigateToPreviousDay?: () => void;
   timedEvents?: GridEvent[];
 } = {}) => {
   const queryClient = createCompassQueryClient();
@@ -147,8 +143,6 @@ const renderEditShortcuts = ({
         allDayEvents,
         dependencies,
         navigateToDate,
-        navigateToNextDay,
-        navigateToPreviousDay,
         timedEvents,
       }),
     {
@@ -342,33 +336,72 @@ describe("useDayEventNudgeShortcuts", () => {
     expect(document.activeElement).toBe(later);
   });
 
-  it("pages to the next day with ArrowRight when a grid event is focused", () => {
-    focusCalendarTarget(TIMED_EVENT_ID, "timed");
-    const navigateToNextDay = mock(() => {});
-    renderEditShortcuts({ navigateToNextDay });
+  it("focuses the chronologically next event with ArrowRight", () => {
+    const earlier = focusCalendarTarget(TIMED_EVENT_ID, "timed");
+    const laterEvent: GridEvent = {
+      ...timedEvent,
+      _id: "cccccccccccccccccccccccc",
+      startDate: "2026-05-20T11:00:00.000",
+      endDate: "2026-05-20T12:00:00.000",
+      title: "Later event",
+    };
+    const later = focusCalendarTarget(laterEvent._id!, "timed");
+    earlier.focus();
+    const navigateToDate = mock(() => {});
+    renderEditShortcuts({
+      navigateToDate,
+      timedEvents: [timedEvent, laterEvent],
+    });
 
     pressKey("ArrowRight");
 
-    expect(navigateToNextDay).toHaveBeenCalledTimes(1);
+    expect(document.activeElement).toBe(later);
+    expect(navigateToDate).not.toHaveBeenCalled();
   });
 
-  it("pages to the previous day with ArrowLeft when a grid event is focused", () => {
-    focusCalendarTarget(TIMED_EVENT_ID, "timed");
-    const navigateToPreviousDay = mock(() => {});
-    renderEditShortcuts({ navigateToPreviousDay });
+  it("focuses the chronologically previous event with ArrowLeft", () => {
+    const earlier = focusCalendarTarget(TIMED_EVENT_ID, "timed");
+    const laterEvent: GridEvent = {
+      ...timedEvent,
+      _id: "cccccccccccccccccccccccc",
+      startDate: "2026-05-20T11:00:00.000",
+      endDate: "2026-05-20T12:00:00.000",
+      title: "Later event",
+    };
+    const later = focusCalendarTarget(laterEvent._id!, "timed");
+    later.focus();
+    const navigateToDate = mock(() => {});
+    renderEditShortcuts({
+      navigateToDate,
+      timedEvents: [timedEvent, laterEvent],
+    });
 
     pressKey("ArrowLeft");
 
-    expect(navigateToPreviousDay).toHaveBeenCalledTimes(1);
+    expect(document.activeElement).toBe(earlier);
+    expect(navigateToDate).not.toHaveBeenCalled();
   });
 
-  it("does not page the day with ArrowRight when nothing is focused", () => {
-    const navigateToNextDay = mock(() => {});
-    renderEditShortcuts({ navigateToNextDay });
+  it("does not change focus with ArrowRight when nothing is focused", () => {
+    const laterEvent: GridEvent = {
+      ...timedEvent,
+      _id: "cccccccccccccccccccccccc",
+      startDate: "2026-05-20T11:00:00.000",
+      endDate: "2026-05-20T12:00:00.000",
+      title: "Later event",
+    };
+    focusCalendarTarget(TIMED_EVENT_ID, "timed").blur();
+    focusCalendarTarget(laterEvent._id!, "timed").blur();
+    const navigateToDate = mock(() => {});
+    renderEditShortcuts({
+      navigateToDate,
+      timedEvents: [timedEvent, laterEvent],
+    });
 
     pressKey("ArrowRight");
 
-    expect(navigateToNextDay).not.toHaveBeenCalled();
+    expect(navigateToDate).not.toHaveBeenCalled();
+    expect(document.activeElement).not.toBeInstanceOf(HTMLButtonElement);
   });
 
   it("does not delete a grid event when Delete is pressed inside an open event form", () => {

--- a/packages/web/src/views/Day/hooks/shortcuts/useDayEventNudgeShortcuts.test.tsx
+++ b/packages/web/src/views/Day/hooks/shortcuts/useDayEventNudgeShortcuts.test.tsx
@@ -29,6 +29,7 @@ import { useDayEventNudgeShortcuts } from "./useDayEventNudgeShortcuts";
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 
 const TIMED_EVENT_ID = "aaaaaaaaaaaaaaaaaaaaaaaa";
+const LATER_TIMED_EVENT_ID = "cccccccccccccccccccccccc";
 const ALL_DAY_EVENT_ID = "bbbbbbbbbbbbbbbbbbbbbbbb";
 
 const timedEvent: GridEvent = {
@@ -40,6 +41,14 @@ const timedEvent: GridEvent = {
   startDate: "2026-05-20T09:00:00.000",
   title: "Timed event",
   user: "user-1",
+};
+
+const laterTimedEvent: GridEvent = {
+  ...timedEvent,
+  _id: LATER_TIMED_EVENT_ID,
+  startDate: "2026-05-20T11:00:00.000",
+  endDate: "2026-05-20T12:00:00.000",
+  title: "Later event",
 };
 
 const allDayEvent: GridEvent = {
@@ -320,16 +329,9 @@ describe("useDayEventNudgeShortcuts", () => {
 
   it("focuses the chronologically next event with ArrowDown", () => {
     const earlier = focusCalendarTarget(TIMED_EVENT_ID, "timed");
-    const laterEvent: GridEvent = {
-      ...timedEvent,
-      _id: "cccccccccccccccccccccccc",
-      startDate: "2026-05-20T11:00:00.000",
-      endDate: "2026-05-20T12:00:00.000",
-      title: "Later event",
-    };
-    const later = focusCalendarTarget(laterEvent._id!, "timed");
+    const later = focusCalendarTarget(LATER_TIMED_EVENT_ID, "timed");
     earlier.focus();
-    renderEditShortcuts({ timedEvents: [timedEvent, laterEvent] });
+    renderEditShortcuts({ timedEvents: [timedEvent, laterTimedEvent] });
 
     pressKey("ArrowDown");
 
@@ -338,19 +340,12 @@ describe("useDayEventNudgeShortcuts", () => {
 
   it("focuses the chronologically next event with ArrowRight", () => {
     const earlier = focusCalendarTarget(TIMED_EVENT_ID, "timed");
-    const laterEvent: GridEvent = {
-      ...timedEvent,
-      _id: "cccccccccccccccccccccccc",
-      startDate: "2026-05-20T11:00:00.000",
-      endDate: "2026-05-20T12:00:00.000",
-      title: "Later event",
-    };
-    const later = focusCalendarTarget(laterEvent._id!, "timed");
+    const later = focusCalendarTarget(LATER_TIMED_EVENT_ID, "timed");
     earlier.focus();
     const navigateToDate = mock(() => {});
     renderEditShortcuts({
       navigateToDate,
-      timedEvents: [timedEvent, laterEvent],
+      timedEvents: [timedEvent, laterTimedEvent],
     });
 
     pressKey("ArrowRight");
@@ -361,19 +356,12 @@ describe("useDayEventNudgeShortcuts", () => {
 
   it("focuses the chronologically previous event with ArrowLeft", () => {
     const earlier = focusCalendarTarget(TIMED_EVENT_ID, "timed");
-    const laterEvent: GridEvent = {
-      ...timedEvent,
-      _id: "cccccccccccccccccccccccc",
-      startDate: "2026-05-20T11:00:00.000",
-      endDate: "2026-05-20T12:00:00.000",
-      title: "Later event",
-    };
-    const later = focusCalendarTarget(laterEvent._id!, "timed");
+    const later = focusCalendarTarget(LATER_TIMED_EVENT_ID, "timed");
     later.focus();
     const navigateToDate = mock(() => {});
     renderEditShortcuts({
       navigateToDate,
-      timedEvents: [timedEvent, laterEvent],
+      timedEvents: [timedEvent, laterTimedEvent],
     });
 
     pressKey("ArrowLeft");
@@ -383,19 +371,12 @@ describe("useDayEventNudgeShortcuts", () => {
   });
 
   it("does not change focus with ArrowRight when nothing is focused", () => {
-    const laterEvent: GridEvent = {
-      ...timedEvent,
-      _id: "cccccccccccccccccccccccc",
-      startDate: "2026-05-20T11:00:00.000",
-      endDate: "2026-05-20T12:00:00.000",
-      title: "Later event",
-    };
     focusCalendarTarget(TIMED_EVENT_ID, "timed").blur();
-    focusCalendarTarget(laterEvent._id!, "timed").blur();
+    focusCalendarTarget(LATER_TIMED_EVENT_ID, "timed").blur();
     const navigateToDate = mock(() => {});
     renderEditShortcuts({
       navigateToDate,
-      timedEvents: [timedEvent, laterEvent],
+      timedEvents: [timedEvent, laterTimedEvent],
     });
 
     pressKey("ArrowRight");

--- a/packages/web/src/views/Day/hooks/shortcuts/useDayEventNudgeShortcuts.ts
+++ b/packages/web/src/views/Day/hooks/shortcuts/useDayEventNudgeShortcuts.ts
@@ -9,7 +9,6 @@ import {
   type ActiveShiftHint,
   useShiftHoldEventHints,
 } from "@web/shortcuts/shift-hint/useShiftHoldEventHints";
-import { requestFocusFirstDayCalendarEvent } from "@web/views/Day/interaction/day-event.focus";
 import {
   focusDayGridEventTarget,
   getFocusedDayGridEventTarget,
@@ -18,26 +17,21 @@ import {
 
 /**
  * Day-view edit shortcuts: Delete, Mod+D, Shift+arrows (nudge / day-move),
- * Arrow keys to reposition an open draft or focus the neighboring event,
- * ArrowLeft/Right to page the day and focus its first event, and `e`+field
- * sequences to open/focus form fields.
+ * Arrow keys to reposition an open draft or focus the neighboring event, and
+ * `e`+field sequences to open/focus form fields.
  * Shift+ArrowLeft/Right move a focused event by one day and follow that day
- * in the Day view.
+ * in the Day view. Period navigation (changing the visible day) stays on j/k.
  */
 export function useDayEventNudgeShortcuts({
   allDayEvents = [],
   dependencies = {},
   navigateToDate,
-  navigateToNextDay,
-  navigateToPreviousDay,
   timedEvents,
 }: {
   allDayEvents?: GridEvent[];
   dependencies?: EventMutationDependencies;
   /** Follow draft Left/Right moves so the draft stays on screen. */
   navigateToDate?: (date: Dayjs) => void;
-  navigateToNextDay?: () => void;
-  navigateToPreviousDay?: () => void;
   timedEvents: GridEvent[];
 }): { shiftHints: ActiveShiftHint[] } {
   const targeting = {
@@ -53,14 +47,6 @@ export function useDayEventNudgeShortcuts({
     dayBoundary: {
       kind: "follow",
       onCrossed: (date) => navigateToDate?.(date),
-      onFocusPageDay: (direction) => {
-        if (direction === "previous") {
-          navigateToPreviousDay?.();
-        } else {
-          navigateToNextDay?.();
-        }
-        requestFocusFirstDayCalendarEvent();
-      },
     },
     targeting,
     repositionDraftByKey: (key) => {

--- a/packages/web/src/views/Day/interaction/day-event.focus.ts
+++ b/packages/web/src/views/Day/interaction/day-event.focus.ts
@@ -3,9 +3,6 @@ import {
   getFirstVisibleDayGridEventTarget,
 } from "@web/views/Day/interaction/targeting/day-event.targeting";
 
-/** Set when ArrowLeft/Right pages the day; consumed once events for the new day paint. */
-let pendingFocusFirstDayEvent = false;
-
 export function focusFirstDayCalendarEvent() {
   const target = getFirstVisibleDayGridEventTarget();
 
@@ -13,36 +10,6 @@ export function focusFirstDayCalendarEvent() {
     return;
   }
 
-  target.element.scrollIntoView({ block: "nearest" });
-  focusDayGridEventTarget(target);
-}
-
-export function requestFocusFirstDayCalendarEvent() {
-  pendingFocusFirstDayEvent = true;
-}
-
-/**
- * Focus the first visible event if a day-page Left/Right asked for it.
- * Keeps the pending flag while the destination day is still loading so a
- * later paint can retry. Clears without focusing when `allowEmpty` is true
- * (day settled with no events).
- */
-export function consumePendingFocusFirstDayCalendarEvent({
-  allowEmpty = false,
-}: {
-  allowEmpty?: boolean;
-} = {}) {
-  if (!pendingFocusFirstDayEvent) return;
-
-  const target = getFirstVisibleDayGridEventTarget();
-  if (!target) {
-    if (allowEmpty) {
-      pendingFocusFirstDayEvent = false;
-    }
-    return;
-  }
-
-  pendingFocusFirstDayEvent = false;
   target.element.scrollIntoView({ block: "nearest" });
   focusDayGridEventTarget(target);
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Day view ArrowLeft/Right no longer change the visible day when a grid event is focused. They move chronological event focus (same as Up/Down), matching week-view intent. Day changes stay on j/k.

Removed the day Left/Right `onFocusPageDay` paging path and the pending focus-first-event plumbing that only existed for that behavior.

## Simplicity

Production diff is mostly deletion (`onFocusPageDay`, pending-focus module state, Day grid consumer `useEffect`). Follow-up commit deduped repeated later-event fixtures in the day nudge shortcut tests. No new React state/effects.

## Automated validation

Browser at `http://localhost:9080/day/2026-08-10` (anonymous):
- Created Event A (2pm) and Event B (4pm)
- Focused Event A; ArrowRight/Down/Left kept the day on Monday Aug 10
- `k` advanced to Tuesday Aug 11; `j` returned to Monday Aug 10
- With nothing focused, ArrowRight did not change the day
- No console errors observed

## Independent review

Fresh read-only review of the base-to-head diff: no confirmed findings. Week spatial arrows, Shift+arrow nudge, draft arrows, and j/k day navigation remain intact.

## Test plan

- `bun test:web` on `useDayEventNudgeShortcuts.test.tsx` and `shortcuts.data.test.ts` (34 pass)
- `bun run lint` (exit 0; pre-existing warnings only)
- GitHub CI on PR head: lint, type-check, knip, unit (core/web/backend/sync/scripts), e2e, CodeQL — all success
- Local `bun run verify` selected a11y; failed only because Playwright Chromium is not installed in this VM (CI e2e already green)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e37dde22-42e8-46e2-b138-b234a9094304?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e37dde22-42e8-46e2-b138-b234a9094304&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

