### PR TITLE
feat(backend,web): record trial state server-side; wire trial CTA

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -34,6 +34,7 @@
         "cors": "^2.8.5",
         "exponential-backoff": "^3.1.2",
         "express": "^4.17.1",
+        "express-rate-limit": "^7.5.1",
         "google-auth-library": "^10.5.0",
         "helmet": "^7.0.0",
         "lodash": "^4.18.1",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -9,6 +9,7 @@
     "cors": "^2.8.5",
     "exponential-backoff": "^3.1.2",
     "express": "^4.17.1",
+    "express-rate-limit": "^7.5.1",
     "google-auth-library": "^10.5.0",
     "helmet": "^7.0.0",
     "lodash": "^4.18.1",

--- a/packages/backend/src/billing/billing.constants.ts
+++ b/packages/backend/src/billing/billing.constants.ts
@@ -1,0 +1,10 @@
+/**
+ * Placeholder trial/pricing terms, set 2026-08-10 to unblock implementation
+ * (see compass-calendar-internal/projects/keyboard-education/03-monetization-trial-checkout.md).
+ * Every value here is expected to change in the founder's post-ship pricing
+ * sweep -- kept in one module, not scattered literals, so that sweep is a
+ * small diff instead of a re-implementation.
+ */
+export const BILLING_DEFAULTS = {
+  TRIAL_LENGTH_DAYS: 14,
+} as const;

--- a/packages/backend/src/billing/billing.routes.config.ts
+++ b/packages/backend/src/billing/billing.routes.config.ts
@@ -1,0 +1,55 @@
+import type express from "express";
+import rateLimit from "express-rate-limit";
+import { verifySession } from "@backend/auth/session/session.middleware";
+import { CommonRoutesConfig } from "@backend/common/common.routes.config";
+import billingController from "./controllers/billing.controller";
+
+// A user can only ever start their own trial once (see billing.service's
+// idempotent startTrial), but this still gates the endpoint against a
+// retry storm or scripted abuse the same way any other write route should.
+const startTrialLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  limit: 5,
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
+/**
+ * Billing Routes Configuration
+ *
+ * Trial state only today -- no payment collection or Stripe webhooks yet.
+ * See compass-calendar-internal/projects/keyboard-education/03-monetization-trial-checkout.md
+ * for what remains before this is a real checkout flow.
+ */
+export class BillingRoutes extends CommonRoutesConfig {
+  constructor(app: express.Application) {
+    super(app, "BillingRoutes");
+  }
+
+  configureRoutes(): express.Application {
+    /**
+     * GET /api/billing/status
+     * Returns the current user's trial/subscription status.
+     *
+     * @auth Required - Supertokens session
+     */
+    this.app
+      .route(`/api/billing/status`)
+      .all(verifySession())
+      .get(billingController.getStatus);
+
+    /**
+     * POST /api/billing/trial/start
+     * Starts a trial for the current user. Idempotent: a user who already
+     * has one does not get a second, later window.
+     *
+     * @auth Required - Supertokens session
+     */
+    this.app
+      .route(`/api/billing/trial/start`)
+      .all(verifySession())
+      .post(startTrialLimiter, billingController.startTrial);
+
+    return this.app;
+  }
+}

--- a/packages/backend/src/billing/controllers/billing.controller.ts
+++ b/packages/backend/src/billing/controllers/billing.controller.ts
@@ -1,0 +1,35 @@
+import { type Request, type Response } from "express";
+import { Status } from "@core/errors/status.codes";
+import { type BillingStatusResponse } from "@core/types/billing.types";
+import { zObjectId } from "@core/types/type.utils";
+import billingService from "@backend/billing/services/billing.service";
+
+class BillingController {
+  getStatus = async (
+    req: Request<never, BillingStatusResponse, never, never>,
+    res: Response<BillingStatusResponse>,
+  ) => {
+    try {
+      const userId = zObjectId.parse(req.session?.getUserId());
+      const status = await billingService.getStatus(userId.toString());
+      res.status(Status.OK).json(status);
+    } catch {
+      res.status(Status.INTERNAL_SERVER).send();
+    }
+  };
+
+  startTrial = async (
+    req: Request<never, BillingStatusResponse, never, never>,
+    res: Response<BillingStatusResponse>,
+  ) => {
+    try {
+      const userId = zObjectId.parse(req.session?.getUserId());
+      const status = await billingService.startTrial(userId.toString());
+      res.status(Status.OK).json(status);
+    } catch {
+      res.status(Status.INTERNAL_SERVER).send();
+    }
+  };
+}
+
+export default new BillingController();

