### PR TITLE
fix(sync): stop stale-command sweep from freezing fleet-wide on one bad row

### DIFF
--- a/packages/sync/src/app.ts
+++ b/packages/sync/src/app.ts
@@ -617,6 +617,11 @@ function buildSchedulers(
               writer: eventWriter,
               custody: new CredentialCustody(repos.credentials, authAdapter),
             },
+            onRetryError: (error, commandId) =>
+              logger.error(
+                `Sync stale-command sweep could not retry command ${commandId}; skipping it and continuing`,
+                error,
+              ),
           },
           before,
           () => new Date(),

--- a/packages/sync/src/domain/stale-command-retry.service.db.test.ts
+++ b/packages/sync/src/domain/stale-command-retry.service.db.test.ts
@@ -240,6 +240,72 @@ describe("retryStaleCommands", () => {
     expect(writer.deleteCalls).toHaveLength(0);
   });
 
+  // Reproduces the 2026-07-31 failure class (one unparseable job doc froze
+  // calendar sync fleet-wide for 23h) for THIS sweep: listStaleNonterminal
+  // sorts oldest-updatedAt-first, so a command whose retry throws something
+  // unexpected (not ProviderWriteUnavailableError) must not abort the batch -
+  // every stale command behind it still needs its own attempt.
+  it("keeps retrying later commands after an earlier one throws unexpectedly", async () => {
+    const poisoned = await seedStuckDelete();
+    const healthy = await seedStuckDelete();
+    const writer = new FakeDeleteWriter();
+    // listStaleNonterminal sorts oldest-updatedAt-first, so `poisoned` (seeded
+    // first) is guaranteed to be attempted before `healthy` - throw only on
+    // that first delete call to simulate the poisoned command specifically.
+    const originalDeleteEvent = writer.deleteEvent.bind(writer);
+    let calls = 0;
+    writer.deleteEvent = async (input) => {
+      calls++;
+      if (calls === 1) throw new Error("unexpected: malformed row");
+      return originalDeleteEvent(input);
+    };
+
+    const onRetryErrorCalls: Array<{ error: unknown; commandId: string }> = [];
+
+    const result = await retryStaleCommands(
+      {
+        commands,
+        events,
+        calendars,
+        occurrences,
+        markers,
+        execution: "active",
+        provider: { writer, custody: tokenSource() },
+        onRetryError: (error, commandId) =>
+          onRetryErrorCalls.push({ error, commandId }),
+      },
+      before(),
+      now,
+    );
+
+    expect(result).toEqual({ attempted: 2, stillStale: 1 });
+    expect(onRetryErrorCalls).toHaveLength(1);
+    expect(onRetryErrorCalls[0]?.commandId).toBe(poisoned.command._id);
+
+    const poisonedStored = await commands.findById(
+      poisoned.tenantId,
+      poisoned.principalId,
+      poisoned.command._id,
+    );
+    expect(poisonedStored?.outcome.state).toBe("pending");
+
+    // The healthy command, seeded after the poisoned one and so sorted
+    // behind it, still got its own attempt and converged.
+    const healthyStored = await commands.findById(
+      healthy.tenantId,
+      healthy.principalId,
+      healthy.command._id,
+    );
+    expect(healthyStored?.outcome.state).toBe("confirmed");
+    expect(
+      await events.findById(
+        healthy.tenantId,
+        healthy.principalId,
+        healthy.event._id,
+      ),
+    ).toBeNull();
+  });
+
   // Reproduces the exact data-loss scenario independent review flagged:
   // update A->B gets stuck pending (transient failure), the user edits again
   // B->C and that one succeeds, then the sweep later finds the stale A->B

