### PR TITLE
Sandbox mode: keyboard-only entry + synthetic practice events for onboarding tour

### DIFF
--- a/packages/web/src/calendars/useCalendarLookup.ts
+++ b/packages/web/src/calendars/useCalendarLookup.ts
@@ -109,13 +109,18 @@ export function resolveCalendarCardIdentity(
 /**
  * Grid-only content flags that force read-only treatment regardless of
  * calendar write capability (passed as the `isBusy` argument to
- * {@link isEventReadOnly}).
+ * {@link isEventReadOnly}). isSandboxReadOnly covers ephemeral onboarding
+ * sandbox events (see OnboardingTour/onboarding.sandbox-events.ts), which
+ * have nothing real for a write to persist to.
  */
 export const isGridEventContentReadOnly = (event: {
   isBusy?: boolean;
   isTimedMultiDayDisplay?: boolean;
+  isSandboxReadOnly?: boolean;
 }): boolean =>
-  (event.isBusy ?? false) || (event.isTimedMultiDayDisplay ?? false);
+  (event.isBusy ?? false) ||
+  (event.isTimedMultiDayDisplay ?? false) ||
+  (event.isSandboxReadOnly ?? false);
 
 /**
  * An event is read-only (inspectable but never mutable) when either:
@@ -163,6 +168,7 @@ export function isGridEventInteractionReadOnly(
     calendarId?: CalendarId | null;
     isBusy?: boolean;
     isTimedMultiDayDisplay?: boolean;
+    isSandboxReadOnly?: boolean;
   },
 ): boolean {
   return isEventReadOnly(

--- a/packages/web/src/common/types/web.event.types.ts
+++ b/packages/web/src/common/types/web.event.types.ts
@@ -81,6 +81,11 @@ const GridEventSchema = WebEventSchema.extend({
   // The meeting also exists on this other connected account; this card is the
   // surviving copy of a cross-account merge. Joined like isDemo above.
   otherAccount: CrossAccountDuplicateSchema.optional(),
+  // Ephemeral onboarding-sandbox event (see OnboardingTour/onboarding.sandbox-events.ts):
+  // forces read-only alongside isBusy/isTimedMultiDayDisplay in
+  // isGridEventContentReadOnly, since a fake event has nothing to persist a
+  // write to. Joined like isDemo above.
+  isSandboxReadOnly: z.boolean().optional(),
   // Read-only, provider-sourced. Joined like calendarId/color above.
   location: z.string().nullable().optional(),
   organizer: OrganizerSchema.nullable().optional(),

--- a/packages/web/src/components/OnboardingTour/OnboardingTour.tsx
+++ b/packages/web/src/components/OnboardingTour/OnboardingTour.tsx
@@ -10,6 +10,7 @@ import {
   selectOnboardingTourStepId,
   useOnboardingTourStore,
 } from "@web/components/OnboardingTour/onboarding.tour.store";
+import { useOnboardingSandboxKeyboardOnly } from "@web/components/OnboardingTour/useOnboardingSandboxKeyboardOnly";
 import { useOnboardingTourProgress } from "@web/components/OnboardingTour/useOnboardingTourProgress";
 
 /**
@@ -19,6 +20,7 @@ import { useOnboardingTourProgress } from "@web/components/OnboardingTour/useOnb
  */
 export const OnboardingTour: FC = () => {
   useOnboardingTourProgress();
+  useOnboardingSandboxKeyboardOnly();
 
   const isActive = useOnboardingTourStore(selectOnboardingTourActive);
   const stepId = useOnboardingTourStore(selectOnboardingTourStepId);

--- a/packages/web/src/components/OnboardingTour/onboarding.sandbox-events.test.ts
+++ b/packages/web/src/components/OnboardingTour/onboarding.sandbox-events.test.ts
@@ -1,0 +1,96 @@
+import { CalendarIdSchema } from "@core/types/domain-primitives";
+import dayjs from "@core/util/date/dayjs";
+import { createObjectIdString } from "@web/common/utils/id/object-id.util";
+import {
+  buildSandboxEventData,
+  isSandboxStep,
+  mergeSandboxEventData,
+} from "@web/components/OnboardingTour/onboarding.sandbox-events";
+import { describe, expect, it } from "bun:test";
+
+const calendarId = CalendarIdSchema.parse(createObjectIdString());
+const anchor = dayjs("2026-08-10T00:00:00-05:00");
+
+describe("isSandboxStep", () => {
+  it("is true only for moveFocus/editSequence/targetEvent/nudge", () => {
+    expect(isSandboxStep("moveFocus")).toBe(true);
+    expect(isSandboxStep("editSequence")).toBe(true);
+    expect(isSandboxStep("targetEvent")).toBe(true);
+    expect(isSandboxStep("nudge")).toBe(true);
+    expect(isSandboxStep("create")).toBe(false);
+    expect(isSandboxStep("fork")).toBe(false);
+    expect(isSandboxStep("done")).toBe(false);
+  });
+});
+
+describe("buildSandboxEventData", () => {
+  it("returns undefined for a non-sandbox step", () => {
+    expect(
+      buildSandboxEventData("create", anchor, calendarId, "UTC"),
+    ).toBeUndefined();
+  });
+
+  it("marks every moveFocus event read-only", () => {
+    const data = buildSandboxEventData("moveFocus", anchor, calendarId, "UTC");
+    expect(data).toBeDefined();
+    expect(data!.ids.length).toBeGreaterThan(0);
+    expect(data!.sandboxReadOnlyEventIds).toEqual(data!.ids);
+  });
+
+  it("leaves the nudge event mutable (the one lesson that teaches a mutation)", () => {
+    const data = buildSandboxEventData("nudge", anchor, calendarId, "UTC");
+    expect(data).toBeDefined();
+    expect(data!.ids.length).toBe(1);
+    expect(data!.sandboxReadOnlyEventIds).toEqual([]);
+  });
+
+  it("anchors every event to the given day and calendar", () => {
+    const data = buildSandboxEventData(
+      "targetEvent",
+      anchor,
+      calendarId,
+      "UTC",
+    );
+    for (const id of data!.ids) {
+      const event = data!.entities[id];
+      expect(event.calendarId).toBe(calendarId);
+      expect(event.schedule.kind).toBe("timed");
+      if (event.schedule.kind === "timed") {
+        expect(dayjs(event.schedule.start).isSame(anchor, "day")).toBe(true);
+      }
+    }
+  });
+});
+
+describe("mergeSandboxEventData", () => {
+  const realId = "real-event-id" as never;
+  const real = {
+    ids: [realId],
+    entities: { [realId]: { id: realId } } as never,
+  };
+
+  it("returns the real data unchanged when there is nothing to splice", () => {
+    expect(mergeSandboxEventData(real, undefined)).toBe(real);
+  });
+
+  it("returns the sandbox data unchanged when there is no real data yet", () => {
+    const sandbox = buildSandboxEventData("nudge", anchor, calendarId, "UTC");
+    expect(mergeSandboxEventData(undefined, sandbox)).toBe(sandbox);
+  });
+
+  it("splices sandbox events onto real data without dropping either", () => {
+    const sandbox = buildSandboxEventData(
+      "moveFocus",
+      anchor,
+      calendarId,
+      "UTC",
+    )!;
+    const merged = mergeSandboxEventData(real, sandbox)!;
+    expect(merged.ids).toEqual([realId, ...sandbox.ids]);
+    expect(merged.entities[realId]).toBeDefined();
+    for (const id of sandbox.ids) {
+      expect(merged.entities[id]).toBeDefined();
+    }
+    expect(merged.sandboxReadOnlyEventIds).toEqual(sandbox.ids);
+  });
+});

--- a/packages/web/src/components/OnboardingTour/onboarding.sandbox-events.ts
+++ b/packages/web/src/components/OnboardingTour/onboarding.sandbox-events.ts
@@ -1,0 +1,138 @@
+import {
+  type CalendarId,
+  DateTimeSchema,
+  EventIdSchema,
+  TimeZoneSchema,
+} from "@core/types/domain-primitives";
+import { type Event, EventScheduleSchema } from "@core/types/event.contracts";
+import { type Dayjs } from "@core/util/date/dayjs";
+import { type NormalizedEventQueryData } from "@web/events/queries/event.query.types";
+import { type OnboardingTourStepId } from "./onboarding.tour.steps";
+
+/**
+ * Tour steps that need visible practice events - see 06's brief: mouse
+ * clicks are disabled during these (useOnboardingSandboxKeyboardOnly.ts) and
+ * this module supplies the ephemeral events they target. Every other step
+ * (create, save, palette, shortcuts, fork, undo, done) works against the
+ * user's real calendar as-is.
+ */
+export const SANDBOX_STEP_IDS: ReadonlySet<OnboardingTourStepId> = new Set([
+  "moveFocus",
+  "editSequence",
+  "targetEvent",
+  "nudge",
+]);
+
+export function isSandboxStep(stepId: OnboardingTourStepId): boolean {
+  return SANDBOX_STEP_IDS.has(stepId);
+}
+
+const sandboxEventId = (suffix: string) =>
+  EventIdSchema.parse(`sandbox-${suffix}`);
+
+/** 15-minute-aligned timed event at `hour:minute` on the anchor's day. */
+function buildEvent(
+  idSuffix: string,
+  title: string,
+  anchor: Dayjs,
+  calendarId: CalendarId,
+  timeZone: string,
+  hour: number,
+  minute = 0,
+  durationMinutes = 30,
+): Event {
+  const start = anchor
+    .clone()
+    .hour(hour)
+    .minute(minute)
+    .second(0)
+    .millisecond(0);
+  const end = start.clone().add(durationMinutes, "minute");
+
+  return {
+    id: sandboxEventId(idSuffix),
+    calendarId,
+    content: { kind: "details", title, description: "" },
+    schedule: EventScheduleSchema.parse({
+      kind: "timed",
+      start: start.format(),
+      end: end.format(),
+      timeZone: TimeZoneSchema.parse(timeZone),
+    }),
+    recurrence: { kind: "single" },
+    createdAt: DateTimeSchema.parse(start.toISOString()),
+    updatedAt: null,
+  };
+}
+
+/**
+ * Per-step practice events, anchored to the tour's active view so they land
+ * on whatever day/week is currently open. Every event is read-only except
+ * nudge's, which is the one lesson that teaches a mutation.
+ */
+export function buildSandboxEventData(
+  stepId: OnboardingTourStepId,
+  anchor: Dayjs,
+  calendarId: CalendarId,
+  timeZone: string,
+): NormalizedEventQueryData | undefined {
+  if (!isSandboxStep(stepId)) return undefined;
+
+  const build = (idSuffix: string, title: string, hour: number, minute = 0) =>
+    buildEvent(idSuffix, title, anchor, calendarId, timeZone, hour, minute);
+
+  const events: Event[] =
+    stepId === "moveFocus"
+      ? [
+          build("moveFocus-1", "Practice: focus me", 9),
+          build("moveFocus-2", "Practice: then me", 11),
+          build("moveFocus-3", "Practice: and me", 14),
+        ]
+      : stepId === "editSequence"
+        ? [build("editSequence-1", "Practice: E then T", 10)]
+        : stepId === "targetEvent"
+          ? [
+              build("targetEvent-1", "Practice: jump here", 9, 30),
+              build("targetEvent-2", "Practice: or here", 12),
+              build("targetEvent-3", "Practice: or here", 15, 30),
+            ]
+          : [build("nudge-1", "Practice: nudge me", 13)];
+
+  // nudge's event is deliberately left out of sandboxReadOnlyEventIds so its
+  // Shift+Arrow shortcut isn't blocked by the read-only gate. The write
+  // itself still safely no-ops (useUpdateEvent's findEventInCache never
+  // resolves a sandbox id, since these are never written into the query
+  // cache - see mergeSandboxEventData) - no error, no toast, nothing
+  // persisted. Wiring a real, visible local reposition would mean touching
+  // the shared grid-focus/mutation pipeline the brief calls out as needing
+  // isolated review; left as a known follow-up rather than a rushed patch
+  // to that code under this brief.
+  const sandboxReadOnlyEventIds =
+    stepId === "nudge" ? [] : events.map((event) => event.id);
+
+  return {
+    ids: events.map((event) => event.id),
+    entities: Object.fromEntries(events.map((event) => [event.id, event])),
+    sandboxReadOnlyEventIds,
+  };
+}
+
+/**
+ * Splices sandbox events into real query data. Reference-stable when there
+ * is nothing to splice, so the pipeline cache in useCalendarEventViewModel
+ * keeps hitting outside the tour.
+ */
+export function mergeSandboxEventData(
+  real: NormalizedEventQueryData | undefined,
+  sandbox: NormalizedEventQueryData | undefined,
+): NormalizedEventQueryData | undefined {
+  if (!sandbox) return real;
+  if (!real) return sandbox;
+
+  return {
+    ...real,
+    ids: [...real.ids, ...sandbox.ids],
+    entities: { ...real.entities, ...sandbox.entities },
+    sandboxReadOnlyEventIds: sandbox.sandboxReadOnlyEventIds,
+  };
+}

--- a/packages/web/src/components/OnboardingTour/useOnboardingSandboxEvents.ts
+++ b/packages/web/src/components/OnboardingTour/useOnboardingSandboxEvents.ts
@@ -1,0 +1,43 @@
+import { type Dayjs } from "@core/util/date/dayjs";
+import { useCalendarsQuery } from "@web/calendars/calendar.query";
+import { useDefaultTargetCalendar } from "@web/calendars/useDefaultTargetCalendar";
+import { getBrowserTimeZone } from "@web/common/utils/datetime/web.date.util";
+import { type NormalizedEventQueryData } from "@web/events/queries/event.query.types";
+import { buildSandboxEventData } from "./onboarding.sandbox-events";
+import {
+  selectOnboardingTourActive,
+  selectOnboardingTourStepId,
+  useOnboardingTourStore,
+} from "./onboarding.tour.store";
+
+const NO_CALENDARS: never[] = [];
+
+/**
+ * Ephemeral practice events for the tour's sandbox steps (see
+ * onboarding.sandbox-events.ts), or undefined outside of them. Merge into
+ * real query data with {@link import("./onboarding.sandbox-events").mergeSandboxEventData}
+ * before handing off to useCalendarEventViewModel - never written to
+ * IndexedDB or the mutation pipeline.
+ *
+ * `anchor` is undefined when the caller opts out (e.g. a component that
+ * isn't the tour's actual grid, like the Up Next card) - always call this
+ * hook unconditionally and pass undefined rather than skipping the call, so
+ * hook order stays stable.
+ */
+export function useOnboardingSandboxEventData(
+  anchor: Dayjs | undefined,
+): NormalizedEventQueryData | undefined {
+  const isActive = useOnboardingTourStore(selectOnboardingTourActive);
+  const stepId = useOnboardingTourStore(selectOnboardingTourStepId);
+  const { data: calendars } = useCalendarsQuery();
+  const defaultCalendar = useDefaultTargetCalendar(calendars ?? NO_CALENDARS);
+
+  if (!isActive || !anchor || !defaultCalendar) return undefined;
+
+  return buildSandboxEventData(
+    stepId,
+    anchor,
+    defaultCalendar.id,
+    getBrowserTimeZone(),
+  );
+}

--- a/packages/web/src/components/OnboardingTour/useOnboardingSandboxKeyboardOnly.test.ts
+++ b/packages/web/src/components/OnboardingTour/useOnboardingSandboxKeyboardOnly.test.ts
@@ -1,0 +1,78 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import {
+  initialOnboardingTourState,
+  useOnboardingTourStore,
+} from "@web/components/OnboardingTour/onboarding.tour.store";
+import { useOnboardingSandboxKeyboardOnly } from "@web/components/OnboardingTour/useOnboardingSandboxKeyboardOnly";
+import {
+  initialKeyboardOnlyState,
+  selectKeyboardOnlyActive,
+  useKeyboardOnlyStore,
+} from "@web/shortcuts/keyboard-only/keyboard-only.store";
+import { beforeEach, describe, expect, it } from "bun:test";
+
+const isKeyboardOnlyActive = () =>
+  selectKeyboardOnlyActive(useKeyboardOnlyStore.getState());
+
+beforeEach(() => {
+  useOnboardingTourStore.setState({ ...initialOnboardingTourState });
+  useKeyboardOnlyStore.setState({ ...initialKeyboardOnlyState });
+});
+
+describe("useOnboardingSandboxKeyboardOnly", () => {
+  it("enters keyboard-only mode on a sandbox step and exits on a non-sandbox step", async () => {
+    useOnboardingTourStore.setState({ isActive: true, stepId: "create" });
+    renderHook(() => useOnboardingSandboxKeyboardOnly());
+
+    expect(isKeyboardOnlyActive()).toBe(false);
+
+    act(() => {
+      useOnboardingTourStore.setState({ stepId: "moveFocus" });
+    });
+    await waitFor(() => expect(isKeyboardOnlyActive()).toBe(true));
+
+    act(() => {
+      useOnboardingTourStore.setState({ stepId: "palette" });
+    });
+    await waitFor(() => expect(isKeyboardOnlyActive()).toBe(false));
+  });
+
+  it("exits on tour skip (isActive -> false) from a sandbox step", async () => {
+    useOnboardingTourStore.setState({ isActive: true, stepId: "nudge" });
+    renderHook(() => useOnboardingSandboxKeyboardOnly());
+    await waitFor(() => expect(isKeyboardOnlyActive()).toBe(true));
+
+    act(() => {
+      useOnboardingTourStore.setState({ ...initialOnboardingTourState });
+    });
+    await waitFor(() => expect(isKeyboardOnlyActive()).toBe(false));
+  });
+
+  it("exits on the fork exit path (targetEvent step change, e.g. after fork)", async () => {
+    useOnboardingTourStore.setState({ isActive: true, stepId: "targetEvent" });
+    renderHook(() => useOnboardingSandboxKeyboardOnly());
+    await waitFor(() => expect(isKeyboardOnlyActive()).toBe(true));
+
+    act(() => {
+      useOnboardingTourStore.setState({ stepId: "undo" });
+    });
+    await waitFor(() => expect(isKeyboardOnlyActive()).toBe(false));
+  });
+
+  it("exits on unmount while a sandbox step is active (covers Escape/skip and browser back)", async () => {
+    useOnboardingTourStore.setState({ isActive: true, stepId: "editSequence" });
+    const { unmount } = renderHook(() => useOnboardingSandboxKeyboardOnly());
+    await waitFor(() => expect(isKeyboardOnlyActive()).toBe(true));
+
+    unmount();
+    expect(isKeyboardOnlyActive()).toBe(false);
+  });
+
+  it("never enters keyboard-only mode for non-sandbox steps", async () => {
+    useOnboardingTourStore.setState({ isActive: true, stepId: "save" });
+    renderHook(() => useOnboardingSandboxKeyboardOnly());
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(isKeyboardOnlyActive()).toBe(false);
+  });
+});

--- a/packages/web/src/components/OnboardingTour/useOnboardingSandboxKeyboardOnly.ts
+++ b/packages/web/src/components/OnboardingTour/useOnboardingSandboxKeyboardOnly.ts
@@ -1,0 +1,33 @@
+import { useEffect } from "react";
+import { keyboardOnlyActions } from "@web/shortcuts/keyboard-only/keyboard-only.store";
+import { isSandboxStep } from "./onboarding.sandbox-events";
+import {
+  selectOnboardingTourActive,
+  selectOnboardingTourStepId,
+  useOnboardingTourStore,
+} from "./onboarding.tour.store";
+
+/**
+ * Programmatic keyboard-only entry for the tour's sandbox steps (see brief
+ * 06's "Why this is split out from 01"): mouse clicks disable for the steps
+ * that target a synthetic practice event, on top of the existing
+ * double-Shift gesture in useKeyboardOnlyMode.ts.
+ *
+ * The effect cleanup is the whole exit-path audit: it fires on every path
+ * that stops `shouldBeActive` being true - tour skip/finish (isActive flips
+ * false), the fork exit and every other step change (stepId leaves the
+ * sandbox set), and unmount - so there is exactly one place that can leak
+ * keyboard-only mode, and it self-corrects by construction.
+ */
+export function useOnboardingSandboxKeyboardOnly() {
+  const isTourActive = useOnboardingTourStore(selectOnboardingTourActive);
+  const stepId = useOnboardingTourStore(selectOnboardingTourStepId);
+  const shouldBeActive = isTourActive && isSandboxStep(stepId);
+
+  useEffect(() => {
+    if (!shouldBeActive) return;
+
+    keyboardOnlyActions.enter();
+    return () => keyboardOnlyActions.exit();
+  }, [shouldBeActive]);
+}

--- a/packages/web/src/events/event-view.types.ts
+++ b/packages/web/src/events/event-view.types.ts
@@ -20,6 +20,14 @@ export type NormalizedEvents = {
    * `otherAccount` the same way demoEventIds becomes `isDemo`.
    */
   crossAccountDuplicates?: ReadonlyMap<EventId, CrossAccountDuplicate>;
+  /**
+   * Ephemeral onboarding-sandbox event ids (see
+   * OnboardingTour/onboarding.sandbox-events.ts) - joined onto GridEvent as
+   * `isSandboxReadOnly` the same way demoEventIds becomes `isDemo`. Absent
+   * for real query data; only set by the sandbox merge in
+   * useWeekEventsQuery/useDayEventsQuery.
+   */
+  sandboxReadOnlyEventIds?: readonly EventId[];
 };
 
 export type OptimisticEvent = {

--- a/packages/web/src/events/queries/event.view-model.ts
+++ b/packages/web/src/events/queries/event.view-model.ts
@@ -27,7 +27,7 @@ export const BUSY_EVENT_TITLE = "Busy";
 // crossAccountDuplicates -> otherAccount).
 type EventAnnotations = Pick<
   NormalizedEventQueryData,
-  "demoEventIds" | "crossAccountDuplicates"
+  "demoEventIds" | "crossAccountDuplicates" | "sandboxReadOnlyEventIds"
 >;
 
 type EventToGridEventOptions = EventAnnotations & {
@@ -50,6 +50,7 @@ const eventToGridEvent = (
   {
     demoEventIds,
     crossAccountDuplicates,
+    sandboxReadOnlyEventIds,
     scheduleOverride,
   }: EventToGridEventOptions = {},
 ): GridEvent => {
@@ -80,6 +81,7 @@ const eventToGridEvent = (
     calendarId: event.calendarId,
     isBusy,
     isDemo: Boolean(demoEventIds?.includes(event.id)),
+    isSandboxReadOnly: Boolean(sandboxReadOnlyEventIds?.includes(event.id)),
     ...(crossAccountDuplicates?.has(event.id)
       ? { otherAccount: crossAccountDuplicates.get(event.id) }
       : {}),
@@ -208,6 +210,7 @@ const computeCalendarEventViewModel = (
   const annotations: EventAnnotations = {
     demoEventIds,
     crossAccountDuplicates: data?.crossAccountDuplicates,
+    sandboxReadOnlyEventIds: data?.sandboxReadOnlyEventIds,
   };
   const timedEvents = timedEventsFrom(events, annotations);
   const allDayEvents = allDayEventsFrom(events, annotations);

--- a/packages/web/src/events/queries/useDayEventsQuery.ts
+++ b/packages/web/src/events/queries/useDayEventsQuery.ts
@@ -1,4 +1,7 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
+import dayjs from "@core/util/date/dayjs";
+import { mergeSandboxEventData } from "@web/components/OnboardingTour/onboarding.sandbox-events";
+import { useOnboardingSandboxEventData } from "@web/components/OnboardingTour/useOnboardingSandboxEvents";
 import { deriveOverlappingEventQueryData } from "@web/events/queries/event.query.cache";
 import { dayEventsQueryOptions } from "@web/events/queries/event.query.options";
 import { useEventRepositorySource } from "@web/events/repositories/event.repository.source.store";
@@ -26,8 +29,23 @@ export function useDayEventsQuery({ startDate, endDate }: DayEventsQueryArgs) {
   return { ...query, calendarIds };
 }
 
-export function useDayEventViewModel(args: DayEventsQueryArgs) {
+/**
+ * `includeSandboxEvents` defaults false: this hook also backs the sidebar's
+ * Up Next card (useUpNextEvent.ts), which queries "today" independent of
+ * whichever view the tour actually has open - opt in only from the day
+ * grid itself so a sandbox lesson's practice events never leak into a
+ * component the tour isn't pointing at.
+ */
+export function useDayEventViewModel(
+  args: DayEventsQueryArgs,
+  options: { includeSandboxEvents?: boolean } = {},
+) {
   const query = useDayEventsQuery(args);
-  const viewModel = useCalendarEventViewModel(query.data);
+  const sandboxData = useOnboardingSandboxEventData(
+    options.includeSandboxEvents ? dayjs(args.startDate) : undefined,
+  );
+  const viewModel = useCalendarEventViewModel(
+    mergeSandboxEventData(query.data, sandboxData),
+  );
   return { ...query, ...viewModel };
 }

--- a/packages/web/src/events/queries/useWeekEventsQuery.ts
+++ b/packages/web/src/events/queries/useWeekEventsQuery.ts
@@ -1,6 +1,8 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { type Dayjs } from "@core/util/date/dayjs";
 import { toUTCOffset } from "@web/common/utils/datetime/web.date.util";
+import { mergeSandboxEventData } from "@web/components/OnboardingTour/onboarding.sandbox-events";
+import { useOnboardingSandboxEventData } from "@web/components/OnboardingTour/useOnboardingSandboxEvents";
 import { deriveOverlappingEventQueryData } from "@web/events/queries/event.query.cache";
 import { weekEventsQueryOptions } from "@web/events/queries/event.query.options";
 import { useEventRepositorySource } from "@web/events/repositories/event.repository.source.store";
@@ -41,6 +43,9 @@ export function useWeekEventsQuery({
 
 export function useWeekEventViewModel(args: WeekEventsQueryArgs) {
   const query = useWeekEventsQuery(args);
-  const viewModel = useCalendarEventViewModel(query.data);
+  const sandboxData = useOnboardingSandboxEventData(args.startOfView);
+  const viewModel = useCalendarEventViewModel(
+    mergeSandboxEventData(query.data, sandboxData),
+  );
   return { ...query, ...viewModel };
 }

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
@@ -88,7 +88,9 @@ export function DayCalendarGrid() {
     isPending,
     refetch,
     timedEvents,
-  } = useDayEventViewModel(dayEventQueryRange(dateInView));
+  } = useDayEventViewModel(dayEventQueryRange(dateInView), {
+    includeSandboxEvents: true,
+  });
   // Session expiry already surfaces SessionExpiredToast — don't also show
   // "Couldn't load events" / Retry for the same failure.
   const showEventsLoadError = shouldShowContextualLoadError(


### PR DESCRIPTION
## Summary
- Programmatic keyboard-only mode entry/exit for the tour's moveFocus/editSequence/targetEvent/nudge steps, reusing the existing `keyboardOnlyActions.enter()/exit()` store API (already a plain, non-gesture-coupled API — no store changes needed). A single `useEffect` cleanup guarantees exit on every path (skip, finish, fork exit, step change, Escape, unmount).
- Ephemeral, non-persisted practice events for those same steps, merged into the Week/Day view-model pipeline right before grid consumption — never written to IndexedDB or routed through the mutation pipeline. Read-only enforcement reuses `isGridEventContentReadOnly` via a new `isSandboxReadOnly` flag (mirrors the existing `isDemo`/`demoEventIds` pattern), gated off for every sandbox event except the one built for the "nudge" lesson.
- `useDayEventViewModel` gained an opt-in `includeSandboxEvents` flag so sandbox events only surface from the day grid itself, not from the sidebar's Up Next card (which also consumes that hook for an independent "today" range) — caught in review.

## Known follow-up (documented in code + internal brief log)
The nudge lesson's mutation attempt safely no-ops (no error, no toast, nothing persisted) rather than visibly repositioning the practice event, since sandbox events are intentionally never written into the real query cache the mutation pipeline reads. Wiring a visible local reposition would mean touching the shared grid-focus/mutation code this brief was explicitly split out to keep isolated — left as a fast-follow rather than a rushed patch under this PR.

## Test plan
- [x] `bun run type-check` clean
- [x] `biome check` clean on touched files
- [x] `bun run knip` clean
- [x] New unit tests: exit-path audit (`useOnboardingSandboxKeyboardOnly.test.ts`) and sandbox event builder/read-only gating (`onboarding.sandbox-events.test.ts`)
- [x] Full targeted suite (OnboardingTour, event-query hooks, Up Next, Day view) green — 166 pass
- [x] Independent review pass (code-reviewer agent) — found 2 real issues, both fixed (Up Next leak scoped out; nudge no-op documented as a safe, known limitation)
- [ ] e2e for a full lesson with mouse disabled — not added in this PR, flagged for follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)