### PR TITLE
feat(web): replace google import overlay with pirate scouting loader

### DIFF
--- a/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.util.ts
+++ b/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.util.ts
@@ -319,10 +319,10 @@ export const getGoogleSyncStatus = (
  * a routine incremental catch-up on an already-established account. Both
  * collapse to the same aggregate "IMPORTING" product state, so a caller that
  * only checks that (e.g. the grid's empty-week overlay, before this was
- * introduced) shows first-import copy ("Importing from Google…") to a
- * long-established user during ordinary background catch-up. lastHealthyAt is
- * the one signal that distinguishes them: it is set once, the first time the
- * connection ever finishes healthy, and never cleared.
+ * introduced) would treat ordinary background catch-up like a brand-new
+ * first import. lastHealthyAt is the one signal that distinguishes them: it
+ * is set once, the first time the connection ever finishes healthy, and
+ * never cleared.
  */
 export const isFirstImportInProgress = (
   connection?: GoogleSyncConnectionSummary | null,

--- a/packages/web/src/components/WelcomeModal/PixelPirateScouting.tsx
+++ b/packages/web/src/components/WelcomeModal/PixelPirateScouting.tsx
@@ -1,0 +1,64 @@
+import classNames from "classnames";
+
+const hat = "var(--accent)";
+const skin = "#F4D7B5";
+const dark = "#0d1017";
+const beard = "#8B5E3C";
+const white = "#E6EDF3";
+const shirt = "#c2c6cc";
+const metal = "#5A6570";
+const lens = "#1A2330";
+
+export function PixelPirateScouting({ className }: { className?: string }) {
+  return (
+    <div className={classNames("c-pirate-scout", className)}>
+      <svg
+        className="h-full w-full"
+        viewBox="0 0 16 16"
+        role="img"
+        aria-label="Pixel pirate scouting with binoculars"
+        shapeRendering="crispEdges"
+      >
+        {/* Hat with skull mark */}
+        <rect x={4} y={0} width={8} height={1} fill={hat} />
+        <rect x={3} y={1} width={10} height={1} fill={hat} />
+        <rect x={2} y={2} width={12} height={1} fill={hat} />
+        <rect x={3} y={3} width={10} height={1} fill={hat} />
+        <rect x={7} y={1} width={2} height={1} fill={white} />
+
+        {/* Face (eyes covered by binoculars) */}
+        <rect x={4} y={4} width={8} height={5} fill={skin} />
+
+        {/* Binoculars: metal body, dark lenses, white glints */}
+        <rect x={4} y={5} width={3} height={3} fill={metal} />
+        <rect x={9} y={5} width={3} height={3} fill={metal} />
+        <rect x={7} y={6} width={2} height={1} fill={metal} />
+        <rect x={5} y={6} width={1} height={1} fill={lens} />
+        <rect x={10} y={6} width={1} height={1} fill={lens} />
+        <rect x={5} y={5} width={1} height={1} fill={white} />
+        <rect x={10} y={5} width={1} height={1} fill={white} />
+
+        {/* Beard */}
+        <rect x={4} y={9} width={8} height={1} fill={beard} />
+        <rect x={5} y={10} width={6} height={1} fill={beard} />
+
+        {/* Shirt with belt */}
+        <rect x={4} y={11} width={8} height={1} fill={shirt} />
+        <rect x={5} y={12} width={6} height={1} fill={shirt} />
+        <rect x={5} y={13} width={6} height={1} fill={dark} />
+
+        {/* Legs */}
+        <rect x={6} y={14} width={1} height={1} fill={dark} />
+        <rect x={9} y={14} width={1} height={1} fill={dark} />
+
+        {/* Arms holding binoculars */}
+        <rect x={2} y={6} width={1} height={1} fill={skin} />
+        <rect x={3} y={5} width={1} height={2} fill={skin} />
+        <rect x={13} y={6} width={1} height={1} fill={skin} />
+        <rect x={12} y={5} width={1} height={2} fill={skin} />
+        <rect x={2} y={7} width={1} height={2} fill={skin} />
+        <rect x={13} y={7} width={1} height={2} fill={skin} />
+      </svg>
+    </div>
+  );
+}

--- a/packages/web/src/grid/components/EventGrid.test.tsx
+++ b/packages/web/src/grid/components/EventGrid.test.tsx
@@ -216,6 +216,91 @@ describe("EventGrid", () => {
     ).toBeInTheDocument();
   });
 
