### PR TITLE
fix(web): suppress load-error UI during session expiry

### DIFF
--- a/docs/acceptance/auth.md
+++ b/docs/acceptance/auth.md
@@ -260,8 +260,9 @@ When a previously authenticated session becomes invalid, the app should guide th
 
 ### Expected Results
 
-- The toast says `Session expired. Please sign in again.`
+- The toast says `You've been signed out. Please sign in again.`
 - Clicking `Sign in` opens the login modal.
+- The calendar does **not** also show a local “Couldn't load events” / “Couldn't load calendars” Retry UI for the same session failure — session recovery owns that story.
 - Re-authenticating restores normal app usage.
 
 ## Scenario 11: Logout And Persisted Gate State

--- a/packages/web/src/api/util/api.util.test.ts
+++ b/packages/web/src/api/util/api.util.test.ts
@@ -12,9 +12,12 @@ import {
 import {
   createApiError as buildApiError,
   getApiErrorCode,
+  getErrorStatus,
   handleErrorResponse,
+  isSessionLevelError,
   parseApiError,
   parseGoogleConnectError,
+  shouldShowContextualLoadError,
 } from "./api.util";
 import { describe, expect, it, mock, spyOn } from "bun:test";
 
@@ -63,6 +66,77 @@ describe("createApiError", () => {
 
     expect(error.message).toBe("Request failed for DELETE /event/abc");
     expect(error.response).toBeUndefined();
+  });
+});
+
+describe("getErrorStatus", () => {
+  it("reads the structured ApiError response status", () => {
+    const error = createApiError({ status: Status.UNAUTHORIZED });
+    expect(getErrorStatus(error)).toBe(Status.UNAUTHORIZED);
+  });
+
+  it("falls back to trailing message digits when there is no response", () => {
+    const error = new Error("Request failed with status 500");
+    expect(getErrorStatus(error)).toBe(500);
+  });
+
+  it("returns undefined for unrelated values", () => {
+    expect(getErrorStatus(undefined)).toBeUndefined();
+    expect(getErrorStatus("nope")).toBeUndefined();
+    expect(getErrorStatus(new Error("no status here"))).toBeUndefined();
+  });
+});
+
+describe("isSessionLevelError", () => {
+  it.each([
+    Status.UNAUTHORIZED,
+    Status.GONE,
+  ])("is true for session status %s", (status) => {
+    expect(isSessionLevelError(createApiError({ status }))).toBe(true);
+  });
+
+  it("is false for other HTTP failures", () => {
+    expect(
+      isSessionLevelError(createApiError({ status: Status.INTERNAL_SERVER })),
+    ).toBe(false);
+    expect(
+      isSessionLevelError(createApiError({ status: Status.NOT_FOUND })),
+    ).toBe(false);
+  });
+});
+
+describe("shouldShowContextualLoadError", () => {
+  it("shows local Retry UI for ordinary load failures", () => {
+    expect(
+      shouldShowContextualLoadError(
+        true,
+        createApiError({ status: Status.INTERNAL_SERVER }),
+      ),
+    ).toBe(true);
+  });
+
+  it("hides local Retry UI when session recovery already owns the toast", () => {
+    expect(
+      shouldShowContextualLoadError(
+        true,
+        createApiError({ status: Status.UNAUTHORIZED }),
+      ),
+    ).toBe(false);
+    expect(
+      shouldShowContextualLoadError(
+        true,
+        createApiError({ status: Status.GONE }),
+      ),
+    ).toBe(false);
+  });
+
+  it("is false when the query is not in error", () => {
+    expect(
+      shouldShowContextualLoadError(
+        false,
+        createApiError({ status: Status.UNAUTHORIZED }),
+      ),
+    ).toBe(false);
   });
 });
 

