### PR TITLE
fix(web): keep earlier recurrence instances when opening an occurrence

### DIFF
--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/useRecurrence/useRecurrence.test.ts
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/useRecurrence/useRecurrence.test.ts
@@ -228,21 +228,24 @@ describe("useRecurrence hook", () => {
         seriesId: EventIdSchema.parse("0123456789abcdefaaaaaaaa"),
       },
     });
-    const draft = editGridEventDraft(source);
-    if (!draft) throw new Error("expected edit draft");
+    const editedDraft = editGridEventDraft(source);
+    if (!editedDraft) throw new Error("expected edit draft");
 
-    expect(draft.values.recurrence).toEqual({ kind: "preserve" });
-    expect(suppressedSeriesIdForDraft(draft)).toBeNull();
+    expect(editedDraft.values.recurrence).toEqual({ kind: "preserve" });
+    expect(suppressedSeriesIdForDraft(editedDraft)).toBeNull();
 
-    const setDraft = mock();
-    const nextSetDraft = mock();
+    let draft: GridEventDraft = editedDraft;
+    let setDraftCalls = 0;
+    const setDraft: Dispatch<SetStateAction<GridEventDraft | null>> = (
+      updater,
+    ) => {
+      setDraftCalls++;
+      const next = typeof updater === "function" ? updater(draft) : updater;
+      if (next) draft = next;
+    };
 
-    const { result, rerender } = renderHook(
-      ({ setDraftProp }) =>
-        useRecurrence(draft, { setDraft: setDraftProp }, seriesRules),
-      {
-        initialProps: { setDraftProp: setDraft },
-      },
+    const { result, rerender } = renderHook(() =>
+      useRecurrence(draft, { setDraft }, seriesRules),
     );
 
     expect(result.current.hasRecurrence).toBe(true);
@@ -254,12 +257,14 @@ describe("useRecurrence hook", () => {
       "thursday",
       "friday",
     ]);
-    expect(setDraft).not.toHaveBeenCalled();
+    expect(setDraftCalls).toBe(0);
+    expect(draft.values.recurrence).toEqual({ kind: "preserve" });
     expect(suppressedSeriesIdForDraft(draft)).toBeNull();
 
-    rerender({ setDraftProp: nextSetDraft });
+    rerender();
 
-    expect(nextSetDraft).not.toHaveBeenCalled();
+    expect(setDraftCalls).toBe(0);
+    expect(draft.values.recurrence).toEqual({ kind: "preserve" });
     expect(suppressedSeriesIdForDraft(draft)).toBeNull();
   });
 

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/useRecurrence/useRecurrence.test.ts
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/useRecurrence/useRecurrence.test.ts
@@ -10,6 +10,7 @@ import {
   createGridEventDraft,
   editGridEventDraft,
   resolveDraftRecurrenceRules,
+  suppressedSeriesIdForDraft,
 } from "@web/events/grid-event-draft.adapter";
 import { useRecurrence } from "./useRecurrence";
 import { afterEach, describe, expect, it, mock, spyOn } from "bun:test";
@@ -212,6 +213,54 @@ describe("useRecurrence hook", () => {
     rerender({ setDraftProp: nextSetDraft });
 
     expect(nextSetDraft).not.toHaveBeenCalled();
+  });
+
+  // Regression: opening a later weekday occurrence of a Google-style series
+  // (BYDAY without INTERVAL=1) used to rewrite the rule on mount, flip
+  // preserve→series, suppress earlier siblings, and leave only the clicked
+  // day + forward previews visible.
+  it("does not rewrite a preserve occurrence draft whose series omits INTERVAL=1", () => {
+    const seriesRules = ["RRULE:FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR"];
+    const source = createMockEvent({
+      schedule: SCHEDULE,
+      recurrence: {
+        kind: "occurrence",
+        seriesId: EventIdSchema.parse("0123456789abcdefaaaaaaaa"),
+      },
+    });
+    const draft = editGridEventDraft(source);
+    if (!draft) throw new Error("expected edit draft");
+
+    expect(draft.values.recurrence).toEqual({ kind: "preserve" });
+    expect(suppressedSeriesIdForDraft(draft)).toBeNull();
+
+    const setDraft = mock();
+    const nextSetDraft = mock();
+
+    const { result, rerender } = renderHook(
+      ({ setDraftProp }) =>
+        useRecurrence(draft, { setDraft: setDraftProp }, seriesRules),
+      {
+        initialProps: { setDraftProp: setDraft },
+      },
+    );
+
+    expect(result.current.hasRecurrence).toBe(true);
+    expect(result.current.freq).toBe(Frequency.WEEKLY);
+    expect(result.current.weekDays).toEqual([
+      "monday",
+      "tuesday",
+      "wednesday",
+      "thursday",
+      "friday",
+    ]);
+    expect(setDraft).not.toHaveBeenCalled();
+    expect(suppressedSeriesIdForDraft(draft)).toBeNull();
+
+    rerender({ setDraftProp: nextSetDraft });
+
+    expect(nextSetDraft).not.toHaveBeenCalled();
+    expect(suppressedSeriesIdForDraft(draft)).toBeNull();
   });
 
   // Regression for React error #185 (max update depth exceeded): a timed

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/useRecurrence/useRecurrence.ts
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/useRecurrence/useRecurrence.ts
@@ -56,8 +56,14 @@ const WEEKDAY_MAP: Record<
   {} as Record<number | string | keyof typeof WEEKDAY_RRULE_MAP, Weekday>,
 );
 