--- a/packages/backend/src/billing/services/billing.service.test.ts
+++ b/packages/backend/src/billing/services/billing.service.test.ts
@@ -1,0 +1,61 @@
+import { deriveBillingStatus } from "./billing.service";
+import { describe, expect, it } from "bun:test";
+
+describe("deriveBillingStatus", () => {
+  const now = new Date("2026-08-10T00:00:00.000Z");
+
+  it("returns none when no billing record exists", () => {
+    expect(deriveBillingStatus(undefined, now)).toEqual({
+      subscriptionStatus: "none",
+      trialEndsAt: null,
+      isReadOnly: false,
+    });
+  });
+
+  it("returns trialing and writable while the trial window is open", () => {
+    const trialEndsAt = new Date("2026-08-20T00:00:00.000Z");
+    const status = deriveBillingStatus(
+      {
+        subscriptionStatus: "trialing",
+        trialStartedAt: new Date("2026-08-06T00:00:00.000Z"),
+        trialEndsAt,
+      },
+      now,
+    );
+
+    expect(status).toEqual({
+      subscriptionStatus: "trialing",
+      trialEndsAt: trialEndsAt.toISOString(),
+      isReadOnly: false,
+    });
+  });
+
+  it("flips to expired and read-only once the trial end date has passed", () => {
+    const trialEndsAt = new Date("2026-08-01T00:00:00.000Z");
+    const status = deriveBillingStatus(
+      {
+        subscriptionStatus: "trialing",
+        trialStartedAt: new Date("2026-07-18T00:00:00.000Z"),
+        trialEndsAt,
+      },
+      now,
+    );
+
+    expect(status).toEqual({
+      subscriptionStatus: "expired",
+      trialEndsAt: trialEndsAt.toISOString(),
+      isReadOnly: true,
+    });
+  });
+
+  it("treats exactly-at-boundary as expired", () => {
+    const trialEndsAt = now;
+    const status = deriveBillingStatus(
+      { subscriptionStatus: "trialing", trialEndsAt },
+      now,
+    );
+
+    expect(status.subscriptionStatus).toBe("expired");
+    expect(status.isReadOnly).toBe(true);
+  });
+});

--- a/packages/backend/src/billing/services/billing.service.ts
+++ b/packages/backend/src/billing/services/billing.service.ts
@@ -1,0 +1,89 @@
+import { type BillingStatusResponse } from "@core/types/billing.types";
+import { type Schema_UserBilling } from "@core/types/user.types";
+import { BILLING_DEFAULTS } from "@backend/billing/billing.constants";
+import mongoService from "@backend/common/services/mongo.service";
+
+/**
+ * Pure status derivation: a trial past its end date reads as expired even
+ * before anything writes that back to the document. Keeps `getStatus` a
+ * simple read with no write-on-read race to reason about.
+ */
+export const deriveBillingStatus = (
+  billing: Schema_UserBilling | undefined,
+  now: Date,
+): BillingStatusResponse => {
+  if (!billing || billing.subscriptionStatus === "none") {
+    return { subscriptionStatus: "none", trialEndsAt: null, isReadOnly: false };
+  }
+
+  const trialEndsAt = billing.trialEndsAt ?? null;
+  const trialExpired =
+    trialEndsAt !== null && trialEndsAt.getTime() <= now.getTime();
+
+  if (billing.subscriptionStatus === "trialing" && !trialExpired) {
+    return {
+      subscriptionStatus: "trialing",
+      trialEndsAt: trialEndsAt?.toISOString() ?? null,
+      isReadOnly: false,
+    };
+  }
+
+  return {
+    subscriptionStatus: "expired",
+    trialEndsAt: trialEndsAt?.toISOString() ?? null,
+    isReadOnly: true,
+  };
+};
+
+class BillingService {
+  /**
+   * Starts a trial once per user; a second call is a no-op that just
+   * returns the existing state, so retried/duplicate CTA clicks can never
+   * push the trial window out further.
+   */
+  startTrial = async (userId: string): Promise<BillingStatusResponse> => {
+    const user = await mongoService.user.findOne({
+      _id: mongoService.objectId(userId),
+    });
+    if (!user) {
+      throw new Error("User not found");
+    }
+
+    const now = new Date();
+
+    if (user.billing?.trialStartedAt) {
+      return deriveBillingStatus(user.billing, now);
+    }
+
+    const trialEndsAt = new Date(now);
+    trialEndsAt.setDate(
+      trialEndsAt.getDate() + BILLING_DEFAULTS.TRIAL_LENGTH_DAYS,
+    );
+
+    const billing: Schema_UserBilling = {
+      subscriptionStatus: "trialing",
+      trialStartedAt: now,
+      trialEndsAt,
+    };
+
+    await mongoService.user.updateOne(
+      { _id: mongoService.objectId(userId) },
+      { $set: { billing } },
+    );
+
+    return deriveBillingStatus(billing, now);
+  };
+
+  getStatus = async (userId: string): Promise<BillingStatusResponse> => {
+    const user = await mongoService.user.findOne({
+      _id: mongoService.objectId(userId),
+    });
+    if (!user) {
+      throw new Error("User not found");
+    }
+
+    return deriveBillingStatus(user.billing, new Date());
+  };
+}
+
+export default new BillingService();

