### PR TITLE
fix(web,core): rebase remote promote-all onto series master delta

### DIFF
--- a/packages/core/src/util/event/shift-series-schedule-by-occurrence-edit.test.ts
+++ b/packages/core/src/util/event/shift-series-schedule-by-occurrence-edit.test.ts
@@ -1,0 +1,110 @@
+import {
+  DateOnlySchema,
+  DateTimeSchema,
+  TimeZoneSchema,
+} from "@core/types/domain-primitives";
+import { type EventSchedule } from "@core/types/event.contracts";
+import { shiftSeriesScheduleByOccurrenceEdit } from "@core/util/event/shift-series-schedule-by-occurrence-edit";
+import { describe, expect, it } from "bun:test";
+
+const timed = (start: string, end: string): EventSchedule => ({
+  kind: "timed",
+  start: DateTimeSchema.parse(start),
+  end: DateTimeSchema.parse(end),
+  timeZone: TimeZoneSchema.parse("UTC"),
+});
+
+const allDay = (start: string, end: string): EventSchedule => ({
+  kind: "allDay",
+  start: DateOnlySchema.parse(start),
+  end: DateOnlySchema.parse(end),
+});
+
+describe("shiftSeriesScheduleByOccurrenceEdit", () => {
+  it("shifts a timed series master by a middle occurrence's day delta", () => {
+    const base = timed("2026-05-04T09:00:00.000Z", "2026-05-04T10:00:00.000Z");
+    const edited = timed(
+      "2026-05-07T09:00:00.000Z",
+      "2026-05-07T10:00:00.000Z",
+    );
+
+    expect(
+      shiftSeriesScheduleByOccurrenceEdit(
+        base,
+        "2026-05-06T09:00:00.000Z",
+        edited,
+      ),
+    ).toEqual(timed("2026-05-05T09:00:00+00:00", "2026-05-05T10:00:00+00:00"));
+  });
+
+  it("propagates a timed duration change onto the master", () => {
+    const base = timed("2026-05-04T09:00:00.000Z", "2026-05-04T10:00:00.000Z");
+    const edited = timed(
+      "2026-05-06T09:00:00.000Z",
+      "2026-05-06T11:00:00.000Z",
+    );
+
+    expect(
+      shiftSeriesScheduleByOccurrenceEdit(
+        base,
+        "2026-05-06T09:00:00.000Z",
+        edited,
+      ),
+    ).toEqual(timed("2026-05-04T09:00:00+00:00", "2026-05-04T11:00:00+00:00"));
+  });
+
+  it("returns the timed base unchanged for a zero delta", () => {
+    const base = timed("2026-05-04T09:00:00.000Z", "2026-05-04T10:00:00.000Z");
+    const edited = timed(
+      "2026-05-06T09:00:00.000Z",
+      "2026-05-06T10:00:00.000Z",
+    );
+
+    expect(
+      shiftSeriesScheduleByOccurrenceEdit(
+        base,
+        "2026-05-06T09:00:00.000Z",
+        edited,
+      ),
+    ).toBe(base);
+  });
+
+  it("shifts an all-day series master by a middle occurrence's day delta", () => {
+    const base = allDay("2026-05-04", "2026-05-05");
+    const edited = allDay("2026-05-07", "2026-05-08");
+
+    expect(
+      shiftSeriesScheduleByOccurrenceEdit(
+        base,
+        "2026-05-06T00:00:00.000Z",
+        edited,
+      ),
+    ).toEqual(allDay("2026-05-05", "2026-05-06"));
+  });
+
+  it("returns the all-day base unchanged for a zero delta", () => {
+    const base = allDay("2026-05-04", "2026-05-05");
+    const edited = allDay("2026-05-06", "2026-05-07");
+
+    expect(
+      shiftSeriesScheduleByOccurrenceEdit(
+        base,
+        "2026-05-06T00:00:00.000Z",
+        edited,
+      ),
+    ).toBe(base);
+  });
+
+  it("returns edited unchanged on a timed ↔ allDay kind flip", () => {
+    const base = timed("2026-05-04T09:00:00.000Z", "2026-05-04T10:00:00.000Z");
+    const edited = allDay("2026-05-07", "2026-05-08");
+
+    expect(
+      shiftSeriesScheduleByOccurrenceEdit(
+        base,
+        "2026-05-06T09:00:00.000Z",
+        edited,
+      ),
+    ).toBe(edited);
+  });
+});

--- a/packages/core/src/util/event/shift-series-schedule-by-occurrence-edit.ts
+++ b/packages/core/src/util/event/shift-series-schedule-by-occurrence-edit.ts
@@ -2,8 +2,6 @@ import { DateOnlySchema, DateTimeSchema } from "@core/types/domain-primitives";
 import { type EventSchedule } from "@core/types/event.contracts";
 import dayjs from "@core/util/date/dayjs";
 
