### PR TITLE
fix(sync,web): clear remaining event-color optimistic risks

### DIFF
--- a/packages/sync/src/domain/merge-update-content.test.ts
+++ b/packages/sync/src/domain/merge-update-content.test.ts
@@ -80,6 +80,128 @@ describe("mergeUpdateContent", () => {
     });
   });
 
+  it("drops colorHex when a slot color is applied", () => {
+    const existing = {
+      title: "Labeled",
+      description: "",
+      location: null,
+      organizer: null,
+      attendees: [],
+      conference: null,
+      colorHex: "#009688",
+    };
+
+    expect(
+      mergeUpdateContent(existing, {
+        title: "Labeled",
+        description: "",
+        location: null,
+        organizer: null,
+        attendees: [],
+        conference: null,
+        color: "blue",
+      }),
+    ).toEqual({
+      title: "Labeled",
+      description: "",
+      location: null,
+      organizer: null,
+      attendees: [],
+      conference: null,
+      color: "blue",
+    });
+  });
+
+  it("drops colorHex when clearing a prior slot color", () => {
+    const existing = {
+      title: "Slotted",
+      description: "",
+      location: null,
+      organizer: null,
+      attendees: [],
+      conference: null,
+      color: "blue" as const,
+      colorHex: "#009688",
+    };
+
+    expect(
+      mergeUpdateContent(existing, {
+        title: "Slotted",
+        description: "",
+        location: null,
+        organizer: null,
+        attendees: [],
+        conference: null,
+        color: null,
+      }),
+    ).toEqual({
+      title: "Slotted",
+      description: "",
+      location: null,
+      organizer: null,
+      attendees: [],
+      conference: null,
+    });
+  });
+
+  it("keeps colorHex when drafts send null color on a hex-only event", () => {
+    const existing = {
+      title: "Labeled",
+      description: "",
+      location: null,
+      organizer: null,
+      attendees: [],
+      conference: null,
+      colorHex: "#009688",
+    };
+
+    expect(
+      mergeUpdateContent(existing, {
+        title: "Labeled",
+        description: "edited",
+        location: null,
+        organizer: null,
+        attendees: [],
+        conference: null,
+        color: null,
+      }),
+    ).toEqual({
+      title: "Labeled",
+      description: "edited",
+      location: null,
+      organizer: null,
+      attendees: [],
+      conference: null,
+      colorHex: "#009688",
+    });
+  });
+
+  it("preserves colorHex when color is omitted", () => {
+    const existing = {
+      title: "Labeled",
+      description: "",
+      location: null,
+      organizer: null,
+      attendees: [],
+      conference: null,
+      colorHex: "#009688",
+    };
+
+    expect(
+      mergeUpdateContent(existing, {
+        title: "Renamed",
+        description: "",
+        location: null,
+        organizer: null,
+        attendees: [],
+        conference: null,
+      }),
+    ).toEqual({
+      ...existing,
+      title: "Renamed",
+    });
+  });
+
   it("clears an existing color when the command sends null", () => {
     const existing = {
       title: "Old",

--- a/packages/sync/src/domain/merge-update-content.ts
+++ b/packages/sync/src/domain/merge-update-content.ts
@@ -7,23 +7,42 @@ import { type SyncEventContent } from "@core/types/sync/event.contracts";
 //
 // Merge editable fields from the command; keep the rest from existing.
 // Color: slot replaces, null clears (omit the field), omit keeps existing.
+// colorHex is provider-read-only; a slot write (or clear of a prior slot)
+// must drop it so palette resolution cannot resurrect the old fill after
+// settle. Drafts often send color:null for "no slot" on hex-only events —
+// that must not wipe colorHex.
 export function mergeUpdateContent(
   existing: SyncEventContent,
   incoming: SyncEventContent,
 ): SyncEventContent {
-  const { color: existingColor, ...existingWithoutColor } = existing;
+  const {
+    color: existingColor,
+    colorHex: existingColorHex,
+    ...existingRest
+  } = existing;
   const merged: SyncEventContent = {
-    ...existingWithoutColor,
+    ...existingRest,
     title: incoming.title,
     description: incoming.description,
     location: incoming.location,
   };
 
-  if (incoming.color === null) return merged;
-  if (incoming.color !== undefined) return { ...merged, color: incoming.color };
-  return existingColor !== undefined
-    ? { ...merged, color: existingColor }
-    : merged;
+  if (incoming.color === null) {
+    if (existingColor !== undefined) return merged;
+    return existingColorHex !== undefined
+      ? { ...merged, colorHex: existingColorHex }
+      : merged;
+  }
+  if (incoming.color !== undefined) {
+    return { ...merged, color: incoming.color };
+  }
+
+  let kept = merged;
+  if (existingColor !== undefined) kept = { ...kept, color: existingColor };
+  if (existingColorHex !== undefined) {
+    kept = { ...kept, colorHex: existingColorHex };
+  }
+  return kept;
 }
 
 // Null is a write-command "clear" signal. Stored/read rows omit the field;

--- a/packages/sync/src/providers/google/google-color.map.test.ts
+++ b/packages/sync/src/providers/google/google-color.map.test.ts
@@ -25,10 +25,7 @@ describe("google-color.map", () => {
   });
 
   it("builds Google colorId body fields for set, clear, and omit", () => {
-    expect(googleColorIdFields("blue")).toEqual({
-      colorId: "7",
-      eventLabelId: "",
-    });
+    expect(googleColorIdFields("blue")).toEqual({ colorId: "7" });
     expect(googleColorIdFields(null)).toEqual({ colorId: null });
     expect(googleColorIdFields(undefined)).toEqual({});
   });

--- a/packages/sync/src/providers/google/google-color.map.test.ts
+++ b/packages/sync/src/providers/google/google-color.map.test.ts
@@ -25,7 +25,10 @@ describe("google-color.map", () => {
   });
 
   it("builds Google colorId body fields for set, clear, and omit", () => {
-    expect(googleColorIdFields("blue")).toEqual({ colorId: "7" });
+    expect(googleColorIdFields("blue")).toEqual({
+      colorId: "7",
+      eventLabelId: "",
+    });
     expect(googleColorIdFields(null)).toEqual({ colorId: null });
     expect(googleColorIdFields(undefined)).toEqual({});
   });

--- a/packages/sync/src/providers/google/google-color.map.ts
+++ b/packages/sync/src/providers/google/google-color.map.ts
@@ -35,10 +35,22 @@ export function slotToGoogleColorId(slot: EventColorSlot): string {
 
 // Fields for a Google create/patch body: a slot sets colorId, null clears it,
 // undefined leaves Google's existing color untouched (omit the key).
+//
+// Setting a slot also clears eventLabelId: Google custom labels supersede
+// colorId on read and rehydrate as Compass colorHex. Leaving the label in
+// place would resurrect the old hex fill after the next provider pull.
+// Clearing color (null) only touches colorId — drafts often send null for
+// "no slot" without intending to wipe a label-only color.
 export function googleColorIdFields(
   color: EventColorSlot | null | undefined,
-): { colorId: string | null } | Record<string, never> {
+):
+  | { colorId: string; eventLabelId: string }
+  | { colorId: null }
+  | Record<string, never> {
   if (color === undefined) return {};
   if (color === null) return { colorId: null };
-  return { colorId: slotToGoogleColorId(color) };
+  return {
+    colorId: slotToGoogleColorId(color),
+    eventLabelId: "",
+  };
 }

--- a/packages/sync/src/providers/google/google-color.map.ts
+++ b/packages/sync/src/providers/google/google-color.map.ts
@@ -36,21 +36,14 @@ export function slotToGoogleColorId(slot: EventColorSlot): string {
 // Fields for a Google create/patch body: a slot sets colorId, null clears it,
 // undefined leaves Google's existing color untouched (omit the key).
 //
-// Setting a slot also clears eventLabelId: Google custom labels supersede
-// colorId on read and rehydrate as Compass colorHex. Leaving the label in
-// place would resurrect the old hex fill after the next provider pull.
-// Clearing color (null) only touches colorId — drafts often send null for
-// "no slot" without intending to wipe a label-only color.
+// Clearing a prior custom eventLabelId is not done here: eventLabelVersion=1
+// is required to write eventLabelId, and that version ignores colorId. The
+// writer clears labels in a separate preconditioned patch before the colorId
+// write (see GoogleEventWriter.patchEvent).
 export function googleColorIdFields(
   color: EventColorSlot | null | undefined,
-):
-  | { colorId: string; eventLabelId: string }
-  | { colorId: null }
-  | Record<string, never> {
+): { colorId: string | null } | Record<string, never> {
   if (color === undefined) return {};
   if (color === null) return { colorId: null };
-  return {
-    colorId: slotToGoogleColorId(color),
-    eventLabelId: "",
-  };
+  return { colorId: slotToGoogleColorId(color) };
 }

--- a/packages/sync/src/providers/google/google-event-writer.adapter.test.ts
+++ b/packages/sync/src/providers/google/google-event-writer.adapter.test.ts
@@ -445,9 +445,8 @@ describe("GoogleEventWriter", () => {
     await writer.patchEvent({ ...basePatch, content: content() });
 
     expect(api.calls.insert[0].requestBody.colorId).toBe("7");
-    expect(api.calls.insert[0].requestBody.eventLabelId).toBe("");
+    expect(api.calls.patch).toHaveLength(1);
     expect(api.calls.patch[0].requestBody).not.toHaveProperty("colorId");
-    expect(api.calls.patch[0].requestBody).not.toHaveProperty("eventLabelId");
   });
 
   it("clears Google colorId when content.color is null", async () => {
@@ -459,21 +458,34 @@ describe("GoogleEventWriter", () => {
       content: content({ color: null }),
     });
 
+    expect(api.calls.patch).toHaveLength(1);
     expect(api.calls.patch[0].requestBody.colorId).toBeNull();
-    expect(api.calls.patch[0].requestBody).not.toHaveProperty("eventLabelId");
+    expect(api.calls.patch[0]).not.toHaveProperty("eventLabelVersion");
   });
 
-  it("clears eventLabelId when patching a slot color onto a labeled event", async () => {
+  it("clears eventLabelId under v1 before writing a slot colorId", async () => {
     const api = new FakeEventsApi();
     const { writer } = writerWith(api);
 
     await writer.patchEvent({
       ...basePatch,
+      expectedVersion: '"etag-v1"',
       content: content({ color: "coral" }),
     });
 
-    expect(api.calls.patch[0].requestBody.colorId).toBe("4");
-    expect(api.calls.patch[0].requestBody.eventLabelId).toBe("");
+    expect(api.calls.patch).toHaveLength(2);
+    expect(api.calls.patch[0]).toMatchObject({
+      requestBody: { eventLabelId: "" },
+      sendUpdates: "none",
+      eventLabelVersion: 1,
+      ifMatch: '"etag-v1"',
+    });
+    expect(api.calls.patch[1]).toMatchObject({
+      requestBody: { colorId: "4" },
+      ifMatch: '"v2"',
+    });
+    expect(api.calls.patch[1]).not.toHaveProperty("eventLabelVersion");
+    expect(api.calls.patch[1].requestBody).not.toHaveProperty("eventLabelId");
   });
 
   it("maps each invitation intent straight to sendUpdates", async () => {

--- a/packages/sync/src/providers/google/google-event-writer.adapter.test.ts
+++ b/packages/sync/src/providers/google/google-event-writer.adapter.test.ts
@@ -445,7 +445,9 @@ describe("GoogleEventWriter", () => {
     await writer.patchEvent({ ...basePatch, content: content() });
 
     expect(api.calls.insert[0].requestBody.colorId).toBe("7");
+    expect(api.calls.insert[0].requestBody.eventLabelId).toBe("");
     expect(api.calls.patch[0].requestBody).not.toHaveProperty("colorId");
+    expect(api.calls.patch[0].requestBody).not.toHaveProperty("eventLabelId");
   });
 
   it("clears Google colorId when content.color is null", async () => {
@@ -458,6 +460,20 @@ describe("GoogleEventWriter", () => {
     });
 
     expect(api.calls.patch[0].requestBody.colorId).toBeNull();
+    expect(api.calls.patch[0].requestBody).not.toHaveProperty("eventLabelId");
+  });
+
+  it("clears eventLabelId when patching a slot color onto a labeled event", async () => {
+    const api = new FakeEventsApi();
+    const { writer } = writerWith(api);
+
+    await writer.patchEvent({
+      ...basePatch,
+      content: content({ color: "coral" }),
+    });
+
+    expect(api.calls.patch[0].requestBody.colorId).toBe("4");
+    expect(api.calls.patch[0].requestBody.eventLabelId).toBe("");
   });
 
   it("maps each invitation intent straight to sendUpdates", async () => {

--- a/packages/sync/src/providers/google/google-event-writer.adapter.ts
+++ b/packages/sync/src/providers/google/google-event-writer.adapter.ts
@@ -42,6 +42,10 @@ export interface GoogleEventsApi {
     requestBody: gSchema$Event;
     sendUpdates: string;
     ifMatch: string | null;
+    // Required to write eventLabelId. Under version 1, colorId is ignored —
+    // callers that both clear a label and set a slot color must use two
+    // patches (label clear at v1, then colorId at the default v0).
+    eventLabelVersion?: 1;
   }): Promise<gSchema$Event>;
   delete(params: {
     calendarId: string;
@@ -84,9 +88,23 @@ const defaultApiFactory: GoogleEventsApiFactory = (accessToken) => {
       });
       return data;
     },
-    async patch({ calendarId, eventId, requestBody, sendUpdates, ifMatch }) {
+    async patch({
+      calendarId,
+      eventId,
+      requestBody,
+      sendUpdates,
+      ifMatch,
+      eventLabelVersion,
+    }) {
       const { data } = await gcal.events.patch(
-        { calendarId, eventId, requestBody, sendUpdates },
+        {
+          calendarId,
+          eventId,
+          requestBody,
+          sendUpdates,
+          // Installed @googleapis/calendar types predate event labels.
+          ...(eventLabelVersion !== undefined ? { eventLabelVersion } : {}),
+        } as calendar_v3.Params$Resource$Events$Patch,
         ifMatchOptions(ifMatch),
       );
       return data;
@@ -161,6 +179,22 @@ export class GoogleEventWriter implements ProviderEventWriter {
   async patchEvent(input: ProviderPatchInput): Promise<ProviderWriteResult> {
     const api = this.#makeApi(input.accessToken);
     try {
+      let ifMatch = input.expectedVersion;
+      // A slot color must also clear any custom event label. Labels supersede
+      // colorId on read and rehydrate as Compass colorHex. Google only accepts
+      // eventLabelId writes under eventLabelVersion=1, and that version ignores
+      // colorId — so clear the label first, then write colorId at default v0.
+      if (typeof input.content.color === "string") {
+        const cleared = await api.patch({
+          calendarId: input.calendarId,
+          eventId: input.providerEventId,
+          requestBody: { eventLabelId: "" },
+          sendUpdates: "none",
+          ifMatch,
+          eventLabelVersion: 1,
+        });
+        if (cleared.etag) ifMatch = cleared.etag;
+      }
       const patched = await api.patch({
         calendarId: input.calendarId,
         eventId: input.providerEventId,
@@ -170,7 +204,7 @@ export class GoogleEventWriter implements ProviderEventWriter {
           input.recurrence,
         ),
         sendUpdates: toSendUpdates(input.invitation),
-        ifMatch: input.expectedVersion,
+        ifMatch,
       });
       return toResult(patched);
     } catch (error) {

--- a/packages/sync/src/providers/google/google-event-writer.adapter.ts
+++ b/packages/sync/src/providers/google/google-event-writer.adapter.ts
@@ -33,13 +33,13 @@ import { redactedCause } from "@sync/safety/redact-error";
 export interface GoogleEventsApi {
   insert(params: {
     calendarId: string;
-    requestBody: calendar_v3.Schema$Event;
+    requestBody: gSchema$Event;
     sendUpdates: string;
   }): Promise<gSchema$Event>;
   patch(params: {
     calendarId: string;
     eventId: string;
-    requestBody: calendar_v3.Schema$Event;
+    requestBody: gSchema$Event;
     sendUpdates: string;
     ifMatch: string | null;
   }): Promise<gSchema$Event>;
@@ -126,7 +126,7 @@ export class GoogleEventWriter implements ProviderEventWriter {
 
   async createEvent(input: ProviderCreateInput): Promise<ProviderWriteResult> {
     const api = this.#makeApi(input.accessToken);
-    const requestBody: calendar_v3.Schema$Event = {
+    const requestBody: gSchema$Event = {
       id: input.providerEventId,
       ...toGoogleBody(input.content, input.schedule, input.recurrence),
     };
@@ -271,7 +271,7 @@ function toGoogleBody(
   content: SyncEventContent,
   schedule: EventSchedule,
   recurrence: ProviderWriteRecurrence,
-): calendar_v3.Schema$Event {
+): gSchema$Event {
   return {
     summary: content.title,
     description: content.description,

--- a/packages/web/src/events/mutations/useEventMutations.ts
+++ b/packages/web/src/events/mutations/useEventMutations.ts
@@ -246,7 +246,7 @@ export type EventMutations = {
   replace: (
     payload: { id: EventId; input: ReplaceEventInput },
     callbacks?: EventMutationCallbacks,
-  ) => void;
+  ) => boolean;
   delete: (payload: { id: EventId; scope: RecurrenceScope }) => void;
   promoteRecurring: (
     opportunity: RecurrenceScopeOpportunity,
@@ -697,20 +697,20 @@ export function useEventMutations(
       replace: (
         payload: { id: EventId; input: ReplaceEventInput },
         callbacks?: EventMutationCallbacks,
-      ) => {
+      ): boolean => {
         const original = findEventInCache(queryClient, payload.id, source);
         if (isTargetReadOnly(original)) {
           console.warn(
             `[useEventMutations] blocked replace on read-only event ${payload.id}`,
           );
-          return;
+          return false;
         }
         if (
           blockReconnectRequiredCalendar(
             payload.input.calendarId ?? original?.calendarId,
           )
         ) {
-          return;
+          return false;
         }
         const writeKey = seriesWriteKey(
           original,
@@ -746,6 +746,7 @@ export function useEventMutations(
           { ...payload, writeKey, opportunityId, callbacks },
           callbacks,
         );
+        return true;
       },
       delete: (payload: { id: EventId; scope: RecurrenceScope }) => {
         const original = findEventInCache(queryClient, payload.id, source);

--- a/packages/web/src/events/mutations/useUpdateEvent.test.tsx
+++ b/packages/web/src/events/mutations/useUpdateEvent.test.tsx
@@ -1,0 +1,120 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { type PropsWithChildren } from "react";
+import { type Event } from "@core/types/event.contracts";
+import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
+import { type GridEvent } from "@web/common/types/web.event.types";
+import { gridEventDefaultPosition } from "@web/common/utils/event/event.util";
+import { editGridEventDraft } from "@web/events/grid-event-draft.adapter";
+import { eventQueryKeys } from "@web/events/queries/event.query.keys";
+import { type NormalizedEventQueryData } from "@web/events/queries/event.query.types";
+import {
+  draftActions,
+  initialDraftState,
+  useDraftStore,
+} from "@web/events/stores/draft.store";
+import { useUpdateEvent } from "./useUpdateEvent";
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+
+const calendarKey = eventQueryKeys.week({
+  source: "local",
+  start: "2026-07-01T00:00:00.000Z",
+  end: "2026-07-08T00:00:00.000Z",
+});
+
+const normalized = (...events: Event[]): NormalizedEventQueryData => ({
+  ids: events.map(({ id }) => id),
+  entities: Object.fromEntries(events.map((item) => [item.id, item])),
+});
+
+function toGridEvent(event: Event): GridEvent {
+  if (event.schedule.kind !== "timed") {
+    throw new Error("expected timed schedule");
+  }
+  return {
+    _id: event.id,
+    title: event.content.kind === "details" ? event.content.title : "",
+    description:
+      event.content.kind === "details" ? event.content.description : "",
+    startDate: event.schedule.start,
+    endDate: event.schedule.end,
+    isAllDay: false,
+    origin: event.origin ?? ("compass" as never),
+    position: gridEventDefaultPosition,
+    user: "user-1",
+  };
+}
+
+function createWrapper(events: Event[]) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  queryClient.setQueryData(calendarKey, normalized(...events));
+
+  function Wrapper({ children }: PropsWithChildren) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  }
+
+  return { queryClient, Wrapper };
+}
+
+describe("useUpdateEvent", () => {
+  beforeEach(() => {
+    draftActions.discard();
+  });
+
+  it("runs onOptimisticApplied after the optimistic cache write", async () => {
+    const existing = createMockEvent({
+      content: {
+        kind: "details",
+        title: "Timed",
+        description: "",
+      },
+      schedule: {
+        kind: "timed",
+        start: "2026-07-02T16:00:00.000Z" as never,
+        end: "2026-07-02T17:00:00.000Z" as never,
+        timeZone: "UTC" as never,
+      },
+    });
+    const draft = editGridEventDraft(existing);
+    if (!draft) throw new Error("expected edit draft");
+    draftActions.startGridDraft({ activity: "gridClick", draft });
+
+    const { queryClient, Wrapper } = createWrapper([existing]);
+    const { result } = renderHook(() => useUpdateEvent(), {
+      wrapper: Wrapper,
+    });
+
+    let startAtCallback: unknown;
+    const onOptimisticApplied = mock(() => {
+      startAtCallback = (
+        queryClient.getQueryData<NormalizedEventQueryData>(calendarKey)
+          ?.entities[existing.id].schedule as { start?: string }
+      ).start;
+      draftActions.discard();
+    });
+
+    const moved = toGridEvent(existing);
+    moved.startDate = "2026-07-02T18:00:00.000Z";
+    moved.endDate = "2026-07-02T19:00:00.000Z";
+
+    expect(useDraftStore.getState().gridDraft).not.toBeNull();
+
+    act(() => {
+      result.current({ event: moved }, true, { onOptimisticApplied });
+    });
+
+    // Discard must not run synchronously before onMutate's cache write.
+    expect(onOptimisticApplied).not.toHaveBeenCalled();
+    expect(useDraftStore.getState().gridDraft).not.toBeNull();
+
+    await waitFor(() => {
+      expect(onOptimisticApplied).toHaveBeenCalledTimes(1);
+    });
+    expect(startAtCallback).toBe("2026-07-02T18:00:00Z");
+    expect(useDraftStore.getState()).toEqual(initialDraftState);
+  });
+});

--- a/packages/web/src/events/mutations/useUpdateEvent.test.tsx
+++ b/packages/web/src/events/mutations/useUpdateEvent.test.tsx
@@ -1,6 +1,7 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { type PropsWithChildren } from "react";
+import { Origin } from "@core/constants/core.constants";
 import { type Event } from "@core/types/event.contracts";
 import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
 import { type GridEvent } from "@web/common/types/web.event.types";
@@ -39,7 +40,7 @@ function toGridEvent(event: Event): GridEvent {
     startDate: event.schedule.start,
     endDate: event.schedule.end,
     isAllDay: false,
-    origin: event.origin ?? ("compass" as never),
+    origin: Origin.COMPASS,
     position: gridEventDefaultPosition,
     user: "user-1",
   };

--- a/packages/web/src/events/mutations/useUpdateEvent.ts
+++ b/packages/web/src/events/mutations/useUpdateEvent.ts
@@ -48,20 +48,28 @@ export function useUpdateEvent(dependencies: EventMutationDependencies = {}) {
       },
       saveImmediate = true,
       callbacks?: EventMutationCallbacks,
-    ) => {
+    ): boolean => {
       const { event, shouldRemove, applyTo } = payload;
 
-      if (!event._id) return;
+      // Callers pass onOptimisticApplied to tear down covering drafts. When
+      // the mutation never starts (blocked/no-op), still run it so drafts do
+      // not stick — same teardown, without an optimistic cache write.
+      const finishWithoutMutation = () => {
+        callbacks?.onOptimisticApplied?.();
+        return false;
+      };
 
-      if (!saveImmediate) return;
+      if (!event._id) return finishWithoutMutation();
+
+      if (!saveImmediate) return finishWithoutMutation();
 
       if (shouldRemove) {
         removeEventFromQueries(queryClient, event._id);
-        return;
+        return finishWithoutMutation();
       }
 
       const sourceEvent = findEventInCache(queryClient, event._id);
-      if (!sourceEvent) return;
+      if (!sourceEvent) return finishWithoutMutation();
 
       // A differing calendarId means the drag dropped the event on another
       // calendar's column (Day view). Guard here so a blocked move reverts
@@ -73,7 +81,7 @@ export function useUpdateEvent(dependencies: EventMutationDependencies = {}) {
       if (nextCalendarId) {
         if (sourceEvent.recurrence.kind !== "single") {
           showErrorToast("Repeating events can't move to another calendar.");
-          return;
+          return finishWithoutMutation();
         }
         const lookup = buildCalendarLookup(
           queryClient.getQueryData<Calendar[]>(calendarQueryKeys.all),
@@ -81,7 +89,7 @@ export function useUpdateEvent(dependencies: EventMutationDependencies = {}) {
         if (isEventReadOnly(lookup, nextCalendarId, false)) {
           const name = lookup.get(nextCalendarId)?.name ?? "that calendar";
           showErrorToast(`You can't move events to ${name}.`);
-          return;
+          return finishWithoutMutation();
         }
       }
 
@@ -89,7 +97,9 @@ export function useUpdateEvent(dependencies: EventMutationDependencies = {}) {
         sourceEvent,
         toRecurrenceScope(applyTo),
       );
-      if (!sourceDraft || sourceDraft.kind !== "edit") return;
+      if (!sourceDraft || sourceDraft.kind !== "edit") {
+        return finishWithoutMutation();
+      }
 
       const patchedDraft = {
         ...sourceDraft,
@@ -114,21 +124,25 @@ export function useUpdateEvent(dependencies: EventMutationDependencies = {}) {
         !nextCalendarId &&
         fastDeepEqual(patchedDraft.values, sourceDraft.values)
       ) {
-        return;
+        return finishWithoutMutation();
       }
 
       const parsed = parseGridEventDraft(patchedDraft);
-      if (parsed.ok && parsed.mode === "edit") {
-        replace(
-          {
-            id: parsed.eventId,
-            input: nextCalendarId
-              ? { ...parsed.input, calendarId: nextCalendarId }
-              : parsed.input,
-          },
-          callbacks,
-        );
+      if (!(parsed.ok && parsed.mode === "edit")) {
+        return finishWithoutMutation();
       }
+
+      const started = replace(
+        {
+          id: parsed.eventId,
+          input: nextCalendarId
+            ? { ...parsed.input, calendarId: nextCalendarId }
+            : parsed.input,
+        },
+        callbacks,
+      );
+      if (!started) return finishWithoutMutation();
+      return true;
     },
     [replace, queryClient],
   );

--- a/packages/web/src/events/mutations/useUpdateEvent.ts
+++ b/packages/web/src/events/mutations/useUpdateEvent.ts
@@ -19,6 +19,7 @@ import {
   timedGridSchedule,
 } from "@web/events/grid-event-draft.adapter";
 import {
+  type EventMutationCallbacks,
   type EventMutationDependencies,
   useEventMutations,
 } from "@web/events/mutations/useEventMutations";
@@ -46,6 +47,7 @@ export function useUpdateEvent(dependencies: EventMutationDependencies = {}) {
         applyTo?: RecurringEventUpdateScope;
       },
       saveImmediate = true,
+      callbacks?: EventMutationCallbacks,
     ) => {
       const { event, shouldRemove, applyTo } = payload;
 
@@ -117,12 +119,15 @@ export function useUpdateEvent(dependencies: EventMutationDependencies = {}) {
 
       const parsed = parseGridEventDraft(patchedDraft);
       if (parsed.ok && parsed.mode === "edit") {
-        replace({
-          id: parsed.eventId,
-          input: nextCalendarId
-            ? { ...parsed.input, calendarId: nextCalendarId }
-            : parsed.input,
-        });
+        replace(
+          {
+            id: parsed.eventId,
+            input: nextCalendarId
+              ? { ...parsed.input, calendarId: nextCalendarId }
+              : parsed.input,
+          },
+          callbacks,
+        );
       }
     },
     [replace, queryClient],

--- a/packages/web/src/grid/shortcuts/useGridEventEditShortcuts.ts
+++ b/packages/web/src/grid/shortcuts/useGridEventEditShortcuts.ts
@@ -227,14 +227,15 @@ export function useGridEventEditShortcuts({
       event,
       keyboardEvent,
       onNudge: (nudgedEvent, nextEdge) => {
-        updateEvent({ event: nudgedEvent }, true);
+        updateEvent({ event: nudgedEvent }, true, {
+          onOptimisticApplied: () => draftActions.discard(),
+        });
         edgeFocusActions.setEdge(
           event._id!,
           nextEdge,
           describeEdgeDate(nudgedEvent, nextEdge),
         );
       },
-      afterNudge: () => draftActions.discard(),
     });
   };
 
@@ -275,7 +276,9 @@ export function useGridEventEditShortcuts({
         event,
         keyboardEvent,
         onNudge: (nudgedEvent) => {
-          updateEvent({ event: nudgedEvent }, true);
+          updateEvent({ event: nudgedEvent }, true, {
+            onOptimisticApplied: () => draftActions.discard(),
+          });
           if (dayBoundary.kind === "follow") {
             const nextStart = dayjs(nudgedEvent.startDate).startOf("day");
             if (!nextStart.isSame(previousStart, "day")) {
@@ -283,7 +286,6 @@ export function useGridEventEditShortcuts({
             }
           }
         },
-        afterNudge: () => draftActions.discard(),
       });
       return;
     }

--- a/packages/web/src/views/Day/interaction/DayInteractionCoordinator.tsx
+++ b/packages/web/src/views/Day/interaction/DayInteractionCoordinator.tsx
@@ -91,8 +91,9 @@ export const DayInteractionCoordinator: FC<Props> = ({
       return;
     }
 
-    updateEvent({ event: result.event }, true);
-    draftActions.discard();
+    updateEvent({ event: result.event }, true, {
+      onOptimisticApplied: () => draftActions.discard(),
+    });
   };
 
   runtimeRef.current = {

--- a/packages/web/src/views/Forms/hooks/useSetEventColor.test.tsx
+++ b/packages/web/src/views/Forms/hooks/useSetEventColor.test.tsx
@@ -109,6 +109,39 @@ describe("useSetEventColor", () => {
     expect(useDraftStore.getState()).toEqual(initialDraftState);
   });
 
+  it("rewrites the same slot when a provider colorHex is still winning the palette", async () => {
+    const existing = createMockEvent({
+      content: {
+        kind: "details",
+        title: "Labeled",
+        description: "",
+        color: "coral",
+        colorHex: "#009688",
+      },
+      schedule: {
+        kind: "allDay",
+        start: "2026-07-02" as never,
+        end: "2026-07-03" as never,
+      },
+    });
+    const { queryClient, Wrapper } = createWrapper([existing]);
+    const { result } = renderHook(() => useSetEventColor(existing.id), {
+      wrapper: Wrapper,
+    });
+
+    act(() => {
+      result.current("coral");
+    });
+
+    await waitFor(() => {
+      const content =
+        queryClient.getQueryData<NormalizedEventQueryData>(calendarKey)
+          ?.entities[existing.id]?.content;
+      expect(content).toMatchObject({ color: "coral" });
+      expect(content).not.toHaveProperty("colorHex");
+    });
+  });
+
   it("updates a right-click draft that still held the old color", async () => {
     const existing = createMockEvent({
       content: {

--- a/packages/web/src/views/Forms/hooks/useSetEventColor.ts
+++ b/packages/web/src/views/Forms/hooks/useSetEventColor.ts
@@ -22,11 +22,12 @@ export function useSetEventColor(_id: string) {
     (color: EventColorSlot | null) => {
       if (!existingEvent) return;
 
-      const currentColor =
-        existingEvent.content.kind === "details"
-          ? (existingEvent.content.color ?? null)
-          : null;
-      if (currentColor === color) {
+      const details =
+        existingEvent.content.kind === "details" ? existingEvent.content : null;
+      const currentColor = details?.color ?? null;
+      // Same slot (or default) is a no-op unless a provider hex is still
+      // winning the palette — then this write clears it via replace merge.
+      if (currentColor === color && details?.colorHex === undefined) {
         draftActions.discard();
         return;
       }

--- a/packages/web/src/views/Week/components/Draft/hooks/actions/useDraftActions.ts
+++ b/packages/web/src/views/Week/components/Draft/hooks/actions/useDraftActions.ts
@@ -190,12 +190,17 @@ export const useDraftActions = (
           });
 
           if (parsed.ok && parsed.mode === "edit") {
-            mutations.replace(
+            const started = mutations.replace(
               { id: parsed.eventId, input: parsed.input },
               isFormOpenBeforeDragging
                 ? undefined
                 : { onOptimisticApplied: discard },
             );
+            if (!started && !isFormOpenBeforeDragging) {
+              discard();
+            }
+          } else if (!isFormOpenBeforeDragging) {
+            discard();
           }
 
           if (isFormOpenBeforeDragging) {

--- a/packages/web/src/views/Week/components/Draft/hooks/actions/useDraftActions.ts
+++ b/packages/web/src/views/Week/components/Draft/hooks/actions/useDraftActions.ts
@@ -190,13 +190,16 @@ export const useDraftActions = (
           });
 
           if (parsed.ok && parsed.mode === "edit") {
-            mutations.replace({ id: parsed.eventId, input: parsed.input });
+            mutations.replace(
+              { id: parsed.eventId, input: parsed.input },
+              isFormOpenBeforeDragging
+                ? undefined
+                : { onOptimisticApplied: discard },
+            );
           }
 
           if (isFormOpenBeforeDragging) {
             setIsFormOpen(true);
-          } else {
-            discard();
           }
           return;
         }

--- a/packages/web/src/views/Week/interaction/WeekInteractionCoordinator.tsx
+++ b/packages/web/src/views/Week/interaction/WeekInteractionCoordinator.tsx
@@ -151,8 +151,9 @@ export const WeekInteractionCoordinator: FC<Props> = ({
       return;
     }
 
-    updateEvent({ event: result.event }, true);
-    draftActions.discard();
+    updateEvent({ event: result.event }, true, {
+      onOptimisticApplied: () => draftActions.discard(),
+    });
   };
 
   runtimeRef.current = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #2744 / `v1.1.181`. Clears the two remaining optimistic color risks without reworking the shipped draft/`onOptimisticApplied` color path.

### Risk 1 — `colorHex` rehydrates after settle
- **`mergeUpdateContent`**: slot writes drop provider `colorHex`; clearing a prior slot does too. Hex-only events that receive draft `color: null` keep `colorHex` (avoids wiping labels on unrelated edits/drags).
- **Google writer**: setting a slot color uses a two-step patch — clear `eventLabelId` under `eventLabelVersion=1`, then write `colorId` at default v0 (Google ignores `colorId` under v1).
- **`useSetEventColor`**: picking the same slot still writes when a lingering `colorHex` is winning the palette.

### Risk 2 — drag/resize early draft discard
Reuse existing `onOptimisticApplied` plumbing so covering drafts stay up until the optimistic cache write lands:
- Week / Day interaction coordinators
- `useDraftActions` UPDATE submit
- keyboard nudge shortcuts via `useUpdateEvent` callbacks
- `replace` returns whether the mutation started; blocked/no-op paths still tear down covering drafts

## Simplification
Kept discard teardown on the existing `onOptimisticApplied` callback (including blocked paths) instead of adding a second callback. Google label clear is a dedicated preconditioned patch rather than overloading `googleColorIdFields`.

## Validation
- `bun test:sync:fast` / focused Google writer + merge tests
- `bun test:web` focused: `useUpdateEvent`, `useSetEventColor`, `useEventMutations`, Day interaction
- Browser smoke at http://localhost:9080: create timed event, drag 2–4pm → 5–7pm, resize to 5–8pm — settled with no flash-back; no critical console errors
- `bun run type-check`, `bun run lint`
- Independent review: fixed confirmed Google label-clear / stuck-draft findings

## Independent review
Addressed: two-step Google label clear; discard when replace/update never mutates. Residual: intentional hex-only + `color: null` still preserves `colorHex` by design to avoid draft null wiping labels.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a0dbfd0c-1d09-4b00-9c28-063b3e018aa4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a0dbfd0c-1d09-4b00-9c28-063b3e018aa4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