--- a/packages/web/src/api/util/api.util.ts
+++ b/packages/web/src/api/util/api.util.ts
@@ -50,6 +50,38 @@ export const isApiError = (error: unknown): error is ApiError => {
 };
 
 /**
+ * Prefer the structured status on ApiError; fall back to the trailing status
+ * digits in the message for errors that only carry text (same convention as
+ * {@link createApiError}).
+ */
+export const getErrorStatus = (error: unknown): number | undefined => {
+  if (isApiError(error) && typeof error.response?.status === "number") {
+    return error.response.status;
+  }
+  if (error instanceof Error) {
+    const parsed = parseInt(error.message.slice(-3), 10);
+    return Number.isNaN(parsed) ? undefined : parsed;
+  }
+  return undefined;
+};
+
+/**
+ * GONE/UNAUTHORIZED are session-level failures — the API interceptor signs the
+ * user out and shows SessionExpiredToast, so callers must not add a second
+ * recovery UI (load-error overlays, mutation toasts, etc.).
+ */
+export const isSessionLevelError = (error: unknown): boolean => {
+  const status = getErrorStatus(error);
+  return status === Status.UNAUTHORIZED || status === Status.GONE;
+};
+
+/** True when a fetch failed for a reason that still needs a local Retry UI. */
+export const shouldShowContextualLoadError = (
+  isError: boolean,
+  error: unknown,
+): boolean => isError && !isSessionLevelError(error);
+
+/**
  * Extracts the error code from an API error's response data.
  * Returns undefined when the response has no object body with a string `code` property.
  */

--- a/packages/web/src/common/utils/event/event.util.ts
+++ b/packages/web/src/common/utils/event/event.util.ts
@@ -9,6 +9,7 @@ import { EventMutationErrorSchema } from "@core/types/event-command.contracts";
 import { type WithId } from "@core/types/type.utils";
 import dayjs, { type Dayjs } from "@core/util/date/dayjs";
 import { type ApiError } from "@web/api/api.types";
+import { getErrorStatus, isSessionLevelError } from "@web/api/util/api.util";
 import { isBackendUnavailableError } from "@web/api/util/backend-unavailable-error.util";
 import { getUserId } from "@web/auth/compass/session/session.util";
 import { getPosthogClient } from "@web/auth/posthog/posthog.bootstrap";