--- a/packages/backend/src/servers/express/express.server.ts
+++ b/packages/backend/src/servers/express/express.server.ts
@@ -5,6 +5,7 @@ import {
   middleware as supertokensMiddleware,
 } from "supertokens-node/framework/express";
 import { AuthRoutes } from "@backend/auth/auth.routes.config";
+import { BillingRoutes } from "@backend/billing/billing.routes.config";
 import { CalendarRoutes } from "@backend/calendar/calendar.routes.config";
 import { type CommonRoutesConfig } from "@backend/common/common.routes.config";
 import corsWhitelist from "@backend/common/middleware/cors.middleware";
@@ -41,6 +42,7 @@ export const initExpressServer = () => {
   routes.push(new ConfigRoutes(app));
   routes.push(new AuthRoutes(app));
   routes.push(new UserRoutes(app));
+  routes.push(new BillingRoutes(app));
   routes.push(new EventRoutes(app));
   routes.push(new EventsRoutes(app));
   routes.push(new CalendarRoutes(app));

--- a/packages/core/src/types/billing.types.ts
+++ b/packages/core/src/types/billing.types.ts
@@ -1,0 +1,9 @@
+import { type BillingSubscriptionStatus } from "./user.types";
+
+/** Wire shape: dates are ISO strings, matching every other JSON API response. */
+export interface BillingStatusResponse {
+  subscriptionStatus: BillingSubscriptionStatus;
+  trialEndsAt: string | null;
+  /** True once the trial has ended with no active subscription. */
+  isReadOnly: boolean;
+}

--- a/packages/core/src/types/user.types.ts
+++ b/packages/core/src/types/user.types.ts
@@ -22,6 +22,28 @@ export interface Schema_User {
    *  every (re)connect, distinct from `lastLoggedInAt`'s sign-in moment.
    *  Used to tell an active user apart from an abandoned account (A40). */
   lastSeenAt?: Date;
+  /**
+   * Trial/subscription state. Optional and absent for every user who
+   * existed before this field shipped -- treat absence as "none" (never
+   * started a trial), matching the established incremental-field pattern
+   * for this schema. No backfill: a required field here would need every
+   * existing document migrated at deploy time.
+   *
+   * NOTE: this only records that a trial started, when it ends, and (once
+   * wired) live Stripe subscription state. It does not yet reflect actual
+   * payment collection -- see keyboard-education/03-monetization-trial-checkout.md.
+   */
+  billing?: Schema_UserBilling;
+}
+
+export type BillingSubscriptionStatus = "none" | "trialing" | "expired";
+
+export interface Schema_UserBilling {
+  subscriptionStatus: BillingSubscriptionStatus;
+  trialStartedAt?: Date;
+  trialEndsAt?: Date;
+  stripeCustomerId?: string;
+  stripeSubscriptionId?: string;
 }
 
 /**

--- a/packages/web/src/api/billing.api.ts
+++ b/packages/web/src/api/billing.api.ts
@@ -1,0 +1,18 @@
+import { type BillingStatusResponse } from "@core/types/billing.types";
+import { BaseApi } from "@web/api/base/base.api";
+
+const BillingApi = {
+  async getStatus(): Promise<BillingStatusResponse> {
+    const response =
+      await BaseApi.get<BillingStatusResponse>(`/billing/status`);
+    return response.data;
+  },
+
+  async startTrial(): Promise<BillingStatusResponse> {
+    const response =
+      await BaseApi.post<BillingStatusResponse>(`/billing/trial/start`);
+    return response.data;
+  },
+};
+
+export { BillingApi };

--- a/packages/web/src/components/PostOnboardingFlow/TrialCTA.tsx
+++ b/packages/web/src/components/PostOnboardingFlow/TrialCTA.tsx
@@ -1,21 +1,26 @@
-import { type FC, useContext, useEffect, useRef } from "react";
+import { type FC, useContext, useEffect, useRef, useState } from "react";
+import { BillingApi } from "@web/api/billing.api";
 import { SessionContext } from "@web/auth/compass/session/session.context";
 import { track } from "@web/auth/posthog/track";
 import { Z_INDEX_TOOLTIP } from "@web/common/constants/web.constants";
+import { showErrorToast } from "@web/common/utils/toast/error-toast.util";
+import { getToast } from "@web/common/utils/toast/toast.port";
 import { useAuthModal } from "@web/components/AuthModal/hooks/useAuthModal";
 import { postOnboardingFlowActions } from "@web/components/PostOnboardingFlow/post-onboarding-flow.store";
 
 /**
  * "Ready to try it for real?" — the last step of the connect/trial flow.
- * Billing does not exist yet (see keyboard-education/03), so accepting for
- * an anonymous user opens signup; an already-authenticated user (arrived via
- * Connect Google, which signs up on its own) gets a coming-soon toast in
- * place of real checkout until 03 ships.
+ * Records a real, durable trial start server-side (see
+ * keyboard-education/03), but there is no payment collection or Stripe
+ * integration yet — accepting for an anonymous user opens signup first;
+ * an authenticated user (arrived via Connect Google, which signs up on its
+ * own) gets the trial recorded directly with no card step.
  */
 export const TrialCTA: FC = () => {
   const { authenticated } = useContext(SessionContext);
   const { openModal } = useAuthModal();
   const shownRef = useRef(false);
+  const [isStarting, setIsStarting] = useState(false);
 
   useEffect(() => {
     if (!shownRef.current) {
@@ -24,13 +29,24 @@ export const TrialCTA: FC = () => {
     }
   }, []);
 
-  const onStartTrial = () => {
-    track("trial_started");
+  const onStartTrial = async () => {
     if (!authenticated) {
       openModal("signUp");
       return;
     }
-    postOnboardingFlowActions.dismissTrial();
+    if (isStarting) return;
+
+    setIsStarting(true);
+    try {
+      const status = await BillingApi.startTrial();
+      track("trial_started", { subscriptionStatus: status.subscriptionStatus });
+      getToast().info("Your free trial has started");
+      postOnboardingFlowActions.dismissTrial();
+    } catch {
+      showErrorToast("We couldn't start your trial. Please try again.");
+    } finally {
+      setIsStarting(false);
+    }
   };
 
   return (
@@ -54,10 +70,11 @@ export const TrialCTA: FC = () => {
           </button>
           <button
             className="c-button c-button-primary rounded-full px-4 py-1.5 text-xs"
+            disabled={isStarting}
             onClick={onStartTrial}
             type="button"
           >
-            Start free trial
+            {isStarting ? "Starting…" : "Start free trial"}
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
Stacked on #2736 (uses `PostOnboardingFlow/TrialCTA.tsx` from that branch).

- Adds durable, server-side trial/subscription state on the user record via a new `billing` module: `POST /api/billing/trial/start` (rate-limited, 5/min) and `GET /api/billing/status`. `startTrial` is idempotent — a retried or duplicate CTA click can never push the trial window out further.
- New field is optional on `Schema_User` (`billing?: Schema_UserBilling`) with no backfill needed — matches the existing incremental-field pattern on that schema (see `lastSeenAt`).
- Placeholder terms only (14-day trial, no payment collection) per `keyboard-education/03-monetization-trial-checkout.md`, isolated in one `BILLING_DEFAULTS` constants module so the founder's pricing sweep is a small diff, not a re-implementation.
- The web `TrialCTA` now calls this for real (for authenticated users) instead of a no-op stub, with a loading state and error toast on failure.

## Explicitly NOT done in this pass
So this isn't mistaken for a working checkout:
- No Stripe integration, no payment-method collection, no webhooks.
- No read-only access enforcement wired into the actual event-mutation routes — `GET /api/billing/status` returns `isReadOnly`, but nothing currently checks it before allowing a write. That's real scope for a follow-up, not a security claim this PR is making.
- No repo previously had any rate-limiting middleware at all (`express-rate-limit` wasn't a dependency anywhere) — added it fresh for this route per the CodeQL `js/missing-rate-limiting` gate on new authenticated routes.

## Test plan
- [x] `bun run test:backend:fast` — 243/243 passing (includes new `deriveBillingStatus` unit tests: none/trialing/expired/exact-boundary)
- [x] `bun test src/components/PostOnboardingFlow/` — 4/4 passing
- [x] `bun run type-check` — clean across core/backend/web
- [x] `biome check` on all touched files — clean
- [ ] Live browser/route verification — not possible in this worktree: the backend fails to boot without `SYNC_SERVICE_URL`/`SYNC_INTERNAL_AUTH_TOKEN` env vars not present here (pre-existing environment gap, unrelated to this change). Routes were verified by reading the existing `UserRoutes` pattern this mirrors exactly (`CommonRoutesConfig`, `verifySession()`, controller → service → `mongoService.user`), not by hitting them live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)