### PR TITLE
fix(web,sync): close the silent dead ends in the Google connect flow

### DIFF
--- a/compass.example.yaml
+++ b/compass.example.yaml
@@ -54,6 +54,7 @@ sync:
   mongoUri: mongodb+srv://compass_sync:REPLACE_WITH_SYNC_MONGO_PASSWORD@cluster/compass_sync?retryWrites=true&w=majority
   internalAuthToken: REPLACE_WITH_SYNC_INTERNAL_AUTH_TOKEN # any string; must match the value the API uses
   callbackBaseUrl: http://localhost:3010 # public base URL for provider OAuth/webhook callbacks
+  postConnectRedirectUrl: http://localhost:9080 # where the browser lands after connect/reconnect — set to web.url. Unset falls back to callbackBaseUrl (this service's own host), stranding the user there.
   serviceUrl: http://localhost:3010 # base URL the API uses to reach this service; compose uses http://sync:3010
   # cloudMutationMode: enabled # enabled (default) | maintenance — maintenance rejects cloud edits / connect with typed MAINTENANCE
   # execution: passive # passive | active — active required for OAuth begin + provider import/jobs

--- a/docs/Config/README.md
+++ b/docs/Config/README.md
@@ -84,7 +84,7 @@ database and must not share the backend's database user/data.
 | `sync.mongoUri` | Yes | Isolated Sync Mongo URI. Never point this at the API database. |
 | `sync.internalAuthToken` | Yes | Shared secret for Sync internal routes. Must match what the API uses. |
 | `sync.callbackBaseUrl` | Yes | Public base URL for provider OAuth/webhook callbacks (proxied as `/sync/*`). |