+// Strip RRULE defaults the rrule library re-emits on rebuild (INTERVAL=1,
+// WKST) so open-for-edit doesn't treat serialization drift as a real edit.
+// Without this, Google-style rules like FREQ=WEEKLY;BYDAY=MO..FR flip the
+// draft from preserve→series and hide earlier sibling instances.
 const normalizeRecurrenceRule = (rule: string[] | null | undefined): string[] =>
-  (rule ?? []).map((entry) => entry.replace(/;WKST=[A-Z]{2}/, ""));
+  (rule ?? []).map((entry) =>
+    entry.replace(/;INTERVAL=1(?=;|$)/, "").replace(/;WKST=[A-Z]{2}/, ""),
+  );
 
 const weekdayKeyFromByweekday = (
   day: number | Weekday,

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/useRecurrence/useRecurrence.ts
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/useRecurrence/useRecurrence.ts
@@ -62,7 +62,10 @@ const WEEKDAY_MAP: Record<
 // draft from preserve→series and hide earlier sibling instances.
 const normalizeRecurrenceRule = (rule: string[] | null | undefined): string[] =>
   (rule ?? []).map((entry) =>
-    entry.replace(/;INTERVAL=1(?=;|$)/, "").replace(/;WKST=[A-Z]{2}/, ""),
+    entry
+      .replace(/;INTERVAL=1(?=;|$)/g, "")
+      .replace(/:INTERVAL=1;/g, ":")
+      .replace(/;WKST=[A-Z]{2}/g, ""),
   );
 
 const weekdayKeyFromByweekday = (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Opening a later weekday occurrence of a recurring series (e.g. Mon–Fri standup → click Thursday) made earlier instances disappear, even though the form still showed M–F selected.

Cause: `useRecurrence` rebuilds the RRULE on open and re-emits default `INTERVAL=1`. Google-style rules omit that default, so the mount effect treated serialization drift as a real edit, flipped the draft from `preserve` → `series`, suppressed sibling occurrences, and only showed forward draft previews from the clicked day.

Fix: Extend `normalizeRecurrenceRule` to treat default `INTERVAL=1` as equivalent to an omitted interval (alongside the existing `WKST` strip), so open-for-edit stays `preserve`.

![All five weekday standup instances visible](https://cursor.com/artifacts/c/art-cc04153c-8f37-43fb-9c99-61f79417e706)
![After clicking Thursday, earlier instances remain](https://cursor.com/artifacts/c/art-8eb58a8f-0243-47e0-a9de-d1aad4fa1be2)

## Simplicity

No separate simplify commit. The change is a one-line-class normalize extension plus a focused regression test. Sibling suppression and forward-only draft previews are left as-is — they are correct once a real recurrence edit exists.

## Automated validation

Browser at http://localhost:9080 (anonymous IndexedDB):
1. Created Mon–Fri Daily standup at 9 AM for Aug 10–14, 2026 — all five instances visible
2. Clicked Thursday instance — Mon/Tue/Wed/Fri remained visible; form still showed M–F selected
3. No console errors

## Independent review

Fresh diff-first review: CLEAN after follow-ups.
- Fixed: regression test now applies a real setDraft updater so suppressedSeriesIdForDraft asserts are meaningful
- Fixed: INTERVAL=1 stripped in either RRULE position (;INTERVAL=1 or :INTERVAL=1;)

Residual risk: other RRULE serialization drift beyond INTERVAL/WKST could still false-trigger a rewrite; not observed for the reported path.

## Test plan

- bun test:web useRecurrence.test.ts — 12 pass
- bun run lint — pass (pre-existing unrelated warnings only)
- CI on HEAD fa369550: lint, type-check, knip, unit (core/web/backend/sync/scripts), e2e, CodeQL — all green
- Browser golden path above — PASS

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b5383a68-0d6a-48f1-ac6f-a419c50cd8f4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b5383a68-0d6a-48f1-ac6f-a419c50cd8f4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