+  it("shows a scouting pirate when the visible range is empty during import", () => {
+    render(
+      <EventGrid
+        allDayEventsLayer={<div />}
+        gridRefs={createGridRefs()}
+        isImportingEmpty
+        onAllDayMouseDown={mock()}
+        onTimedMouseDown={mock()}
+        timedEventsLayer={<div />}
+        today={dayjs("2026-05-20T00:00:00.000")}
+        visibleDates={[
+          {
+            date: dayjs("2026-05-20T00:00:00.000"),
+            key: "date-0",
+          },
+        ]}
+      />,
+    );
+
+    const status = screen.getByRole("status", { name: "Looking for events" });
+    expect(status).toHaveClass("pointer-events-none");
+    expect(
+      screen.getByRole("img", {
+        name: "Pixel pirate scouting with binoculars",
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/Importing from Google/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides the scouting pirate while events are loading or in error", () => {
+    const { rerender } = render(
+      <EventGrid
+        allDayEventsLayer={<div />}
+        gridRefs={createGridRefs()}
+        isImportingEmpty
+        isLoadingEvents
+        onAllDayMouseDown={mock()}
+        onTimedMouseDown={mock()}
+        timedEventsLayer={<div />}
+        today={dayjs("2026-05-20T00:00:00.000")}
+        visibleDates={[
+          {
+            date: dayjs("2026-05-20T00:00:00.000"),
+            key: "date-0",
+          },
+        ]}
+      />,
+    );
+
+    expect(
+      screen.queryByRole("status", { name: "Looking for events" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("status", { name: "Loading events" }),
+    ).toBeInTheDocument();
+
+    rerender(
+      <EventGrid
+        allDayEventsLayer={<div />}
+        gridRefs={createGridRefs()}
+        isErrorEvents
+        isImportingEmpty
+        onAllDayMouseDown={mock()}
+        onTimedMouseDown={mock()}
+        timedEventsLayer={<div />}
+        today={dayjs("2026-05-20T00:00:00.000")}
+        visibleDates={[
+          {
+            date: dayjs("2026-05-20T00:00:00.000"),
+            key: "date-0",
+          },
+        ]}
+      />,
+    );
+
+    expect(
+      screen.queryByRole("status", { name: "Looking for events" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Couldn't load events.",
+    );
+  });
+
   it("shows the loader for first load and for retry after error", () => {
     expect(isEventGridLoading(true, false, false)).toBe(true);
     expect(isEventGridLoading(false, true, true)).toBe(true);

--- a/packages/web/src/grid/components/EventGrid.test.tsx
+++ b/packages/web/src/grid/components/EventGrid.test.tsx
@@ -235,10 +235,12 @@ describe("EventGrid", () => {
       />,
     );
 
-    const status = screen.getByRole("status", { name: "Looking for events" });
-    expect(status).toHaveClass("pointer-events-none");
+    const status = screen.getByRole("status");
+    expect(status).toHaveClass("sr-only");
+    expect(status).toHaveTextContent("Looking for events");
     expect(
       screen.getByRole("img", {
+        hidden: true,
         name: "Pixel pirate scouting with binoculars",
       }),
     ).toBeInTheDocument();
@@ -293,9 +295,7 @@ describe("EventGrid", () => {
       />,
     );
 
-    expect(
-      screen.queryByRole("status", { name: "Looking for events" }),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText("Looking for events")).not.toBeInTheDocument();
     expect(screen.getByRole("alert")).toHaveTextContent(
       "Couldn't load events.",
     );

--- a/packages/web/src/grid/components/EventGrid.tsx
+++ b/packages/web/src/grid/components/EventGrid.tsx
@@ -6,6 +6,7 @@ import {
 import { type Dayjs } from "@core/util/date/dayjs";
 import { ZIndex } from "@web/common/constants/web.constants";
 import { AbsoluteOverflowLoader } from "@web/components/AbsoluteOverflowLoader/AbsoluteOverflowLoader";
+import { PixelPirateScouting } from "@web/components/WelcomeModal/PixelPirateScouting";
 import {
   type GridRefs,
   type GridVisibleDate,
@@ -24,7 +25,7 @@ export interface EventGridProps {
   isErrorEvents?: boolean;
   /**
    * Google import is in progress and the visible range has no events yet —
-   * show expectation-setting copy instead of a blank grid (non-blocking).
+   * show a non-blocking scouting indicator instead of a blank grid.
    */
   isImportingEmpty?: boolean;
   onRetryEvents?: () => void;
@@ -91,14 +92,13 @@ export const EventGrid: FC<EventGridProps> = ({
     )}
     {isImportingEmpty && !isLoadingEvents && !isErrorEvents && (
       <div
+        aria-label="Looking for events"
         aria-live="polite"
         className="pointer-events-none absolute inset-0 flex items-center justify-center px-4"
         role="status"
         style={{ zIndex: ZIndex.MAX }}
       >
-        <p className="max-w-sm text-center text-sm text-text-muted">
-          Importing from Google. Larger calendars can take a few minutes.
-        </p>
+        <PixelPirateScouting className="h-16 w-16" />
       </div>
     )}
     {isErrorEvents && !isLoadingEvents && (

--- a/packages/web/src/grid/components/EventGrid.tsx
+++ b/packages/web/src/grid/components/EventGrid.tsx
@@ -91,15 +91,18 @@ export const EventGrid: FC<EventGridProps> = ({
       />
     )}
     {isImportingEmpty && !isLoadingEvents && !isErrorEvents && (
-      <div
-        aria-label="Looking for events"
-        aria-live="polite"
-        className="pointer-events-none absolute inset-0 flex items-center justify-center px-4"
-        role="status"
-        style={{ zIndex: ZIndex.MAX }}
-      >
-        <PixelPirateScouting className="h-16 w-16" />
-      </div>
+      <>
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-0 flex items-center justify-center px-4"
+          style={{ zIndex: ZIndex.MAX }}
+        >
+          <PixelPirateScouting className="h-16 w-16" />
+        </div>
+        <span aria-live="polite" className="sr-only" role="status">
+          Looking for events
+        </span>
+      </>
     )}
     {isErrorEvents && !isLoadingEvents && (
       <div

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -151,6 +151,7 @@
   --animate-sync-text-wave: syncTextWave 2.4s linear infinite;
   --animate-sync-icon-wave: syncIconWave 2.4s linear infinite;
   --animate-loader-spin: loaderSpin 1.1s linear infinite;
+  --animate-pirate-scout: pirateScout 2.2s ease-in-out infinite;
 
   @keyframes loaderSpin {
     from {
@@ -176,6 +177,23 @@
     }
     to {
       mask-position: -50% 0;
+    }
+  }
+
+  /* Pan left/right with a light bob — reads even in a short flash. */
+  @keyframes pirateScout {
+    0%,
+    100% {
+      transform: translate(0, 0);
+    }
+    25% {
+      transform: translate(-6.25%, -6.25%);
+    }
+    50% {
+      transform: translate(0, 0);
+    }
+    75% {
+      transform: translate(6.25%, -6.25%);
     }
   }
 }
@@ -319,6 +337,14 @@
   @media (prefers-reduced-motion: reduce) {
     animation: none;
     mask: none;
+  }
+}
+
+@utility c-pirate-scout {
+  animation: var(--animate-pirate-scout);
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
   }
 }
 

--- a/packages/web/src/views/Week/components/Grid/Grid.tsx
+++ b/packages/web/src/views/Week/components/Grid/Grid.tsx
@@ -61,8 +61,8 @@ export const Grid: FC<Props> = ({
   // already-established account's routine catch-up - both collapse to the
   // same aggregate IMPORTING state. Without isFirstImportInProgress, an
   // established user viewing a genuinely empty week during ordinary
-  // background catch-up would see "Importing from Google…" as if this were
-  // a brand-new account.
+  // background catch-up would see the empty-import scouting overlay as if
+  // this were a brand-new account.
   const isImportingEmpty =
     isSuccess &&
     !hasVisibleEvents &&


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When the calendar grid is empty during a first Google import, EventGrid previously showed multi-sentence “Importing from Google…” copy. That flashed on rapid view changes, was often inaccurate after onboarding, and was too text-heavy for a brief empty state.

This replaces that overlay with a non-blocking pixel-pirate-with-binoculars animation (`Looking for events` for assistive tech), keeping the same `isImportingEmpty` gate. Reduced-motion users get a static frame.

## Test plan

- [ ] During first import, open an empty day/week and confirm the scouting pirate appears (no Google import paragraph)
- [ ] Rapidly change views and confirm the animation feels intentional without claiming an import is still running
- [ ] Confirm first-load spinner and error/retry overlays still take precedence
- [ ] With `prefers-reduced-motion`, confirm the pirate is static
- [ ] `bun test packages/web/src/grid/components/EventGrid.test.tsx`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ac37d18f-63ea-4a72-b8a3-0eef0d55ac24?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ac37d18f-63ea-4a72-b8a3-0eef0d55ac24&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

