### PR TITLE
fix(web): stop the UI from claiming stale sync state is current

### DIFF
--- a/packages/web/src/auth/compass/user/util/user-metadata.util.test.ts
+++ b/packages/web/src/auth/compass/user/util/user-metadata.util.test.ts
@@ -1,0 +1,66 @@
+import { type UserMetadata } from "@core/types/user.types";
+import { createTestToastPort } from "@web/__tests__/helpers/web-test-seams";
+import { resetGoogleReconnectRequiredForTests } from "@web/auth/google/state/google.reconnect.state";
+import { GOOGLE_DELAYED_TOAST_ID } from "@web/common/constants/toast.constants";
+import { registerToastPort } from "@web/common/utils/toast/toast.port";
+import { applyUserMetadataSideEffects } from "./user-metadata.util";
+import { beforeEach, describe, expect, it } from "bun:test";
+
+const healthy: UserMetadata = { google: { connectionState: "HEALTHY" } };
+const attention: UserMetadata = { google: { connectionState: "ATTENTION" } };
+
+describe("applyUserMetadataSideEffects - delayed toast lifecycle", () => {
+  const { port, mocks } = createTestToastPort();
+
+  beforeEach(() => {
+    mocks.error.mockClear();
+    mocks.dismiss.mockClear();
+    registerToastPort(port);
+    resetGoogleReconnectRequiredForTests();
+  });
+
+  it("shows the delayed toast on ATTENTION", () => {
+    applyUserMetadataSideEffects(attention);
+
+    expect(mocks.error).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ toastId: GOOGLE_DELAYED_TOAST_ID }),
+    );
+  });
+
+  it("does not re-show the toast on a repeated ATTENTION payload", () => {
+    applyUserMetadataSideEffects(attention);
+    mocks.error.mockClear();
+
+    applyUserMetadataSideEffects(attention);
+
+    expect(mocks.error).not.toHaveBeenCalled();
+  });
+
+  it("dismisses the toast once the connection recovers", () => {
+    applyUserMetadataSideEffects(attention);
+
+    applyUserMetadataSideEffects(healthy);
+
+    expect(mocks.dismiss).toHaveBeenCalledWith(GOOGLE_DELAYED_TOAST_ID);
+  });
+
+  it("does not dismiss the delayed toast on recovery if it was never shown", () => {
+    applyUserMetadataSideEffects(healthy);
+
+    expect(mocks.dismiss).not.toHaveBeenCalledWith(GOOGLE_DELAYED_TOAST_ID);
+  });
+
+  it("shows the toast again for a later, separate ATTENTION episode after recovering", () => {
+    applyUserMetadataSideEffects(attention);
+    applyUserMetadataSideEffects(healthy);
+    mocks.error.mockClear();
+
+    applyUserMetadataSideEffects(attention);
+
+    expect(mocks.error).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ toastId: GOOGLE_DELAYED_TOAST_ID }),
+    );
+  });
+});

--- a/packages/web/src/auth/compass/user/util/user-metadata.util.ts
+++ b/packages/web/src/auth/compass/user/util/user-metadata.util.ts
@@ -10,7 +10,10 @@ import {
   findPrimaryGoogleSyncConnectionFromMetadata,
   userMetadataActions,
 } from "@web/auth/state/user-metadata.store";
