### PR TITLE
fix(web): stop the import overlay lying to established users, name the account

### DIFF
--- a/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.util.test.ts
+++ b/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.util.test.ts
@@ -1,9 +1,11 @@
+import { type GoogleSyncConnectionSummary } from "@core/types/user.types";
 import {
   formatLastSyncedLabel,
   formatLastUpdatedClause,
   getGoogleConnectionConfig,
   getGoogleSyncStatus,
   getSidebarSyncStatus,
+  isFirstImportInProgress,
 } from "./useConnectGoogle.util";
 import { beforeEach, describe, expect, it, mock } from "bun:test";
 
@@ -368,7 +370,7 @@ describe("getSidebarSyncStatus", () => {
     });
   });
 
-  it("shows Calendar needs reconnecting for actionRequired", () => {
+  it("names the account for actionRequired, so multiple accounts don't collapse into one anonymous warning", () => {
     expect(
       getSidebarSyncStatus({
         connection: {
@@ -386,8 +388,99 @@ describe("getSidebarSyncStatus", () => {
       }),
     ).toEqual({
       variant: "error",
+      text: "a@example.com needs reconnecting",
+    });
+  });
+
+  it("falls back to the generic reconnect text with no account email to name", () => {
+    expect(
+      getSidebarSyncStatus({
+        connection: {
+          id: "c1",
+          state: "actionRequired",
+          stateReason: "authorizationRevoked",
+          lastSyncedAt: null,
+          lastHealthyAt: null,
+          accountEmail: null,
+          connectionState: "RECONNECT_REQUIRED",
+        },
+        isConnecting: false,
+        state: "RECONNECT_REQUIRED",
+        nowMs,
+      }),
+    ).toEqual({
+      variant: "error",
       text: "Calendar needs reconnecting",
     });
+  });
+});
+
+describe("isFirstImportInProgress", () => {
+  const makeConnection = (
+    overrides: Partial<GoogleSyncConnectionSummary> = {},
+  ): GoogleSyncConnectionSummary => ({
+    id: "c1",
+    state: "importing",
+    stateReason: null,
+    lastSyncedAt: null,
+    lastHealthyAt: null,
+    accountEmail: "a@example.com",
+    connectionState: "IMPORTING",
+    ...overrides,
+  });
+
+  it("returns false with no connection", () => {
+    expect(isFirstImportInProgress(null)).toBe(false);
+    expect(isFirstImportInProgress(undefined)).toBe(false);
+  });
+
+  it.each([
+    "connecting",
+    "importing",
+    "catchingUp",
+  ] as const)("returns true for a never-healthy connection in state %s", (state) => {
+    expect(
+      isFirstImportInProgress(makeConnection({ state, lastHealthyAt: null })),
+    ).toBe(true);
+  });
+
+  it("returns false once the connection has ever gone healthy, even mid-catchingUp", () => {
+    // This is the exact bug it fixes: an established account's ROUTINE
+    // catch-up collapses to the same aggregate IMPORTING state as a brand-new
+    // account's first import - lastHealthyAt is the only signal that tells
+    // them apart.
+    expect(
+      isFirstImportInProgress(
+        makeConnection({
+          state: "catchingUp",
+          lastHealthyAt: "2026-07-24T11:45:00.000Z",
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("returns false for a healthy connection", () => {
+    expect(
+      isFirstImportInProgress(
+        makeConnection({
+          state: "healthy",
+          lastHealthyAt: "2026-07-24T11:45:00.000Z",
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("returns false for a delayed/reconnect-needed state, even if never healthy", () => {
+    expect(
+      isFirstImportInProgress(
+        makeConnection({ state: "delayed", lastHealthyAt: null }),
+      ),
+    ).toBe(false);
+    expect(
+      isFirstImportInProgress(
+        makeConnection({ state: "actionRequired", lastHealthyAt: null }),
+      ),
+    ).toBe(false);
   });
 });
 

--- a/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.util.ts
+++ b/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.util.ts
@@ -16,6 +16,17 @@ const RECONNECT_STATUS: SyncStatus = {
   text: "Calendar needs reconnecting",
 };
 
+// Settings lists every account as its own row (email visible right above this
+// text), so a generic message there is unambiguous. The sidebar's status bar
+// collapses every account into one line with no account context at all - with
+// multiple accounts connected, "Calendar needs reconnecting" doesn't say
+// which one, and the user has to open Settings just to find out. Named only
+// in getSidebarSyncStatus's own reconnect returns, below.
+const reconnectStatusFor = (accountEmail?: string | null): SyncStatus =>
+  accountEmail
+    ? { variant: "error", text: `${accountEmail} needs reconnecting` }
+    : RECONNECT_STATUS;
+
 /** Sync disconnected / product reconnect / session override after a live 410. */
 export const connectionHasReconnectRequired = (
   connection?: GoogleSyncConnectionSummary | null,
@@ -295,6 +306,27 @@ export const getGoogleSyncStatus = (
 };
 
 /**
+ * Whether this connection's FIRST-EVER import is still running, as opposed to
+ * a routine incremental catch-up on an already-established account. Both
+ * collapse to the same aggregate "IMPORTING" product state, so a caller that
+ * only checks that (e.g. the grid's empty-week overlay, before this was
+ * introduced) shows first-import copy ("Importing from Google…") to a
+ * long-established user during ordinary background catch-up. lastHealthyAt is
+ * the one signal that distinguishes them: it is set once, the first time the
+ * connection ever finishes healthy, and never cleared.
+ */
+export const isFirstImportInProgress = (
+  connection?: GoogleSyncConnectionSummary | null,
+): boolean =>
+  Boolean(
+    connection &&
+      !connection.lastHealthyAt &&
+      (connection.state === "connecting" ||
+        connection.state === "importing" ||
+        connection.state === "catchingUp"),
+  );
+
+/**
  * The sidebar's take on one account's status. Two rules the sidebar applies
  * that Settings doesn't: a connect/reconnect that has been clicked but hasn't
  * round-tripped yet wins over the (still pre-click) connection summary, and a
@@ -326,7 +358,7 @@ export const getSidebarSyncStatus = ({
   }
 
   if (connectionNeedsReconnect(state, connection)) {
-    return RECONNECT_STATUS;
+    return reconnectStatusFor(connection?.accountEmail);
   }
 
   if (
@@ -367,7 +399,7 @@ export const getSidebarSyncStatus = ({
         };
       case "actionRequired":
       case "disconnected":
-        return RECONNECT_STATUS;
+        return reconnectStatusFor(connection.accountEmail);
       case "connecting":
       case "importing":
         return connection.lastHealthyAt

--- a/packages/web/src/grid/components/EventGrid.tsx
+++ b/packages/web/src/grid/components/EventGrid.tsx
@@ -97,7 +97,7 @@ export const EventGrid: FC<EventGridProps> = ({
         style={{ zIndex: ZIndex.MAX }}
       >
         <p className="max-w-sm text-center text-sm text-text-muted">
-          Importing from Google — events usually appear within a minute.
+          Importing from Google. Larger calendars can take a few minutes.
         </p>
       </div>
     )}

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
@@ -8,7 +8,8 @@ import { YEAR_MONTH_DAY_FORMAT } from "@core/constants/date.constants";
 import { type Calendar } from "@core/types/calendar.contracts";
 import { type CalendarId } from "@core/types/domain-primitives";
 import dayjs from "@core/util/date/dayjs";
-import { useGoogleUiState } from "@web/auth/google/hooks/useConnectGoogle/useGoogleUiState";
+import { useConnectGoogle } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle";
+import { isFirstImportInProgress } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle.util";
 import { useCalendarsQuery } from "@web/calendars/calendar.query";
 import { useDefaultTargetCalendar } from "@web/calendars/useDefaultTargetCalendar";
 import { type GridEvent } from "@web/common/types/web.event.types";
@@ -88,12 +89,15 @@ export function DayCalendarGrid() {
     isErrorEvents,
     isFetching,
   );
-  const googleState = useGoogleUiState();
+  const { connection, state: googleState } = useConnectGoogle();
+  // See Grid.tsx's Week-view equivalent: googleState alone can't tell a
+  // first-ever import apart from routine catch-up on an established account.
   const isImportingEmpty =
     !isPending &&
     !isErrorEvents &&
     dayEvents.length === 0 &&
-    googleState === "IMPORTING";
+    googleState === "IMPORTING" &&
+    isFirstImportInProgress(connection);
   const {
     calendarColumnIndexById,
     displayedAllDayEvents,

--- a/packages/web/src/views/Week/components/Grid/Grid.tsx
+++ b/packages/web/src/views/Week/components/Grid/Grid.tsx
@@ -1,7 +1,8 @@
 import { type FC, useMemo } from "react";
 import { YEAR_MONTH_DAY_FORMAT } from "@core/constants/date.constants";
 import { type Dayjs } from "@core/util/date/dayjs";
-import { useGoogleUiState } from "@web/auth/google/hooks/useConnectGoogle/useGoogleUiState";
+import { useConnectGoogle } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle";
+import { isFirstImportInProgress } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle.util";
 import { useWeekEventViewModel } from "@web/events/queries/useWeekEventsQuery";
 import { selectGridDraft, useDraftStore } from "@web/events/stores/draft.store";
 import { EventGrid, isEventGridLoading } from "@web/grid/components/EventGrid";
@@ -49,15 +50,24 @@ export const Grid: FC<Props> = ({
     startOfView: weekProps.query.startOfView,
     endOfView: weekProps.query.endOfView,
   });
-  const googleState = useGoogleUiState();
+  const { connection, state: googleState } = useConnectGoogle();
   const isLoadingEvents = isEventGridLoading(
     isPending,
     isErrorEvents,
     isFetching,
   );
   const hasVisibleEvents = (data?.ids?.length ?? 0) > 0;
+  // googleState alone can't tell a first-ever import apart from an
+  // already-established account's routine catch-up - both collapse to the
+  // same aggregate IMPORTING state. Without isFirstImportInProgress, an
+  // established user viewing a genuinely empty week during ordinary
+  // background catch-up would see "Importing from Google…" as if this were
+  // a brand-new account.
   const isImportingEmpty =
-    isSuccess && !hasVisibleEvents && googleState === "IMPORTING";
+    isSuccess &&
+    !hasVisibleEvents &&
+    googleState === "IMPORTING" &&
+    isFirstImportInProgress(connection);
 
   useDragEdgeNavigation(mainGridRef, weekProps);
 


### PR DESCRIPTION
## Summary

An established user's routine background catch-up and a brand-new account's first-ever import both collapse to the same aggregate `IMPORTING` product state. The week/day grid's empty-week overlay only checked that aggregate state, so a long-established user viewing a genuinely empty week during ordinary catch-up saw "Importing from Google..." as if this were a fresh connection — the exact misleading-state bug `getSidebarSyncStatus`'s `lastHealthyAt` distinction already exists to prevent, just not reused here.

- Extracts that distinction into `isFirstImportInProgress()` and gates the grid overlay on it, so it only shows during an account's actual first import (Week's `Grid.tsx` and Day's `DayCalendarGrid.tsx`).
- Softens the overlay's copy, which promised results "within a minute" unconditionally — true for a small calendar, false for a large one — to something that doesn't overpromise a timeline, and fixes a stray em-dash in the same string.
- The sidebar's collapsed one-line status never named which account a reconnect problem belonged to (unlike Settings, where every account gets its own row with its email visible). `getSidebarSyncStatus`'s reconnect-required text now includes the account's email when one is available; Settings' own `getGoogleSyncStatus` is untouched since it doesn't need it.

Last of the fixes from a pre-launch sync stability + UX audit (first: #2728, second: #2729, third: #2731, fourth: #2732).

## Test plan
- [x] New tests: `isFirstImportInProgress` (6 cases covering the exact routine-catchup-vs-first-import distinction), reconnect-status text with/without an account email
- [x] Updated 1 existing test whose expectation intentionally changed (reconnect text now names the account)
- [x] Full web suite: 2044 pass, 0 fail
- [x] Full repo `bun run type-check` — clean
- [x] `biome check` on all touched files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)