### PR TITLE
fix(web): close ends-on datepicker on outside click

### DIFF
--- a/packages/web/src/components/DatePicker/DatePicker.tsx
+++ b/packages/web/src/components/DatePicker/DatePicker.tsx
@@ -1,6 +1,6 @@
 import classNames from "classnames";
 import type React from "react";
-import { useId } from "react";
+import { useEffect, useId, useRef } from "react";
 import * as ReactDatePickerModule from "react-datepicker";
 import { type ReactDatePickerProps } from "react-datepicker";
 import dayjs from "@core/util/date/dayjs";
@@ -62,9 +62,37 @@ export const DatePicker: React.FC<Props> = (datePickerProps) => {
     ...props
   } = datePickerProps;
   const layerId = useId();
+  const calendarRef = useRef<HTMLDivElement>(null);
+  const onCalendarCloseRef = useRef(datePickerProps.onCalendarClose);
+  onCalendarCloseRef.current = datePickerProps.onCalendarClose;
   // Sidebar month grid stays mounted and visible; only transient grid popovers
   // own Escape (same carve-out the old DOM probe encoded via Month picker).
   useFloatingLayer(`datePicker:${layerId}`, view === "grid" && isOpen);
+  // EventForm (and similar shells) stop mousedown bubbling so grid clicks
+  // underneath don't fire. That also blocks react-datepicker's document
+  // bubble-phase outside-click listener. Capture-phase closes grid popovers
+  // even when a parent calls stopPropagation.
+  useEffect(() => {
+    if (view !== "grid" || !isOpen) return;
+
+    const onMouseDownCapture = (event: MouseEvent) => {
+      const target = event.target;
+      if (!(target instanceof Node)) return;
+      if (calendarRef.current?.contains(target)) return;
+
+      const input = document.querySelector(
+        `[data-datepicker-input="${CSS.escape(layerId)}"]`,
+      );
+      if (input?.contains(target)) return;
+
+      onCalendarCloseRef.current?.();
+    };
+
+    document.addEventListener("mousedown", onMouseDownCapture, true);
+    return () => {
+      document.removeEventListener("mousedown", onMouseDownCapture, true);
+    };
+  }, [isOpen, layerId, view]);
   const isDarkTheme = useThemeStore(selectTheme) === "dark-abyss";
   const resolvedBgColor =
     bgColor ?? (isDarkTheme ? colors.background : lightColors.background);