--- a/packages/sync/src/domain/stale-command-retry.service.ts
+++ b/packages/sync/src/domain/stale-command-retry.service.ts
@@ -8,6 +8,10 @@ import { type CommandRepository } from "@sync/storage/repositories/command.repos
 
 export interface StaleCommandRetryDeps extends CloudCommandDeps {
   commands: CommandRepository;
+  // Called once per command that threw something other than
+  // ProviderWriteUnavailableError. The sweep keeps going; the caller decides
+  // how loud to be.
+  onRetryError?: (error: unknown, commandId: string) => void;
 }
 
 export interface StaleCommandRetryResult {
@@ -39,6 +43,14 @@ const RETRYABLE_KINDS: readonly SyncCommandInput["kind"][] = [
 // newer edit would be silent data loss. A GLOBAL scan across owners (system
 // liveness, not a user request) - mirrors failed-job-requeue.service.ts's
 // sweep shape.
+//
+// Each command is retried independently: one that throws something
+// unexpected is reported and skipped, never allowed to abandon the rest of
+// the batch. listStaleNonterminal sorts oldest-updatedAt-first, so a single
+// doomed command would otherwise sort to the front and block this sweep for
+// EVERY tenant on every cycle, forever - the same class of failure
+// enqueueForResources was hardened against (2026-07-31: one unparseable job
+// doc froze calendar sync fleet-wide for 23h).
 export async function retryStaleCommands(
   deps: StaleCommandRetryDeps,
   before: Date,
@@ -67,7 +79,10 @@ export async function retryStaleCommands(
         stillStale++;
         continue;
       }
-      throw error;
+      // Anything else is unexpected (a malformed row, a bug) - report it and
+      // move on rather than losing every command behind this one, forever.
+      deps.onRetryError?.(error, command._id);
+      stillStale++;
     }
   }
 

--- a/packages/sync/src/server/command.routes.ts
+++ b/packages/sync/src/server/command.routes.ts
@@ -1,5 +1,6 @@
 import { type Express, type RequestHandler } from "express";
 import { Status } from "@core/errors/status.codes";
+import { Logger } from "@core/logger/winston.logger";
 import {
   CommandSubmitRequestSchema,
   type CommandSubmitResponse,
@@ -14,6 +15,7 @@ import {
 } from "@sync/domain/cloud-command.service";
 import { type ProviderAuthAdapter } from "@sync/providers/provider-auth.port";
 import { type ProviderEventWriter } from "@sync/providers/provider-event-writer.port";
+import { redactedCause } from "@sync/safety/redact-error";
 import {
   ensureConnected,
   internalRateLimit,
@@ -25,6 +27,8 @@ import { type SyncMongoService } from "@sync/storage/sync-mongo.service";
 import { syncRepositories } from "@sync/storage/sync-repositories";
 
 export const COMMANDS_PATH = "/internal/commands";
+
+const logger = Logger("sync:command.routes");
 
 export interface CommandApiDeps {
   authMiddleware: RequestHandler;
@@ -167,6 +171,7 @@ export function registerCommandRoutes(
             .json({ error: "provider_write_unavailable" });
           return;
         }
+        logger.error("Failed to submit command", redactedCause(error));
         respondInternalError(res);
       }
     },

--- a/packages/sync/src/server/notification.routes.ts
+++ b/packages/sync/src/server/notification.routes.ts
@@ -74,6 +74,17 @@ export function registerNotificationRoutes(
         now,
       );
 
+      // Never reveal the verdict to the caller (response stays 200 either
+      // way), but a rejection is still worth a quiet log line - a fleet-wide
+      // channel/resource desync (e.g. every callback suddenly unknownChannel)
+      // would otherwise be invisible until reconcile's 15-min fallback masks
+      // the symptom.
+      if (verdict.status === "rejected") {
+        logger.warn(
+          `Rejected notification for channel ${notification.channelId}: ${verdict.reason}`,
+        );
+      }
+
       // Only an authentic change schedules work. Coalescing on the resource
       // collapses duplicate deliveries of the same change into one job.
       if (verdict.status === "process" && resource) {


### PR DESCRIPTION
## Summary
- `retryStaleCommands` rethrew any unexpected error, and its finder sorts oldest-first — one poisoned command would sort to the front and block the sweep for the whole fleet, every cycle, forever. Same failure class as the documented 2026-07-31 23h outage; applies the same per-item try/catch fix that `enqueueForResources` already got.
- The primary command-submit route (`POST /internal/commands`) swallowed every error with no logging — a systemic write failure would have been invisible in sync's logs.
- Rejected webhook notifications (unknown channel, token/resource mismatch, expired) were silently 200'd with no signal — a fleet-wide channel/resource desync would go unnoticed until reconcile's 15-min fallback masked the symptom.

First of several fixes from a pre-launch sync stability + UX audit (backend durability, frontend status UX, OAuth/onboarding flow).

## Test plan
- [x] `bun packages/scripts/src/testing/test-mongo-env.ts sync --` — 857 pass, 0 fail
- [x] New test: `keeps retrying later commands after an earlier one throws unexpectedly` reproduces the poisoned-command scenario and asserts the healthy command behind it still converges
- [x] Full repo `bunx typescript@7.0.2 --noEmit` — clean
- [x] `biome check` on touched files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)