### PR TITLE
feat(web): place timed drafts with shift+arrow

### DIFF
--- a/packages/web/src/common/utils/draft/draft.util.test.ts
+++ b/packages/web/src/common/utils/draft/draft.util.test.ts
@@ -7,7 +7,7 @@ import {
 import { Categories_Event } from "@web/common/types/web.event.types";
 import { createObjectIdString } from "@web/common/utils/id/object-id.util";
 import { createGridEventDraft } from "@web/events/grid-event-draft.adapter";
-import { useDraftStore } from "@web/events/stores/draft.store";
+import { draftActions, useDraftStore } from "@web/events/stores/draft.store";
 import { assembleDefaultEvent } from "../event/event.util";
 import {
   createAlldayDraft,
@@ -41,6 +41,10 @@ describe("assembleDefaultEvent", () => {
 });
 
 describe("shortcut draft creation", () => {
+  afterEach(() => {
+    draftActions.discard();
+  });
+
   it("creates a one-day all-day draft on today when today is inside the visible week", async () => {
     setSystemTime(new Date("2026-05-20T10:07:00.000Z"));
 
@@ -112,6 +116,27 @@ describe("shortcut draft creation", () => {
     expect(useDraftStore.getState().gridDraft?.values.calendarId).toBe(
       calendarId,
     );
+  });
+
+  it("creates a keyboardPlace timed draft with the form closed", async () => {
+    setSystemTime(new Date("2026-05-20T10:07:00.000Z"));
+
+    await createTimedDraft(
+      true,
+      dayjs("2026-05-20T00:00:00.000Z"),
+      "keyboardPlace",
+    );
+
+    const { gridDraft, status } = useDraftStore.getState();
+
+    expect(status?.activity).toBe("keyboardPlace");
+    expect(status?.isFormOpen).toBe(false);
+    expect(status?.eventType).toBe(Categories_Event.TIMED);
+    expectSameTime(
+      gridDraft?.values.schedule.start,
+      "2026-05-20T10:15:00.000Z",
+    );
+    expectSameTime(gridDraft?.values.schedule.end, "2026-05-20T11:15:00.000Z");
   });
 
   it("stores a provided calendarId on all-day shortcut drafts", async () => {

--- a/packages/web/src/common/utils/draft/draft.util.ts
+++ b/packages/web/src/common/utils/draft/draft.util.ts
@@ -5,11 +5,13 @@ import {
   ID_GRID_EVENTS_TIMED,
   ID_GRID_MAIN,
 } from "@web/common/constants/web.constants";
+import { focusCalendarEventElement } from "@web/common/utils/event/event.util";
 import { getElemById, getMinuteHeight } from "@web/common/utils/grid/grid.util";
 import { roundToNext } from "@web/common/utils/round/round.util";
 import { type GridEventDraft } from "@web/events/event-draft.types";
 import {
   createGridEventDraft,
+  getGridDraftId,
   timedGridSchedule,
 } from "@web/events/grid-event-draft.adapter";
 import { draftActions } from "@web/events/stores/draft.store";
@@ -23,7 +25,7 @@ const VISIBLE_START_MARGIN_MIN = 30;
 export const createTimedDraft = (
   isCurrentWeek: boolean,
   startOfView: Dayjs,
-  activity: "createShortcut",
+  activity: "createShortcut" | "keyboardPlace",
   calendarId: CalendarId | null = null,
 ) => {
   const { startDate, endDate } = getDraftTimes(isCurrentWeek, startOfView);
@@ -34,6 +36,15 @@ export const createTimedDraft = (
   );
 
   draftActions.startGridDraft({ activity, draft });
+
+  // Place-create keeps the form closed; focus the draft card so further
+  // Shift+Arrow / Enter operate on the grid event rather than the title.
+  if (activity === "keyboardPlace") {
+    const draftId = getGridDraftId(draft);
+    if (draftId) {
+      focusCalendarEventElement(draftId);
+    }
+  }
 };
 
 export const createAlldayDraft = (

--- a/packages/web/src/common/utils/draft/draft.util.ts
+++ b/packages/web/src/common/utils/draft/draft.util.ts
@@ -12,7 +12,6 @@ import { roundToNext } from "@web/common/utils/round/round.util";
 import { type GridEventDraft } from "@web/events/event-draft.types";
 import {
   createGridEventDraft,
-  getGridDraftId,
   timedGridSchedule,
 } from "@web/events/grid-event-draft.adapter";
 import { draftActions } from "@web/events/stores/draft.store";
@@ -30,11 +29,12 @@ export const createTimedDraft = (
   calendarId: CalendarId | null = null,
 ) => {
   const { startDate, endDate } = getDraftTimes(isCurrentWeek, startOfView);
+  // Stable grid identity so place-create can focus the card and Enter can
+  // open the live draft without reseeding.
+  const clientId = EventIdSchema.parse(createObjectIdString());
   const draft = createGridEventDraft(
     timedGridSchedule(new Date(startDate), new Date(endDate)),
-    // Stable grid identity so place-create can focus the card and Enter can
-    // open the live draft without reseeding.
-    EventIdSchema.parse(createObjectIdString()),
+    clientId,
     calendarId,
   );
 
@@ -43,10 +43,7 @@ export const createTimedDraft = (
   // Place-create keeps the form closed; focus the draft card so further
   // Shift+Arrow / Enter operate on the grid event rather than the title.
   if (activity === "keyboardPlace") {
-    const draftId = getGridDraftId(draft);
-    if (draftId) {
-      focusCalendarEventElement(draftId);
-    }
+    focusCalendarEventElement(clientId);
   }
 };
 

--- a/packages/web/src/common/utils/draft/draft.util.ts
+++ b/packages/web/src/common/utils/draft/draft.util.ts
@@ -1,4 +1,4 @@
-import { type CalendarId } from "@core/types/domain-primitives";
+import { type CalendarId, EventIdSchema } from "@core/types/domain-primitives";
 import dayjs, { type Dayjs } from "@core/util/date/dayjs";
 import {
   ID_GRID_EVENTS_ALLDAY,
@@ -7,6 +7,7 @@ import {
 } from "@web/common/constants/web.constants";
 import { focusCalendarEventElement } from "@web/common/utils/event/event.util";
 import { getElemById, getMinuteHeight } from "@web/common/utils/grid/grid.util";
+import { createObjectIdString } from "@web/common/utils/id/object-id.util";
 import { roundToNext } from "@web/common/utils/round/round.util";
 import { type GridEventDraft } from "@web/events/event-draft.types";
 import {
@@ -31,7 +32,9 @@ export const createTimedDraft = (
   const { startDate, endDate } = getDraftTimes(isCurrentWeek, startOfView);
   const draft = createGridEventDraft(
     timedGridSchedule(new Date(startDate), new Date(endDate)),
-    undefined,
+    // Stable grid identity so place-create can focus the card and Enter can
+    // open the live draft without reseeding.
+    EventIdSchema.parse(createObjectIdString()),
     calendarId,
   );
 

--- a/packages/web/src/common/utils/draft/reposition-draft-by-keyboard.util.test.ts
+++ b/packages/web/src/common/utils/draft/reposition-draft-by-keyboard.util.test.ts
@@ -60,4 +60,23 @@ describe("repositionDraftByKeyboard", () => {
       }),
     ).toBeNull();
   });
+
+  it("moves a keyboardPlace timed draft by 15 minutes with ArrowDown", () => {
+    const draft = createGridEventDraft(
+      timedGridSchedule(
+        new Date("2026-05-20T09:00:00.000"),
+        new Date("2026-05-20T10:00:00.000"),
+      ),
+    );
+
+    const next = repositionDraftByKeyboard({
+      activity: "keyboardPlace",
+      draft,
+      key: "ArrowDown",
+    });
+
+    expect(dayjs(next?.values.schedule.start).format()).toBe(
+      dayjs("2026-05-20T09:15:00.000").format(),
+    );
+  });
 });

--- a/packages/web/src/common/utils/draft/reposition-draft-by-keyboard.util.ts
+++ b/packages/web/src/common/utils/draft/reposition-draft-by-keyboard.util.ts
@@ -15,7 +15,8 @@ const canRepositionDraftByKeyboard = (
 ) =>
   activity === "createShortcut" ||
   activity === "gridClick" ||
-  activity === "keyboardEdit";
+  activity === "keyboardEdit" ||
+  activity === "keyboardPlace";
 
 /**
  * Moves a draft by one arrow step. Returns the updated draft when the move

--- a/packages/web/src/events/stores/draft.store.ts
+++ b/packages/web/src/events/stores/draft.store.ts
@@ -12,6 +12,11 @@ export type Activity_DraftEvent =
   | "eventRightClick"
   | "gridClick"
   | "keyboardEdit"
+  /**
+   * Shift+Arrow place-create: timed draft on the grid with the form closed so
+   * the user can keep repositioning before opening details with Enter.
+   */
+  | "keyboardPlace"
   | "sidebarClick";
 
 export interface Status_DraftEvent {
@@ -69,6 +74,7 @@ export const draftActions = {
       | "eventRightClick"
       | "gridClick"
       | "keyboardEdit"
+      | "keyboardPlace"
     >;
     draft: GridEventDraft;
   }) =>

--- a/packages/web/src/grid/shortcuts/useGridEventEditShortcuts.ts
+++ b/packages/web/src/grid/shortcuts/useGridEventEditShortcuts.ts
@@ -82,6 +82,7 @@ export function useGridEventEditShortcuts({
   allDayEvents = [],
   dayBoundary,
   dependencies = {},
+  placeTimedDraft,
   repositionDraftByKey,
   targeting,
   timedEvents,
@@ -89,6 +90,11 @@ export function useGridEventEditShortcuts({
   allDayEvents?: GridEvent[];
   dayBoundary: GridEventEditDayBoundary;
   dependencies?: EventMutationDependencies;
+  /**
+   * Shift+Arrow place-create when nothing is focused and no draft can move.
+   * Seeds a timed draft at the same default as `c`, form closed.
+   */
+  placeTimedDraft?: () => void;
   /**
    * View-owned draft move. Return true when the draft moved so the shared
    * hook can preventDefault. Day may also navigate here on day-cross.
@@ -232,50 +238,61 @@ export function useGridEventEditShortcuts({
     if (isEventFormOpen()) return;
 
     const event = getFocusedMutableCalendarEvent();
-    if (!event?._id) return;
+    if (event?._id) {
+      const edgeFocus = useEdgeFocusStore.getState();
+      if (edgeFocus.eventId === event._id && edgeFocus.edge) {
+        moveFocusedEventEdge(keyboardEvent, event, edgeFocus.edge);
+        return;
+      }
 
-    const edgeFocus = useEdgeFocusStore.getState();
-    if (edgeFocus.eventId === event._id && edgeFocus.edge) {
-      moveFocusedEventEdge(keyboardEvent, event, edgeFocus.edge);
+      const movement = getArrowKeyMovement(
+        keyboardEvent.key,
+        Boolean(event.isAllDay),
+      );
+      if (!movement) return;
+
+      if (dayBoundary.kind === "clamp") {
+        const start = dayjs(event.startDate);
+        const { weekDays } = dayBoundary;
+        if (movement.days === -1 && !start.isAfter(weekDays[0], "day")) {
+          return;
+        }
+        if (
+          movement.days === 1 &&
+          !start.isBefore(weekDays[weekDays.length - 1], "day")
+        ) {
+          return;
+        }
+      }
+
+      const previousStart = dayjs(event.startDate).startOf("day");
+
+      nudgeEventFromKeyboard({
+        event,
+        keyboardEvent,
+        onNudge: (nudgedEvent) => {
+          updateEvent({ event: nudgedEvent }, true);
+          if (dayBoundary.kind === "follow") {
+            const nextStart = dayjs(nudgedEvent.startDate).startOf("day");
+            if (!nextStart.isSame(previousStart, "day")) {
+              dayBoundary.onCrossed(nextStart);
+            }
+          }
+        },
+        afterNudge: () => draftActions.discard(),
+      });
       return;
     }
 
-    const movement = getArrowKeyMovement(
-      keyboardEvent.key,
-      Boolean(event.isAllDay),
-    );
-    if (!movement) return;
-
-    if (dayBoundary.kind === "clamp") {
-      const start = dayjs(event.startDate);
-      const { weekDays } = dayBoundary;
-      if (movement.days === -1 && !start.isAfter(weekDays[0], "day")) {
-        return;
-      }
-      if (
-        movement.days === 1 &&
-        !start.isBefore(weekDays[weekDays.length - 1], "day")
-      ) {
-        return;
-      }
+    // No focused saved event: reposition a form-closed draft, or place one.
+    const didMoveDraft = repositionDraftByKey(keyboardEvent.key);
+    if (didMoveDraft) {
+      keyboardEvent.preventDefault();
+      keyboardEvent.stopPropagation();
+      return;
     }
 
-    const previousStart = dayjs(event.startDate).startOf("day");
-
-    nudgeEventFromKeyboard({
-      event,
-      keyboardEvent,
-      onNudge: (nudgedEvent) => {
-        updateEvent({ event: nudgedEvent }, true);
-        if (dayBoundary.kind === "follow") {
-          const nextStart = dayjs(nudgedEvent.startDate).startOf("day");
-          if (!nextStart.isSame(previousStart, "day")) {
-            dayBoundary.onCrossed(nextStart);
-          }
-        }
-      },
-      afterNudge: () => draftActions.discard(),
-    });
+    placeTimedDraft?.();
   };
 
   const cycleEdgeFocus = (keyboardEvent: KeyboardEvent) => {

--- a/packages/web/src/grid/shortcuts/useGridEventEditShortcuts.ts
+++ b/packages/web/src/grid/shortcuts/useGridEventEditShortcuts.ts
@@ -241,7 +241,6 @@ export function useGridEventEditShortcuts({
   const moveFocusedCalendarEvent = (keyboardEvent: KeyboardEvent) => {
     if (isEventFormOpen()) return;
 
-    const focusedTarget = targeting.getFocused();
     const event = getFocusedMutableCalendarEvent();
     if (event?._id) {
       const edgeFocus = useEdgeFocusStore.getState();
@@ -299,7 +298,7 @@ export function useGridEventEditShortcuts({
       return;
     }
 
-    if (focusedTarget || useDraftStore.getState().gridDraft) {
+    if (targeting.getFocused() || useDraftStore.getState().gridDraft) {
       return;
     }
 

--- a/packages/web/src/grid/shortcuts/useGridEventEditShortcuts.ts
+++ b/packages/web/src/grid/shortcuts/useGridEventEditShortcuts.ts
@@ -28,7 +28,11 @@ import {
 } from "@web/events/mutations/useEventMutations";
 import { useUpdateEvent } from "@web/events/mutations/useUpdateEvent";
 import { findEventInCache } from "@web/events/queries/event.query.cache";
-import { draftActions, isEventFormOpen } from "@web/events/stores/draft.store";
+import {
+  draftActions,
+  isEventFormOpen,
+  useDraftStore,
+} from "@web/events/stores/draft.store";
 import {
   edgeFocusActions,
   useEdgeFocusStore,
@@ -237,6 +241,7 @@ export function useGridEventEditShortcuts({
   const moveFocusedCalendarEvent = (keyboardEvent: KeyboardEvent) => {
     if (isEventFormOpen()) return;
 
+    const focusedTarget = targeting.getFocused();
     const event = getFocusedMutableCalendarEvent();
     if (event?._id) {
       const edgeFocus = useEdgeFocusStore.getState();
@@ -284,11 +289,17 @@ export function useGridEventEditShortcuts({
       return;
     }
 
-    // No focused saved event: reposition a form-closed draft, or place one.
+    // No focused mutable saved event: reposition a form-closed draft, or
+    // place one when the grid is idle. Do not place over an existing draft
+    // (failed clamp/midnight move) or while a read-only/draft card is focused.
     const didMoveDraft = repositionDraftByKey(keyboardEvent.key);
     if (didMoveDraft) {
       keyboardEvent.preventDefault();
       keyboardEvent.stopPropagation();
+      return;
+    }
+
+    if (focusedTarget || useDraftStore.getState().gridDraft) {
       return;
     }
 

--- a/packages/web/src/shortcuts/data/shortcuts.data.test.ts
+++ b/packages/web/src/shortcuts/data/shortcuts.data.test.ts
@@ -126,6 +126,16 @@ describe("shortcuts.data", () => {
           label: "Create all-day event",
         },
       );
+      expect(stripMetadata(findCreate("day")?.shortcuts ?? [])).toContainEqual({
+        keys: ["Shift", "Arrow keys"],
+        label: "Place timed draft on grid",
+      });
+      expect(stripMetadata(findCreate("week")?.shortcuts ?? [])).toContainEqual(
+        {
+          keys: ["Shift", "Arrow keys"],
+          label: "Place timed draft on grid",
+        },
+      );
     });
 
     it("lists u/i focus shortcuts per view", () => {

--- a/packages/web/src/shortcuts/shortcuts.registry.ts
+++ b/packages/web/src/shortcuts/shortcuts.registry.ts
@@ -108,6 +108,12 @@ export const SHORTCUTS_REGISTRY: Shortcut[] = [
     label: "Create all-day event",
     section: "create",
   },
+  {
+    id: "create-place-timed",
+    keys: ["Shift", "Arrow keys"],
+    label: "Place timed draft on grid",
+    section: "create",
+  },
 
   // Focus
   {

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarEventCards.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarEventCards.tsx
@@ -71,14 +71,14 @@ export const DayAllDayCalendarEvent = ({
     [event._id, hasEventIdentity],
   );
   // Unregistered for drag/resize also means the interaction engine's own
-  // click resolution never fires, so a read-only card would otherwise stop
-  // being clickable - events must stay inspectable even when they can't be
-  // mutated. Wiring the click straight to the same "open" action the
-  // keyboard path uses bypasses the engine entirely for this card.
-  const onEventMouseDown = isReadOnly
-    ? (_mouseEvent: MouseEvent, clickedEvent: GridEvent) =>
-        onOpenEvent(clickedEvent)
-    : undefined;
+  // click resolution never fires, so a read-only or draft-only card would
+  // otherwise stop being clickable. Wire the click to the same "open" action
+  // the keyboard path uses.
+  const onEventMouseDown =
+    isReadOnly || isPlaceholder
+      ? (_mouseEvent: MouseEvent, clickedEvent: GridEvent) =>
+          onOpenEvent(clickedEvent)
+      : undefined;
 
   const position = getAllDayEventPosition(event, {
     columnIndex,
@@ -143,13 +143,13 @@ export const DayTimedCalendarEvent = ({
     [event._id, hasEventIdentity],
   );
   // Unregistered for drag/resize also means the interaction engine's own
-  // click resolution never fires, so a read-only card would otherwise stop
-  // being clickable - events must stay inspectable even when they can't be
-  // mutated. Wiring the click straight to the same "open" action the
-  // keyboard path uses bypasses the engine entirely for this card.
-  const onEventMouseDown = isReadOnly
-    ? (clickedEvent: GridEvent) => onOpenEvent(clickedEvent)
-    : undefined;
+  // click resolution never fires, so a read-only or draft-only card would
+  // otherwise stop being clickable. Wire the click to the same "open" action
+  // the keyboard path uses.
+  const onEventMouseDown =
+    isReadOnly || isPlaceholder
+      ? (clickedEvent: GridEvent) => onOpenEvent(clickedEvent)
+      : undefined;
   const deckBoxShadow = (() => {
     if (!isDeck) return undefined;
     const ring = `0 0 0 0.75px var(--background)`;

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.test.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.test.tsx
@@ -23,9 +23,11 @@ import {
   ZIndex,
 } from "@web/common/constants/web.constants";
 import { emitViewCommand } from "@web/common/utils/dom/view-command-bus";
+import { createTimedDraft } from "@web/common/utils/draft/draft.util";
 import { createObjectIdString } from "@web/common/utils/id/object-id.util";
 import {
   createGridEventDraft,
+  getGridDraftId,
   gridEventDraftToSchemaEvent,
   timedGridSchedule,
 } from "@web/events/grid-event-draft.adapter";
@@ -555,22 +557,28 @@ describe("DayCalendarGrid", () => {
   });
 
   it("opens the form when Enter is pressed on a form-closed keyboardPlace draft", async () => {
-    const draft = createGridEventDraft(
-      timedGridSchedule(
-        new Date("2026-05-20T10:00:00.000"),
-        new Date("2026-05-20T11:00:00.000"),
-      ),
-    );
+    createTimedDraft(false, dayjs("2026-05-20T00:00:00.000"), "keyboardPlace");
+    const draft = getGridDraft();
+    expect(draft).not.toBeNull();
+    if (!draft) return;
     draft.values.title = "Placed draft";
-    draftActions.startGridDraft({ activity: "keyboardPlace", draft });
+    draftActions.setGridDraft(draft);
     expect(getIsFormOpen()).toBe(false);
 
     const { user } = renderDayCalendarGrid();
-    const card = screen.getByRole("button", { name: /placed draft/i });
+    const card = screen.getByRole("button", {
+      name: /timed event: placed draft/i,
+    });
+    const draftId = getGridDraftId(getGridDraft()!);
+    expect(card.getAttribute("data-day-interaction-event-id")).toBe(draftId);
+
     card.focus();
+    expect(document.activeElement).toBe(card);
     await user.keyboard("{Enter}");
 
-    expect(getIsFormOpen()).toBe(true);
+    await waitFor(() => {
+      expect(getIsFormOpen()).toBe(true);
+    });
     expect(useDraftStore.getState().status?.activity).toBe("keyboardPlace");
   });
 

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.test.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.test.tsx
@@ -554,6 +554,26 @@ describe("DayCalendarGrid", () => {
     expect(getIsFormOpen()).toBe(true);
   });
 
+  it("opens the form when Enter is pressed on a form-closed keyboardPlace draft", async () => {
+    const draft = createGridEventDraft(
+      timedGridSchedule(
+        new Date("2026-05-20T10:00:00.000"),
+        new Date("2026-05-20T11:00:00.000"),
+      ),
+    );
+    draft.values.title = "Placed draft";
+    draftActions.startGridDraft({ activity: "keyboardPlace", draft });
+    expect(getIsFormOpen()).toBe(false);
+
+    const { user } = renderDayCalendarGrid();
+    const card = screen.getByRole("button", { name: /placed draft/i });
+    card.focus();
+    await user.keyboard("{Enter}");
+
+    expect(getIsFormOpen()).toBe(true);
+    expect(useDraftStore.getState().status?.activity).toBe("keyboardPlace");
+  });
+
   it("opens the event form from a Day card pointer interaction", async () => {
     const event = createTimedEvent({
       _id: "pointer-open",

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.test.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.test.tsx
@@ -570,7 +570,10 @@ describe("DayCalendarGrid", () => {
       name: /timed event: placed draft/i,
     });
     const draftId = getGridDraftId(getGridDraft()!);
-    expect(card.getAttribute("data-day-interaction-event-id")).toBe(draftId);
+    expect(draftId).toBeDefined();
+    expect(card.getAttribute("data-day-interaction-event-id")).toBe(
+      draftId ?? null,
+    );
 
     card.focus();
     expect(document.activeElement).toBe(card);

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
@@ -20,7 +20,10 @@ import {
 } from "@web/common/utils/draft/draft.util";
 import { showErrorToast } from "@web/common/utils/toast/error-toast.util";
 import { type GridEventDraft } from "@web/events/event-draft.types";
-import { createGridEventDraftFromGridEvent } from "@web/events/grid-event-draft.adapter";
+import {
+  createGridEventDraftFromGridEvent,
+  getGridDraftId,
+} from "@web/events/grid-event-draft.adapter";
 import { useDayEventViewModel } from "@web/events/queries/useDayEventsQuery";
 import {
   draftActions,
@@ -116,9 +119,28 @@ export function DayCalendarGrid() {
     gridRefs.mainGridRef,
     visibleDates,
   );
+  const placeTimedDraftFromShortcut = useCallback(() => {
+    // Same guards as openShortcutDraft / Week place: no sticky null calendar
+    // while calendars load, and don't replace an existing draft (Shift+Arrow
+    // repositions that draft instead via useGridEventEditShortcuts).
+    if (useDraftStore.getState().gridDraft) {
+      return;
+    }
+    if (isCalendarsPending && !defaultTargetCalendarId) {
+      return;
+    }
+
+    createTimedDraft(
+      dateInView.isSame(dayjs(), "day"),
+      dateInView,
+      "keyboardPlace",
+      defaultTargetCalendarId,
+    );
+  }, [dateInView, defaultTargetCalendarId, isCalendarsPending]);
   const { shiftHints } = useDayEventNudgeShortcuts({
     allDayEvents: displayedAllDayEvents,
     navigateToDate,
+    placeTimedDraft: placeTimedDraftFromShortcut,
     timedEvents: displayedTimedEvents,
   });
   const gridDraft = useDraftStore(selectGridDraft);
@@ -173,6 +195,14 @@ export function DayCalendarGrid() {
   const openEventFormForEvent = useCallback(
     (event: GridEvent) => {
       if (!event._id) {
+        return;
+      }
+
+      const currentDraft = useDraftStore.getState().gridDraft;
+      if (currentDraft && getGridDraftId(currentDraft) === event._id) {
+        // Form-closed place-create (and other live drafts): open details
+        // without reseeding the draft from the card.
+        draftActions.setFormOpen(true);
         return;
       }
 

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
@@ -119,30 +119,6 @@ export function DayCalendarGrid() {
     gridRefs.mainGridRef,
     visibleDates,
   );
-  const placeTimedDraftFromShortcut = useCallback(() => {
-    // Same guards as openShortcutDraft / Week place: no sticky null calendar
-    // while calendars load, and don't replace an existing draft (Shift+Arrow
-    // repositions that draft instead via useGridEventEditShortcuts).
-    if (useDraftStore.getState().gridDraft) {
-      return;
-    }
-    if (isCalendarsPending && !defaultTargetCalendarId) {
-      return;
-    }
-
-    createTimedDraft(
-      dateInView.isSame(dayjs(), "day"),
-      dateInView,
-      "keyboardPlace",
-      defaultTargetCalendarId,
-    );
-  }, [dateInView, defaultTargetCalendarId, isCalendarsPending]);
-  const { shiftHints } = useDayEventNudgeShortcuts({
-    allDayEvents: displayedAllDayEvents,
-    navigateToDate,
-    placeTimedDraft: placeTimedDraftFromShortcut,
-    timedEvents: displayedTimedEvents,
-  });
   const gridDraft = useDraftStore(selectGridDraft);
   // Strip height must include the all-day draft: layer rendering used to
   // re-stack with the draft while EventGrid still sized from saved events only.
@@ -249,7 +225,7 @@ export function DayCalendarGrid() {
     dateCalcs.getDateStrByXY(clientX, 0, YEAR_MONTH_DAY_FORMAT);
 
   const openShortcutDraft = useCallback(
-    (createDraft: () => void) => {
+    (createDraft: () => void, openForm = true) => {
       if (gridDraft) {
         return;
       }
@@ -260,7 +236,9 @@ export function DayCalendarGrid() {
       }
 
       createDraft();
-      draftActions.setFormOpen(true);
+      if (openForm) {
+        draftActions.setFormOpen(true);
+      }
     },
     [defaultTargetCalendarId, gridDraft, isCalendarsPending],
   );
@@ -290,6 +268,29 @@ export function DayCalendarGrid() {
       ),
     [dateInView, defaultTargetCalendarId, openShortcutDraft],
   );
+
+  // Form stays closed so Shift+Arrow can keep repositioning; Enter opens it.
+  // Existing-draft / focus guards also live in useGridEventEditShortcuts.
+  const placeTimedDraftFromShortcut = useCallback(
+    () =>
+      openShortcutDraft(
+        () =>
+          createTimedDraft(
+            dateInView.isSame(dayjs(), "day"),
+            dateInView,
+            "keyboardPlace",
+            defaultTargetCalendarId,
+          ),
+        false,
+      ),
+    [dateInView, defaultTargetCalendarId, openShortcutDraft],
+  );
+  const { shiftHints } = useDayEventNudgeShortcuts({
+    allDayEvents: displayedAllDayEvents,
+    navigateToDate,
+    placeTimedDraft: placeTimedDraftFromShortcut,
+    timedEvents: displayedTimedEvents,
+  });
 
   // onViewCommand returns its own unsubscribe and emitViewCommand reads the
   // listener set at emit time, so re-subscribing when the handler identity

--- a/packages/web/src/views/Day/hooks/shortcuts/useDayEventNudgeShortcuts.test.tsx
+++ b/packages/web/src/views/Day/hooks/shortcuts/useDayEventNudgeShortcuts.test.tsx
@@ -16,6 +16,7 @@ import { createCompassQueryClient } from "@web/api/query-client";
 import { ID_EVENT_FORM, ID_SIDEBAR } from "@web/common/constants/web.constants";
 import { type GridEvent } from "@web/common/types/web.event.types";
 import { getBrowserTimeZone } from "@web/common/utils/datetime/web.date.util";
+import { createTimedDraft } from "@web/common/utils/draft/draft.util";
 import { gridEventDefaultPosition } from "@web/common/utils/event/event.util";
 import {
   createGridEventDraft,
@@ -114,10 +115,12 @@ const focusCalendarTarget = (
 const renderEditShortcuts = ({
   allDayEvents = [],
   navigateToDate,
+  placeTimedDraft,
   timedEvents = [timedEvent],
 }: {
   allDayEvents?: GridEvent[];
   navigateToDate?: (date: Dayjs) => void;
+  placeTimedDraft?: () => void;
   timedEvents?: GridEvent[];
 } = {}) => {
   const queryClient = createCompassQueryClient();
@@ -156,6 +159,7 @@ const renderEditShortcuts = ({
         allDayEvents,
         dependencies,
         navigateToDate,
+        placeTimedDraft,
         timedEvents,
       }),
     {
@@ -295,6 +299,65 @@ describe("useDayEventNudgeShortcuts", () => {
 
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(getEditMutation(queryClient)).toBeUndefined();
+  });
+
+  it("places a keyboardPlace timed draft when Shift+Arrow is pressed with no focus", () => {
+    const placeTimedDraft = mock(() => {
+      createTimedDraft(true, dayjs("2026-05-20T00:00:00.000"), "keyboardPlace");
+    });
+    renderEditShortcuts({ placeTimedDraft });
+
+    pressKey("ArrowDown", shiftKey);
+
+    expect(placeTimedDraft).toHaveBeenCalled();
+    const { status } = useDraftStore.getState();
+    expect(status?.activity).toBe("keyboardPlace");
+    expect(status?.isFormOpen).toBe(false);
+  });
+
+  it("repositions a keyboardPlace draft with a later Shift+Arrow", () => {
+    const placeTimedDraft = mock(() => {
+      createTimedDraft(
+        false,
+        dayjs("2026-05-20T00:00:00.000"),
+        "keyboardPlace",
+      );
+    });
+    renderEditShortcuts({ placeTimedDraft });
+
+    pressKey("ArrowDown", shiftKey);
+
+    const placedStart =
+      useDraftStore.getState().gridDraft?.values.schedule.start;
+    expect(placedStart).toBeDefined();
+
+    pressKey("ArrowDown", shiftKey);
+
+    expect(
+      dayjs(useDraftStore.getState().gridDraft?.values.schedule.start).format(),
+    ).toBe(dayjs(placedStart).add(15, "minutes").format());
+    expect(useDraftStore.getState().status?.isFormOpen).toBe(false);
+    expect(placeTimedDraft).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not place a draft when Shift+Arrow is pressed while the form is open", () => {
+    const placeTimedDraft = mock(() => {});
+    const draft = createGridEventDraft(
+      timedGridSchedule(
+        new Date("2026-05-20T09:00:00.000"),
+        new Date("2026-05-20T10:00:00.000"),
+      ),
+    );
+    draftActions.startGridDraft({ activity: "keyboardPlace", draft });
+    draftActions.setFormOpen(true);
+    renderEditShortcuts({ placeTimedDraft });
+
+    pressKey("ArrowDown", shiftKey);
+
+    expect(placeTimedDraft).not.toHaveBeenCalled();
+    expect(
+      dayjs(useDraftStore.getState().gridDraft?.values.schedule.start).format(),
+    ).toBe(dayjs("2026-05-20T09:00:00.000").format());
   });
 
   it("deletes the focused timed calendar event with Delete", () => {

--- a/packages/web/src/views/Day/hooks/shortcuts/useDayEventNudgeShortcuts.ts
+++ b/packages/web/src/views/Day/hooks/shortcuts/useDayEventNudgeShortcuts.ts
@@ -26,12 +26,15 @@ export function useDayEventNudgeShortcuts({
   allDayEvents = [],
   dependencies = {},
   navigateToDate,
+  placeTimedDraft,
   timedEvents,
 }: {
   allDayEvents?: GridEvent[];
   dependencies?: EventMutationDependencies;
   /** Follow draft Left/Right moves so the draft stays on screen. */
   navigateToDate?: (date: Dayjs) => void;
+  /** Shift+Arrow place-create when nothing is focused and no draft can move. */
+  placeTimedDraft?: () => void;
   timedEvents: GridEvent[];
 }): { shiftHints: ActiveShiftHint[] } {
   const targeting = {
@@ -48,6 +51,7 @@ export function useDayEventNudgeShortcuts({
       kind: "follow",
       onCrossed: (date) => navigateToDate?.(date),
     },
+    placeTimedDraft,
     targeting,
     repositionDraftByKey: (key) => {
       const { gridDraft, status } = useDraftStore.getState();

--- a/packages/web/src/views/Week/components/Draft/grid/GridDraft.test.tsx
+++ b/packages/web/src/views/Week/components/Draft/grid/GridDraft.test.tsx
@@ -1,10 +1,12 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { Origin } from "@core/constants/core.constants";
 import dayjs from "@core/util/date/dayjs";
 import { type GridEvent } from "@web/common/types/web.event.types";
 import { gridEventDefaultPosition } from "@web/common/utils/event/event.util";
 import { type GridEventDraft } from "@web/events/event-draft.types";
 import { createGridEventDraft } from "@web/events/grid-event-draft.adapter";
+import { draftActions, useDraftStore } from "@web/events/stores/draft.store";
 import { DECK_MIN_WIDTH } from "@web/grid/grid.constants";
 import { DraftContext } from "@web/views/Week/components/Draft/context/DraftContext";
 import { type WeekProps } from "@web/views/Week/hooks/useWeek";
@@ -124,6 +126,7 @@ const renderGridDraft = ({
 
 afterEach(() => {
   document.body.innerHTML = "";
+  draftActions.discard();
 });
 
 describe("GridDraft", () => {
@@ -207,5 +210,19 @@ describe("GridDraft", () => {
     expect(
       screen.getAllByRole("button", { name: /Timed event: Planning/ }),
     ).toHaveLength(3);
+  });
+
+  it("opens the form when Enter is pressed on a form-closed draft", async () => {
+    const draft = createDraft();
+    draftActions.startGridDraft({ activity: "keyboardPlace", draft });
+    expect(useDraftStore.getState().status?.isFormOpen).toBe(false);
+
+    renderGridDraft({ draft });
+    const user = userEvent.setup();
+    const card = screen.getByRole("button", { name: /Timed event: Planning/ });
+    card.focus();
+    await user.keyboard("{Enter}");
+
+    expect(useDraftStore.getState().status?.isFormOpen).toBe(true);
   });
 });

--- a/packages/web/src/views/Week/components/Draft/grid/GridDraft.tsx
+++ b/packages/web/src/views/Week/components/Draft/grid/GridDraft.tsx
@@ -8,6 +8,8 @@ import {
 import { focusEventFormTitle } from "@web/common/utils/form/form.util";
 import { gridEventDraftToGridEvent } from "@web/events/grid-event-draft.adapter";
 import {
+  draftActions,
+  isEventFormOpen,
   selectDraftActivity,
   useDraftStore,
 } from "@web/events/stores/draft.store";
@@ -33,6 +35,14 @@ interface Props {
 }
 
 const handleGridDraftClick = () => {};
+
+const openDraftFormOrFocusTitle = () => {
+  if (!isEventFormOpen()) {
+    draftActions.setFormOpen(true);
+    return;
+  }
+  focusEventFormTitle();
+};
 
 export const GridDraft: FC<Props> = ({
   activeAllDayDraftEvent = null,
@@ -137,7 +147,7 @@ export const GridDraft: FC<Props> = ({
           isPlaceholder={false}
           key={`draft-${draftAsGridEvent._id}`}
           measurements={measurements}
-          onKeyDown={focusEventFormTitle}
+          onKeyDown={openDraftFormOrFocusTitle}
           onMouseDown={
             isMultiDayTimedDraft
               ? undefined
@@ -164,7 +174,7 @@ export const GridDraft: FC<Props> = ({
             e.preventDefault();
             onMouseDown(e, event);
           }}
-          onEventKeyDown={focusEventFormTitle}
+          onEventKeyDown={openDraftFormOrFocusTitle}
           onScalerMouseDown={handleScalerMouseDown}
           weekProps={weekProps}
         />

--- a/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcutOwner.test.tsx
+++ b/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcutOwner.test.tsx
@@ -20,6 +20,7 @@ import { ID_EVENT_FORM, ID_SIDEBAR } from "@web/common/constants/web.constants";
 import { getBrowserTimeZone } from "@web/common/utils/datetime/web.date.util";
 import { emitViewCommand } from "@web/common/utils/dom/view-command-bus";
 import { createObjectIdString } from "@web/common/utils/id/object-id.util";
+import { getGridDraftId } from "@web/events/grid-event-draft.adapter";
 import { eventQueryKeys } from "@web/events/queries/event.query.keys";
 import { draftActions, useDraftStore } from "@web/events/stores/draft.store";
 import { initialViewState, useViewStore } from "@web/events/stores/view.store";
@@ -597,6 +598,8 @@ describe("useWeekShortcutOwner shift+arrow event moves", () => {
       await Promise.resolve();
     });
     expect(getEditMutation(queryClient)).toBeUndefined();
+    // Read-only focus must not fall through into place-create either.
+    expect(useDraftStore.getState().gridDraft).toBeNull();
   });
 
   it("moves the focused timed event by 15 minutes with Shift+ArrowUp and Shift+ArrowDown", async () => {
@@ -710,6 +713,23 @@ describe("useWeekShortcutOwner shift+arrow event moves", () => {
 
     expect(repositionDraftByKeyboard).toHaveBeenCalledWith("ArrowDown");
     expect(useDraftStore.getState().status?.isFormOpen).toBe(false);
+  });
+
+  it("does not reseed a keyboardPlace draft when Shift+Arrow cannot move it", async () => {
+    repositionDraftByKeyboard = mock(() => false);
+    renderShortcuts();
+
+    pressKey("ArrowDown", shiftKey);
+
+    await waitFor(() => {
+      expect(useDraftStore.getState().status?.activity).toBe("keyboardPlace");
+    });
+    const placedId = getGridDraftId(useDraftStore.getState().gridDraft!);
+
+    pressKey("ArrowDown", shiftKey);
+
+    expect(getGridDraftId(useDraftStore.getState().gridDraft!)).toBe(placedId);
+    expect(useDraftStore.getState().status?.activity).toBe("keyboardPlace");
   });
 });
 

--- a/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcutOwner.test.tsx
+++ b/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcutOwner.test.tsx
@@ -21,7 +21,7 @@ import { getBrowserTimeZone } from "@web/common/utils/datetime/web.date.util";
 import { emitViewCommand } from "@web/common/utils/dom/view-command-bus";
 import { createObjectIdString } from "@web/common/utils/id/object-id.util";
 import { eventQueryKeys } from "@web/events/queries/event.query.keys";
-import { useDraftStore } from "@web/events/stores/draft.store";
+import { draftActions, useDraftStore } from "@web/events/stores/draft.store";
 import { initialViewState, useViewStore } from "@web/events/stores/view.store";
 import {
   initialEdgeFocusState,
@@ -157,6 +157,7 @@ beforeEach(() => {
   HotkeyManager.resetInstance();
   repositionDraftByKeyboard = mock();
   useEdgeFocusStore.setState(initialEdgeFocusState, true);
+  draftActions.discard();
 });
 
 afterEach(() => {
@@ -166,6 +167,7 @@ afterEach(() => {
   weekEventRegistry.clear();
   useViewStore.setState(initialViewState);
   useEdgeFocusStore.setState(initialEdgeFocusState, true);
+  draftActions.discard();
 });
 
 const addCalendarTarget = (
@@ -677,6 +679,37 @@ describe("useWeekShortcutOwner shift+arrow event moves", () => {
     pressKey("ArrowRight", shiftKey);
 
     expect(getEditMutation(queryClient)).toBeUndefined();
+  });
+
+  it("places a keyboardPlace timed draft when Shift+Arrow is pressed with no focus", async () => {
+    renderShortcuts();
+
+    pressKey("ArrowDown", shiftKey);
+
+    await waitFor(() => {
+      const { gridDraft, status } = useDraftStore.getState();
+      expect(status?.activity).toBe("keyboardPlace");
+      expect(status?.isFormOpen).toBe(false);
+      expect(gridDraft?.values.calendarId).toBe(writableCalendar.id);
+    });
+  });
+
+  it("repositions a keyboardPlace draft with a later Shift+Arrow", async () => {
+    repositionDraftByKeyboard = mock(() =>
+      Boolean(useDraftStore.getState().gridDraft),
+    );
+    renderShortcuts();
+
+    pressKey("ArrowDown", shiftKey);
+
+    await waitFor(() => {
+      expect(useDraftStore.getState().status?.activity).toBe("keyboardPlace");
+    });
+
+    pressKey("ArrowDown", shiftKey);
+
+    expect(repositionDraftByKeyboard).toHaveBeenCalledWith("ArrowDown");
+    expect(useDraftStore.getState().status?.isFormOpen).toBe(false);
   });
 });
 

--- a/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcutOwner.ts
+++ b/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcutOwner.ts
@@ -9,7 +9,11 @@ import {
 } from "@web/common/utils/draft/draft.util";
 import { useFocusSidebarShortcut } from "@web/components/Sidebar/useFocusSidebarShortcut";
 import { useWeekEventViewModel } from "@web/events/queries/useWeekEventsQuery";
-import { draftActions, isEventFormOpen } from "@web/events/stores/draft.store";
+import {
+  draftActions,
+  isEventFormOpen,
+  useDraftStore,
+} from "@web/events/stores/draft.store";
 import { useGridEventEditShortcuts } from "@web/grid/shortcuts/useGridEventEditShortcuts";
 import { useGridEventFormFieldSequences } from "@web/grid/shortcuts/useGridEventFormFieldSequences";
 import {
@@ -129,6 +133,11 @@ export const useWeekShortcutOwner = ({
   }, [defaultTargetCalendarId, isCalendarsPending, isCurrentWeek, startOfView]);
 
   const placeTimedDraftEvent = useCallback(() => {
+    // Same guard as Day: reposition owns further Shift+Arrow once a draft
+    // exists; do not wipe a clamped/unmoved draft back to the default time.
+    if (useDraftStore.getState().gridDraft) {
+      return;
+    }
     if (isCalendarsPending && !defaultTargetCalendarId) {
       return;
     }

--- a/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcutOwner.ts
+++ b/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcutOwner.ts
@@ -128,6 +128,19 @@ export const useWeekShortcutOwner = ({
     );
   }, [defaultTargetCalendarId, isCalendarsPending, isCurrentWeek, startOfView]);
 
+  const placeTimedDraftEvent = useCallback(() => {
+    if (isCalendarsPending && !defaultTargetCalendarId) {
+      return;
+    }
+
+    void createTimedDraft(
+      isCurrentWeek,
+      startOfView,
+      "keyboardPlace",
+      defaultTargetCalendarId,
+    );
+  }, [defaultTargetCalendarId, isCalendarsPending, isCurrentWeek, startOfView]);
+
   // The command palette's create-event rows (event.cmd.constants.ts) can only
   // reach this view through the bus; the "C"/"A" keys below call the create
   // functions directly. Resubscribes when the create handlers change (week in
@@ -168,6 +181,7 @@ export const useWeekShortcutOwner = ({
     timedEvents,
     dayBoundary: { kind: "clamp", weekDays },
     targeting,
+    placeTimedDraft: placeTimedDraftEvent,
     repositionDraftByKey: repositionDraftByKeyboard,
   });
 

--- a/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcutOwner.ts
+++ b/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcutOwner.ts
@@ -9,11 +9,7 @@ import {
 } from "@web/common/utils/draft/draft.util";
 import { useFocusSidebarShortcut } from "@web/components/Sidebar/useFocusSidebarShortcut";
 import { useWeekEventViewModel } from "@web/events/queries/useWeekEventsQuery";
-import {
-  draftActions,
-  isEventFormOpen,
-  useDraftStore,
-} from "@web/events/stores/draft.store";
+import { draftActions, isEventFormOpen } from "@web/events/stores/draft.store";
 import { useGridEventEditShortcuts } from "@web/grid/shortcuts/useGridEventEditShortcuts";
 import { useGridEventFormFieldSequences } from "@web/grid/shortcuts/useGridEventFormFieldSequences";
 import {
@@ -132,12 +128,9 @@ export const useWeekShortcutOwner = ({
     );
   }, [defaultTargetCalendarId, isCalendarsPending, isCurrentWeek, startOfView]);
 
+  // Idle Shift+Arrow place-create. Existing-draft / focused-target guards live
+  // in useGridEventEditShortcuts so a failed clamp/midnight move never reseeds.
   const placeTimedDraftEvent = useCallback(() => {
-    // Same guard as Day: reposition owns further Shift+Arrow once a draft
-    // exists; do not wipe a clamped/unmoved draft back to the default time.
-    if (useDraftStore.getState().gridDraft) {
-      return;
-    }
     if (isCalendarsPending && !defaultTargetCalendarId) {
       return;
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a place-first timed draft flow via Shift+Arrow. Unfocused Shift+Arrow places a timed draft like c with the form closed; further Shift+Arrow repositions; Enter opens details; focused saved events still nudge. Guards prevent place-create over an existing draft or while any grid card (including read-only) is focused.

## Simplicity

Day place-create reuses openShortcutDraft with openForm false. Redundant Week draft-existence guard removed in favor of the shared Shift+Arrow handler. Place drafts focus via the known clientId.

## Automated validation

Browser at http://localhost:9080 Week view: place, reposition +15m, Enter opens form, focused saved-event nudge — all observed. bun test:web on touched suites, bun type-check, and bun lint passed.

## Independent review

No confirmed findings after guard fixes. Earlier reseed-on-failed-move and read-only place-create issues were fixed before this ready state.

## Test plan

Focused web suites for Week/Day shortcuts and DayCalendarGrid; bun type-check; bun lint; browser golden path above.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-80e5ff5c-b39a-4953-aa12-65115250b82b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-80e5ff5c-b39a-4953-aa12-65115250b82b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