@@ -98,6 +126,7 @@ export const DatePicker: React.FC<Props> = (datePickerProps) => {
       })}
       calendarContainer={({ children, className }) => (
         <div
+          ref={calendarRef}
           className={classNames("c-date-picker", className)}
           data-dark={usesThemeText}
           data-view={view}
@@ -114,6 +143,7 @@ export const DatePicker: React.FC<Props> = (datePickerProps) => {
             "w-28 transition-colors duration-300",
             inputClassName,
           )}
+          data-datepicker-input={layerId}
           style={{
             backgroundColor: inputColor,
             color: inputColor ? theme.getContrastText(inputColor) : undefined,
@@ -128,7 +158,8 @@ export const DatePicker: React.FC<Props> = (datePickerProps) => {
       {...props}
       // Close the picker when the user clicks away (react-datepicker has no
       // onCalendarClose for outside-clicks). onCalendarOpen/onCalendarClose/
-      // onSelect flow straight through {...props}.
+      // onSelect flow straight through {...props}. Kept as a fallback for
+      // contexts where bubble-phase delivery still reaches document.
       onClickOutside={() => {
         datePickerProps.onCalendarClose?.();
       }}

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/RecurrenceSection.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/RecurrenceSection.test.tsx
@@ -70,8 +70,13 @@ const recurringDraft = () => {
 
 function renderRecurrenceSection({
   initialDraft = baseDraft(),
+  withFormLikeStopPropagation = false,
 }: {
   initialDraft?: GridEventDraft;
+  // EventForm stops mousedown bubbling so week-grid handlers underneath do
+  // not fire. That also breaks react-datepicker's bubble-phase outside-click
+  // listener; opt in to reproduce that shell when testing popover close.
+  withFormLikeStopPropagation?: boolean;
 } = {}) {
   const setDraftSpy = mock();
 
@@ -89,7 +94,23 @@ function renderRecurrenceSection({
       });
     }, []);
 
-    return <RecurrenceSection draft={draft} setDraft={handleSetDraft} />;
+    const section = (
+      <RecurrenceSection draft={draft} setDraft={handleSetDraft} />
+    );
+
+    if (!withFormLikeStopPropagation) return section;
+
+    return (
+      // biome-ignore lint/a11y/noStaticElementInteractions: test harness mirrors EventFormShell's mousedown stopPropagation.
+      <div
+        onMouseDown={(event) => {
+          event.stopPropagation();
+        }}
+      >
+        {section}
+        <button type="button">Outside</button>
+      </div>
+    );
   }
 
   const view = render(<Harness />);
@@ -156,6 +177,23 @@ describe("RecurrenceSection", () => {
     expect(ownDate.getAttribute("aria-label")).toMatch(/^Choose /);
     expect(ownDate).not.toHaveClass("react-datepicker__day--disabled");
     expect(ownDate.getAttribute("aria-disabled")).not.toBe("true");
+  });
+
+  // Regression: EventFormShell stops mousedown bubbling, which used to leave
+  // the Ends on calendar open after an outside click (focus left, popover stayed).
+  it("closes the Ends on picker on outside click when mousedown propagation is stopped", async () => {
+    const user = userEvent.setup();
+    renderRecurrenceSection({
+      initialDraft: recurringDraft(),
+      withFormLikeStopPropagation: true,
+    });
+
+    await user.click(await screen.findByRole("textbox"));
+    expect(await screen.findByLabelText(/Choose .*2026/i)).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Outside" }));
+
+    expect(screen.queryByLabelText(/Choose .*2026/i)).not.toBeInTheDocument();
   });
 
   it("turning off Repeat on an existing recurring event clears the controls", async () => {

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/RecurrenceSection.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/RecurrenceSection.test.tsx
@@ -189,11 +189,13 @@ describe("RecurrenceSection", () => {
     });
 
     await user.click(await screen.findByRole("textbox"));
-    expect(await screen.findByLabelText(/Choose .*2026/i)).toBeInTheDocument();
+    expect(
+      (await screen.findAllByLabelText(/Choose .*2026/i)).length,
+    ).toBeGreaterThan(0);
 
     await user.click(screen.getByRole("button", { name: "Outside" }));
 
-    expect(screen.queryByLabelText(/Choose .*2026/i)).not.toBeInTheDocument();
+    expect(screen.queryAllByLabelText(/Choose .*2026/i)).toHaveLength(0);
   });
 
   it("turning off Repeat on an existing recurring event clears the controls", async () => {

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/RecurrenceSection.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/RecurrenceSection.test.tsx
@@ -198,6 +198,19 @@ describe("RecurrenceSection", () => {
     expect(screen.queryAllByLabelText(/Choose .*2026/i)).toHaveLength(0);
   });
 
+  // Regression: opening via TooltipTrigger onClick re-opened the popover when a
+  // day click bubbled from the local portal; open only via the input path.
+  it("closes the Ends on picker after selecting a day", async () => {
+    const user = userEvent.setup();
+    renderRecurrenceSection({ initialDraft: recurringDraft() });
+
+    await user.click(await screen.findByRole("textbox"));
+    const [day] = await screen.findAllByLabelText(/^Choose /);
+    await user.click(day);
+
+    expect(screen.queryAllByLabelText(/^Choose /)).toHaveLength(0);
+  });
+
   it("turning off Repeat on an existing recurring event clears the controls", async () => {
     // Guards against the toggle being a no-op on an edit draft: clearing
     // recurrence used to resolve to "preserve", which read the source

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/components/EndsOnDate.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/components/EndsOnDate.tsx
@@ -1,4 +1,3 @@
-import type React from "react";
 import { useMemo, useState } from "react";
 import { parseCompassEventDate } from "@core/util/event/event.util";
 import { DatePicker } from "@web/components/DatePicker/DatePicker";

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/components/EndsOnDate.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/components/EndsOnDate.tsx
@@ -30,17 +30,16 @@ export const EndsOnDate = ({
           borderBottomStyle: "solid",
         }}
       >
-        <TooltipWrapper
-          description="Select recurrence end date"
-          onClick={() => setOpen(true)}
-        >
+        <TooltipWrapper description="Select recurrence end date">
           <div id="portal">
             <DatePicker
               calendarClassName="recurrenceUntilDatePicker"
               isOpen={open}
               minDate={miniDate.toDate()}
               onCalendarClose={() => setOpen(false)}
+              onCalendarOpen={() => setOpen(true)}
               onChange={() => null}
+              onInputClick={() => setOpen(true)}
               onSelect={(date) => {
                 setUntil(date);
                 setOpen(false);

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/components/EndsOnDate.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/components/EndsOnDate.tsx
@@ -42,7 +42,10 @@ export const EndsOnDate = ({
               minDate={miniDate.toDate()}
               onCalendarClose={() => setOpen(false)}
               onChange={() => null}
-              onSelect={(date) => setUntil(date)}
+              onSelect={(date) => {
+                setUntil(date);
+                setOpen(false);
+              }}
               selected={until}
               title="Select recurrence end date"
               view="grid"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The recurrence **"Ends on"** calendar stayed open after an outside click: focus left the input, but the popover blocked the form until the whole event form was closed.

**Root cause:** `EventFormShell` stops `mousedown` bubbling so the week grid underneath does not receive clicks. That also prevents react-datepicker’s document **bubble-phase** outside-click listener from running. Start/end pickers still closed via form `onMouseUp`; Ends on did not.

**Fix:**
- Shared grid `DatePicker` closes via a **capture-phase** `mousedown` listener (skips clicks on the input and calendar, including portaled calendars).
- `EndsOnDate` opens via `onInputClick` / `onCalendarOpen` (not `TooltipTrigger` `onClick`, which re-opened after day select bubbled from the local portal) and closes on day select.
- Regression tests cover outside click under stopPropagation and day-select close.

## Simplicity

No EventForm state plumbing. Ends on already had `onCalendarClose`; the shared picker now delivers that callback inside the form shell. Retained `useEffect` + refs sync the capture listener to `document` (non-React); `onCalendarCloseRef` avoids stale closures without rebinding every render.

## Automated validation

- `bun test:web packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/RecurrenceSection.test.tsx` — 6 pass
- `bun lint` — warnings only (pre-existing elsewhere)
- Manual browser on http://localhost:9080 — outside click closes Ends on; day select closes; month nav stays open

## Independent review

Confirmed medium: TooltipTrigger `onClick` re-opened after day select — fixed by opening via input path only, with a select-to-close regression test. No remaining confirmed findings. Capture-phase close is scoped to `view === "grid" && isOpen`.

## Test plan

- `bun test:web packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/RecurrenceSection.test.tsx`
- `bun lint`
- Manual: open Ends on, click Description/Title → calendar closes; select a day → closes; month arrows → stays open

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3fc23c52-27cb-4a00-ac1f-2898525100e1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3fc23c52-27cb-4a00-ac1f-2898525100e1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