-| `sync.postConnectRedirectUrl` | No | Browser redirect after OAuth connect; defaults to `callbackBaseUrl`. |
+| `sync.postConnectRedirectUrl` | No | Browser redirect after OAuth connect. **Set this to `web.url`** — an unset value falls back to `callbackBaseUrl` (Sync's own API host), which strands the user there instead of back on the calendar. |
 | `sync.serviceUrl` | Yes | Base URL the **backend** uses to reach Sync (e.g. `http://localhost:3010`). The backend refuses to start without this and `internalAuthToken` set. |
 | `sync.cloudMutationMode` | No | `enabled` (default) or `maintenance`. Maintenance rejects cloud edits/connect with typed `MAINTENANCE` (`503`). |
 | `sync.execution` | No | `passive` (default) or `active`. Active is required for OAuth begin and provider import/jobs. |

--- a/packages/backend/src/auth/services/google/google.auth.service.db.test.ts
+++ b/packages/backend/src/auth/services/google/google.auth.service.db.test.ts
@@ -150,9 +150,12 @@ describe("googleAuthService", () => {
 
       mockDetermineGoogleAuthMode().mockResolvedValue(decision);
 
-      await expect(googleAuthService.handleGoogleAuth(success)).rejects.toThrow(
-        "Refresh token expected for new user sign-up",
-      );
+      await expect(
+        googleAuthService.handleGoogleAuth(success),
+      ).rejects.toMatchObject({
+        result: "Refresh token expected for new user sign-up",
+        code: "GOOGLE_REFRESH_TOKEN_MISSING",
+      });
     });
 
     it("routes SIGNIN to repairGoogleConnection", async () => {

--- a/packages/backend/src/auth/services/google/google.auth.service.test.ts
+++ b/packages/backend/src/auth/services/google/google.auth.service.test.ts
@@ -158,9 +158,12 @@ describe("handleGoogleAuth", () => {
         makeDecision({ authMode: "SIGNUP" }),
       );
 
-      await expect(googleAuthService.handleGoogleAuth(success)).rejects.toThrow(
-        "Refresh token expected for new user sign-up",
-      );
+      await expect(
+        googleAuthService.handleGoogleAuth(success),
+      ).rejects.toMatchObject({
+        result: "Refresh token expected for new user sign-up",
+        code: "GOOGLE_REFRESH_TOKEN_MISSING",
+      });
 
       expect(googleAuthService.googleSignup).not.toHaveBeenCalled();
       expect(adoptCalls).toHaveLength(0);

--- a/packages/backend/src/auth/services/google/google.auth.service.ts
+++ b/packages/backend/src/auth/services/google/google.auth.service.ts
@@ -249,7 +249,16 @@ async function handleGoogleAuth(success: GoogleSignInSuccess): Promise<void> {
 
       const refreshToken = oAuthTokens.refresh_token;
       if (!refreshToken) {
-        throw new Error("Refresh token expected for new user sign-up");
+        // Google omits a refresh token when this browser already consented
+        // once before (e.g. an earlier signup attempt reached Google's
+        // consent screen but failed after, before Compass finished linking).
+        // A typed, client-visible code (not a bare Error) so the web client
+        // can retry with prompt=consent instead of leaving the user stuck
+        // retrying the exact same silent-refusal forever.
+        throw error(
+          AuthError.GoogleRefreshTokenMissing,
+          "Refresh token expected for new user sign-up",
+        );
       }
 
       const persisted = await googleAuthService.googleSignup(

--- a/packages/backend/src/common/errors/auth/auth.errors.ts
+++ b/packages/backend/src/common/errors/auth/auth.errors.ts
@@ -7,6 +7,7 @@ interface AuthErrors {
   GoogleConnectEmailMismatch: ErrorMetadata;
   GoogleNotConfigured: ErrorMetadata;
   GoogleRedirectUriMismatch: ErrorMetadata;
+  GoogleRefreshTokenMissing: ErrorMetadata;
   InadequatePermissions: ErrorMetadata;
   NoGAuthAccessToken: ErrorMetadata;
   SyncConnectionUnavailable: ErrorMetadata;
@@ -40,6 +41,13 @@ export const AuthError: AuthErrors = {
   GoogleRedirectUriMismatch: {
     description: "Google redirect URI does not match this Compass instance",
     status: Status.BAD_REQUEST,
+    isOperational: true,
+  },
+  GoogleRefreshTokenMissing: {
+    code: "GOOGLE_REFRESH_TOKEN_MISSING",
+    description:
+      "Google did not grant a fresh authorization. Please try again.",
+    status: Status.CONFLICT,
     isOperational: true,
   },
   InadequatePermissions: {

--- a/packages/core/src/types/auth.types.ts
+++ b/packages/core/src/types/auth.types.ts
@@ -38,6 +38,11 @@ const GoogleConnectErrorCodeSchema = z.enum([
   "GOOGLE_ACCOUNT_ALREADY_CONNECTED",
   "GOOGLE_CONNECT_EMAIL_MISMATCH",
   "GOOGLE_NOT_CONFIGURED",
+  // Google withheld a refresh token because this browser already consented
+  // to the app before (e.g. a prior signup attempt failed after Google-side
+  // consent but before Compass finished linking). Retrying with `prompt:
+  // consent` forces Google to re-issue one.
+  "GOOGLE_REFRESH_TOKEN_MISSING",
 ]);
 
 export const GoogleConnectErrorResponseSchema = ApiErrorResponseSchema.extend({

--- a/packages/sync/src/app.ts
+++ b/packages/sync/src/app.ts
@@ -87,6 +87,17 @@ export function createSyncService(
   const readiness = new ReadinessRegistry();
   const shutdown = new ShutdownCoordinator();
 
+  // Unset POST_CONNECT_REDIRECT_URL silently falls back to this service's own
+  // CALLBACK_BASE_URL (an API host, not the web app) - every OAuth connect
+  // and reconnect would drop the browser there instead of back on the
+  // calendar. Only worth warning about in active mode: passive never
+  // completes an OAuth round-trip.
+  if (config.EXECUTION === "active" && !config.POST_CONNECT_REDIRECT_URL) {
+    logger.warn(
+      "sync.postConnectRedirectUrl is not set - Google connect/reconnect will redirect users to this service's own URL instead of the web app. Set it to the web app's origin.",
+    );
+  }
+
   // The internal connection API mounts only when storage is provided. Its
   // routes read the connected db per request, so the app is still built before
   // Mongo connects (liveness-first startup).

--- a/packages/sync/src/server/connection.routes.db.test.ts
+++ b/packages/sync/src/server/connection.routes.db.test.ts
@@ -742,6 +742,34 @@ describe("GET /sync/google", () => {
     expect(adapter.exchanges).toHaveLength(0);
   });
 
+  // Unlike the signup path (checked client-side before it ever reaches here),
+  // this callback used to link the connection regardless of what scopes
+  // Google actually granted - discovery would then 403 and the user would see
+  // a generic "couldn't update your calendar" with no mention of the real
+  // cause (leaving the calendar box unchecked on Google's consent screen).
+  it("redirects with missingScopes and links nothing when calendar access was not granted", async () => {
+    const tenantId = objectId();
+    const principalId = objectId();
+    adapter.exchangeResult = {
+      ...adapter.exchangeResult,
+      // Only identity was granted - both calendar scopes withheld.
+      grantedScopes: ["https://www.googleapis.com/auth/userinfo.email"],
+    };
+    await startService(activeConfig(), adapter);
+
+    const res = await hitCallback(
+      `code=auth-code&state=${encodeURIComponent(validState(tenantId, principalId))}`,
+    );
+
+    expect(statusOf(res)).toBe("missingScopes");
+    expect(
+      await connections.listByPrincipal(
+        tenantId as TenantId,
+        principalId as PrincipalId,
+      ),
+    ).toHaveLength(0);
+  });
+
   // Reconnect: the state names a specific connection. The account Google
   // returns must match it, or a wrong-account consent would silently spawn a
   // second connection and leave the broken one stuck.

--- a/packages/sync/src/server/connection.routes.ts
+++ b/packages/sync/src/server/connection.routes.ts
@@ -658,6 +658,21 @@ export function registerConnectionRoutes(
       return redirect("error");
     }
 
+    // Google grants a SUBSET of the requested scopes when the user unchecks
+    // one on the consent screen (e.g. leaves the calendar box unticked).
+    // Unlike the signup path (complete-google-authorization.ts, which checks
+    // client-side before ever reaching here), this route previously linked
+    // the connection anyway - discovery would then 403 and durably fail the
+    // resource, surfacing as "Couldn't update your calendar" with no mention
+    // of the actual cause. Catch it here, before any connection is created.
+    if (
+      !googleCapabilitiesFromScopes(authorization.grantedScopes).includes(
+        "readEvents",
+      )
+    ) {
+      return redirect("missingScopes");
+    }
+
     try {
       // authAdapter is non-null here (gated above); pass it so the helper needs
       // no assertion.

--- a/packages/web/src/__tests__/helpers/web-test-seams.ts
+++ b/packages/web/src/__tests__/helpers/web-test-seams.ts
@@ -47,6 +47,8 @@ export function createTestToastPort() {
   const toastUpdate = mock();
   const toastDismiss = mock();
   const toastError = mock();
+  const toastInfo = mock();
+  const toastSuccess = mock();
   const toastIsActive = mock(() => false);
 
   const toast = Object.assign(toastFn, {
@@ -54,9 +56,9 @@ export function createTestToastPort() {
     TYPE: actualReactToastify.toast.TYPE,
     dismiss: toastDismiss,
     error: toastError,
-    info: mock(),
+    info: toastInfo,
     isActive: toastIsActive,
-    success: mock(),
+    success: toastSuccess,
     update: toastUpdate,
     warning: mock(),
     warn: mock(),
@@ -75,6 +77,8 @@ export function createTestToastPort() {
       update: toastUpdate,
       dismiss: toastDismiss,
       error: toastError,
+      info: toastInfo,
+      success: toastSuccess,
       isActive: toastIsActive,
     },
   };

--- a/packages/web/src/app.bootstrap.tsx
+++ b/packages/web/src/app.bootstrap.tsx
@@ -2,8 +2,11 @@ import "react-datepicker/dist/react-datepicker.css";
 import { createRoot } from "react-dom/client";
 import "react-toastify/dist/ReactToastify.css";
 import { sessionInit } from "@web/auth/compass/session/SessionProvider";
+import {
+  readGoogleConnectStatus,
+  showGoogleConnectStatusToast,
+} from "@web/auth/google/authorization/google-connect-status.util";
 import { configureGoogleRevocationApiHandler } from "@web/auth/google/util/google-revocation-api.config";
-import { track } from "@web/auth/posthog/track";
 import {
   initializeDatabaseWithErrorHandling,
   showDbInitErrorToast,
@@ -16,13 +19,7 @@ export async function bootstrapApp(): Promise<void> {
 
   // Read before the router mounts: validateAuthSearch strips unrecognized
   // query params (like these) on the first navigation.
-  const connectParams = new URLSearchParams(window.location.search);
-  if (
-    connectParams.get("provider") === "google" &&
-    connectParams.get("status") === "connected"
-  ) {
-    track("calendar_connected");
-  }
+  const connectStatus = readGoogleConnectStatus();
 
   const container = document.getElementById("root");
   if (!container) {
@@ -39,9 +36,12 @@ export async function bootstrapApp(): Promise<void> {
 
   root.render(<App />);
 
-  // Show error toast after app renders (so toast container is available)
+  // Show toasts after app renders (so the toast container is available)
   if (dbInitError) {
     console.error(dbInitError);
     showDbInitErrorToast(dbInitError);
+  }
+  if (connectStatus) {
+    showGoogleConnectStatusToast(connectStatus);
   }
 }

--- a/packages/web/src/auth/google/authorization/complete-google-authorization.ts
+++ b/packages/web/src/auth/google/authorization/complete-google-authorization.ts
@@ -1,5 +1,6 @@
 import {
   type GoogleAuthCodeRequest,
+  type GoogleConnectErrorResponse,
   GoogleConnectErrorResponseSchema,
 } from "@core/types/auth.types";
 import { type ApiError } from "@web/api/api.types";
@@ -11,6 +12,7 @@ import {
 } from "./google-authorization.constants";
 import {
   clearGoogleAuthorizationIntent,
+  markGoogleAuthNeedsConsentRetry,
   readGoogleAuthorizationIntent,
 } from "./google-authorization.storage";
 import {
@@ -65,11 +67,13 @@ const getApiError = (error: unknown): ApiError | undefined => {
   return error as ApiError;
 };
 
-const parseGoogleConnectErrorMessage = (error: unknown): string | undefined => {
+const parseGoogleConnectError = (
+  error: unknown,
+): GoogleConnectErrorResponse | undefined => {
   const data = getApiError(error)?.response?.data;
   const parsed = GoogleConnectErrorResponseSchema.safeParse(data);
 
-  return parsed.success ? parsed.data.message : undefined;
+  return parsed.success ? parsed.data : undefined;
 };
 
 export async function completeGoogleAuthorization({
@@ -126,10 +130,19 @@ export async function completeGoogleAuthorization({
       isNewUser: result.createdNewRecipeUser,
     };
   } catch (error) {
-    const parsedMessage = parseGoogleConnectErrorMessage(error);
+    const parsedError = parseGoogleConnectError(error);
 
-    if (parsedMessage) {
-      return fail(parsedMessage, returnPath);
+    if (parsedError?.code === "GOOGLE_REFRESH_TOKEN_MISSING") {
+      // This browser already consented once before (e.g. an earlier attempt
+      // failed after Google-side consent but before Compass finished
+      // linking) - Google silently withholds the refresh token on a repeat
+      // consent. Mark it so the NEXT attempt forces prompt=consent, or it
+      // fails the exact same way forever.
+      markGoogleAuthNeedsConsentRetry();
+    }
+
+    if (parsedError?.message) {
+      return fail(parsedError.message, returnPath);
     }
 
     return fail(GOOGLE_AUTHORIZATION_ERROR_MESSAGE, returnPath);

--- a/packages/web/src/auth/google/authorization/google-authorization.storage.ts
+++ b/packages/web/src/auth/google/authorization/google-authorization.storage.ts
@@ -68,3 +68,24 @@ export function readGoogleAuthorizationIntent(
 export function clearGoogleAuthorizationIntent(state: string): void {
   sessionBrowserStore.remove(getStorageKey(state));
 }
+
+// Not keyed by state (unlike the intent above): this needs to survive INTO
+// the next authorization attempt, which mints a fresh state of its own. Set
+// when Google withholds a refresh token because this browser already
+// consented once before (GOOGLE_REFRESH_TOKEN_MISSING) - the next attempt
+// must pass prompt=consent or it fails the exact same way, forever.
+const NEEDS_CONSENT_RETRY_KEY = `${GOOGLE_AUTH_INTENT_STORAGE_PREFIX}.needsConsentRetry`;
+
+export function markGoogleAuthNeedsConsentRetry(): void {
+  sessionBrowserStore.set(NEEDS_CONSENT_RETRY_KEY, "1");
+}
+
+// Read-and-clear: the flag is consumed by exactly the next attempt, not every
+// attempt afterward.
+export function consumeGoogleAuthNeedsConsentRetry(): boolean {
+  const needsRetry = sessionBrowserStore.get(NEEDS_CONSENT_RETRY_KEY) !== null;
+  if (needsRetry) {
+    sessionBrowserStore.remove(NEEDS_CONSENT_RETRY_KEY);
+  }
+  return needsRetry;
+}

--- a/packages/web/src/auth/google/authorization/google-authorization.test.ts
+++ b/packages/web/src/auth/google/authorization/google-authorization.test.ts
@@ -1,6 +1,7 @@
 import { completeGoogleAuthorization } from "./complete-google-authorization";
 import { GOOGLE_AUTH_SCOPES_REQUIRED } from "./google-authorization.constants";
 import {
+  consumeGoogleAuthNeedsConsentRetry,
   readGoogleAuthorizationIntent,
   writeGoogleAuthorizationIntent,
 } from "./google-authorization.storage";
@@ -88,6 +89,43 @@ describe("completeGoogleAuthorization", () => {
     expect(deps.authApi.loginOrSignup).not.toHaveBeenCalled();
     expect(deps.completeAuthentication).not.toHaveBeenCalled();
     expect(readGoogleAuthorizationIntent("state-3")).toBeNull();
+  });
+
+  it("marks the next attempt for a forced consent retry when Google withheld a refresh token", async () => {
+    const deps = makeDeps();
+    deps.authApi.loginOrSignup = mock(async () => {
+      throw Object.assign(new Error("Conflict"), {
+        response: {
+          data: {
+            code: "GOOGLE_REFRESH_TOKEN_MISSING",
+            message:
+              "Google did not grant a fresh authorization. Please try again.",
+          },
+        },
+      });
+    });
+    writeGoogleAuthorizationIntent("state-4", {
+      intent: "signIn",
+      returnPath: "/week",
+      createdAt: Date.now(),
+    });
+
+    expect(consumeGoogleAuthNeedsConsentRetry()).toBe(false);
+
+    await expect(
+      completeGoogleAuthorization({
+        ...deps,
+        search: callbackSearch("state-4"),
+      }),
+    ).resolves.toEqual({
+      status: "failed",
+      message: "Google did not grant a fresh authorization. Please try again.",
+      returnPath: "/week",
+    });
+
+    // Read-and-clear: true exactly once, for the next attempt only.
+    expect(consumeGoogleAuthNeedsConsentRetry()).toBe(true);
+    expect(consumeGoogleAuthNeedsConsentRetry()).toBe(false);
   });
 
   it("rejects callbacks without a saved intent", async () => {

--- a/packages/web/src/auth/google/authorization/google-connect-status.util.test.ts
+++ b/packages/web/src/auth/google/authorization/google-connect-status.util.test.ts
@@ -1,0 +1,133 @@
+import { createTestToastPort } from "@web/__tests__/helpers/web-test-seams";
+import { registerToastPort } from "@web/common/utils/toast/toast.port";
+import {
+  readGoogleConnectStatus,
+  showGoogleConnectStatusToast,
+} from "./google-connect-status.util";
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
+
+describe("google-connect-status.util", () => {
+  const { port, mocks } = createTestToastPort();
+
+  let rafCallbacks: FrameRequestCallback[];
+  let rafSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    mocks.toast.mockClear();
+    mocks.info.mockClear();
+    mocks.success.mockClear();
+    mocks.error.mockClear();
+    registerToastPort(port);
+    rafCallbacks = [];
+    rafSpy = spyOn(globalThis, "requestAnimationFrame").mockImplementation(((
+      callback: FrameRequestCallback,
+    ) => {
+      rafCallbacks.push(callback);
+      return rafCallbacks.length;
+    }) as typeof requestAnimationFrame);
+  });
+
+  afterEach(() => {
+    rafSpy.mockRestore();
+  });
+
+  /** Flush both rAF frames used by `showGoogleConnectStatusToast`. */
+  const runToastAfterPaint = () => {
+    const first = [...rafCallbacks];
+    rafCallbacks = [];
+    for (const callback of first) callback(0);
+    const second = [...rafCallbacks];
+    rafCallbacks = [];
+    for (const callback of second) callback(0);
+  };
+
+  describe("readGoogleConnectStatus", () => {
+    it("reads connected/declined/error off a provider=google redirect", () => {
+      expect(readGoogleConnectStatus("?provider=google&status=connected")).toBe(
+        "connected",
+      );
+      expect(readGoogleConnectStatus("?provider=google&status=declined")).toBe(
+        "declined",
+      );
+      expect(readGoogleConnectStatus("?provider=google&status=error")).toBe(
+        "error",
+      );
+    });
+
+    it("reads missingScopes off a partial-grant redirect", () => {
+      expect(
+        readGoogleConnectStatus("?provider=google&status=missingScopes"),
+      ).toBe("missingScopes");
+    });
+
+    it("returns null when provider is missing or not google", () => {
+      expect(readGoogleConnectStatus("?status=connected")).toBeNull();
+      expect(
+        readGoogleConnectStatus("?provider=outlook&status=connected"),
+      ).toBeNull();
+    });
+
+    it("returns null for an unrecognized status value", () => {
+      expect(
+        readGoogleConnectStatus("?provider=google&status=pending"),
+      ).toBeNull();
+    });
+
+    it("returns null with no query string at all", () => {
+      expect(readGoogleConnectStatus("")).toBeNull();
+    });
+  });
+
+  describe("showGoogleConnectStatusToast", () => {
+    it("does nothing until the deferred paint frame runs", () => {
+      showGoogleConnectStatusToast("connected");
+      expect(mocks.toast).not.toHaveBeenCalled();
+    });
+
+    it("shows a success toast for connected", () => {
+      showGoogleConnectStatusToast("connected");
+      runToastAfterPaint();
+
+      expect(mocks.success).toHaveBeenCalledWith(
+        "Google Calendar connected.",
+        expect.objectContaining({ toastId: "google-connect-success" }),
+      );
+    });
+
+    it("shows a neutral, non-blaming toast for declined", () => {
+      showGoogleConnectStatusToast("declined");
+      runToastAfterPaint();
+
+      expect(mocks.info).toHaveBeenCalledWith(
+        "No problem - nothing was connected. You can add the account anytime from Settings.",
+        expect.objectContaining({ toastId: "google-connect-declined" }),
+      );
+    });
+
+    it("shows a scope-specific toast for missingScopes, not the generic connect-failed one", () => {
+      showGoogleConnectStatusToast("missingScopes");
+      runToastAfterPaint();
+
+      expect(mocks.error).toHaveBeenCalledWith(
+        "Compass needs calendar permission to sync. Reconnect from Settings and leave the calendar box checked.",
+        expect.objectContaining({
+          toastId: "google-connect-missing-scopes",
+          autoClose: false,
+        }),
+      );
+    });
+
+    it("shows a retryable error toast for error", () => {
+      showGoogleConnectStatusToast("error");
+      runToastAfterPaint();
+
+      expect(mocks.error).toHaveBeenCalledWith(
+        "We couldn't connect your Google account. Please try again from Settings.",
+        expect.objectContaining({
+          toastId: "google-connect-failed",
+          autoClose: false,
+        }),
+      );
+    });
+  });
+});

--- a/packages/web/src/auth/google/authorization/google-connect-status.util.ts
+++ b/packages/web/src/auth/google/authorization/google-connect-status.util.ts
@@ -1,0 +1,100 @@
+import { track } from "@web/auth/posthog/track";
+import {
+  GOOGLE_CONNECT_FAILED_TOAST_ID,
+  getToastDefaultOptions,
+} from "@web/common/constants/toast.constants";
+import { getToast } from "@web/common/utils/toast/toast.port";
+
+// Mirrors the `status` values sync/server/connection.routes.ts's
+// redirectAfterConnect can send: "connected" on a successful link, "declined"
+// when the user canceled or Google returned an error on its consent screen,
+// "missingScopes" when Google granted a subset of scopes that leaves out
+// calendar access (the box was unchecked), "error" for everything else
+// (expired OAuth state, a failed code exchange, a failed link). Anything else
+// in the URL (a stray/foreign value, or the params simply absent) is not a
+// connect redirect at all.
+export type GoogleConnectStatus =
+  | "connected"
+  | "declined"
+  | "missingScopes"
+  | "error";
+
+const CONNECT_DECLINED_TOAST_ID = "google-connect-declined";
+const CONNECT_SUCCESS_TOAST_ID = "google-connect-success";
+const CONNECT_MISSING_SCOPES_TOAST_ID = "google-connect-missing-scopes";
+
+const STATUS_VALUES: readonly GoogleConnectStatus[] = [
+  "connected",
+  "declined",
+  "missingScopes",
+  "error",
+];
+
+// Read the post-connect redirect params BEFORE the router mounts: the root
+// route's search validation strips unrecognized params (including these) on
+// the first navigation, so this has to run at bootstrap or the signal is
+// gone.
+export function readGoogleConnectStatus(
+  search = window.location.search,
+): GoogleConnectStatus | null {
+  const params = new URLSearchParams(search);
+  if (params.get("provider") !== "google") return null;
+  const status = params.get("status");
+  return (STATUS_VALUES as readonly string[]).includes(status ?? "")
+    ? (status as GoogleConnectStatus)
+    : null;
+}
+
+// Every non-success outcome of the add-account/reconnect OAuth round-trip
+// used to be a silent dead end: the user cancels on Google's consent screen,
+// or the OAuth state expires, or linking fails, and lands back on an
+// unchanged calendar with no feedback at all - the button they clicked looks
+// like it did nothing. Called once at bootstrap, immediately after
+// `root.render` - deferred a frame (like showDbInitErrorToast) so the
+// ToastContainer has mounted before the toast fires.
+export function showGoogleConnectStatusToast(
+  status: GoogleConnectStatus,
+): void {
+  requestAnimationFrame(() => {
+    requestAnimationFrame(() => fireGoogleConnectStatusToast(status));
+  });
+}
+
+function fireGoogleConnectStatusToast(status: GoogleConnectStatus): void {
+  const toast = getToast();
+  switch (status) {
+    case "connected":
+      track("calendar_connected");
+      toast.success("Google Calendar connected.", {
+        ...getToastDefaultOptions(),
+        toastId: CONNECT_SUCCESS_TOAST_ID,
+      });
+      return;
+    case "declined":
+      toast.info(
+        "No problem - nothing was connected. You can add the account anytime from Settings.",
+        { ...getToastDefaultOptions(), toastId: CONNECT_DECLINED_TOAST_ID },
+      );
+      return;
+    case "missingScopes":
+      toast.error(
+        "Compass needs calendar permission to sync. Reconnect from Settings and leave the calendar box checked.",
+        {
+          ...getToastDefaultOptions(),
+          autoClose: false,
+          toastId: CONNECT_MISSING_SCOPES_TOAST_ID,
+        },
+      );
+      return;
+    case "error":
+      toast.error(
+        "We couldn't connect your Google account. Please try again from Settings.",
+        {
+          ...getToastDefaultOptions(),
+          autoClose: false,
+          toastId: GOOGLE_CONNECT_FAILED_TOAST_ID,
+        },
+      );
+      return;
+  }
+}

--- a/packages/web/src/components/AuthModal/AuthModal.test.tsx
+++ b/packages/web/src/components/AuthModal/AuthModal.test.tsx
@@ -18,6 +18,7 @@ import {
   resetEmailPasswordPort,
 } from "@web/auth/compass/hooks/emailpassword.port";
 import { registerUseCompleteAuthenticationForTests } from "@web/auth/compass/hooks/useCompleteAuthentication.registry";
+import { markGoogleAuthNeedsConsentRetry } from "@web/auth/google/authorization/google-authorization.storage";
 import { registerUseStartGoogleAuthorizationForTests } from "@web/auth/google/authorization/useStartGoogleAuthorization";
 import {
   resetGoogleAvailabilityForTests,
@@ -29,6 +30,10 @@ import { useAuthModal, validateAuthSearch } from "./hooks/useAuthModal";
 import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
 
 const mockGoogleLogin = mock();
+const mockUseStartGoogleAuthorization = mock(() => ({
+  loading: false,
+  startGoogleAuthorization: mockGoogleLogin,
+}));
 const mockCompleteAuthentication = mock().mockResolvedValue(undefined);
 let mockEmailPassword = createTestEmailPasswordPort();
 
@@ -118,14 +123,12 @@ const renderWithDayRedirectRoute = async (initialRoute: string) => {
 
 function installAuthModalTestSeams() {
   mockGoogleLogin.mockClear();
+  mockUseStartGoogleAuthorization.mockClear();
   mockCompleteAuthentication.mockClear();
   mockCompleteAuthentication.mockResolvedValue(undefined);
   mockEmailPassword = createTestEmailPasswordPort();
 
-  registerUseStartGoogleAuthorizationForTests(() => ({
-    loading: false,
-    startGoogleAuthorization: mockGoogleLogin,
-  }));
+  registerUseStartGoogleAuthorizationForTests(mockUseStartGoogleAuthorization);
   registerUseCompleteAuthenticationForTests(() => mockCompleteAuthentication);
   registerEmailPasswordPort(mockEmailPassword);
   resetGoogleAvailabilityForTests();
@@ -134,6 +137,7 @@ function installAuthModalTestSeams() {
 
 describe("AuthModal", () => {
   beforeEach(() => {
+    sessionStorage.clear();
     installAuthModalTestSeams();
   });
 
@@ -234,6 +238,26 @@ describe("AuthModal", () => {
       await waitFor(() => {
         expect(router.state.location.searchStr).toBe("");
       });
+    });
+  });
+
+  describe("Google retry after a withheld refresh token", () => {
+    it("does not force prompt=consent on a normal mount", async () => {
+      await renderWithProviders(<ModalTrigger />);
+
+      expect(mockUseStartGoogleAuthorization).toHaveBeenCalledWith(
+        expect.objectContaining({ prompt: undefined }),
+      );
+    });
+
+    it("forces prompt=consent once, after Google withheld a refresh token on the prior attempt", async () => {
+      markGoogleAuthNeedsConsentRetry();
+
+      await renderWithProviders(<ModalTrigger />);
+
+      expect(mockUseStartGoogleAuthorization).toHaveBeenCalledWith(
+        expect.objectContaining({ prompt: "consent" }),
+      );
     });
   });
 

--- a/packages/web/src/components/AuthModal/AuthModal.tsx
+++ b/packages/web/src/components/AuthModal/AuthModal.tsx
@@ -1,6 +1,7 @@
 import { DotIcon } from "@phosphor-icons/react";
 import { useSearch } from "@tanstack/react-router";
 import { type FC, useCallback, useEffect, useRef, useState } from "react";
+import { consumeGoogleAuthNeedsConsentRetry } from "@web/auth/google/authorization/google-authorization.storage";
 import { useStartGoogleAuthorization } from "@web/auth/google/authorization/useStartGoogleAuthorization";
 import { useIsGoogleAvailable } from "@web/auth/google/hooks/useIsGoogleAvailable/useIsGoogleAvailable";
 import {
@@ -43,9 +44,15 @@ export const AuthModal: FC = () => {
   const handleGoogleAuthStart = useCallback(() => {
     dismissErrorToast(SESSION_EXPIRED_TOAST_ID);
   }, []);
+  // Consumed once per fresh mount (i.e. once per return from a failed
+  // attempt): Google withholds a refresh token on a repeat consent, so a
+  // signup that failed after Google-side consent but before Compass finished
+  // linking would otherwise fail the exact same way on every retry, forever.
+  const [needsConsentRetry] = useState(consumeGoogleAuthNeedsConsentRetry);
   const googleAuth = useStartGoogleAuthorization({
     intent: "signIn",
     onStart: handleGoogleAuthStart,
+    prompt: needsConsentRetry ? "consent" : undefined,
   });
   const {
     loading: isGoogleAuthLoading,

--- a/self-host/compass.example.yaml
+++ b/self-host/compass.example.yaml
@@ -52,6 +52,9 @@ sync:
   mongoUri: mongodb://compass:REPLACE_WITH_MONGO_PASSWORD@mongo:27017/compass_sync?authSource=admin&replicaSet=rs0
   internalAuthToken: REPLACE_WITH_SYNC_INTERNAL_AUTH_TOKEN # any string; must match the value the API uses
   callbackBaseUrl: REPLACE_WITH_YOUR_WEB_URL # public base URL for provider OAuth/webhook callbacks; needs a real domain for Google to deliver push notifications, localhost works for OAuth only
+  # postConnectRedirectUrl not needed here: this topology's callbackBaseUrl IS
+  # the web app's own public URL (routed to sync via /sync/*), so the default
+  # fallback already lands the browser back on the calendar after connect.
   serviceUrl: http://sync:3010 # base URL the API uses to reach this service
   cloudMutationMode: enabled # enabled (default) | maintenance — maintenance rejects cloud edits / connect with typed MAINTENANCE
   execution: active


### PR DESCRIPTION
## Summary

Every non-success outcome of the add-account/reconnect OAuth round-trip was a silent dead end: the user cancels on Google's consent screen, the OAuth state expires, or linking fails, and lands back on an unchanged calendar with zero feedback — the button they clicked looks like it did nothing. This is plausibly the single most likely thing to make a first-time user think the product is broken.

- `app.bootstrap.tsx` now reads the sync callback's `status` (`connected`/`declined`/`missingScopes`/`error`) and shows a matching toast, instead of only firing an analytics event on success.
- The sync-owned callback (add-account/reconnect) previously linked a connection regardless of granted scopes; discovery would then 403 and the user would see a generic "couldn't update your calendar" with no mention of the real cause (unchecking the calendar box on Google's consent screen). It now checks capabilities before linking and redirects `missingScopes` with dedicated copy.
- `POST_CONNECT_REDIRECT_URL` silently fell back to the sync service's own URL (an API host, not the web app) when unset — documented in `compass.example.yaml`/docs, and sync now warns loudly at startup in active mode if it's missing.
- The signup path could permanently lock a new user out after one failed attempt: Google withholds a refresh token on a repeat consent, and the retry never passed `prompt=consent`. The backend now returns a typed `GOOGLE_REFRESH_TOKEN_MISSING` code (previously a bare `Error`), and the web client uses it to force `prompt=consent` on exactly the next attempt.

Third of several fixes from a pre-launch sync stability + UX audit (first: #2728, second: #2729).

## Test plan
- [x] New tests: connect-status toast util (10 cases), sync callback `missingScopes` redirect + no-connection-created, signup consent-retry flag lifecycle, `AuthModal` passes `prompt=consent` only after the flag is set
- [x] Updated 2 backend tests to assert the new typed error shape (`result`/`code`) instead of a bare message
- [x] Full suites: sync 858 pass, backend 297 pass (1 skip), web 2004 pass — all 0 fail
- [x] Full repo `bun run type-check` — clean
- [x] `biome check` on all touched files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)