### PR TITLE
Rewrite welcome-modal copy to pitch the keyboard-first identity

### DIFF
--- a/packages/web/src/components/WelcomeModal/WelcomeGuideBody.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeGuideBody.tsx
@@ -25,11 +25,12 @@ export function WelcomeGuideBody() {
     <>
       <div className="flex flex-col gap-2">
         <h2 className="font-bold text-2xl text-text leading-snug">
-          Compass Calendar helps you manage your time, simply.
+          The best place to manage your schedule at the keyboard.
         </h2>
         <p className="text-text-muted">
-          A small, but mighty calendar app. Built for busy minimalists who get
-          things done.
+          Move fast, stay focused, and never reach for the mouse. Even
+          scheduling itself is quicker from the keyboard than any other
+          calendar.
         </p>
       </div>
 

--- a/packages/web/src/components/WelcomeModal/WelcomeModal.test.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeModal.test.tsx
@@ -66,13 +66,11 @@ describe("WelcomeModal", () => {
 
     expect(
       screen.getByRole("heading", {
-        name: "Compass Calendar helps you manage your time, simply.",
+        name: "The best place to manage your schedule at the keyboard.",
       }),
     ).toBeTruthy();
     expect(
-      screen.getByText(
-        /A small, but mighty calendar app\. Built for busy minimalists/,
-      ),
+      screen.getByText(/Move fast, stay focused, and never reach for/),
     ).toBeTruthy();
     expect(screen.getByRole("img", { name: /pixel pirate/i })).toBeTruthy();
     expect(screen.getByText("No signup required")).toBeTruthy();
@@ -170,7 +168,7 @@ describe("WelcomeModal", () => {
     expect(answer).toHaveAttribute("aria-hidden", "false");
     expect(answer).toHaveAttribute("data-state", "open");
     expect(
-      screen.getByText(/Compass is for busy minimalists who value focus/),
+      screen.getByText(/Compass is for busy minimalists who'd rather fly/),
     ).toBeTruthy();
 
     await user.click(questionButton);

--- a/packages/web/src/components/WelcomeModal/faq.ts
+++ b/packages/web/src/components/WelcomeModal/faq.ts
@@ -2,7 +2,7 @@ export const FAQ_ITEMS = [
   {
     question: "Who is Compass for?",
     answer:
-      "Compass is for busy minimalists who value focus, speed, and independent software. If that's you, Compass will help you do more with less.",
+      "Compass is for busy minimalists who'd rather fly through their calendar at the keyboard than hunt for it with a mouse. If that's you, Compass will help you do more with less.",
   },
   {
     question: "Can I try it without handing over my email?",
@@ -12,6 +12,6 @@ export const FAQ_ITEMS = [
   {
     question: "How is Compass different?",
     answer:
-      "We're simpler, faster, open-source...er. We remind you of your mortality (/life).",
+      "Every action, including scheduling itself, is faster from the keyboard than any other calendar. We're simpler, faster, open-source...er. We remind you of your mortality (/life).",
   },
 ];


### PR DESCRIPTION
## Summary
- Closes out the last open item from brief 02 (see internal `keyboard-education` project): the welcome overview and FAQ still pitched Compass as a generic "small but mighty" calendar rather than leading with the keyboard-first identity the rest of onboarding (tour, sandbox, shortcut tips) already teaches.
- Rewrote the headline/subheading in `WelcomeGuideBody.tsx` and two of the three FAQ answers in `faq.ts` to lead with "the best place to manage your schedule at the keyboard." Left the "no trial/email/card required" FAQ answer untouched — that's owned by a separate, not-yet-final billing-copy workstream.
- No em-dashes added, per house style.

## Test plan
- [x] `bun run type-check` clean
- [x] `biome check` clean
- [x] `WelcomeModal.test.tsx` updated to assert the new copy and passes (6/6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)