@@ -237,13 +238,10 @@ export const handleError = (error: Error) => {
 
   // Prefer the structured status on ApiError; fall back to the trailing
   // status digits in the message for errors that only carry text.
-  const code =
-    (error as ApiError).response?.status ??
-    parseInt(error.message.slice(-3), 10);
+  const code = getErrorStatus(error) ?? Number.NaN;
 
-  // GONE/UNAUTHORIZED are session-level failures — the api interceptor signs
-  // the user out, which has its own messaging, so nothing more is shown here.
-  if (code === Status.GONE || code === Status.UNAUTHORIZED) {
+  // Session recovery already owns the toast — do not stack a second message.
+  if (isSessionLevelError(error)) {
     return;
   }
   // NOT_FOUND is not a session failure (e.g. syncing onto a calendar the

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarList.test.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarList.test.tsx
@@ -1,5 +1,6 @@
 import { act, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { Status } from "@core/errors/status.codes";
 import {
   type Calendar,
   getCalendarCapabilities,
@@ -15,6 +16,8 @@ import { createMockConnection as makeConnection } from "@web/__tests__/utils/fac
 import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
 import { type ApiRequestConfig } from "@web/api/api.types";
 import { BaseApi } from "@web/api/base/base.api";
+import { createApiError } from "@web/api/util/api.util";
+import { session } from "@web/auth/compass/session/Session";
 import { userMetadataActions } from "@web/auth/state/user-metadata.store";
 import { calendarQueryKeys } from "@web/calendars/calendar.query";
 import { isCalendarHidden } from "@web/calendars/calendar-visibility.storage";
@@ -678,5 +681,43 @@ describe("CalendarList", () => {
     await waitFor(() => {
       expect(screen.getByText("Work")).toBeInTheDocument();
     });
+  });
+
+  it("does not show the calendars load error for a session-level failure", async () => {
+    // Session recovery already owns the signed-out toast; Retry would keep
+    // failing while remote source stays selected.
+    window.history.pushState({}, "", "/week");
+    const signOutSpy = spyOn(session, "signOut").mockResolvedValue(undefined);
+    BaseApi.defaults.adapter = async (
+      config: ApiRequestConfig & { body?: unknown },
+    ) => {
+      throw createApiError(config, {
+        config,
+        data: {},
+        headers: new Headers(),
+        status: Status.UNAUTHORIZED,
+        statusText: "Unauthorized",
+      });
+    };
+    mockUseSession.mockReturnValue({
+      authenticated: true,
+      setAuthenticated: () => {},
+    });
+    const { wrapper } = createStoreWrapper();
+    render(<CalendarList />, { wrapper });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/connect google to see your calendars/i),
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByText(/couldn.t load calendars/i),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Retry" }),
+    ).not.toBeInTheDocument();
+
+    signOutSpy.mockRestore();
   });
 });

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarList.test.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarList.test.tsx
@@ -685,7 +685,8 @@ describe("CalendarList", () => {
 
   it("does not show the calendars load error for a session-level failure", async () => {
     // Session recovery already owns the signed-out toast; Retry would keep
-    // failing while remote source stays selected.
+    // failing while remote source stays selected. Stay quiet rather than
+    // inventing an empty-list story ("Connect Google…" / "No calendars yet.").
     window.history.pushState({}, "", "/week");
     const signOutSpy = spyOn(session, "signOut").mockResolvedValue(undefined);
     BaseApi.defaults.adapter = async (
@@ -707,16 +708,18 @@ describe("CalendarList", () => {
     render(<CalendarList />, { wrapper });
 
     await waitFor(() => {
+      expect(screen.getByLabelText("Calendars")).toBeInTheDocument();
       expect(
-        screen.getByText(/connect google to see your calendars/i),
-      ).toBeInTheDocument();
+        screen.queryByText(/couldn.t load calendars/i),
+      ).not.toBeInTheDocument();
     });
-    expect(
-      screen.queryByText(/couldn.t load calendars/i),
-    ).not.toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: "Retry" }),
     ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/connect google to see your calendars/i),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/no calendars yet/i)).not.toBeInTheDocument();
 
     signOutSpy.mockRestore();
   });

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarList.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarList.tsx
@@ -37,8 +37,9 @@ export const CalendarList: FC = () => {
   const hasConnectedAccount = accountEmailOrder.length > 0;
   const isAnonymous = !email;
   // Session expiry already surfaces SessionExpiredToast — don't also show
-  // "Couldn't load calendars" / Retry for the same failure.
+  // "Couldn't load calendars" / Retry (or a false empty-list story) for it.
   const showCalendarsLoadError = shouldShowContextualLoadError(isError, error);
+  const hideCalendarsBody = isPending || (isError && !showCalendarsLoadError);
 
   // Re-groups on every calendar-visibility/collapse toggle otherwise, since
   // those live in sibling external stores this component also subscribes to.
@@ -95,7 +96,7 @@ export const CalendarList: FC = () => {
           heading with no way to tell them apart. */}
       {groups.length === 0 && !isAnonymous && <CalendarListHeader />}
 
-      {isPending ? null : showCalendarsLoadError ? (
+      {hideCalendarsBody ? null : showCalendarsLoadError ? (
         <div className="flex items-center justify-between gap-2 text-xs">
           <p className="text-error">Couldn't load calendars.</p>
           <button

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarList.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarList.tsx
@@ -1,5 +1,6 @@
 import { type FC, useMemo } from "react";
 import { type Calendar } from "@core/types/calendar.contracts";
+import { shouldShowContextualLoadError } from "@web/api/util/api.util";
 import { useSession } from "@web/auth/compass/session/useSession";
 import { useUser } from "@web/auth/compass/user/hooks/useUser";
 import { useConnectGoogle } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle";
@@ -26,7 +27,7 @@ export const CalendarList: FC = () => {
   const { authenticated } = useSession();
   const { email } = useUser();
   const { isAvailable, state } = useConnectGoogle();
-  const { data, isPending, isError, refetch } = useCalendarsQuery();
+  const { data, error, isPending, isError, refetch } = useCalendarsQuery();
   const { toggleCalendarVisibility, failureAnnouncement } =
     useCalendarVisibility();
   const connections = useUserMetadataStore(selectGoogleSyncConnections);
@@ -35,6 +36,9 @@ export const CalendarList: FC = () => {
 
   const hasConnectedAccount = accountEmailOrder.length > 0;
   const isAnonymous = !email;
+  // Session expiry already surfaces SessionExpiredToast — don't also show
+  // "Couldn't load calendars" / Retry for the same failure.
+  const showCalendarsLoadError = shouldShowContextualLoadError(isError, error);
 
   // Re-groups on every calendar-visibility/collapse toggle otherwise, since
   // those live in sibling external stores this component also subscribes to.
@@ -91,7 +95,7 @@ export const CalendarList: FC = () => {
           heading with no way to tell them apart. */}
       {groups.length === 0 && !isAnonymous && <CalendarListHeader />}
 
-      {isPending ? null : isError ? (
+      {isPending ? null : showCalendarsLoadError ? (
         <div className="flex items-center justify-between gap-2 text-xs">
           <p className="text-error">Couldn't load calendars.</p>
           <button

--- a/packages/web/src/grid/components/EventGrid.test.tsx
+++ b/packages/web/src/grid/components/EventGrid.test.tsx
@@ -157,6 +157,34 @@ describe("EventGrid", () => {
     expect(onRetryEvents).toHaveBeenCalledTimes(1);
   });
 
+  it("does not show the load overlay when callers suppress session-level errors", () => {
+    // Week/Day pass shouldShowContextualLoadError(...) so SessionExpiredToast
+    // remains the only recovery CTA after 401/410.
+    render(
+      <EventGrid
+        allDayEventsLayer={<div />}
+        gridRefs={createGridRefs()}
+        isErrorEvents={false}
+        onAllDayMouseDown={mock()}
+        onRetryEvents={mock()}
+        onTimedMouseDown={mock()}
+        timedEventsLayer={<div />}
+        today={dayjs("2026-05-20T00:00:00.000")}
+        visibleDates={[
+          {
+            date: dayjs("2026-05-20T00:00:00.000"),
+            key: "date-0",
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Retry" }),
+    ).not.toBeInTheDocument();
+  });
+
   it("hides the error overlay while events are loading", () => {
     render(
       <EventGrid

--- a/packages/web/src/grid/components/EventGrid.test.tsx
+++ b/packages/web/src/grid/components/EventGrid.test.tsx
@@ -157,34 +157,6 @@ describe("EventGrid", () => {
     expect(onRetryEvents).toHaveBeenCalledTimes(1);
   });
 
-  it("does not show the load overlay when callers suppress session-level errors", () => {
-    // Week/Day pass shouldShowContextualLoadError(...) so SessionExpiredToast
-    // remains the only recovery CTA after 401/410.
-    render(
-      <EventGrid
-        allDayEventsLayer={<div />}
-        gridRefs={createGridRefs()}
-        isErrorEvents={false}
-        onAllDayMouseDown={mock()}
-        onRetryEvents={mock()}
-        onTimedMouseDown={mock()}
-        timedEventsLayer={<div />}
-        today={dayjs("2026-05-20T00:00:00.000")}
-        visibleDates={[
-          {
-            date: dayjs("2026-05-20T00:00:00.000"),
-            key: "date-0",
-          },
-        ]}
-      />,
-    );
-
-    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
-    expect(
-      screen.queryByRole("button", { name: "Retry" }),
-    ).not.toBeInTheDocument();
-  });
-
   it("hides the error overlay while events are loading", () => {
     render(
       <EventGrid

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
@@ -8,6 +8,7 @@ import { YEAR_MONTH_DAY_FORMAT } from "@core/constants/date.constants";
 import { type Calendar } from "@core/types/calendar.contracts";
 import { type CalendarId } from "@core/types/domain-primitives";
 import dayjs from "@core/util/date/dayjs";
+import { shouldShowContextualLoadError } from "@web/api/util/api.util";
 import { useConnectGoogle } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle";
 import { isFirstImportInProgress } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle.util";
 import { useCalendarsQuery } from "@web/calendars/calendar.query";
@@ -77,6 +78,7 @@ export function DayCalendarGrid() {
     useDefaultTargetCalendar(calendars)?.id ?? null;
   const {
     allDayEvents,
+    error: eventsError,
     events: dayEvents,
     isError: isErrorEvents,
     isFetching,
@@ -84,9 +86,15 @@ export function DayCalendarGrid() {
     refetch,
     timedEvents,
   } = useDayEventViewModel(dayEventQueryRange(dateInView));
+  // Session expiry already surfaces SessionExpiredToast — don't also show
+  // "Couldn't load events" / Retry for the same failure.
+  const showEventsLoadError = shouldShowContextualLoadError(
+    isErrorEvents,
+    eventsError,
+  );
   const isLoadingEvents = isEventGridLoading(
     isPending,
-    isErrorEvents,
+    showEventsLoadError,
     isFetching,
   );
   const { connection, state: googleState } = useConnectGoogle();
@@ -94,7 +102,7 @@ export function DayCalendarGrid() {
   // first-ever import apart from routine catch-up on an established account.
   const isImportingEmpty =
     !isPending &&
-    !isErrorEvents &&
+    !showEventsLoadError &&
     dayEvents.length === 0 &&
     googleState === "IMPORTING" &&
     isFirstImportInProgress(connection);
@@ -394,7 +402,7 @@ export function DayCalendarGrid() {
           allDayEventsLayer={allDayEventsLayer}
           allDayRowsCount={allDayRowsCount}
           gridRefs={gridRefs}
-          isErrorEvents={isErrorEvents}
+          isErrorEvents={showEventsLoadError}
           isImportingEmpty={isImportingEmpty}
           isLoadingEvents={isLoadingEvents}
           onAllDayMouseDown={handleAllDayMouseDown}

--- a/packages/web/src/views/Week/components/Grid/Grid.tsx
+++ b/packages/web/src/views/Week/components/Grid/Grid.tsx
@@ -1,6 +1,7 @@
 import { type FC, useMemo } from "react";
 import { YEAR_MONTH_DAY_FORMAT } from "@core/constants/date.constants";
 import { type Dayjs } from "@core/util/date/dayjs";
+import { shouldShowContextualLoadError } from "@web/api/util/api.util";
 import { useConnectGoogle } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle";
 import { isFirstImportInProgress } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle.util";
 import { useWeekEventViewModel } from "@web/events/queries/useWeekEventsQuery";
@@ -40,6 +41,7 @@ export const Grid: FC<Props> = ({
   // their load without issuing a second fetch.
   const {
     allDayEvents,
+    error: eventsError,
     isPending,
     isFetching,
     isError: isErrorEvents,
@@ -51,9 +53,15 @@ export const Grid: FC<Props> = ({
     endOfView: weekProps.query.endOfView,
   });
   const { connection, state: googleState } = useConnectGoogle();
+  // Session expiry already surfaces SessionExpiredToast — don't also show
+  // "Couldn't load events" / Retry for the same failure.
+  const showEventsLoadError = shouldShowContextualLoadError(
+    isErrorEvents,
+    eventsError,
+  );
   const isLoadingEvents = isEventGridLoading(
     isPending,
-    isErrorEvents,
+    showEventsLoadError,
     isFetching,
   );
   const hasVisibleEvents = (data?.ids?.length ?? 0) > 0;
@@ -128,7 +136,7 @@ export const Grid: FC<Props> = ({
                 allDayGridOffsetTopPx={GRID_Y_START}
                 allDayRowsCount={allDayRowsCount}
                 gridRefs={gridRefs}
-                isErrorEvents={isErrorEvents}
+                isErrorEvents={showEventsLoadError}
                 isImportingEmpty={isImportingEmpty}
                 isLoadingEvents={isLoadingEvents}
                 onAllDayMouseDown={onAllDayMouseDown}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When a session expires, the API interceptor already signs the user out and shows the global **You've been signed out** toast. Event/calendar queries still landed in `isError`, so the UI also showed **Couldn't load…** + Retry — two conflicting CTAs.

Session recovery now owns that story: contextual load-error UI only appears for non-session failures. CalendarList stays quiet on 401/410 instead of inventing an empty-list message.

## Simplicity

Shared `shouldShowContextualLoadError` / `isSessionLevelError` helpers; callers stay thin. Review follow-up removed a weak presentational EventGrid test that did not exercise Day/Week wiring.

## Automated validation

- Focused web unit tests for api.util helpers, event.util mutation suppress path, EventGrid, CalendarList (401 quiet + ordinary Retry).
- No live browser session-expiry scenario: requires SuperTokens/auth cookies not provisioned in this environment (AGENTS.md login rule). Covered by interceptor + UI unit tests instead.

## Independent review

Fresh diff-first review: **ship-with-nits**. Confirmed important finding fixed — CalendarList no longer falls through to “Connect Google…” / “No calendars yet.” after session-level load failure. Residual: Day/Week session suppress is util-tested but not integration-tested; pre-existing 410 toast copy differs from 401.

## Test plan

- `bun test:web` on `api.util.test.ts`, `event.util.test.ts`, `EventGrid.test.tsx`, `CalendarList.test.tsx` — pass
- `bun lint` — pass for this change
- CI on PR (lint, type-check, unit, e2e, CodeQL) — pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-61fe2e38-927d-4a9f-8f67-aa78365380d0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-61fe2e38-927d-4a9f-8f67-aa78365380d0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