-const MS_PER_DAY = 24 * 60 * 60 * 1000;
-
 /**
  * Apply an occurrence edit's schedule delta onto the series base.
  *
@@ -58,12 +56,8 @@ export function shiftSeriesScheduleByOccurrenceEdit(
   const originalEnd = dayjs(originalStart)
     .add(baseDurationDays, "day")
     .format("YYYY-MM-DD");
-  const startDeltaDays = Math.round(
-    dayjs(edited.start).diff(dayjs(originalStart)) / MS_PER_DAY,
-  );
-  const endDeltaDays = Math.round(
-    dayjs(edited.end).diff(dayjs(originalEnd)) / MS_PER_DAY,
-  );
+  const startDeltaDays = dayjs(edited.start).diff(dayjs(originalStart), "day");
+  const endDeltaDays = dayjs(edited.end).diff(dayjs(originalEnd), "day");
   if (startDeltaDays === 0 && endDeltaDays === 0) {
     return base;
   }

--- a/packages/core/src/util/event/shift-series-schedule-by-occurrence-edit.ts
+++ b/packages/core/src/util/event/shift-series-schedule-by-occurrence-edit.ts
@@ -1,0 +1,79 @@
+import { DateOnlySchema, DateTimeSchema } from "@core/types/domain-primitives";
+import { type EventSchedule } from "@core/types/event.contracts";
+import dayjs from "@core/util/date/dayjs";
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/**
+ * Apply an occurrence edit's schedule delta onto the series base.
+ *
+ * Clients send the occurrence's absolute schedule on replace. Treating that
+ * absolute value as the series DTSTART would shift the whole series by the
+ * occurrence's offset from the master. Infer the pre-edit occurrence end from
+ * the master's duration so a duration change on the occurrence still
+ * propagates.
+ *
+ * Kind flips (timed ↔ allDay) return `edited` unchanged — there is no
+ * unambiguous delta onto a differently-shaped master schedule.
+ */
+export function shiftSeriesScheduleByOccurrenceEdit(
+  base: EventSchedule,
+  occurrenceStart: string,
+  edited: EventSchedule,
+): EventSchedule {
+  if (base.kind !== edited.kind) {
+    return edited;
+  }
+
+  if (base.kind === "timed" && edited.kind === "timed") {
+    const originalStart = dayjs(occurrenceStart);
+    const originalEnd = originalStart.add(
+      dayjs(base.end).diff(base.start),
+      "millisecond",
+    );
+    const startDelta = dayjs(edited.start).diff(originalStart);
+    const endDelta = dayjs(edited.end).diff(originalEnd);
+    if (
+      startDelta === 0 &&
+      endDelta === 0 &&
+      base.timeZone === edited.timeZone
+    ) {
+      return base;
+    }
+    return {
+      kind: "timed",
+      start: DateTimeSchema.parse(
+        dayjs(base.start).add(startDelta, "millisecond").format(),
+      ),
+      end: DateTimeSchema.parse(
+        dayjs(base.end).add(endDelta, "millisecond").format(),
+      ),
+      timeZone: edited.timeZone,
+    };
+  }
+
+  // allDay: occurrence ids embed midnight-Z; schedules use YYYY-MM-DD.
+  const originalStart = dayjs(occurrenceStart).utc().format("YYYY-MM-DD");
+  const baseDurationDays = dayjs(base.end).diff(base.start, "day");
+  const originalEnd = dayjs(originalStart)
+    .add(baseDurationDays, "day")
+    .format("YYYY-MM-DD");
+  const startDeltaDays = Math.round(
+    dayjs(edited.start).diff(dayjs(originalStart)) / MS_PER_DAY,
+  );
+  const endDeltaDays = Math.round(
+    dayjs(edited.end).diff(dayjs(originalEnd)) / MS_PER_DAY,
+  );
+  if (startDeltaDays === 0 && endDeltaDays === 0) {
+    return base;
+  }
+  return {
+    kind: "allDay",
+    start: DateOnlySchema.parse(
+      dayjs(base.start).add(startDeltaDays, "day").format("YYYY-MM-DD"),
+    ),
+    end: DateOnlySchema.parse(
+      dayjs(base.end).add(endDeltaDays, "day").format("YYYY-MM-DD"),
+    ),
+  };
+}

--- a/packages/web/src/events/mutations/useEventMutations.test.tsx
+++ b/packages/web/src/events/mutations/useEventMutations.test.tsx
@@ -221,6 +221,44 @@ const replacePayload = (
   },
 });
 