-import { showGoogleDelayedToast } from "@web/common/utils/toast/google-delayed.toast";
+import {
+  dismissGoogleDelayedToast,
+  showGoogleDelayedToast,
+} from "@web/common/utils/toast/google-delayed.toast";
 import {
   clearGoogleReconnectToastGate,
   dismissGoogleReconnectToast,
@@ -60,12 +63,17 @@ export const applyUserMetadataSideEffects = (metadata: UserMetadata): void => {
     clearGoogleReconnectToastGate();
   }
 
-  if (
-    metadata.google?.connectionState === "ATTENTION" &&
-    !hasShownDelayedToastThisLoad
-  ) {
-    hasShownDelayedToastThisLoad = true;
-    showGoogleDelayedToast();
+  if (metadata.google?.connectionState === "ATTENTION") {
+    if (!hasShownDelayedToastThisLoad) {
+      hasShownDelayedToastThisLoad = true;
+      showGoogleDelayedToast();
+    }
+  } else if (hasShownDelayedToastThisLoad) {
+    // Recovered: a CRITICAL toast (autoClose: false) never closes on its
+    // own, so leaving it up would contradict its own "delayed" copy once
+    // the connection is healthy again.
+    hasShownDelayedToastThisLoad = false;
+    dismissGoogleDelayedToast();
   }
 };
 

--- a/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.util.ts
+++ b/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.util.ts
@@ -39,6 +39,15 @@ const CONNECTED_STATUS: SyncStatus = {
   text: "Calendar connected",
 };
 
+// Shown instead of CONNECTED_STATUS (never over a reconnect/attention/syncing
+// status - those already say something more urgent) when the live SSE stream
+// has been down long enough that "connected" and its freshness timestamp can
+// no longer be trusted. See useSseDegraded / sse.client.ts.
+export const SSE_DEGRADED_STATUS: SyncStatus = {
+  variant: "warning",
+  text: "Reconnecting live updates…",
+};
+
 // Plain backlog under this age stays silent in the sidebar and reads as
 // connected in Settings. Matches the short provider-error delay band so a
 // freshly clicked Refresh does not invent its own warning.

--- a/packages/web/src/common/constants/toast.constants.ts
+++ b/packages/web/src/common/constants/toast.constants.ts
@@ -17,6 +17,7 @@ export const ACCOUNT_DISCONNECTED_TOAST_ID: Id = "account-disconnected";
 export const SUBSCRIBE_TO_UPDATES_TOAST_ID: Id = "subscribe-to-updates";
 export const EXPORT_MY_DATA_TOAST_ID: Id = "export-my-data";
 export const LOGGED_OUT_TOAST_ID: Id = "logged-out";
+export const EVENT_SAVE_UNAVAILABLE_TOAST_ID: Id = "event-save-unavailable";
 
 const toastPalette: Record<
   ThemeName,

--- a/packages/web/src/common/utils/event/event.util.test.ts
+++ b/packages/web/src/common/utils/event/event.util.test.ts
@@ -3,7 +3,10 @@ import { Status } from "@core/errors/status.codes";
 import { createMockStandaloneEvent } from "@core/util/test/ccal.event.factory";
 import { createTestToastPort } from "@web/__tests__/helpers/web-test-seams";
 import { type ApiError, type ApiResponse } from "@web/api/api.types";
-import { GENERIC_ERROR_TOAST_ID } from "@web/common/constants/toast.constants";
+import {
+  EVENT_SAVE_UNAVAILABLE_TOAST_ID,
+  GENERIC_ERROR_TOAST_ID,
+} from "@web/common/constants/toast.constants";
 import { type GridEvent } from "@web/common/types/web.event.types";
 import {
   addId,
@@ -62,14 +65,25 @@ describe("handleError", () => {
     consoleErrorSpy.mockRestore();
   });
 
-  it("does not log backend-unavailable errors", () => {
+  it("shows a distinct toast on a backend-unavailable error instead of silently reverting", () => {
+    // No `response` at all: the browser never got an HTTP response back
+    // (offline, DNS, dropped connection) - previously this returned early
+    // with zero feedback and the optimistic edit just snapped back.
     const error = new Error("Request failed");
     error.name = "ApiError";
 
     handleError(error);
 
     expect(consoleErrorSpy).not.toHaveBeenCalled();
-    expect(mocks.error).not.toHaveBeenCalled();
+    expect(mockCaptureException).not.toHaveBeenCalled();
+    expect(mocks.error).toHaveBeenCalledTimes(1);
+    expect(mocks.error.mock.calls[0]?.[1]).toMatchObject({
+      toastId: EVENT_SAVE_UNAVAILABLE_TOAST_ID,
+    });
+    // Distinct from the generic catchall - a save failure and a generic
+    // backend error are different situations and must not dedupe on the
+    // same toastId.
+    expect(EVENT_SAVE_UNAVAILABLE_TOAST_ID).not.toBe(GENERIC_ERROR_TOAST_ID);
   });
 
   it("logs once and does not reload on a server error", () => {

--- a/packages/web/src/common/utils/event/event.util.ts
+++ b/packages/web/src/common/utils/event/event.util.ts
@@ -12,7 +12,10 @@ import { type ApiError } from "@web/api/api.types";
 import { isBackendUnavailableError } from "@web/api/util/backend-unavailable-error.util";
 import { getUserId } from "@web/auth/compass/session/session.util";
 import { getPosthogClient } from "@web/auth/posthog/posthog.bootstrap";
-import { GENERIC_ERROR_TOAST_ID } from "@web/common/constants/toast.constants";
+import {
+  EVENT_SAVE_UNAVAILABLE_TOAST_ID,
+  GENERIC_ERROR_TOAST_ID,
+} from "@web/common/constants/toast.constants";
 import { type PartialMouseEvent } from "@web/common/types/util.types";
 import {
   Categories_Event,
@@ -219,6 +222,16 @@ const showCatchallToast = (message: string) =>
 
 export const handleError = (error: Error) => {
   if (isBackendUnavailableError(error)) {
+    // No HTTP response reached us at all (offline, DNS, dropped connection)
+    // or a 502/503/504 - the optimistic edit is about to roll back with
+    // nothing else on screen to explain why. The BackendDownView full-page
+    // gate only covers a SUSTAINED outage (and only for authenticated users);
+    // this covers the single failed save, including a transient blip that
+    // never trips the page-level gate at all.
+    showErrorToast(
+      "Couldn't save - check your connection. Your change was not applied.",
+      { toastId: EVENT_SAVE_UNAVAILABLE_TOAST_ID },
+    );
     return;
   }
 

--- a/packages/web/src/common/utils/toast/google-delayed.toast.tsx
+++ b/packages/web/src/common/utils/toast/google-delayed.toast.tsx
@@ -52,3 +52,10 @@ export function showGoogleDelayedToast(): Id {
     },
   );
 }
+
+// The toast is CRITICAL severity (autoClose: false, closeOnClick: false) so
+// it never disappears on its own - without this, it can sit on screen after
+// the connection is healthy again, contradicting its own "delayed" copy.
+export function dismissGoogleDelayedToast(): void {
+  getToast().dismiss(GOOGLE_DELAYED_TOAST_ID);
+}

--- a/packages/web/src/components/Settings/SettingsModal.test.tsx
+++ b/packages/web/src/components/Settings/SettingsModal.test.tsx
@@ -81,14 +81,25 @@ mock.module("@web/auth/compass/session/useSession", () => ({
       : actualUseSession(...args),
 }));
 
+let isSseDegraded = false;
+let isSseDegradedMocked = true;
+const actualUseSseDegraded = (await import("@web/sse/hooks/useSseDegraded"))
+  .useSseDegraded;
+mock.module("@web/sse/hooks/useSseDegraded", () => ({
+  useSseDegraded: () =>
+    isSseDegradedMocked ? isSseDegraded : actualUseSseDegraded(),
+}));
+
 afterAll(() => {
   isLogoutConfirmationMocked = false;
   isSessionMocked = false;
+  isSseDegradedMocked = false;
 });
 
 afterEach(() => {
   mockOpenLogoutConfirmation.mockClear();
   resetGoogleReconnectRequiredForTests();
+  isSseDegraded = false;
 });
 
 const settingsModalUrl = new URL(
@@ -178,6 +189,32 @@ describe("SettingsModal", () => {
     });
 
     expect(screen.getByText("Calendar needs reconnecting")).toBeInTheDocument();
+  });
+
+  it("replaces 'Calendar connected' with a live-updates warning when SSE is degraded", () => {
+    isSseDegraded = true;
+    renderSettings({ connections: [connection()] });
+
+    expect(screen.queryByText("Calendar connected")).not.toBeInTheDocument();
+    expect(screen.getByText("Reconnecting live updates…")).toBeInTheDocument();
+  });
+
+  it("does not let the live-updates warning preempt a real reconnect problem", () => {
+    isSseDegraded = true;
+    renderSettings({
+      connections: [
+        connection({
+          state: "actionRequired",
+          stateReason: "authorizationRevoked",
+          connectionState: "RECONNECT_REQUIRED",
+        }),
+      ],
+    });
+
+    expect(screen.getByText("Calendar needs reconnecting")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Reconnecting live updates…"),
+    ).not.toBeInTheDocument();
   });
 
   it("asks for confirmation before disconnecting", async () => {

--- a/packages/web/src/components/Settings/SettingsModal.tsx
+++ b/packages/web/src/components/Settings/SettingsModal.tsx
@@ -8,6 +8,7 @@ import {
   formatLastSyncedLabel,
   getGoogleSyncStatus,
   googleSyncSupportMailto,
+  SSE_DEGRADED_STATUS,
 } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle.util";
 import { useDisconnectGoogleAccount } from "@web/auth/google/hooks/useDisconnectGoogleAccount";
 import { useGoogleSyncRefreshSnapshot } from "@web/auth/google/state/google.sync.refresh";
@@ -47,6 +48,7 @@ import {
   useSettingsStore,
 } from "@web/settings/settings.store";
 import { useAppLockReason } from "@web/shortcuts/app-lock";
+import { useSseDegraded } from "@web/sse/hooks/useSseDegraded";
 
 const OUTLINE_BUTTON_CLASSNAME =
   "c-focus-ring shrink-0 rounded border border-border bg-surface-overlay px-2 py-1 text-xs text-text transition-colors hover:bg-surface-panel disabled:pointer-events-none disabled:opacity-60";
@@ -310,7 +312,8 @@ const AccountRow: FC<AccountRowProps> = ({
 }) => {
   const accountEmail = connection.accountEmail ?? "Unknown account";
   const refreshSnapshot = useGoogleSyncRefreshSnapshot();
-  const status = getGoogleSyncStatus(
+  const sseDegraded = useSseDegraded();
+  const syncStatus = getGoogleSyncStatus(
     connection.connectionState ?? "NOT_CONNECTED",
     connection,
     Date.now(),
@@ -319,7 +322,19 @@ const AccountRow: FC<AccountRowProps> = ({
       refreshInFlight: refreshSnapshot.isRefreshing,
     },
   );
-  const lastSyncedLabel = formatLastSyncedLabel(connection.lastSyncedAt);
+  // Only override an otherwise-healthy "Calendar connected" - a real
+  // reconnect/attention/importing status already says something more
+  // important and must not be preempted by the live-updates warning.
+  const isOtherwiseHealthy = syncStatus?.variant === "healthy";
+  const status =
+    isOtherwiseHealthy && sseDegraded ? SSE_DEGRADED_STATUS : syncStatus;
+  // The "Updated N minutes ago" freshness claim is exactly the thing that
+  // goes silently stale on a dead SSE stream - suppress it rather than
+  // presenting last-known data as current.
+  const lastSyncedLabel =
+    isOtherwiseHealthy && sseDegraded
+      ? null
+      : formatLastSyncedLabel(connection.lastSyncedAt);
   const confirmButtonRef = useRef<HTMLButtonElement>(null);
   const disconnectButtonRef = useRef<HTMLButtonElement>(null);
   const wasConfirmingRef = useRef(isConfirming);

--- a/packages/web/src/components/Sidebar/SidebarStatusBar.test.tsx
+++ b/packages/web/src/components/Sidebar/SidebarStatusBar.test.tsx
@@ -46,8 +46,18 @@ mock.module("@web/auth/google/hooks/useConnectGoogle/useConnectGoogle", () => ({
 // later/parallel suites (LifeView hung under CI). The real coordinator
 // starts idle, which is what these cases need.
 
+let isSseDegraded = false;
+let isSseDegradedMocked = true;
+const actualUseSseDegraded = (await import("@web/sse/hooks/useSseDegraded"))
+  .useSseDegraded;
+mock.module("@web/sse/hooks/useSseDegraded", () => ({
+  useSseDegraded: () =>
+    isSseDegradedMocked ? isSseDegraded : actualUseSseDegraded(),
+}));
+
 afterAll(() => {
   isConnectGoogleMocked = false;
+  isSseDegradedMocked = false;
 });
 
 const statusBarModuleUrl = new URL(
@@ -63,6 +73,7 @@ describe("SidebarStatusBar", () => {
     googleState = "HEALTHY";
     isConnecting = false;
     connection = null;
+    isSseDegraded = false;
   });
 
   it("shows 'Saving changes…' when a mutation is pending", () => {
@@ -211,5 +222,45 @@ describe("SidebarStatusBar", () => {
     render(<SidebarStatusBar />, { wrapper });
 
     expect(screen.getByRole("status").textContent).toBe("");
+  });
+
+  it("shows a live-updates warning when SSE is degraded and sync is otherwise silent", () => {
+    googleState = "HEALTHY";
+    isSseDegraded = true;
+    const { wrapper } = createStoreWrapper();
+
+    render(<SidebarStatusBar />, { wrapper });
+
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Reconnecting live updates…",
+    );
+  });
+
+  it("does not let the live-updates warning preempt a real sync problem", () => {
+    googleState = "ATTENTION";
+    isSseDegraded = true;
+    connection = createMockConnection("ahab@pequod.com", {
+      state: "delayed",
+      stateReason: "workOverdue",
+      connectionState: "ATTENTION",
+    });
+    const { wrapper } = createStoreWrapper();
+
+    render(<SidebarStatusBar />, { wrapper });
+
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Calendar updates are delayed",
+    );
+    expect(screen.queryByText("Reconnecting live updates…")).toBeNull();
+  });
+
+  it("prefers 'Saving changes…' over the live-updates warning when both are true", () => {
+    isSseDegraded = true;
+    const { queryClient, wrapper } = createStoreWrapper();
+    seedPendingEventMutations(queryClient, ["event-1"]);
+
+    render(<SidebarStatusBar />, { wrapper });
+
+    expect(screen.getByRole("status")).toHaveTextContent("Saving changes…");
   });
 });

--- a/packages/web/src/components/Sidebar/SidebarStatusBar.tsx
+++ b/packages/web/src/components/Sidebar/SidebarStatusBar.tsx
@@ -1,6 +1,9 @@
 import { type FC } from "react";
 import { useConnectGoogle } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle";
-import { getSidebarSyncStatus } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle.util";
+import {
+  getSidebarSyncStatus,
+  SSE_DEGRADED_STATUS,
+} from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle.util";
 import { useGoogleSyncRefreshSnapshot } from "@web/auth/google/state/google.sync.refresh";
 import { SYNC_STATUS_VARIANT_CLASSNAME } from "@web/calendars/sync-status.types";
 import { useHasPendingEventMutations } from "@web/events/mutations/useEventPending";
@@ -22,6 +25,7 @@ import {
   selectEventJumpAnnouncement,
   useEventJumpStore,
 } from "@web/shortcuts/shift-hint/event-jump.store";
+import { useSseDegraded } from "@web/sse/hooks/useSseDegraded";
 
 /**
  * Pinned status bar at the bottom of the sidebar, just above the actions bar.
@@ -51,15 +55,20 @@ export const SidebarStatusBar: FC = () => {
   // established and should stay quiet.
   const { connection, isConnecting, state } = useConnectGoogle();
   const refreshSnapshot = useGoogleSyncRefreshSnapshot();
+  const sseDegraded = useSseDegraded();
+  const syncStatus = getSidebarSyncStatus({
+    connection,
+    isConnecting,
+    state,
+    refreshGaveUp: refreshSnapshot.gaveUp,
+    refreshInFlight: refreshSnapshot.isRefreshing,
+  });
+  // sseDegraded only fills in when sync itself has nothing to say (a silent
+  // "healthy" null) - a real reconnect/attention/importing status is always
+  // more useful and must not be preempted by the live-updates warning.
   const status = isSaving
     ? { variant: "syncing" as const, text: "Saving changes…" }
-    : getSidebarSyncStatus({
-        connection,
-        isConnecting,
-        state,
-        refreshGaveUp: refreshSnapshot.gaveUp,
-        refreshInFlight: refreshSnapshot.isRefreshing,
-      });
+    : (syncStatus ?? (sseDegraded ? SSE_DEGRADED_STATUS : null));
 
   const text = status?.text ?? "";
 

--- a/packages/web/src/sse/client/sse.client.test.ts
+++ b/packages/web/src/sse/client/sse.client.test.ts
@@ -1,0 +1,153 @@
+import {
+  closeStream,
+  isSseDegraded,
+  openStream,
+  subscribeSseDegraded,
+} from "./sse.client";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  mock,
+} from "bun:test";
+
+// Minimal EventSource fake: no network, just enough surface for sse.client's
+// addEventListener/removeEventListener/close and readyState check.
+class FakeEventSource {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSED = 2;
+
+  readyState = FakeEventSource.CONNECTING;
+  #listeners = new Map<string, Set<(event: unknown) => void>>();
+
+  addEventListener(type: string, listener: (event: unknown) => void): void {
+    let set = this.#listeners.get(type);
+    if (!set) {
+      set = new Set();
+      this.#listeners.set(type, set);
+    }
+    set.add(listener);
+  }
+
+  removeEventListener(type: string, listener: (event: unknown) => void): void {
+    this.#listeners.get(type)?.delete(listener);
+  }
+
+  close(): void {
+    this.readyState = FakeEventSource.CLOSED;
+  }
+
+  dispatch(type: string, event: unknown = {}): void {
+    for (const listener of this.#listeners.get(type) ?? []) {
+      listener(event);
+    }
+  }
+}
+
+describe("sse.client degraded state", () => {
+  const originalEventSource = globalThis.EventSource;
+  const originalSetTimeout = globalThis.setTimeout;
+  let fakeEs: FakeEventSource;
+  let timerCallbacks: Array<{ callback: () => void; delayMs: number }>;
+  let setTimeoutSpy: ReturnType<typeof mock>;
+
+  afterAll(() => {
+    globalThis.EventSource = originalEventSource;
+    globalThis.setTimeout = originalSetTimeout;
+  });
+
+  beforeEach(() => {
+    fakeEs = new FakeEventSource();
+    // @ts-expect-error test double, not a full EventSource
+    globalThis.EventSource = Object.assign(
+      mock(() => fakeEs),
+      {
+        CONNECTING: FakeEventSource.CONNECTING,
+        OPEN: FakeEventSource.OPEN,
+        CLOSED: FakeEventSource.CLOSED,
+      },
+    );
+
+    timerCallbacks = [];
+    setTimeoutSpy = mock((callback: () => void, delayMs: number) => {
+      timerCallbacks.push({ callback, delayMs });
+      return timerCallbacks.length;
+    });
+    // @ts-expect-error partial override, only setTimeout is invoked by name here
+    globalThis.setTimeout = setTimeoutSpy;
+  });
+
+  afterEach(() => {
+    closeStream();
+  });
+
+  const runDegradedTimer = () => {
+    const due = timerCallbacks.find((t) => t.delayMs === 15_000);
+    due?.callback();
+  };
+
+  it("starts not degraded", () => {
+    expect(isSseDegraded()).toBe(false);
+  });
+
+  it("flips degraded once the stream has been down past the 15s window", () => {
+    openStream();
+    fakeEs.dispatch("error");
+
+    expect(isSseDegraded()).toBe(false);
+
+    runDegradedTimer();
+
+    expect(isSseDegraded()).toBe(true);
+  });
+
+  it("does not report degraded if the stream reopens before the window elapses", () => {
+    openStream();
+    fakeEs.dispatch("error");
+    fakeEs.readyState = FakeEventSource.OPEN;
+    fakeEs.dispatch("open");
+
+    runDegradedTimer();
+
+    expect(isSseDegraded()).toBe(false);
+  });
+
+  it("notifies subscribers when degraded flips", () => {
+    const onChange = mock();
+    const unsubscribe = subscribeSseDegraded(onChange);
+
+    openStream();
+    fakeEs.dispatch("error");
+    runDegradedTimer();
+
+    expect(onChange).toHaveBeenCalled();
+    unsubscribe();
+  });
+
+  it("clears degraded on reconnect (open event)", () => {
+    openStream();
+    fakeEs.dispatch("error");
+    runDegradedTimer();
+    expect(isSseDegraded()).toBe(true);
+
+    fakeEs.readyState = FakeEventSource.OPEN;
+    fakeEs.dispatch("open");
+
+    expect(isSseDegraded()).toBe(false);
+  });
+
+  it("clears degraded when the stream is intentionally closed", () => {
+    openStream();
+    fakeEs.dispatch("error");
+    runDegradedTimer();
+    expect(isSseDegraded()).toBe(true);
+
+    closeStream();
+
+    expect(isSseDegraded()).toBe(false);
+  });
+});

--- a/packages/web/src/sse/client/sse.client.ts
+++ b/packages/web/src/sse/client/sse.client.ts
@@ -5,6 +5,7 @@ import {
 } from "@core/types/server-message.contracts";
 import { getPosthogClient } from "@web/auth/posthog/posthog.bootstrap";
 import { ENV_WEB } from "@web/common/constants/env.constants";
+import { createExternalStore } from "@web/common/utils/external-store.util";
 
 // The backend publishes one `message` SSE event per B10; its JSON `data` is a
 // ServerMessageSchema member. This module is the single parse point: every
@@ -38,6 +39,21 @@ let hasReportedDegraded = false;
 
 const DEGRADED_AFTER_MS = 15_000;
 
+// Whether the live stream has been down long enough that displayed data can
+// no longer be trusted as fresh. Previously this was analytics-only
+// (sse_connection_degraded, PostHog) with no UI representation at all: a tab
+// with a dead stream kept showing "Calendar connected" and a "Updated N
+// minutes ago" timestamp that both silently stopped being true.
+const sseDegradedStore = createExternalStore(false);
+
+export function isSseDegraded(): boolean {
+  return sseDegradedStore.get();
+}
+
+export function subscribeSseDegraded(onChange: () => void): () => void {
+  return sseDegradedStore.subscribe(onChange);
+}
+
 function clearDegradedTimer() {
   if (degradedTimer !== null) {
     clearTimeout(degradedTimer);
@@ -46,6 +62,7 @@ function clearDegradedTimer() {
 }
 
 function reportSseDegraded() {
+  sseDegradedStore.set(true);
   if (hasReportedDegraded) return;
   hasReportedDegraded = true;
   getPosthogClient()?.capture("sse_connection_degraded", {
@@ -93,6 +110,7 @@ export const openStream = (): EventSource => {
   openHandler = () => {
     clearDegradedTimer();
     hasReportedDegraded = false;
+    sseDegradedStore.set(false);
     for (const listener of reopenListeners) {
       listener();
     }
@@ -109,6 +127,7 @@ export const openStream = (): EventSource => {
 
 export const closeStream = (): void => {
   clearDegradedTimer();
+  sseDegradedStore.set(false);
   if (es && forwardingHandler) {
     es.removeEventListener(SSE_MESSAGE_EVENT, forwardingHandler);
   }

--- a/packages/web/src/sse/hooks/useSseDegraded.ts
+++ b/packages/web/src/sse/hooks/useSseDegraded.ts
@@ -1,0 +1,15 @@
+import { useSyncExternalStore } from "react";
+import {
+  isSseDegraded,
+  subscribeSseDegraded,
+} from "@web/sse/client/sse.client";
+
+/**
+ * Whether the live SSE stream has been down long enough that displayed data
+ * can no longer be trusted as fresh. Surfaces sse.client's previously
+ * analytics-only degraded signal to the UI, so a dead stream on an open tab
+ * doesn't keep claiming "Calendar connected" / "Updated N minutes ago".
+ */
+export function useSseDegraded(): boolean {
+  return useSyncExternalStore(subscribeSseDegraded, isSseDegraded);
+}


### PR DESCRIPTION
## Summary

Three places the sync-status UI kept telling users something was true after it had stopped being true:

- **SSE degradation was analytics-only.** `sse_connection_degraded` fired to PostHog with no UI representation at all — a tab with a dead live-updates stream kept showing "Calendar connected" in the sidebar and "Calendar connected / Updated N minutes ago" in Settings indefinitely. `sse.client.ts` now exposes the existing degraded signal through an external store + `useSseDegraded()` hook; the sidebar and Settings both show "Reconnecting live updates…" instead, but **only** when they'd otherwise be silently "healthy" — a real reconnect/attention/importing status is never preempted. Settings also suppresses the "Updated N minutes ago" freshness claim while degraded.
- **Backend-unavailable write failures were silent.** Offline, DNS failure, dropped connection, or a 502/503/504 returned early with zero feedback — the optimistic edit visibly snapped back with no explanation. `handleError` now shows a dedicated toast.
- **The CRITICAL "Calendar updates are delayed" toast never dismissed on recovery.** It's `autoClose: false` and was only ever shown once per page load with no dismiss path — it could sit on screen long after the connection recovered. `applyUserMetadataSideEffects` now dismisses it (and resets the show-once gate) as soon as the connection leaves ATTENTION.

Fourth of several fixes from a pre-launch sync stability + UX audit (first: #2728, second: #2729, third: #2731).

## Test plan
- [x] New tests: `sse.client` degraded-state lifecycle (6 cases, fake EventSource), sidebar + Settings SSE-degraded override (preserves precedence over real problems), `handleError` backend-unavailable toast, delayed-toast show/dismiss/re-show lifecycle
- [x] Full suites: sync 860 pass, backend 297 pass (1 skip), web 2039 pass — all 0 fail
- [x] Full repo `bun run type-check` — clean
- [x] `biome check` on all touched files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)