### PR TITLE
fix(sync): stop misclassifying transient Google read errors as durable

### DIFF
--- a/packages/sync/src/providers/google/google-event-reader.adapter.test.ts
+++ b/packages/sync/src/providers/google/google-event-reader.adapter.test.ts
@@ -232,6 +232,58 @@ describe("GoogleEventReaderAdapter", () => {
     }
   });
 
+  it("maps a 401 to transient (the token can expire mid-job on a long import/repair; the next attempt mints a fresh one)", async () => {
+    const api = new FakeEventListApi([], { response: { status: 401 } });
+    const { adapter } = adapterWith(api);
+
+    await expect(
+      adapter.listEventPage({
+        accessToken: "tok",
+        calendarId: "primary@google.com",
+      }),
+    ).rejects.toMatchObject({ reason: "transient" });
+  });
+
+  it("maps a quota-shaped 403 to transient, like discovery/watch/write already do", async () => {
+    for (const reason of [
+      "rateLimitExceeded",
+      "userRateLimitExceeded",
+      "quotaExceeded",
+      "dailyLimitExceeded",
+    ]) {
+      const api = new FakeEventListApi([], {
+        response: {
+          status: 403,
+          data: { error: { errors: [{ reason }] } },
+        },
+      });
+      const { adapter } = adapterWith(api);
+      await expect(
+        adapter.listEventPage({
+          accessToken: "tok",
+          calendarId: "primary@google.com",
+        }),
+      ).rejects.toMatchObject({ reason: "transient" });
+    }
+  });
+
+  it("maps a permission-refusal 403 (no quota reason) to readFailed", async () => {
+    const api = new FakeEventListApi([], {
+      response: {
+        status: 403,
+        data: { error: { errors: [{ reason: "forbidden" }] } },
+      },
+    });
+    const { adapter } = adapterWith(api);
+
+    await expect(
+      adapter.listEventPage({
+        accessToken: "tok",
+        calendarId: "primary@google.com",
+      }),
+    ).rejects.toMatchObject({ reason: "readFailed" });
+  });
+
   it("maps a networkless failure to transient", async () => {
     const api = new FakeEventListApi([], new Error("socket hang up"));
     const { adapter } = adapterWith(api);

--- a/packages/sync/src/providers/google/google-event-reader.adapter.ts
+++ b/packages/sync/src/providers/google/google-event-reader.adapter.ts
@@ -144,16 +144,44 @@ export class GoogleEventReaderAdapter implements ProviderEventReader {
   }
 }
 
+// Reasons Google's 403 can carry for a quota/rate problem rather than a
+// genuine permission refusal - status alone cannot tell them apart. Same set
+// as the discovery (google-calendar.adapter.ts) and watch/writer
+// (google-notifications.adapter.ts, google-event-writer.adapter.ts) paths.
+const TRANSIENT_REASONS = [
+  "rateLimitExceeded",
+  "userRateLimitExceeded",
+  "quotaExceeded",
+  "dailyLimitExceeded",
+  "backendError",
+  "internalError",
+];
+
 // Map a Google events.list failure to a read-error reason. An expired syncToken
-// (410 Gone) forces a full re-import; a rate limit or server/network error is
-// retryable; anything else is an unrecoverable read failure.
+// (410 Gone) forces a full re-import. Retryable: a rate limit or server/network
+// error, a quota-shaped 403, or a 401 - the token that was valid when
+// getValidAccessToken minted it can expire mid-job on a long-running import or
+// repair, and the NEXT attempt mints a fresh one (calendar-import.service.ts /
+// calendar-repair.service.ts each fetch it once at the top of the job).
+// Anything else is an unrecoverable read failure.
 function classifyReadError(
   error: unknown,
 ): "cursorExpired" | "transient" | "readFailed" {
   const status = httpStatus(error);
   if (status === 410) return "cursorExpired";
-  if (status === 429 || status === undefined || status >= 500) {
+  if (
+    status === 401 ||
+    status === 429 ||
+    status === undefined ||
+    status >= 500
+  ) {
     return "transient";
+  }
+  if (status === 403) {
+    const reason = googleErrorReason(error);
+    if (reason !== undefined && TRANSIENT_REASONS.includes(reason)) {
+      return "transient";
+    }
   }
   return "readFailed";
 }


### PR DESCRIPTION
## Summary
- The event reader (`GoogleEventReaderAdapter`) is the highest-volume Google call in the sync service, but unlike discovery/watch/writer it treated a quota-shaped 403 and a 401 as an unrecoverable `readFailed` — dropping the job, marking the resource with a durable read failure, and surfacing the connection as ATTENTION ("Couldn't update your calendar") to the user.
- A quota 403 and a mid-job-expired access token (each import/repair fetches its token once at job start; a large calendar's pass can outlive the token's ~1h lifetime) both recover on their own. Classifying them `transient` routes them through the existing capped-exponential retry ladder, and the next attempt mints a fresh token before reading a single page — no new token-refresh plumbing needed.
- Mirrors the `TRANSIENT_REASONS` handling already present in `google-calendar.adapter.ts` (discovery) and `google-notifications.adapter.ts`/`google-event-writer.adapter.ts` (watch/writer) — the reader was the one adapter missing it.

Second of several fixes from a pre-launch sync stability + UX audit ([first: #2728](https://github.com/SwitchbackTech/compass-calendar/pull/2728)).

## Test plan
- [x] New tests: 401 → transient, each quota-shaped 403 reason → transient, non-quota 403 → still readFailed
- [x] `bun packages/scripts/src/testing/test-mongo-env.ts sync --` — 860 pass, 0 fail
- [x] Full repo `bunx typescript@7.0.2 --noEmit` — clean
- [x] `biome check` on touched files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)