+type MutationTestContext = ReturnType<typeof setup>;
+
+const replaceAndGetOpportunity = (
+  context: MutationTestContext,
+  id: EventId,
+  overrides: Partial<ReplaceEventInput> = {},
+) => {
+  act(() =>
+    context.hook.result.current.mutations.replace(
+      replacePayload(id, overrides),
+    ),
+  );
+  const opportunity = useRecurrenceScopeOpportunityStore.getState().opportunity;
+  if (!opportunity || opportunity.kind !== "replace") {
+    throw new Error("Expected a recurrence edit opportunity");
+  }
+  return opportunity;
+};
+
+const expectPromotedReplaceCall = async (
+  context: MutationTestContext,
+  id: EventId,
+  expected: Partial<ReplaceEventInput>,
+) => {
+  await waitFor(() => expect(context.calls).toHaveLength(1));
+  act(() => context.pending.resolveNext());
+  await waitFor(() => {
+    expect(context.calls).toContainEqual({
+      method: "replace",
+      value: {
+        id,
+        input: expect.objectContaining(expected),
+      },
+    });
+  });
+  context.pending.resolve();
+};
+
 describe("useEventMutations", () => {
   afterEach(() => {
     recurrenceScopeOpportunityActions.reset();
@@ -300,23 +338,14 @@ describe("useEventMutations", () => {
     });
     context.queryClient.setQueryData(calendarKey, normalized(first, second));
 
-    act(() =>
-      context.hook.result.current.mutations.replace(
-        replacePayload(first.id, {
-          content: {
-            kind: "details",
-            title: "First narrow edit",
-            description: "",
-            location: "",
-          },
-        }),
-      ),
-    );
-    const opportunity =
-      useRecurrenceScopeOpportunityStore.getState().opportunity;
-    if (!opportunity || opportunity.kind !== "replace") {
-      throw new Error("Expected a recurrence edit opportunity");
-    }
+    const opportunity = replaceAndGetOpportunity(context, first.id, {
+      content: {
+        kind: "details",
+        title: "First narrow edit",
+        description: "",
+        location: "",
+      },
+    });
 
     act(() =>
       context.hook.result.current.mutations.promoteRecurring(
@@ -353,7 +382,6 @@ describe("useEventMutations", () => {
 
   test("remote promote all rebases a middle timed occurrence onto the series master", async () => {
     const context = setup("remote");
-    const remoteKey = calendarKeyFor("remote");
     const seriesId = EventIdSchema.parse("aaaaaaaaaaaaaaaaaaaaaaaa");
     const master = seriesMaster(seriesId, {
       schedule: timedSchedule(
@@ -371,26 +399,20 @@ describe("useEventMutations", () => {
       "2026-07-04T16:00:00.000Z",
       "2026-07-04T17:00:00.000Z",
     );
-    context.queryClient.setQueryData(remoteKey, normalized(master, middle));
-
-    act(() =>
-      context.hook.result.current.mutations.replace(
-        replacePayload(middle.id, {
-          content: {
-            kind: "details",
-            title: "Nudged",
-            description: "",
-            location: "",
-          },
-          schedule: moved,
-        }),
-      ),
+    context.queryClient.setQueryData(
+      calendarKeyFor("remote"),
+      normalized(master, middle),
     );
-    const opportunity =
-      useRecurrenceScopeOpportunityStore.getState().opportunity;
-    if (!opportunity || opportunity.kind !== "replace") {
-      throw new Error("Expected a recurrence edit opportunity");
-    }
+
+    const opportunity = replaceAndGetOpportunity(context, middle.id, {
+      content: {
+        kind: "details",
+        title: "Nudged",
+        description: "",
+        location: "",
+      },
+      schedule: moved,
+    });
 
     act(() =>
       context.hook.result.current.mutations.promoteRecurring(
@@ -399,29 +421,17 @@ describe("useEventMutations", () => {
       ),
     );
 
-    await waitFor(() => expect(context.calls).toHaveLength(1));
-    act(() => context.pending.resolveNext());
-    await waitFor(() => {
-      expect(context.calls).toContainEqual({
-        method: "replace",
-        value: {
-          id: middle.id,
-          input: expect.objectContaining({
-            scope: "all",
-            schedule: timedSchedule(
-              "2026-07-02T16:00:00+00:00",
-              "2026-07-02T17:00:00+00:00",
-            ),
-          }),
-        },
-      });
+    await expectPromotedReplaceCall(context, middle.id, {
+      scope: "all",
+      schedule: timedSchedule(
+        "2026-07-02T16:00:00+00:00",
+        "2026-07-02T17:00:00+00:00",
+      ),
     });
-    context.pending.resolve();
   });
 
   test("remote promote all rebases a middle all-day occurrence onto the series master", async () => {
     const context = setup("remote");
-    const remoteKey = calendarKeyFor("remote");
     const seriesId = EventIdSchema.parse("bbbbbbbbbbbbbbbbbbbbbbbb");
     const master = seriesMaster(seriesId, {
       schedule: allDaySchedule("2026-07-01", "2026-07-02"),
@@ -430,26 +440,20 @@ describe("useEventMutations", () => {
       schedule: allDaySchedule("2026-07-03", "2026-07-04"),
     });
     const moved = allDaySchedule("2026-07-04", "2026-07-05");
-    context.queryClient.setQueryData(remoteKey, normalized(master, middle));
-
-    act(() =>
-      context.hook.result.current.mutations.replace(
-        replacePayload(middle.id, {
-          content: {
-            kind: "details",
-            title: "All-day nudged",
-            description: "",
-            location: "",
-          },
-          schedule: moved,
-        }),
-      ),
+    context.queryClient.setQueryData(
+      calendarKeyFor("remote"),
+      normalized(master, middle),
     );
-    const opportunity =
-      useRecurrenceScopeOpportunityStore.getState().opportunity;
-    if (!opportunity || opportunity.kind !== "replace") {
-      throw new Error("Expected a recurrence edit opportunity");
-    }
+
+    const opportunity = replaceAndGetOpportunity(context, middle.id, {
+      content: {
+        kind: "details",
+        title: "All-day nudged",
+        description: "",
+        location: "",
+      },
+      schedule: moved,
+    });
 
     act(() =>
       context.hook.result.current.mutations.promoteRecurring(
@@ -458,26 +462,14 @@ describe("useEventMutations", () => {
       ),
     );
 
-    await waitFor(() => expect(context.calls).toHaveLength(1));
-    act(() => context.pending.resolveNext());
-    await waitFor(() => {
-      expect(context.calls).toContainEqual({
-        method: "replace",
-        value: {
-          id: middle.id,
-          input: expect.objectContaining({
-            scope: "all",
-            schedule: allDaySchedule("2026-07-02", "2026-07-03"),
-          }),
-        },
-      });
+    await expectPromotedReplaceCall(context, middle.id, {
+      scope: "all",
+      schedule: allDaySchedule("2026-07-02", "2026-07-03"),
     });
-    context.pending.resolve();
   });
 
   test("remote promote thisAndFollowing keeps the occurrence absolute schedule", async () => {
     const context = setup("remote");
-    const remoteKey = calendarKeyFor("remote");
     const seriesId = EventIdSchema.parse("cccccccccccccccccccccccc");
     const master = seriesMaster(seriesId, {
       schedule: timedSchedule(
@@ -495,26 +487,20 @@ describe("useEventMutations", () => {
       "2026-07-04T16:00:00.000Z",
       "2026-07-04T17:00:00.000Z",
     );
-    context.queryClient.setQueryData(remoteKey, normalized(master, middle));
-
-    act(() =>
-      context.hook.result.current.mutations.replace(
-        replacePayload(middle.id, {
-          content: {
-            kind: "details",
-            title: "Split nudge",
-            description: "",
-            location: "",
-          },
-          schedule: moved,
-        }),
-      ),
+    context.queryClient.setQueryData(
+      calendarKeyFor("remote"),
+      normalized(master, middle),
     );
-    const opportunity =
-      useRecurrenceScopeOpportunityStore.getState().opportunity;
-    if (!opportunity || opportunity.kind !== "replace") {
-      throw new Error("Expected a recurrence edit opportunity");
-    }
+
+    const opportunity = replaceAndGetOpportunity(context, middle.id, {
+      content: {
+        kind: "details",
+        title: "Split nudge",
+        description: "",
+        location: "",
+      },
+      schedule: moved,
+    });
 
     act(() =>
       context.hook.result.current.mutations.promoteRecurring(
@@ -523,21 +509,10 @@ describe("useEventMutations", () => {
       ),
     );
 
-    await waitFor(() => expect(context.calls).toHaveLength(1));
-    act(() => context.pending.resolveNext());
-    await waitFor(() => {
-      expect(context.calls).toContainEqual({
-        method: "replace",
-        value: {
-          id: middle.id,
-          input: expect.objectContaining({
-            scope: "thisAndFollowing",
-            schedule: moved,
-          }),
-        },
-      });
+    await expectPromotedReplaceCall(context, middle.id, {
+      scope: "thisAndFollowing",
+      schedule: moved,
     });
-    context.pending.resolve();
   });
 
   test("optimistically patches recurring instances across day and week caches", async () => {

--- a/packages/web/src/events/mutations/useEventMutations.test.tsx
+++ b/packages/web/src/events/mutations/useEventMutations.test.tsx
@@ -5,12 +5,14 @@ import {
   DateOnlySchema,
   DateTimeSchema,
   type EventId,
+  EventIdSchema,
 } from "@core/types/domain-primitives";
 import { type Event } from "@core/types/event.contracts";
 import {
   type CreateEventInput,
   type ReplaceEventInput,
 } from "@core/types/event-command.contracts";
+import { composeOccurrenceId } from "@core/util/occurrence-id";
 import { createTestToastPort } from "@web/__tests__/helpers/web-test-seams";
 import { afterAll, afterEach, describe, expect, mock, test } from "bun:test";
 
@@ -43,6 +45,7 @@ import {
   recurrenceScopeOpportunityActions,
   useRecurrenceScopeOpportunityStore,
 } from "@web/events/recurrence/recurrence-scope-opportunity.store";
+import { type EventRepositorySource } from "@web/events/repositories/event.repository.factory";
 import { type EventRepository } from "@web/events/repositories/event.repository.types";
 import {
   runHistoryRestore,
@@ -51,11 +54,14 @@ import {
 import { useEventMutations } from "./useEventMutations";
 import { useHasPendingEventMutations } from "./useEventPending";
 
-const calendarKey = eventQueryKeys.week({
-  source: "local",
-  start: "2026-07-01T00:00:00.000Z",
-  end: "2026-07-08T00:00:00.000Z",
-});
+const calendarKeyFor = (source: EventRepositorySource) =>
+  eventQueryKeys.week({
+    source,
+    start: "2026-07-01T00:00:00.000Z",
+    end: "2026-07-08T00:00:00.000Z",
+  });
+
+const calendarKey = calendarKeyFor("local");
 
 const dayKey = eventQueryKeys.day({
   source: "local",
@@ -70,6 +76,12 @@ const timedSchedule = (start: string, end: string) => ({
   timeZone: "UTC" as never,
 });
 
+const allDaySchedule = (start: string, end: string) => ({
+  kind: "allDay" as const,
+  start: DateOnlySchema.parse(start),
+  end: DateOnlySchema.parse(end),
+});
+
 const event = (overrides: Partial<Event> = {}): Event =>
   createMockEvent({
     content: { kind: "details", title: "Original", description: "" },
@@ -82,6 +94,28 @@ const event = (overrides: Partial<Event> = {}): Event =>
 
 const occurrence = (seriesId: EventId, overrides: Partial<Event> = {}): Event =>
   event({ recurrence: { kind: "occurrence", seriesId }, ...overrides });
+
+const composedOccurrence = (
+  seriesId: EventId,
+  recurrenceId: string,
+  overrides: Partial<Event> = {},
+): Event =>
+  occurrence(seriesId, {
+    id: EventIdSchema.parse(
+      composeOccurrenceId({ eventId: seriesId, recurrenceId }),
+    ),
+    ...overrides,
+  });
+
+const seriesMaster = (
+  seriesId: EventId,
+  overrides: Partial<Event> = {},
+): Event =>
+  event({
+    id: seriesId,
+    recurrence: { kind: "series", rules: ["RRULE:FREQ=DAILY;COUNT=5"] },
+    ...overrides,
+  });
 
 const normalized = (...events: Event[]): NormalizedEventQueryData => ({
   ids: events.map(({ id }) => id),
@@ -122,7 +156,7 @@ const pendingControl = () => {
   };
 };
 
-const setup = () => {
+const setup = (source: EventRepositorySource = "local") => {
   const queryClient = new QueryClient({
     defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
   });
@@ -153,7 +187,7 @@ const setup = () => {
   const hook = renderHook(
     () => ({
       mutations: useEventMutations({
-        source: "local",
+        source,
         repository,
         markWrite: async () => markedWrites.push("marked"),
         reportError: (error) => errors.push(error),
@@ -162,7 +196,7 @@ const setup = () => {
     }),
     { wrapper },
   );
-  return { calls, errors, hook, markedWrites, pending, queryClient };
+  return { calls, errors, hook, markedWrites, pending, queryClient, source };
 };
 
 const replacePayload = (
@@ -312,6 +346,195 @@ describe("useEventMutations", () => {
           id: first.id,
           input: expect.objectContaining({ scope: "all" }),
         }),
+      });
+    });
+    context.pending.resolve();
+  });
+
+  test("remote promote all rebases a middle timed occurrence onto the series master", async () => {
+    const context = setup("remote");
+    const remoteKey = calendarKeyFor("remote");
+    const seriesId = EventIdSchema.parse("aaaaaaaaaaaaaaaaaaaaaaaa");
+    const master = seriesMaster(seriesId, {
+      schedule: timedSchedule(
+        "2026-07-01T16:00:00.000Z",
+        "2026-07-01T17:00:00.000Z",
+      ),
+    });
+    const middle = composedOccurrence(seriesId, "2026-07-03T16:00:00.000Z", {
+      schedule: timedSchedule(
+        "2026-07-03T16:00:00.000Z",
+        "2026-07-03T17:00:00.000Z",
+      ),
+    });
+    const moved = timedSchedule(
+      "2026-07-04T16:00:00.000Z",
+      "2026-07-04T17:00:00.000Z",
+    );
+    context.queryClient.setQueryData(remoteKey, normalized(master, middle));
+
+    act(() =>
+      context.hook.result.current.mutations.replace(
+        replacePayload(middle.id, {
+          content: {
+            kind: "details",
+            title: "Nudged",
+            description: "",
+            location: "",
+          },
+          schedule: moved,
+        }),
+      ),
+    );
+    const opportunity =
+      useRecurrenceScopeOpportunityStore.getState().opportunity;
+    if (!opportunity || opportunity.kind !== "replace") {
+      throw new Error("Expected a recurrence edit opportunity");
+    }
+
+    act(() =>
+      context.hook.result.current.mutations.promoteRecurring(
+        opportunity,
+        "all",
+      ),
+    );
+
+    await waitFor(() => expect(context.calls).toHaveLength(1));
+    act(() => context.pending.resolveNext());
+    await waitFor(() => {
+      expect(context.calls).toContainEqual({
+        method: "replace",
+        value: {
+          id: middle.id,
+          input: expect.objectContaining({
+            scope: "all",
+            schedule: timedSchedule(
+              "2026-07-02T16:00:00+00:00",
+              "2026-07-02T17:00:00+00:00",
+            ),
+          }),
+        },
+      });
+    });
+    context.pending.resolve();
+  });
+
+  test("remote promote all rebases a middle all-day occurrence onto the series master", async () => {
+    const context = setup("remote");
+    const remoteKey = calendarKeyFor("remote");
+    const seriesId = EventIdSchema.parse("bbbbbbbbbbbbbbbbbbbbbbbb");
+    const master = seriesMaster(seriesId, {
+      schedule: allDaySchedule("2026-07-01", "2026-07-02"),
+    });
+    const middle = composedOccurrence(seriesId, "2026-07-03T00:00:00.000Z", {
+      schedule: allDaySchedule("2026-07-03", "2026-07-04"),
+    });
+    const moved = allDaySchedule("2026-07-04", "2026-07-05");
+    context.queryClient.setQueryData(remoteKey, normalized(master, middle));
+
+    act(() =>
+      context.hook.result.current.mutations.replace(
+        replacePayload(middle.id, {
+          content: {
+            kind: "details",
+            title: "All-day nudged",
+            description: "",
+            location: "",
+          },
+          schedule: moved,
+        }),
+      ),
+    );
+    const opportunity =
+      useRecurrenceScopeOpportunityStore.getState().opportunity;
+    if (!opportunity || opportunity.kind !== "replace") {
+      throw new Error("Expected a recurrence edit opportunity");
+    }
+
+    act(() =>
+      context.hook.result.current.mutations.promoteRecurring(
+        opportunity,
+        "all",
+      ),
+    );
+
+    await waitFor(() => expect(context.calls).toHaveLength(1));
+    act(() => context.pending.resolveNext());
+    await waitFor(() => {
+      expect(context.calls).toContainEqual({
+        method: "replace",
+        value: {
+          id: middle.id,
+          input: expect.objectContaining({
+            scope: "all",
+            schedule: allDaySchedule("2026-07-02", "2026-07-03"),
+          }),
+        },
+      });
+    });
+    context.pending.resolve();
+  });
+
+  test("remote promote thisAndFollowing keeps the occurrence absolute schedule", async () => {
+    const context = setup("remote");
+    const remoteKey = calendarKeyFor("remote");
+    const seriesId = EventIdSchema.parse("cccccccccccccccccccccccc");
+    const master = seriesMaster(seriesId, {
+      schedule: timedSchedule(
+        "2026-07-01T16:00:00.000Z",
+        "2026-07-01T17:00:00.000Z",
+      ),
+    });
+    const middle = composedOccurrence(seriesId, "2026-07-03T16:00:00.000Z", {
+      schedule: timedSchedule(
+        "2026-07-03T16:00:00.000Z",
+        "2026-07-03T17:00:00.000Z",
+      ),
+    });
+    const moved = timedSchedule(
+      "2026-07-04T16:00:00.000Z",
+      "2026-07-04T17:00:00.000Z",
+    );
+    context.queryClient.setQueryData(remoteKey, normalized(master, middle));
+
+    act(() =>
+      context.hook.result.current.mutations.replace(
+        replacePayload(middle.id, {
+          content: {
+            kind: "details",
+            title: "Split nudge",
+            description: "",
+            location: "",
+          },
+          schedule: moved,
+        }),
+      ),
+    );
+    const opportunity =
+      useRecurrenceScopeOpportunityStore.getState().opportunity;
+    if (!opportunity || opportunity.kind !== "replace") {
+      throw new Error("Expected a recurrence edit opportunity");
+    }
+
+    act(() =>
+      context.hook.result.current.mutations.promoteRecurring(
+        opportunity,
+        "thisAndFollowing",
+      ),
+    );
+
+    await waitFor(() => expect(context.calls).toHaveLength(1));
+    act(() => context.pending.resolveNext());
+    await waitFor(() => {
+      expect(context.calls).toContainEqual({
+        method: "replace",
+        value: {
+          id: middle.id,
+          input: expect.objectContaining({
+            scope: "thisAndFollowing",
+            schedule: moved,
+          }),
+        },
       });
     });
     context.pending.resolve();

--- a/packages/web/src/events/mutations/useEventMutations.test.tsx
+++ b/packages/web/src/events/mutations/useEventMutations.test.tsx
@@ -373,7 +373,15 @@ describe("useEventMutations", () => {
         method: "replace",
         value: expect.objectContaining({
           id: first.id,
-          input: expect.objectContaining({ scope: "all" }),
+          input: expect.objectContaining({
+            scope: "all",
+            // Local source must keep the occurrence-absolute schedule so
+            // LocalEventRepository.replaceSeries can apply the delta once.
+            schedule: timedSchedule(
+              "2026-07-02T16:00:00.000Z",
+              "2026-07-02T17:00:00.000Z",
+            ),
+          }),
         }),
       });
     });
@@ -513,6 +521,67 @@ describe("useEventMutations", () => {
       scope: "thisAndFollowing",
       schedule: moved,
     });
+  });
+
+  test("remote scope-all rules edit rebases from the pre-optimistic master snapshot", async () => {
+    const context = setup("remote");
+    const seriesId = EventIdSchema.parse("dddddddddddddddddddddddd");
+    const master = seriesMaster(seriesId, {
+      schedule: timedSchedule(
+        "2026-07-01T16:00:00.000Z",
+        "2026-07-01T17:00:00.000Z",
+      ),
+      recurrence: { kind: "series", rules: ["RRULE:FREQ=DAILY;COUNT=5"] },
+    });
+    const middle = composedOccurrence(seriesId, "2026-07-03T16:00:00.000Z", {
+      schedule: timedSchedule(
+        "2026-07-03T16:00:00.000Z",
+        "2026-07-03T17:00:00.000Z",
+      ),
+    });
+    const moved = timedSchedule(
+      "2026-07-04T16:00:00.000Z",
+      "2026-07-04T17:00:00.000Z",
+    );
+    context.queryClient.setQueryData(
+      calendarKeyFor("remote"),
+      normalized(master, middle),
+    );
+
+    // Direct scope-all with new rules: optimistic projection rewrites the
+    // cached master with the occurrence absolute schedule before mutationFn.
+    // Rebase must still use the snapshotted pre-optimistic master.
+    act(() =>
+      context.hook.result.current.mutations.replace(
+        replacePayload(middle.id, {
+          content: {
+            kind: "details",
+            title: "Rules + nudge",
+            description: "",
+            location: "",
+          },
+          schedule: moved,
+          recurrence: { kind: "series", rules: ["RRULE:FREQ=DAILY;COUNT=3"] },
+          scope: "all",
+        }),
+      ),
+    );
+
+    await waitFor(() => expect(context.calls).toHaveLength(1));
+    expect(context.calls[0]).toEqual({
+      method: "replace",
+      value: {
+        id: middle.id,
+        input: expect.objectContaining({
+          scope: "all",
+          schedule: timedSchedule(
+            "2026-07-02T16:00:00+00:00",
+            "2026-07-02T17:00:00+00:00",
+          ),
+        }),
+      },
+    });
+    context.pending.resolve();
   });
 
   test("optimistically patches recurring instances across day and week caches", async () => {

--- a/packages/web/src/events/mutations/useEventMutations.ts
+++ b/packages/web/src/events/mutations/useEventMutations.ts
@@ -10,7 +10,11 @@ import {
   type EventId,
   EventIdSchema,
 } from "@core/types/domain-primitives";
-import { type Event, type EventRecurrence } from "@core/types/event.contracts";
+import {
+  type Event,
+  type EventRecurrence,
+  type EventSchedule,
+} from "@core/types/event.contracts";
 import {
   type CreateEventInput,
   type RecurrenceScope,
@@ -151,28 +155,42 @@ function seriesIdOf(event: Event | null | undefined): EventId | null {
 
 // Remote/sync treat scope-"all" schedule as the series master. The client
 // still sends an occurrence's absolute schedule (same shape local IndexedDB
-// rebases in replaceSeries), so rebase onto the cached master before submit.
-// thisAndFollowing keeps the absolute schedule as remainder DTSTART.
+// rebases in replaceSeries), so rebase onto a pre-optimistic master snapshot
+// before submit. Snapshotting matters: optimistic rules edits can rewrite the
+// cached series row with the occurrence's absolute schedule before mutationFn
+// runs. thisAndFollowing keeps the absolute schedule as remainder DTSTART.
 // Local source skips this — LocalEventRepository already applies the delta.
-function resolveRemoteReplaceSchedule(
+function snapshotSeriesMasterSchedule(
   queryClient: ReturnType<typeof useQueryClient>,
   source: EventRepositorySource,
   id: EventId,
+): EventSchedule | undefined {
+  const parts = decodeOccurrenceId(id);
+  if (!parts) return undefined;
+  const master = findEventInCache(
+    queryClient,
+    EventIdSchema.parse(parts.eventId),
+    source,
+  );
+  return master?.recurrence.kind === "series" ? master.schedule : undefined;
+}
+
+function resolveRemoteReplaceSchedule(
+  source: EventRepositorySource,
+  id: EventId,
   input: ReplaceEventInput,
+  seriesMasterSchedule: EventSchedule | undefined,
 ): ReplaceEventInput {
   if (source !== "remote" || input.scope !== "all") return input;
 
   const parts = decodeOccurrenceId(id);
   if (!parts) return input;
-
-  const seriesId = EventIdSchema.parse(parts.eventId);
-  const master = findEventInCache(queryClient, seriesId, source);
-  if (master?.recurrence.kind !== "series") return input;
+  if (!seriesMasterSchedule) return input;
 
   return {
     ...input,
     schedule: shiftSeriesScheduleByOccurrenceEdit(
-      master.schedule,
+      seriesMasterSchedule,
       parts.recurrenceId,
       input.schedule,
     ),
@@ -259,6 +277,10 @@ type ReplaceVariables = {
   input: ReplaceEventInput;
   writeKey: EventId;
   originalOverride?: Event;
+  // Captured before optimistic cache writes so remote scope-all rebasing
+  // cannot read a master row that projectSeriesRulesChange already polluted
+  // with the occurrence's absolute schedule.
+  seriesMasterSchedule?: EventSchedule;
   opportunityId?: number;
   callbacks?: EventMutationCallbacks;
 };
@@ -562,10 +584,10 @@ export function useEventMutations(
       "replace",
       async (variables) => {
         const input = resolveRemoteReplaceSchedule(
-          queryClient,
           source,
           variables.id,
           variables.input,
+          variables.seriesMasterSchedule,
         );
         await writeAfterPreceding(
           variables.writeKey,
@@ -790,7 +812,16 @@ export function useEventMutations(
         // callbacks rides in variables so onMutate can run onOptimisticApplied
         // in the same task as the cache write (same pattern as create above).
         replaceMutation.mutate(
-          { ...payload, writeKey, opportunityId, callbacks },
+          {
+            ...payload,
+            writeKey,
+            opportunityId,
+            callbacks,
+            seriesMasterSchedule:
+              source === "remote" && payload.input.scope === "all"
+                ? snapshotSeriesMasterSchedule(queryClient, source, payload.id)
+                : undefined,
+          },
           callbacks,
         );
         return true;
@@ -855,15 +886,20 @@ export function useEventMutations(
           recurrenceScopeOpportunityActions.complete(opportunity.id);
         };
         if (opportunity.kind === "replace") {
+          const id = opportunity.original.id as EventId;
           replaceMutation.mutate(
             {
-              id: opportunity.original.id as EventId,
+              id,
               input: { ...opportunity.input, scope },
               // Serialize behind the narrow write for this occurrence. The
               // optimistic projection still uses originalOverride so a
               // deleted/overridden cache entry cannot lose the promotion.
-              writeKey: opportunity.original.id as EventId,
+              writeKey: id,
               originalOverride: opportunity.original,
+              seriesMasterSchedule:
+                source === "remote" && scope === "all"
+                  ? snapshotSeriesMasterSchedule(queryClient, source, id)
+                  : undefined,
             },
             { onSuccess, onSettled },
           );

--- a/packages/web/src/events/mutations/useEventMutations.ts
+++ b/packages/web/src/events/mutations/useEventMutations.ts
@@ -5,13 +5,19 @@ import {
 } from "@tanstack/react-query";
 import { useCallback, useMemo } from "react";
 import { type Calendar } from "@core/types/calendar.contracts";
-import { DateTimeSchema, type EventId } from "@core/types/domain-primitives";
+import {
+  DateTimeSchema,
+  type EventId,
+  EventIdSchema,
+} from "@core/types/domain-primitives";
 import { type Event, type EventRecurrence } from "@core/types/event.contracts";
 import {
   type CreateEventInput,
   type RecurrenceScope,
   type ReplaceEventInput,
 } from "@core/types/event-command.contracts";
+import { shiftSeriesScheduleByOccurrenceEdit } from "@core/util/event/shift-series-schedule-by-occurrence-edit";
+import { decodeOccurrenceId } from "@core/util/occurrence-id";
 import { isCalendarReconnectRequired } from "@web/auth/google/state/google.reconnect.calendar";
 import { track } from "@web/auth/posthog/track";
 import {
@@ -141,6 +147,36 @@ function seriesIdOf(event: Event | null | undefined): EventId | null {
   if (event?.recurrence.kind === "occurrence") return event.recurrence.seriesId;
   if (event?.recurrence.kind === "series") return event.id;
   return null;
+}
+
+// Remote/sync treat scope-"all" schedule as the series master. The client
+// still sends an occurrence's absolute schedule (same shape local IndexedDB
+// rebases in replaceSeries), so rebase onto the cached master before submit.
+// thisAndFollowing keeps the absolute schedule as remainder DTSTART.
+// Local source skips this — LocalEventRepository already applies the delta.
+function resolveRemoteReplaceSchedule(
+  queryClient: ReturnType<typeof useQueryClient>,
+  source: EventRepositorySource,
+  id: EventId,
+  input: ReplaceEventInput,
+): ReplaceEventInput {
+  if (source !== "remote" || input.scope !== "all") return input;
+
+  const parts = decodeOccurrenceId(id);
+  if (!parts) return input;
+
+  const seriesId = EventIdSchema.parse(parts.eventId);
+  const master = findEventInCache(queryClient, seriesId, source);
+  if (master?.recurrence.kind !== "series") return input;
+
+  return {
+    ...input,
+    schedule: shiftSeriesScheduleByOccurrenceEdit(
+      master.schedule,
+      parts.recurrenceId,
+      input.schedule,
+    ),
+  };
 }
 
 // A create's optimistic insert needs a full Event before the server response
@@ -525,15 +561,23 @@ export function useEventMutations(
     buildMutation<ReplaceVariables>(
       "replace",
       async (variables) => {
+        const input = resolveRemoteReplaceSchedule(
+          queryClient,
+          source,
+          variables.id,
+          variables.input,
+        );
         await writeAfterPreceding(
           variables.writeKey,
+          // Must be the exact variables object mutate registered — a spread
+          // clone cannot identify this mutation in the serialization queue.
           variables,
           precedingCreateOk,
           // Same wire-boundary strip as create, see its comment above.
           () =>
             repository.replace(variables.id, {
-              ...variables.input,
-              content: editableContent(variables.input.content),
+              ...input,
+              content: editableContent(input.content),
             }),
           // A promotion replays the saved occurrence mutation at a broader
           // scope. It must reach the repository even if a later narrow edit

--- a/packages/web/src/events/repositories/local.event.repository.ts
+++ b/packages/web/src/events/repositories/local.event.repository.ts
@@ -1,9 +1,5 @@
-import {
-  DateOnlySchema,
-  DateTimeSchema,
-  type EventId,
-} from "@core/types/domain-primitives";
-import { type Event, type EventSchedule } from "@core/types/event.contracts";
+import { DateTimeSchema, type EventId } from "@core/types/domain-primitives";
+import { type Event } from "@core/types/event.contracts";
 import {
   type CreateEventInput,
   type EventListQuery,
@@ -12,6 +8,7 @@ import {
 } from "@core/types/event-command.contracts";
 import dayjs from "@core/util/date/dayjs";
 import { getCompassEventDateFormat } from "@core/util/event/event.util";
+import { shiftSeriesScheduleByOccurrenceEdit } from "@core/util/event/shift-series-schedule-by-occurrence-edit";
 import { getLocalCalendarSentinelId } from "@web/calendars/local-calendar.sentinel";
 import {
   getOfflineDataStore,
@@ -41,8 +38,6 @@ import { type EventRepository } from "./event.repository.types";
 function nowDateTime() {
   return DateTimeSchema.parse(new Date().toISOString());
 }
-
-const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
 // RRULE UNTIL is inclusive, so truncating "everything at/after `beforeStart`"
 // means UNTIL = one second before its instant. Always emits the full UTC
@@ -89,73 +84,6 @@ function resolveRecurrence(
   }
   if (recurrence.kind === "single") return { kind: "single" };
   return fallback;
-}
-
-// Apply an occurrence edit's schedule delta onto the series base. The client
-// sends the occurrence's absolute schedule; rebasing DTSTART to that absolute
-// value would shift the whole series by the occurrence's offset from the
-// master. Infer the pre-edit occurrence end from the master's duration so a
-// duration change on the occurrence still propagates.
-function shiftSeriesScheduleByOccurrenceEdit(
-  base: EventSchedule,
-  occurrenceStart: string,
-  edited: EventSchedule,
-): EventSchedule {
-  if (base.kind !== edited.kind) {
-    return edited;
-  }
-
-  if (base.kind === "timed" && edited.kind === "timed") {
-    const originalStart = dayjs(occurrenceStart);
-    const originalEnd = originalStart.add(
-      dayjs(base.end).diff(base.start),
-      "millisecond",
-    );
-    const startDelta = dayjs(edited.start).diff(originalStart);
-    const endDelta = dayjs(edited.end).diff(originalEnd);
-    if (
-      startDelta === 0 &&
-      endDelta === 0 &&
-      base.timeZone === edited.timeZone
-    ) {
-      return base;
-    }
-    return {
-      kind: "timed",
-      start: DateTimeSchema.parse(
-        dayjs(base.start).add(startDelta, "millisecond").format(),
-      ),
-      end: DateTimeSchema.parse(
-        dayjs(base.end).add(endDelta, "millisecond").format(),
-      ),
-      timeZone: edited.timeZone,
-    };
-  }
-
-  // allDay: occurrence ids embed midnight-Z; schedules use YYYY-MM-DD.
-  const originalStart = dayjs(occurrenceStart).utc().format("YYYY-MM-DD");
-  const baseDurationDays = dayjs(base.end).diff(base.start, "day");
-  const originalEnd = dayjs(originalStart)
-    .add(baseDurationDays, "day")
-    .format("YYYY-MM-DD");
-  const startDeltaDays = Math.round(
-    dayjs(edited.start).diff(dayjs(originalStart)) / MS_PER_DAY,
-  );
-  const endDeltaDays = Math.round(
-    dayjs(edited.end).diff(dayjs(originalEnd)) / MS_PER_DAY,
-  );
-  if (startDeltaDays === 0 && endDeltaDays === 0) {
-    return base;
-  }
-  return {
-    kind: "allDay",
-    start: DateOnlySchema.parse(
-      dayjs(base.start).add(startDeltaDays, "day").format("YYYY-MM-DD"),
-    ),
-    end: DateOnlySchema.parse(
-      dayjs(base.end).add(endDeltaDays, "day").format("YYYY-MM-DD"),
-    ),
-  };
 }
 
 // A series record's recurrence is guaranteed `kind === "series"` by the

--- a/packages/web/src/events/repositories/remote.event.repository.test.ts
+++ b/packages/web/src/events/repositories/remote.event.repository.test.ts
@@ -126,4 +126,53 @@ describe("RemoteEventRepository", () => {
       expect(api.delete).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe("replace", () => {
+    const baseInput = {
+      content: {
+        kind: "details" as const,
+        title: "Updated",
+        description: "",
+        location: "",
+      },
+      schedule: createMockEvent().schedule,
+      recurrence: { kind: "preserve" as const },
+      scope: "this" as const,
+    };
+
+    it("calls EventApi.replace with the event id and input", async () => {
+      const event = createMockEvent();
+      api.replace.mockResolvedValue(event);
+
+      const result = await repository.replace(event.id, baseInput);
+
+      expect(api.replace).toHaveBeenCalledWith(event.id, baseInput);
+      expect(result).toEqual(event);
+    });
+
+    it("falls back to the local repository when the backend is unavailable", async () => {
+      const event = createMockEvent();
+      api.replace.mockRejectedValue(createBackendUnavailableError());
+      localRepository.replace.mockResolvedValue(event);
+
+      await repository.replace(event.id, baseInput);
+
+      expect(localRepository.replace).toHaveBeenCalledWith(event.id, baseInput);
+      expect(isBackendUnavailable()).toBe(true);
+    });
+
+    it("does not fall back for scope-all occurrence replaces when the backend is unavailable", async () => {
+      const occurrenceId =
+        "aaaaaaaaaaaaaaaaaaaaaaaa::2026-07-03T16:00:00.000Z" as EventId;
+      const input = { ...baseInput, scope: "all" as const };
+      const unavailable = createBackendUnavailableError();
+      api.replace.mockRejectedValue(unavailable);
+
+      await expect(repository.replace(occurrenceId, input)).rejects.toBe(
+        unavailable,
+      );
+      expect(localRepository.replace).not.toHaveBeenCalled();
+      expect(isBackendUnavailable()).toBe(true);
+    });
+  });
 });

--- a/packages/web/src/events/repositories/remote.event.repository.ts
+++ b/packages/web/src/events/repositories/remote.event.repository.ts
@@ -6,6 +6,7 @@ import {
   type RecurrenceScope,
   type ReplaceEventInput,
 } from "@core/types/event-command.contracts";
+import { decodeOccurrenceId } from "@core/util/occurrence-id";
 import {
   isBackendUnavailableError,
   markBackendUnavailable,
@@ -51,10 +52,24 @@ export class RemoteEventRepository implements EventRepository {
   }
 
   async replace(id: EventId, input: ReplaceEventInput): Promise<Event> {
-    return this.withLocalFallback(
-      () => this.api.replace(id, input),
-      () => this.localRepository.replace(id, input),
-    );
+    try {
+      return await this.api.replace(id, input);
+    } catch (error) {
+      if (!isBackendUnavailableError(error)) {
+        throw error;
+      }
+
+      markBackendUnavailable();
+      // Signed-in mutationFn may already have rebased scope-"all" onto the
+      // series master. Local replaceSeries applies that delta again, so
+      // falling through would corrupt DTSTART. Prefer failing closed: the
+      // cloud series is the source of truth for this path.
+      if (input.scope === "all" && decodeOccurrenceId(String(id))) {
+        throw error;
+      }
+
+      return this.localRepository.replace(id, input);
+    }
   }
 
   async delete(id: EventId, scope: RecurrenceScope): Promise<void> {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Signed-in recurrence promote (`scope: "all"` after a middle-occurrence SHIFT+ARROW nudge) was forwarding the occurrence’s absolute schedule as the series master DTSTART. Local IndexedDB already rebases via `shiftSeriesScheduleByOccurrenceEdit`; remote did not.

- Extracted shared `shiftSeriesScheduleByOccurrenceEdit` into `@core`; local `replaceSeries` imports it
- Remote replace path rebases occurrence-absolute schedules onto a **pre-optimistic** series master snapshot when `scope === "all"`
- `RemoteEventRepository` skips IndexedDB fallback for occurrence + scope-all (avoids double-applying the delta)
- `thisAndFollowing` keeps absolute remainder DTSTART; local source unchanged

## Simplicity

Collapsed all-day delta math onto `dayjs.diff(..., "day")` and shared promote/assert test helpers. Left `resolveRemoteReplaceSchedule` as a named helper — it documents the remote vs local ownership split.

## Automated validation

- Unit: remote promote `"all"` middle timed + all-day → repository schedule is master+delta
- Unit: remote promote `thisAndFollowing` keeps absolute schedule
- Unit: remote scope-all + rules edit still rebases from pre-optimistic master snapshot
- Unit: local promote still sends absolute schedule (IndexedDB applies delta once)
- Unit: remote replace does not fall back to local for occurrence scope-all when backend is down
- Regression: local `replaceSeries` / nudge→promote suite green
- Signed-in browser not exercised here (auth/Google not provisioned); remote path covered by mutation + repository unit tests

## Independent review

Fresh read-only review found three medium issues; all fixed in follow-up commits:

1. Remote→local fallback double-applied the delta → skip fallback for occurrence scope-all
2. Missing master soft-fails to absolute (by design; sync usually back-fills masters)
3. Optimistic rules edits could pollute cached master before rebase → snapshot master schedule onto mutation variables before `onMutate`

## Test plan

- `bun run test:core -- packages/core/src/util/event/shift-series-schedule-by-occurrence-edit.test.ts`
- `bun run test:web -- packages/web/src/events/mutations/useEventMutations.test.tsx packages/web/src/events/repositories/local.event.repository.test.ts packages/web/src/events/repositories/remote.event.repository.test.ts`
- `bun run type-check`
- `bun run lint`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-df87a940-f716-4417-af8a-9556aae352f0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-df87a940-f716-4417-af8a-9556aae352f0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

