### PR TITLE
feat(web): shift only the start or end of a focused event via keyboard

### DIFF
--- a/packages/web/src/common/utils/event/event-nudge-shortcut.util.ts
+++ b/packages/web/src/common/utils/event/event-nudge-shortcut.util.ts
@@ -1,8 +1,10 @@
 import { type GridEvent } from "@web/common/types/web.event.types";
 import { refocusEventElement } from "@web/common/utils/event/event.util";
 import {
+  type EventEdge,
   getArrowKeyMovement,
   nudgeEventDates,
+  nudgeEventEdgeDates,
 } from "@web/common/utils/event/event-nudge.util";
 
 export function nudgeEventFromKeyboard({
@@ -29,6 +31,40 @@ export function nudgeEventFromKeyboard({
 
   keyboardEvent.preventDefault();
   onNudge({ ...event, ...dates });
+  afterNudge?.();
+  refocusEventElement(event._id);
+  return true;
+}
+
+export function nudgeEventEdgeFromKeyboard({
+  afterNudge,
+  edge,
+  event,
+  keyboardEvent,
+  onNudge,
+}: {
+  afterNudge?: () => void;
+  edge: EventEdge;
+  event: GridEvent;
+  keyboardEvent: KeyboardEvent;
+  onNudge: (event: GridEvent, nextEdge: EventEdge) => void;
+}): boolean {
+  if (!event._id) return false;
+
+  const movement = getArrowKeyMovement(
+    keyboardEvent.key,
+    Boolean(event.isAllDay),
+  );
+  if (!movement) return false;
+
+  const result = nudgeEventEdgeDates(event, edge, movement);
+  if (!result) return false;
+
+  keyboardEvent.preventDefault();
+  onNudge(
+    { ...event, startDate: result.startDate, endDate: result.endDate },
+    result.edge,
+  );
   afterNudge?.();
   refocusEventElement(event._id);
   return true;

--- a/packages/web/src/common/utils/event/event-nudge.util.test.ts
+++ b/packages/web/src/common/utils/event/event-nudge.util.test.ts
@@ -5,6 +5,7 @@ import {
   isTimedEventInsideOneDay,
   isTimedEventMultiDay,
   nudgeEventDates,
+  nudgeEventEdgeDates,
   shouldRenderTimedInAllDayRow,
   timedMultiDayToAllDayDates,
 } from "@web/common/utils/event/event-nudge.util";
@@ -110,6 +111,201 @@ describe("nudgeEventDates", () => {
   it("returns null for minute moves on all-day events", () => {
     const result = nudgeEventDates(
       { startDate: "2026-05-20", endDate: "2026-05-21", isAllDay: true },
+      { days: 0, minutes: 15 },
+    );
+
+    expect(result).toBeNull();
+  });
+});
+
+describe("nudgeEventEdgeDates", () => {
+  const timedEvent = {
+    startDate: "2026-05-20T10:00:00",
+    endDate: "2026-05-20T10:30:00",
+    isAllDay: false,
+  };
+
+  it("moves the start edge later without touching the end", () => {
+    const result = nudgeEventEdgeDates(timedEvent, "startDate", {
+      days: 0,
+      minutes: 15,
+    });
+
+    expect(result?.startDate).toStartWith("2026-05-20T10:15:00");
+    expect(result?.endDate).toStartWith("2026-05-20T10:30:00");
+    expect(result?.edge).toBe("startDate");
+  });
+
+  it("moves the end edge earlier without touching the start", () => {
+    const result = nudgeEventEdgeDates(timedEvent, "endDate", {
+      days: 0,
+      minutes: -15,
+    });
+
+    expect(result?.startDate).toStartWith("2026-05-20T10:00:00");
+    expect(result?.endDate).toStartWith("2026-05-20T10:15:00");
+    expect(result?.edge).toBe("endDate");
+  });
+
+  it("does not flip when the move lands exactly at the 15-minute minimum", () => {
+    const result = nudgeEventEdgeDates(
+      {
+        startDate: "2026-05-20T10:00:00",
+        endDate: "2026-05-20T10:30:00",
+        isAllDay: false,
+      },
+      "startDate",
+      { days: 0, minutes: 15 },
+    );
+
+    expect(result?.startDate).toStartWith("2026-05-20T10:15:00");
+    expect(result?.endDate).toStartWith("2026-05-20T10:30:00");
+    expect(result?.edge).toBe("startDate");
+  });
+
+  it("flips the start edge to the end edge past the minimum duration", () => {
+    const result = nudgeEventEdgeDates(
+      {
+        startDate: "2026-05-20T10:15:00",
+        endDate: "2026-05-20T10:30:00",
+        isAllDay: false,
+      },
+      "startDate",
+      { days: 0, minutes: 15 },
+    );
+
+    expect(result?.startDate).toStartWith("2026-05-20T10:30:00");
+    expect(result?.endDate).toStartWith("2026-05-20T10:45:00");
+    expect(result?.edge).toBe("endDate");
+  });
+
+  it("flips the end edge to the start edge past the minimum duration", () => {
+    const result = nudgeEventEdgeDates(
+      {
+        startDate: "2026-05-20T10:00:00",
+        endDate: "2026-05-20T10:15:00",
+        isAllDay: false,
+      },
+      "endDate",
+      { days: 0, minutes: -15 },
+    );
+
+    expect(result?.startDate).toStartWith("2026-05-20T09:45:00");
+    expect(result?.endDate).toStartWith("2026-05-20T10:00:00");
+    expect(result?.edge).toBe("startDate");
+  });
+
+  it("rejects a start-edge move that would cross into the previous day", () => {
+    const result = nudgeEventEdgeDates(
+      {
+        startDate: "2026-05-20T00:00:00",
+        endDate: "2026-05-20T01:00:00",
+        isAllDay: false,
+      },
+      "startDate",
+      { days: 0, minutes: -15 },
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("allows the end edge to land exactly on next midnight", () => {
+    const result = nudgeEventEdgeDates(
+      {
+        startDate: "2026-05-20T23:00:00",
+        endDate: "2026-05-20T23:45:00",
+        isAllDay: false,
+      },
+      "endDate",
+      { days: 0, minutes: 15 },
+    );
+
+    expect(result?.endDate).toStartWith("2026-05-21T00:00:00");
+  });
+
+  it("rejects a flip that would cross midnight", () => {
+    const result = nudgeEventEdgeDates(
+      {
+        startDate: "2026-05-20T23:38:00",
+        endDate: "2026-05-20T23:50:00",
+        isAllDay: false,
+      },
+      "startDate",
+      { days: 0, minutes: 15 },
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("rejects day movement on a timed edge", () => {
+    const result = nudgeEventEdgeDates(timedEvent, "startDate", {
+      days: 1,
+      minutes: 0,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("moves an all-day start edge earlier without touching the end", () => {
+    const result = nudgeEventEdgeDates(
+      { startDate: "2026-05-20", endDate: "2026-05-22", isAllDay: true },
+      "startDate",
+      { days: -1, minutes: 0 },
+    );
+
+    expect(result).toEqual({
+      startDate: "2026-05-19",
+      endDate: "2026-05-22",
+      edge: "startDate",
+    });
+  });
+
+  it("moves an all-day end edge later without touching the start", () => {
+    const result = nudgeEventEdgeDates(
+      { startDate: "2026-05-20", endDate: "2026-05-22", isAllDay: true },
+      "endDate",
+      { days: 1, minutes: 0 },
+    );
+
+    expect(result).toEqual({
+      startDate: "2026-05-20",
+      endDate: "2026-05-23",
+      edge: "endDate",
+    });
+  });
+
+  it("flips a one-day all-day event's start edge to the end edge", () => {
+    const result = nudgeEventEdgeDates(
+      { startDate: "2026-05-20", endDate: "2026-05-21", isAllDay: true },
+      "startDate",
+      { days: 1, minutes: 0 },
+    );
+
+    expect(result).toEqual({
+      startDate: "2026-05-20",
+      endDate: "2026-05-22",
+      edge: "endDate",
+    });
+  });
+
+  it("flips a one-day all-day event's end edge to the start edge", () => {
+    const result = nudgeEventEdgeDates(
+      { startDate: "2026-05-20", endDate: "2026-05-21", isAllDay: true },
+      "endDate",
+      { days: -1, minutes: 0 },
+    );
+
+    expect(result).toEqual({
+      startDate: "2026-05-19",
+      endDate: "2026-05-21",
+      edge: "startDate",
+    });
+  });
+
+  it("rejects minute movement on an all-day edge", () => {
+    const result = nudgeEventEdgeDates(
+      { startDate: "2026-05-20", endDate: "2026-05-21", isAllDay: true },
+      "startDate",
       { days: 0, minutes: 15 },
     );
 

--- a/packages/web/src/common/utils/event/event-nudge.util.ts
+++ b/packages/web/src/common/utils/event/event-nudge.util.ts
@@ -8,6 +8,9 @@ export interface EventNudgeMovement {
   minutes: number;
 }
 
+/** Matches the drag-resize handle vocabulary (EVENT_RESIZE_HANDLE_ATTRIBUTE). */
+export type EventEdge = "startDate" | "endDate";
+
 export const getArrowKeyMovement = (
   key: string,
   isAllDay: boolean,
@@ -95,4 +98,118 @@ export const nudgeEventDates = (
   }
 
   return { startDate: nextStart.format(), endDate: nextEnd.format() };
+};
+
+/**
+ * Shifts only one edge of a focused event by a single arrow-key step. Timed
+ * events only accept minute movement (Up/Down); all-day events only accept
+ * day movement (Left/Right) — the caller's `getArrowKeyMovement(key, isAllDay)`
+ * already returns null for the other axis on all-day events, but timed events
+ * still resolve day movement, so it's rejected here explicitly.
+ *
+ * Mirrors the mouse drag-resize flip (timed.resize.ts / all-day.resize.ts):
+ * pushing an edge past the minimum duration swaps it to the other edge. Each
+ * keystroke moves by exactly one step, so the flipped span is always exactly
+ * one step wide.
+ */
+export const nudgeEventEdgeDates = (
+  event: Pick<CompassEvent, "startDate" | "endDate" | "isAllDay">,
+  edge: EventEdge,
+  movement: EventNudgeMovement,
+): { startDate: string; endDate: string; edge: EventEdge } | null => {
+  if (!event.startDate || !event.endDate) return null;
+
+  if (event.isAllDay) {
+    if (movement.days === 0) return null;
+    return nudgeAllDayEdgeDates(event, edge, movement.days);
+  }
+
+  if (movement.minutes === 0) return null;
+  return nudgeTimedEdgeDates(event, edge, movement.minutes);
+};
+
+const nudgeTimedEdgeDates = (
+  event: Pick<CompassEvent, "startDate" | "endDate">,
+  edge: EventEdge,
+  minutesDelta: number,
+): { startDate: string; endDate: string; edge: EventEdge } | null => {
+  const start = dayjs(event.startDate);
+  const end = dayjs(event.endDate);
+
+  if (edge === "startDate") {
+    const candidateStart = start.add(minutesDelta, "minute");
+    const latestStart = end.subtract(GRID_TIME_STEP, "minute");
+
+    if (!candidateStart.isAfter(latestStart)) {
+      if (!isTimedEventInsideOneDay(candidateStart, end)) return null;
+      return {
+        startDate: candidateStart.format(),
+        endDate: end.format(),
+        edge: "startDate",
+      };
+    }
+
+    const flippedEnd = end.add(GRID_TIME_STEP, "minute");
+    if (!isTimedEventInsideOneDay(end, flippedEnd)) return null;
+    return {
+      startDate: end.format(),
+      endDate: flippedEnd.format(),
+      edge: "endDate",
+    };
+  }
+
+  const candidateEnd = end.add(minutesDelta, "minute");
+  const earliestEnd = start.add(GRID_TIME_STEP, "minute");
+
+  if (!candidateEnd.isBefore(earliestEnd)) {
+    if (!isTimedEventInsideOneDay(start, candidateEnd)) return null;
+    return {
+      startDate: start.format(),
+      endDate: candidateEnd.format(),
+      edge: "endDate",
+    };
+  }
+
+  const flippedStart = start.subtract(GRID_TIME_STEP, "minute");
+  if (!isTimedEventInsideOneDay(flippedStart, start)) return null;
+  return {
+    startDate: flippedStart.format(),
+    endDate: start.format(),
+    edge: "startDate",
+  };
+};
+
+const nudgeAllDayEdgeDates = (
+  event: Pick<CompassEvent, "startDate" | "endDate">,
+  edge: EventEdge,
+  daysDelta: number,
+): { startDate: string; endDate: string; edge: EventEdge } => {
+  const startDay = dayjs(event.startDate).startOf("day");
+  const inclusiveEnd = dayjs(event.endDate).startOf("day").subtract(1, "day");
+
+  if (edge === "startDate") {
+    const candidate = startDay.add(daysDelta, "day");
+    const [nextStart, nextInclusiveEnd, nextEdge] = candidate.isAfter(
+      inclusiveEnd,
+    )
+      ? ([inclusiveEnd, candidate, "endDate"] as const)
+      : ([candidate, inclusiveEnd, "startDate"] as const);
+
+    return {
+      startDate: nextStart.format(YEAR_MONTH_DAY_FORMAT),
+      endDate: nextInclusiveEnd.add(1, "day").format(YEAR_MONTH_DAY_FORMAT),
+      edge: nextEdge,
+    };
+  }
+
+  const candidate = inclusiveEnd.add(daysDelta, "day");
+  const [nextStart, nextInclusiveEnd, nextEdge] = candidate.isBefore(startDay)
+    ? ([candidate, startDay, "startDate"] as const)
+    : ([startDay, candidate, "endDate"] as const);
+
+  return {
+    startDate: nextStart.format(YEAR_MONTH_DAY_FORMAT),
+    endDate: nextInclusiveEnd.add(1, "day").format(YEAR_MONTH_DAY_FORMAT),
+    edge: nextEdge,
+  };
 };

--- a/packages/web/src/components/Sidebar/SidebarStatusBar.tsx
+++ b/packages/web/src/components/Sidebar/SidebarStatusBar.tsx
@@ -4,6 +4,12 @@ import { getSidebarSyncStatus } from "@web/auth/google/hooks/useConnectGoogle/us
 import { useGoogleSyncRefreshSnapshot } from "@web/auth/google/state/google.sync.refresh";
 import { SYNC_STATUS_VARIANT_CLASSNAME } from "@web/calendars/sync-status.types";
 import { useHasPendingEventMutations } from "@web/events/mutations/useEventPending";
+import { EdgeFocusIndicator } from "@web/grid/shortcuts/EdgeFocusIndicator";
+import {
+  selectEdgeFocusActive,
+  selectEdgeFocusAnnouncement,
+  useEdgeFocusStore,
+} from "@web/grid/shortcuts/edge-focus.store";
 import { settingsActions } from "@web/settings/settings.store";
 import { KeyboardOnlyIndicator } from "@web/shortcuts/keyboard-only/KeyboardOnlyIndicator";
 import {
@@ -33,6 +39,9 @@ export const SidebarStatusBar: FC = () => {
   const isEventJump = useEventJumpStore(selectEventJumpActive);
   const eventJumpAnnouncement = useEventJumpStore(selectEventJumpAnnouncement);
   const showEventJump = isEventJump || Boolean(eventJumpAnnouncement);
+  const isEdgeFocus = useEdgeFocusStore(selectEdgeFocusActive);
+  const edgeFocusAnnouncement = useEdgeFocusStore(selectEdgeFocusAnnouncement);
+  const showEdgeFocus = isEdgeFocus || Boolean(edgeFocusAnnouncement);
   const isSaving = useHasPendingEventMutations();
   // The unscoped hook's `connection` is the primary connection (the one
   // whose own state matches the aggregate) - without it, an account's
@@ -63,6 +72,10 @@ export const SidebarStatusBar: FC = () => {
       ) : showEventJump ? (
         <div className="flex h-full min-w-0 flex-1 items-center">
           <EventJumpIndicator />
+        </div>
+      ) : showEdgeFocus ? (
+        <div className="flex h-full min-w-0 flex-1 items-center">
+          <EdgeFocusIndicator />
         </div>
       ) : (
         <button

--- a/packages/web/src/grid/components/AllDayEventCard.tsx
+++ b/packages/web/src/grid/components/AllDayEventCard.tsx
@@ -19,6 +19,10 @@ import {
   calendarAccentStyle,
 } from "@web/grid/components/calendar-accent.util";
 import { EVENT_RESIZE_HANDLE_ATTRIBUTE } from "@web/grid/interaction/dom";
+import {
+  selectEdgeForEvent,
+  useEdgeFocusStore,
+} from "@web/grid/shortcuts/edge-focus.store";
 import { type EventPosition } from "@web/grid/types/grid.types";
 import { EventRepeatIcon } from "./EventRepeatIcon";
 
@@ -111,9 +115,17 @@ const AllDayEventCardBase = (
   // Fill stays a flat neutral color; the accent + this suffix are the only
   // calendar signal, and the name (never color alone) is what makes it
   // accessible (A9).
-  const accessibleLabel = calendarIdentity
-    ? `${baseAccessibleLabel}${calendarAccentAccessibleSuffix(calendarIdentity)}`
-    : baseAccessibleLabel;
+  const focusedEdge = useEdgeFocusStore(selectEdgeForEvent(event._id));
+  const edgeFocusSuffix =
+    focusedEdge === "startDate"
+      ? ", editing start date"
+      : focusedEdge === "endDate"
+        ? ", editing end date"
+        : "";
+  const accessibleLabel =
+    (calendarIdentity
+      ? `${baseAccessibleLabel}${calendarAccentAccessibleSuffix(calendarIdentity)}`
+      : baseAccessibleLabel) + edgeFocusSuffix;
 
   return (
     // biome-ignore lint/a11y/useSemanticElements: All-day events are draggable/resizable blocks, not native buttons.
@@ -155,6 +167,17 @@ const AllDayEventCardBase = (
           aria-hidden="true"
           className="absolute inset-y-0 left-0 w-[3px]"
           style={calendarAccentStyle(calendarIdentity)}
+        />
+      )}
+      {focusedEdge && (
+        <div
+          aria-hidden="true"
+          className={cn(
+            "absolute inset-y-0 w-[3px] rounded-full bg-accent",
+            focusedEdge === "startDate" ? "left-0" : "right-0",
+          )}
+          data-edge-focus={focusedEdge}
+          style={{ zIndex: ZIndex.LAYER_4 }}
         />
       )}
       <div

--- a/packages/web/src/grid/components/TimedEventCard.tsx
+++ b/packages/web/src/grid/components/TimedEventCard.tsx
@@ -38,6 +38,10 @@ import {
   EVENT_RESIZE_HANDLE_ATTRIBUTE,
   EVENT_TIME_LABEL_ATTRIBUTE,
 } from "@web/grid/interaction/dom";
+import {
+  selectEdgeForEvent,
+  useEdgeFocusStore,
+} from "@web/grid/shortcuts/edge-focus.store";
 import { type EventPosition } from "@web/grid/types/grid.types";
 import { EventRepeatIcon } from "./EventRepeatIcon";
 
@@ -186,6 +190,7 @@ const TimedEventCardBase = (
   } as CSSProperties;
 
   const isCompactEvent = position.height <= COMPACT_EVENT_MAX_HEIGHT;
+  const focusedEdge = useEdgeFocusStore(selectEdgeForEvent(event._id));
 
   const titleStyle: CSSProperties = {
     fontSize: isCompactEvent
@@ -238,9 +243,16 @@ const TimedEventCardBase = (
   // Fill stays a flat neutral color; the accent + this suffix are the only
   // calendar signal, and the name (never color alone) is what makes it
   // accessible (A9).
-  const accessibleLabel = calendarIdentity
-    ? `${samplePrefix}${baseAccessibleLabel}${calendarAccentAccessibleSuffix(calendarIdentity)}`
-    : `${samplePrefix}${baseAccessibleLabel}`;
+  const edgeFocusSuffix =
+    focusedEdge === "startDate"
+      ? ", editing start time"
+      : focusedEdge === "endDate"
+        ? ", editing end time"
+        : "";
+  const accessibleLabel =
+    (calendarIdentity
+      ? `${samplePrefix}${baseAccessibleLabel}${calendarAccentAccessibleSuffix(calendarIdentity)}`
+      : `${samplePrefix}${baseAccessibleLabel}`) + edgeFocusSuffix;
 
   return (
     // biome-ignore lint/a11y/useSemanticElements: Grid events are draggable/resizable blocks, not native buttons.
@@ -289,6 +301,17 @@ const TimedEventCardBase = (
           aria-hidden="true"
           className="absolute inset-y-0 left-0 w-[3px]"
           style={calendarAccentStyle(calendarIdentity)}
+        />
+      )}
+      {focusedEdge && (
+        <div
+          aria-hidden="true"
+          className={cn(
+            "absolute inset-x-0 h-[3px] rounded-full bg-accent",
+            focusedEdge === "startDate" ? "top-0" : "bottom-0",
+          )}
+          data-edge-focus={focusedEdge}
+          style={{ zIndex: ZIndex.LAYER_4 }}
         />
       )}
       <div

--- a/packages/web/src/grid/shortcuts/EdgeFocusIndicator.tsx
+++ b/packages/web/src/grid/shortcuts/EdgeFocusIndicator.tsx
@@ -1,0 +1,26 @@
+import { type FC } from "react";
+import {
+  selectEdgeFocusAnnouncement,
+  useEdgeFocusStore,
+} from "@web/grid/shortcuts/edge-focus.store";
+
+/**
+ * Live region announcing the currently focused start/end edge and the result
+ * of edge nudges (e.g. "Editing start time", "Start 9:15 AM").
+ */
+export const EdgeFocusIndicator: FC = () => {
+  const announcement = useEdgeFocusStore(selectEdgeFocusAnnouncement);
+
+  if (!announcement) return null;
+
+  return (
+    <span
+      aria-live="polite"
+      className="truncate text-text-muted text-xs opacity-80"
+      data-edge-focus-indicator=""
+      role="status"
+    >
+      {announcement}
+    </span>
+  );
+};

--- a/packages/web/src/grid/shortcuts/edge-focus.store.test.ts
+++ b/packages/web/src/grid/shortcuts/edge-focus.store.test.ts
@@ -1,0 +1,84 @@
+import {
+  edgeFocusActions,
+  initialEdgeFocusState,
+  useEdgeFocusStore,
+} from "@web/grid/shortcuts/edge-focus.store";
+import { beforeEach, describe, expect, it } from "bun:test";
+
+describe("edgeFocusActions.cycle", () => {
+  beforeEach(() => {
+    useEdgeFocusStore.setState(initialEdgeFocusState, true);
+  });
+
+  it("cycles whole event -> start -> end -> whole event going forward", () => {
+    edgeFocusActions.cycle("event-1", "forward");
+    expect(useEdgeFocusStore.getState().edge).toBe("startDate");
+
+    edgeFocusActions.cycle("event-1", "forward");
+    expect(useEdgeFocusStore.getState().edge).toBe("endDate");
+
+    edgeFocusActions.cycle("event-1", "forward");
+    expect(useEdgeFocusStore.getState().edge).toBeNull();
+  });
+
+  it("cycles start <- end <- whole event going backward", () => {
+    edgeFocusActions.cycle("event-1", "backward");
+    expect(useEdgeFocusStore.getState().edge).toBe("endDate");
+
+    edgeFocusActions.cycle("event-1", "backward");
+    expect(useEdgeFocusStore.getState().edge).toBe("startDate");
+
+    edgeFocusActions.cycle("event-1", "backward");
+    expect(useEdgeFocusStore.getState().edge).toBeNull();
+  });
+
+  it("starts a fresh cycle when a different event is targeted", () => {
+    edgeFocusActions.cycle("event-1", "forward");
+    edgeFocusActions.cycle("event-1", "forward");
+    expect(useEdgeFocusStore.getState().edge).toBe("endDate");
+
+    edgeFocusActions.cycle("event-2", "forward");
+    expect(useEdgeFocusStore.getState()).toMatchObject({
+      eventId: "event-2",
+      edge: "startDate",
+    });
+  });
+
+  it("sets an announcement for each edge", () => {
+    edgeFocusActions.cycle("event-1", "forward");
+    expect(useEdgeFocusStore.getState().announcement).toBe(
+      "Editing start time",
+    );
+
+    edgeFocusActions.cycle("event-1", "forward");
+    expect(useEdgeFocusStore.getState().announcement).toBe("Editing end time");
+
+    edgeFocusActions.cycle("event-1", "forward");
+    expect(useEdgeFocusStore.getState().announcement).toBe(
+      "Editing whole event",
+    );
+  });
+});
+
+describe("edgeFocusActions.setEdge / reset", () => {
+  beforeEach(() => {
+    useEdgeFocusStore.setState(initialEdgeFocusState, true);
+  });
+
+  it("sets the edge directly", () => {
+    edgeFocusActions.setEdge("event-1", "endDate", "End 9:15 AM");
+
+    expect(useEdgeFocusStore.getState()).toMatchObject({
+      eventId: "event-1",
+      edge: "endDate",
+      announcement: "End 9:15 AM",
+    });
+  });
+
+  it("resets to the initial state", () => {
+    edgeFocusActions.setEdge("event-1", "endDate", "End 9:15 AM");
+    edgeFocusActions.reset();
+
+    expect(useEdgeFocusStore.getState()).toEqual(initialEdgeFocusState);
+  });
+});

--- a/packages/web/src/grid/shortcuts/edge-focus.store.ts
+++ b/packages/web/src/grid/shortcuts/edge-focus.store.ts
@@ -1,0 +1,70 @@
+import { create } from "zustand";
+import { devtools } from "zustand/middleware";
+import { IS_DEV } from "@web/common/constants/env.constants";
+import { type EventEdge } from "@web/common/utils/event/event-nudge.util";
+
+export type EdgeFocusState = {
+  eventId: string | null;
+  edge: EventEdge | null;
+  /** Polite live-region message for the current edge / a nudge result. */
+  announcement: string;
+};
+
+export const initialEdgeFocusState: EdgeFocusState = {
+  eventId: null,
+  edge: null,
+  announcement: "",
+};
+
+export const useEdgeFocusStore = create<EdgeFocusState>()(
+  devtools(() => initialEdgeFocusState, {
+    name: "compass/edge-focus",
+    enabled: IS_DEV,
+  }),
+);
+
+const EDGE_CYCLE: (EventEdge | null)[] = [null, "startDate", "endDate"];
+
+const edgeAnnouncement = (edge: EventEdge | null) =>
+  edge === "startDate"
+    ? "Editing start time"
+    : edge === "endDate"
+      ? "Editing end time"
+      : "Editing whole event";
+
+export const edgeFocusActions = {
+  /** Cycles the given event's edge focus: whole event → start → end → wrap. */
+  cycle: (eventId: string, direction: "forward" | "backward") => {
+    const current = useEdgeFocusStore.getState();
+    const currentEdge = current.eventId === eventId ? current.edge : null;
+    const index = EDGE_CYCLE.indexOf(currentEdge);
+    const step = direction === "forward" ? 1 : -1;
+    const nextEdge =
+      EDGE_CYCLE[(index + step + EDGE_CYCLE.length) % EDGE_CYCLE.length]!;
+
+    useEdgeFocusStore.setState(
+      { eventId, edge: nextEdge, announcement: edgeAnnouncement(nextEdge) },
+      false,
+      { type: "cycle" },
+    );
+  },
+  /** Sets the focused edge directly (e.g. after a keyboard nudge flip). */
+  setEdge: (eventId: string, edge: EventEdge, announcement: string) =>
+    useEdgeFocusStore.setState({ eventId, edge, announcement }, false, {
+      type: "setEdge",
+    }),
+  reset: () =>
+    useEdgeFocusStore.setState(initialEdgeFocusState, false, {
+      type: "reset",
+    }),
+};
+
+export const selectEdgeForEvent =
+  (eventId: string | null | undefined) => (state: EdgeFocusState) =>
+    eventId && state.eventId === eventId ? state.edge : null;
+
+export const selectEdgeFocusAnnouncement = (state: EdgeFocusState) =>
+  state.announcement;
+
+export const selectEdgeFocusActive = (state: EdgeFocusState) =>
+  state.eventId !== null && state.edge !== null;

--- a/packages/web/src/grid/shortcuts/useGridEventEditShortcuts.ts
+++ b/packages/web/src/grid/shortcuts/useGridEventEditShortcuts.ts
@@ -324,12 +324,14 @@ export function useGridEventEditShortcuts({
 
   // Edge focus tracks a specific event's DOM element, which React replaces
   // after every committed nudge (refocusEventElement restores focus to the
-  // new element within a few frames). Settling on focusin+focusout+setTimeout
-  // means that brief focus-to-body gap never reads as "focus left the event"
-  // and resets the mode mid-nudge.
+  // new element within a few frames). A focusin landing on a *different*
+  // event is unambiguous and resets immediately. A focusin/focusout landing
+  // on nothing (the brief focus-to-body gap mid-remount) is ambiguous, so
+  // that case alone waits a tick for refocusEventElement to restore focus
+  // before treating it as "focus left the event".
   useEffect(() => {
     let timer = 0;
-    const sync = () => {
+    const checkAfterDelay = () => {
       window.clearTimeout(timer);
       timer = window.setTimeout(() => {
         const { eventId } = useEdgeFocusStore.getState();
@@ -338,6 +340,20 @@ export function useGridEventEditShortcuts({
           edgeFocusActions.reset();
         }
       }, 0);
+    };
+    const sync = () => {
+      const { eventId } = useEdgeFocusStore.getState();
+      if (!eventId) return;
+
+      const focused = targetingRef.current.getFocused();
+      if (!focused) {
+        checkAfterDelay();
+        return;
+      }
+      if (focused.eventId !== eventId) {
+        window.clearTimeout(timer);
+        edgeFocusActions.reset();
+      }
     };
 
     document.addEventListener("focusin", sync);

--- a/packages/web/src/grid/shortcuts/useGridEventEditShortcuts.ts
+++ b/packages/web/src/grid/shortcuts/useGridEventEditShortcuts.ts
@@ -1,4 +1,5 @@
 import { useQueryClient } from "@tanstack/react-query";
+import { useEffect, useRef } from "react";
 import dayjs, { type Dayjs } from "@core/util/date/dayjs";
 import { useCalendarsQuery } from "@web/calendars/calendar.query";
 import {
@@ -7,8 +8,14 @@ import {
 } from "@web/calendars/useCalendarLookup";
 import { ID_SIDEBAR } from "@web/common/constants/web.constants";
 import { type GridEvent } from "@web/common/types/web.event.types";
-import { getArrowKeyMovement } from "@web/common/utils/event/event-nudge.util";
-import { nudgeEventFromKeyboard } from "@web/common/utils/event/event-nudge-shortcut.util";
+import {
+  type EventEdge,
+  getArrowKeyMovement,
+} from "@web/common/utils/event/event-nudge.util";
+import {
+  nudgeEventEdgeFromKeyboard,
+  nudgeEventFromKeyboard,
+} from "@web/common/utils/event/event-nudge-shortcut.util";
 import {
   isDeleteTextEditingTarget,
   isEditableKeyboardTarget,
@@ -22,6 +29,10 @@ import {
 import { useUpdateEvent } from "@web/events/mutations/useUpdateEvent";
 import { findEventInCache } from "@web/events/queries/event.query.cache";
 import { draftActions, isEventFormOpen } from "@web/events/stores/draft.store";
+import {
+  edgeFocusActions,
+  useEdgeFocusStore,
+} from "@web/grid/shortcuts/edge-focus.store";
 import {
   type FocusableGridEventTarget,
   findCalendarEventForTarget,
@@ -163,11 +174,76 @@ export function useGridEventEditShortcuts({
     draftActions.setFormOpen(true);
   };
 
+  const describeEdgeDate = (event: GridEvent, edge: EventEdge) => {
+    const date = edge === "startDate" ? event.startDate : event.endDate;
+    if (!date) return "";
+    const label = event.isAllDay
+      ? dayjs(date).format("MMM D")
+      : dayjs(date).format("h:mm A");
+    const edgeName = edge === "startDate" ? "Start" : "End";
+    return `${edgeName} ${label}`;
+  };
+
+  const moveFocusedEventEdge = (
+    keyboardEvent: KeyboardEvent,
+    event: GridEvent,
+    edge: EventEdge,
+  ) => {
+    if (!event._id) return;
+
+    const movement = getArrowKeyMovement(
+      keyboardEvent.key,
+      Boolean(event.isAllDay),
+    );
+    if (!movement) return;
+
+    if (dayBoundary.kind === "clamp" && event.isAllDay) {
+      const { weekDays } = dayBoundary;
+      // All-day endDate is stored exclusive (the day after the last occupied
+      // day), so it's shifted back a day to compare against the inclusive
+      // weekDays window — matching nudgeAllDayEdgeDates's own inclusiveEnd.
+      const edgeDate =
+        edge === "startDate"
+          ? dayjs(event.startDate)
+          : dayjs(event.endDate).subtract(1, "day");
+      if (movement.days === -1 && !edgeDate.isAfter(weekDays[0], "day")) {
+        return;
+      }
+      if (
+        movement.days === 1 &&
+        !edgeDate.isBefore(weekDays[weekDays.length - 1], "day")
+      ) {
+        return;
+      }
+    }
+
+    nudgeEventEdgeFromKeyboard({
+      edge,
+      event,
+      keyboardEvent,
+      onNudge: (nudgedEvent, nextEdge) => {
+        updateEvent({ event: nudgedEvent }, true);
+        edgeFocusActions.setEdge(
+          event._id!,
+          nextEdge,
+          describeEdgeDate(nudgedEvent, nextEdge),
+        );
+      },
+      afterNudge: () => draftActions.discard(),
+    });
+  };
+
   const moveFocusedCalendarEvent = (keyboardEvent: KeyboardEvent) => {
     if (isEventFormOpen()) return;
 
     const event = getFocusedMutableCalendarEvent();
     if (!event?._id) return;
+
+    const edgeFocus = useEdgeFocusStore.getState();
+    if (edgeFocus.eventId === event._id && edgeFocus.edge) {
+      moveFocusedEventEdge(keyboardEvent, event, edgeFocus.edge);
+      return;
+    }
 
     const movement = getArrowKeyMovement(
       keyboardEvent.key,
@@ -206,6 +282,73 @@ export function useGridEventEditShortcuts({
       afterNudge: () => draftActions.discard(),
     });
   };
+
+  const cycleEdgeFocus = (keyboardEvent: KeyboardEvent) => {
+    if (isEventFormOpen() || isEditableKeyboardTarget(keyboardEvent)) return;
+    if (isFocusInSidebar()) return;
+
+    const event = getFocusedMutableCalendarEvent();
+    if (!event?._id) return;
+
+    const forward = !keyboardEvent.shiftKey;
+    const { eventId, edge } = useEdgeFocusStore.getState();
+    const currentEdge = eventId === event._id ? edge : null;
+    // Forward enters at the start edge and exits (natively, past the end
+    // edge) rather than wrapping — an unconditional wrap would trap keyboard
+    // focus on the card forever, since Tab is the only way in or out.
+    const exiting = forward
+      ? currentEdge === "endDate"
+      : currentEdge === "startDate";
+    if (exiting) {
+      edgeFocusActions.reset();
+      return;
+    }
+
+    keyboardEvent.preventDefault();
+    keyboardEvent.stopPropagation();
+    edgeFocusActions.cycle(event._id, forward ? "forward" : "backward");
+  };
+
+  const clearEdgeFocus = () => {
+    if (!useEdgeFocusStore.getState().eventId) return;
+    edgeFocusActions.reset();
+  };
+
+  // `targeting` is a fresh object every render for some callers (Day/Week
+  // build it inline), so the settle effect below reads it through a ref
+  // instead of depending on it directly — otherwise it would tear down and
+  // rebuild its listeners on every unrelated re-render, which can cancel a
+  // check that was already in flight.
+  const targetingRef = useRef(targeting);
+  targetingRef.current = targeting;
+
+  // Edge focus tracks a specific event's DOM element, which React replaces
+  // after every committed nudge (refocusEventElement restores focus to the
+  // new element within a few frames). Settling on focusin+focusout+setTimeout
+  // means that brief focus-to-body gap never reads as "focus left the event"
+  // and resets the mode mid-nudge.
+  useEffect(() => {
+    let timer = 0;
+    const sync = () => {
+      window.clearTimeout(timer);
+      timer = window.setTimeout(() => {
+        const { eventId } = useEdgeFocusStore.getState();
+        if (!eventId) return;
+        if (targetingRef.current.getFocused()?.eventId !== eventId) {
+          edgeFocusActions.reset();
+        }
+      }, 0);
+    };
+
+    document.addEventListener("focusin", sync);
+    document.addEventListener("focusout", sync);
+
+    return () => {
+      window.clearTimeout(timer);
+      document.removeEventListener("focusin", sync);
+      document.removeEventListener("focusout", sync);
+    };
+  }, []);
 
   const moveDraftOrFocusAdjacent = (keyboardEvent: KeyboardEvent) => {
     if (isEditableKeyboardTarget(keyboardEvent)) return;
@@ -318,4 +461,7 @@ export function useGridEventEditShortcuts({
   useAppShortcut("Shift+ArrowDown", moveFocusedCalendarEvent);
   useAppShortcut("Shift+ArrowLeft", moveFocusedCalendarEvent);
   useAppShortcut("Shift+ArrowRight", moveFocusedCalendarEvent);
+  useAppShortcut("Tab", cycleEdgeFocus, DRAFT_MOVEMENT_HOTKEY_OPTIONS);
+  useAppShortcut("Shift+Tab", cycleEdgeFocus, DRAFT_MOVEMENT_HOTKEY_OPTIONS);
+  useAppShortcut("Escape", clearEdgeFocus, DRAFT_MOVEMENT_HOTKEY_OPTIONS);
 }

--- a/packages/web/src/shortcuts/shortcuts.registry.ts
+++ b/packages/web/src/shortcuts/shortcuts.registry.ts
@@ -251,6 +251,18 @@ export const SHORTCUTS_REGISTRY: Shortcut[] = [
     label: "Move event 15 min later",
     section: "edit",
   },
+  {
+    id: "edit-cycle-edge",
+    keys: ["Tab"],
+    label: "Cycle start/end edge focus",
+    section: "edit",
+  },
+  {
+    id: "edit-move-edge",
+    keys: ["Shift", "Arrow keys"],
+    label: "Move only the focused edge",
+    section: "edit",
+  },
 
   // Other
   {

--- a/packages/web/src/views/Day/hooks/shortcuts/useDayEventNudgeShortcuts.test.tsx
+++ b/packages/web/src/views/Day/hooks/shortcuts/useDayEventNudgeShortcuts.test.tsx
@@ -622,7 +622,7 @@ describe("useDayEventNudgeShortcuts", () => {
     expect(useEdgeFocusStore.getState().edge).toBeNull();
   });
 
-  it("resets edge focus when a different event is focused", async () => {
+  it("resets edge focus when a different event is focused", () => {
     const laterEvent: GridEvent = {
       ...timedEvent,
       _id: "cccccccccccccccccccccccc",
@@ -641,8 +641,6 @@ describe("useDayEventNudgeShortcuts", () => {
       later.focus();
     });
 
-    await waitFor(() => {
-      expect(useEdgeFocusStore.getState().eventId).toBeNull();
-    });
+    expect(useEdgeFocusStore.getState().eventId).toBeNull();
   });
 });

--- a/packages/web/src/views/Day/hooks/shortcuts/useDayEventNudgeShortcuts.test.tsx
+++ b/packages/web/src/views/Day/hooks/shortcuts/useDayEventNudgeShortcuts.test.tsx
@@ -24,6 +24,10 @@ import {
 import { eventQueryKeys } from "@web/events/queries/event.query.keys";
 import { type EventRepository } from "@web/events/repositories/event.repository.types";
 import { draftActions, useDraftStore } from "@web/events/stores/draft.store";
+import {
+  initialEdgeFocusState,
+  useEdgeFocusStore,
+} from "@web/grid/shortcuts/edge-focus.store";
 import { dayEventRegistry } from "@web/views/Day/interaction/registry/day-event.registry";
 import { useDayEventNudgeShortcuts } from "./useDayEventNudgeShortcuts";
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
@@ -181,12 +185,14 @@ const getDeleteMutation = (
 beforeEach(() => {
   HotkeyManager.resetInstance();
   draftActions.discard();
+  useEdgeFocusStore.setState(initialEdgeFocusState, true);
 });
 
 afterEach(() => {
   cleanup();
   dayEventRegistry.clear();
   draftActions.discard();
+  useEdgeFocusStore.setState(initialEdgeFocusState, true);
   document.body.innerHTML = "";
 });
 
@@ -488,5 +494,155 @@ describe("useDayEventNudgeShortcuts", () => {
 
     expect(useDraftStore.getState().status?.isFormOpen).toBeFalsy();
     expect(useDraftStore.getState().gridDraft).toBeNull();
+  });
+
+  it("cycles edge focus with Tab: whole event -> start -> end -> whole event", () => {
+    focusCalendarTarget(TIMED_EVENT_ID, "timed");
+    renderEditShortcuts();
+
+    pressKey("Tab");
+    expect(useEdgeFocusStore.getState()).toMatchObject({
+      eventId: TIMED_EVENT_ID,
+      edge: "startDate",
+    });
+
+    pressKey("Tab");
+    expect(useEdgeFocusStore.getState().edge).toBe("endDate");
+
+    pressKey("Tab");
+    expect(useEdgeFocusStore.getState().edge).toBeNull();
+  });
+
+  it("lets Tab leave the card natively past the end edge instead of trapping focus", () => {
+    focusCalendarTarget(TIMED_EVENT_ID, "timed");
+    renderEditShortcuts();
+
+    pressKey("Tab");
+    pressKey("Tab");
+    expect(useEdgeFocusStore.getState().edge).toBe("endDate");
+
+    const thirdTab = new KeyboardEvent("keydown", {
+      bubbles: true,
+      cancelable: true,
+      key: "Tab",
+    });
+    document.dispatchEvent(thirdTab);
+
+    expect(thirdTab.defaultPrevented).toBe(false);
+    expect(useEdgeFocusStore.getState().edge).toBeNull();
+  });
+
+  it("cycles edge focus backward with Shift+Tab", () => {
+    focusCalendarTarget(TIMED_EVENT_ID, "timed");
+    renderEditShortcuts();
+
+    pressKey("Tab", shiftKey);
+    expect(useEdgeFocusStore.getState().edge).toBe("endDate");
+
+    pressKey("Tab", shiftKey);
+    expect(useEdgeFocusStore.getState().edge).toBe("startDate");
+  });
+
+  it("does not cycle edge focus with Tab when no event is focused", () => {
+    renderEditShortcuts();
+
+    pressKey("Tab");
+
+    expect(useEdgeFocusStore.getState().eventId).toBeNull();
+  });
+
+  it("moves only the start edge with Shift+ArrowUp when the start edge is focused", async () => {
+    focusCalendarTarget(TIMED_EVENT_ID, "timed");
+    const { queryClient } = renderEditShortcuts();
+    pressKey("Tab");
+
+    pressKey("ArrowUp", shiftKey);
+
+    await waitFor(() => {
+      expect(getEditMutation(queryClient)).toBeDefined();
+    });
+    const { input } = getEditMutation(queryClient)?.state.variables as {
+      input: { schedule: { start: string; end: string } };
+    };
+    expect(input.schedule.start).toBe(
+      offsetString(dayjs(timedEvent.startDate).subtract(15, "minutes")),
+    );
+    expect(input.schedule.end).toBe(offsetString(dayjs(timedEvent.endDate)));
+    expect(useEdgeFocusStore.getState().edge).toBe("startDate");
+  });
+
+  it("moves only the end edge with Shift+ArrowDown when the end edge is focused", async () => {
+    focusCalendarTarget(TIMED_EVENT_ID, "timed");
+    const { queryClient } = renderEditShortcuts();
+    pressKey("Tab");
+    pressKey("Tab");
+
+    pressKey("ArrowDown", shiftKey);
+
+    await waitFor(() => {
+      expect(getEditMutation(queryClient)).toBeDefined();
+    });
+    const { input } = getEditMutation(queryClient)?.state.variables as {
+      input: { schedule: { start: string; end: string } };
+    };
+    expect(input.schedule.start).toBe(
+      offsetString(dayjs(timedEvent.startDate)),
+    );
+    expect(input.schedule.end).toBe(
+      offsetString(dayjs(timedEvent.endDate).add(15, "minutes")),
+    );
+    expect(useEdgeFocusStore.getState().edge).toBe("endDate");
+  });
+
+  it("flips the focused edge from start to end past the minimum duration", async () => {
+    const shortEvent: GridEvent = {
+      ...timedEvent,
+      endDate: "2026-05-20T09:15:00.000",
+    };
+    focusCalendarTarget(TIMED_EVENT_ID, "timed");
+    renderEditShortcuts({ timedEvents: [shortEvent] });
+    pressKey("Tab");
+
+    pressKey("ArrowDown", shiftKey);
+
+    await waitFor(() => {
+      expect(useEdgeFocusStore.getState().edge).toBe("endDate");
+    });
+    expect(useEdgeFocusStore.getState().eventId).toBe(TIMED_EVENT_ID);
+  });
+
+  it("resets edge focus with Escape", () => {
+    focusCalendarTarget(TIMED_EVENT_ID, "timed");
+    renderEditShortcuts();
+    pressKey("Tab");
+    expect(useEdgeFocusStore.getState().edge).toBe("startDate");
+
+    pressKey("Escape");
+
+    expect(useEdgeFocusStore.getState().edge).toBeNull();
+  });
+
+  it("resets edge focus when a different event is focused", async () => {
+    const laterEvent: GridEvent = {
+      ...timedEvent,
+      _id: "cccccccccccccccccccccccc",
+      startDate: "2026-05-20T11:00:00.000",
+      endDate: "2026-05-20T12:00:00.000",
+      title: "Later event",
+    };
+    const earlier = focusCalendarTarget(TIMED_EVENT_ID, "timed");
+    const later = focusCalendarTarget(laterEvent._id!, "timed");
+    earlier.focus();
+    renderEditShortcuts({ timedEvents: [timedEvent, laterEvent] });
+    pressKey("Tab");
+    expect(useEdgeFocusStore.getState().eventId).toBe(TIMED_EVENT_ID);
+
+    act(() => {
+      later.focus();
+    });
+
+    await waitFor(() => {
+      expect(useEdgeFocusStore.getState().eventId).toBeNull();
+    });
   });
 });

--- a/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcutOwner.test.tsx
+++ b/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcutOwner.test.tsx
@@ -23,6 +23,10 @@ import { createObjectIdString } from "@web/common/utils/id/object-id.util";
 import { eventQueryKeys } from "@web/events/queries/event.query.keys";
 import { useDraftStore } from "@web/events/stores/draft.store";
 import { initialViewState, useViewStore } from "@web/events/stores/view.store";
+import {
+  initialEdgeFocusState,
+  useEdgeFocusStore,
+} from "@web/grid/shortcuts/edge-focus.store";
 import { DraftContext } from "@web/views/Week/components/Draft/context/DraftContext";
 import { weekEventRegistry } from "@web/views/Week/interaction/registry/week-event.registry";
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
@@ -64,6 +68,22 @@ const leftmostEvent = createMockEvent({
     start: "2026-05-18T09:00:00.000Z",
     end: "2026-05-18T10:00:00.000Z",
     timeZone: "UTC",
+  }),
+});
+const LEFTMOST_ALL_DAY_EVENT_ID = EventIdSchema.parse(
+  "eeeeeeeeeeeeeeeeeeeeeeee",
+);
+const leftmostAllDayEvent = createMockEvent({
+  id: LEFTMOST_ALL_DAY_EVENT_ID,
+  content: {
+    kind: "details",
+    title: "Leftmost all-day event",
+    description: "",
+  },
+  schedule: EventScheduleSchema.parse({
+    kind: "allDay",
+    start: "2026-05-18",
+    end: "2026-05-19",
   }),
 });
 
@@ -136,6 +156,7 @@ const getEditMutation = (queryClient: QueryClient) =>
 beforeEach(() => {
   HotkeyManager.resetInstance();
   repositionDraftByKeyboard = mock();
+  useEdgeFocusStore.setState(initialEdgeFocusState, true);
 });
 
 afterEach(() => {
@@ -144,6 +165,7 @@ afterEach(() => {
   pendingEventIds = [];
   weekEventRegistry.clear();
   useViewStore.setState(initialViewState);
+  useEdgeFocusStore.setState(initialEdgeFocusState, true);
 });
 
 const addCalendarTarget = (
@@ -655,6 +677,89 @@ describe("useWeekShortcutOwner shift+arrow event moves", () => {
     pressKey("ArrowRight", shiftKey);
 
     expect(getEditMutation(queryClient)).toBeUndefined();
+  });
+});
+
+describe("useWeekShortcutOwner edge focus", () => {
+  it("cycles edge focus with Tab and moves only the focused edge", async () => {
+    const button = addCalendarTarget();
+    button.focus();
+    const { queryClient } = renderShortcuts();
+
+    pressKey("Tab");
+    expect(useEdgeFocusStore.getState()).toMatchObject({
+      eventId: EVENT_1_ID,
+      edge: "startDate",
+    });
+
+    pressKey("ArrowUp", shiftKey);
+
+    await waitFor(() => {
+      expect(getEditMutation(queryClient)).toBeDefined();
+    });
+    const { input } = getEditMutation(queryClient)?.state.variables as {
+      input: { schedule: { start: string; end: string } };
+    };
+    expect(input.schedule.start).toBe(
+      offsetString(dayjs("2026-05-20T09:00:00.000Z").subtract(15, "minutes")),
+    );
+    expect(input.schedule.end).toBe(
+      offsetString(dayjs("2026-05-20T10:00:00.000Z")),
+    );
+  });
+
+  it("refuses an all-day start-edge move that would leave the visible week", () => {
+    const button = addCalendarTarget(LEFTMOST_ALL_DAY_EVENT_ID, "all-day");
+    button.focus();
+    const { queryClient } = renderShortcuts({
+      extraEvents: [leftmostAllDayEvent],
+    });
+
+    pressKey("Tab");
+    pressKey("ArrowLeft", shiftKey);
+
+    expect(getEditMutation(queryClient)).toBeUndefined();
+  });
+
+  it("allows an all-day end-edge move into the visible week's last day", async () => {
+    // weekDays run 2026-05-18..2026-05-24; this event's last occupied day is
+    // 05-23 (exclusive endDate 05-24), so extending into 05-24 is in bounds -
+    // regression test for an off-by-one that compared the exclusive endDate
+    // directly against the inclusive week boundary.
+    const RIGHTMOST_ALL_DAY_EVENT_ID = EventIdSchema.parse(
+      "ffffffffffffffffffffffff",
+    );
+    const rightmostAllDayEvent = createMockEvent({
+      id: RIGHTMOST_ALL_DAY_EVENT_ID,
+      content: {
+        kind: "details",
+        title: "Rightmost all-day event",
+        description: "",
+      },
+      schedule: EventScheduleSchema.parse({
+        kind: "allDay",
+        start: "2026-05-22",
+        end: "2026-05-24",
+      }),
+    });
+    const button = addCalendarTarget(RIGHTMOST_ALL_DAY_EVENT_ID, "all-day");
+    button.focus();
+    const { queryClient } = renderShortcuts({
+      extraEvents: [rightmostAllDayEvent],
+    });
+
+    pressKey("Tab");
+    pressKey("Tab");
+    pressKey("ArrowRight", shiftKey);
+
+    await waitFor(() => {
+      expect(getEditMutation(queryClient)).toBeDefined();
+    });
+    const { input } = getEditMutation(queryClient)?.state.variables as {
+      input: { schedule: { start: string; end: string } };
+    };
+    expect(input.schedule.start).toBe("2026-05-22");
+    expect(input.schedule.end).toBe("2026-05-25");
   });
 });
 


### PR DESCRIPTION
## Summary
- Tab cycles a focused event card through whole-event -> start edge -> end edge (Shift+Tab reverses); Tab past the end edge (or Shift+Tab past the start edge) exits the cycle natively instead of trapping keyboard focus on the card.
- With an edge focused, Shift+Arrow moves only that edge (15 min for timed via Up/Down, 1 day for all-day via Left/Right) instead of the whole event.
- Pushing an edge past the other flips which edge is held, mirroring the existing mouse drag-resize behavior (`timed.resize.ts` / `all-day.resize.ts`).
- An accent bar on the event card and a live-region announcement (mounted in the sidebar status bar) indicate which edge is focused and announce the result of each nudge.
- New legend rows in the shortcuts overlay for Tab cycling and edge-only Shift+Arrow moves.

## Test plan
- [x] `bun run type-check` (repo root) - clean
- [x] `event-nudge.util.test.ts` - edge math: independent start/end moves, no-flip at exact min duration, flips (timed + all-day), midnight-crossing rejection, exclusive-end all-day formatting
- [x] `edge-focus.store.test.ts` (new) - cycle order, fresh cycle per event, reset
- [x] `useDayEventNudgeShortcuts.test.tsx` - Tab cycle, Shift+Tab reverse, edge nudges, flip indicator, Escape reset, reset on refocusing a different event, native-Tab exit past the end edge (regression test for a keyboard-trap fix caught in review)
- [x] `useWeekShortcutOwner.test.tsx` - week-boundary clamp for edge moves at both the start and end edge (regression test for an off-by-one on the exclusive all-day `endDate` caught in review)
- [x] `shortcuts.registry.test.ts` / `SidebarStatusBar.test.tsx` - unaffected, still pass
- [ ] Manual browser verification - not possible in this environment (backend requires `SYNC_SERVICE_URL`/`SYNC_INTERNAL_AUTH_TOKEN` secrets not configured in this worktree)

An independent review pass caught and fixed two issues before this PR: a genuine keyboard trap (Tab could never leave the card) and an off-by-one in the week-boundary clamp for all-day end-edge moves (compared the exclusive `endDate` directly against the inclusive week window).

🤖 Generated with [Claude Code](https://claude.com/claude-code)