### PR TITLE
Sync reliability hardening before Friday launch

### DIFF
--- a/compass.example.yaml
+++ b/compass.example.yaml
@@ -60,5 +60,6 @@ sync:
   # execution: passive # passive | active — active required for OAuth begin + provider import/jobs
 # Public OAuth/webhook paths (via Caddy → sync): /sync/google, /sync/notifications/google
   # maxConcurrency: 4
+  # reservedPullLanes: 1 # of maxConcurrency, how many drains never claim initialImport/repair — keeps pulls from starving behind a wave of long imports. Must stay < maxConcurrency.
   # enforceLeastPrivilege: false # true only where a scoped compass_sync database user exists (managed cloud)
   # compassApiDatabase: prod_calendar # API database the least-privilege check must be denied access to

--- a/packages/core/src/config/compass.config.ts
+++ b/packages/core/src/config/compass.config.ts
@@ -90,6 +90,10 @@ const CompassConfigSchema = z
         postConnectRedirectUrl: z.string().optional(),
         execution: z.enum(["passive", "active"]).optional(),
         maxConcurrency: z.union([z.string(), z.number()]).optional(),
+        // How many of maxConcurrency's drains are reserved away from
+        // initialImport/repair, so a wave of long-running imports can never
+        // head-of-line block webhook/reconcile pulls behind them.
+        reservedPullLanes: z.union([z.string(), z.number()]).optional(),
         enforceLeastPrivilege: z.union([z.boolean(), z.string()]).optional(),
         // The Compass API's database name, used by the least-privilege check.
         compassApiDatabase: z.string().optional(),

--- a/packages/core/src/types/sync/health.contracts.ts
+++ b/packages/core/src/types/sync/health.contracts.ts
@@ -81,3 +81,23 @@ export type SyncReconcileSweepEvent = z.infer<
 >;
 
 export const SYNC_RECONCILE_SWEEP_EVENT = "sync_reconcile_sweep" as const;
+
+// Emitted once per job that exhausts its retries and settles into a terminal
+// failure (state:"failed"). Without this, a dead-lettered job is invisible —
+// it sits holding its coalescing key, so nothing re-enqueues it, and nothing
+// pages anyone either. Sanitized: job kind and provider ids only, never
+// tokens or provider error content.
+export const SyncJobTerminalFailureEventSchema = z.strictObject({
+  environment: z.string().min(1),
+  service: z.literal("compass-sync"),
+  jobKind: z.string().min(1),
+  connectionId: z.string().min(1),
+  resourceId: z.string().nullable(),
+  attempt: z.number().int().nonnegative(),
+});
+export type SyncJobTerminalFailureEvent = z.infer<
+  typeof SyncJobTerminalFailureEventSchema
+>;
+
+export const SYNC_JOB_TERMINAL_FAILURE_EVENT =
+  "sync_job_terminal_failure" as const;

--- a/packages/sync/src/app.ts
+++ b/packages/sync/src/app.ts
@@ -1,7 +1,9 @@
 import { startOtelLogs, stopOtelLogs } from "@core/logger/otel-logs";
 import { Logger } from "@core/logger/winston.logger";
 import {
+  SYNC_JOB_TERMINAL_FAILURE_EVENT,
   SYNC_RECONCILE_SWEEP_EVENT,
+  SyncJobTerminalFailureEventSchema,
   SyncReconcileSweepEventSchema,
 } from "@core/types/sync/health.contracts";
 import {
@@ -440,6 +442,29 @@ function buildSchedulers(
           ),
         onDrop: (job, reason) =>
           logger.warn(`Sync job ${job.kind} (${job._id}) dropped: ${reason}`),
+        // A terminal failure is invisible otherwise: the job sits state:"failed"
+        // holding its coalescing key with nothing paging anyone. Alertable so an
+        // operator can set a PostHog alert on this event over launch weekend.
+        onFail: (job) => {
+          logger.error(
+            `Sync job ${job.kind} (${job._id}) exhausted retries and failed for resource ${
+              job.resourceId ?? "none (connection-wide)"
+            } on connection ${job.connectionId}`,
+          );
+          void captureSafely(posthog, {
+            event: SYNC_JOB_TERMINAL_FAILURE_EVENT,
+            // One service-level distinct id — never a user id (R-SEC-04).
+            distinctId: "compass-sync",
+            properties: SyncJobTerminalFailureEventSchema.parse({
+              environment: identity.environment,
+              service: "compass-sync",
+              jobKind: job.kind,
+              connectionId: job.connectionId,
+              resourceId: job.resourceId,
+              attempt: job.attempt,
+            }),
+          });
+        },
       },
     );
     return new SyncScheduler(

--- a/packages/sync/src/app.ts
+++ b/packages/sync/src/app.ts
@@ -41,6 +41,7 @@ import { redactedCause } from "@sync/safety/redact-error";
 import { NOTIFICATIONS_PATH } from "@sync/server/notification.routes";
 import { buildSyncApp } from "@sync/server/sync.server";
 import { buildServiceIdentity } from "@sync/service-identity";
+import { type JobRecord } from "@sync/storage/contracts/job.contracts";
 import { SyncMongoService } from "@sync/storage/sync-mongo.service";
 import { syncRepositories } from "@sync/storage/sync-repositories";
 import { emitHealthSnapshot } from "@sync/telemetry/health-snapshot.service";
@@ -408,7 +409,16 @@ function buildSchedulers(
   const repos = syncRepositories(mongo);
   const resources = repos.syncResources;
   const jobs = repos.jobs;
-  const buildDrain = (): SyncScheduler => {
+  // Long-running kinds excluded from a reserved lane. initialImport and
+  // repair are the two that can run for minutes on a large calendar; every
+  // other kind is quick, so a reserved lane still drains the whole rest of
+  // the queue, just never adopts one of these two.
+  const RESERVED_LANE_EXCLUDED_KINDS: JobRecord["kind"][] = [
+    "initialImport",
+    "repair",
+  ];
+
+  const buildDrain = (reservedForPulls: boolean): SyncScheduler => {
     const owner = randomUUID();
     const worker = new SyncJobWorker(
       {
@@ -465,6 +475,9 @@ function buildSchedulers(
             }),
           });
         },
+        excludeKinds: reservedForPulls
+          ? RESERVED_LANE_EXCLUDED_KINDS
+          : undefined,
       },
     );
     return new SyncScheduler(
@@ -475,7 +488,13 @@ function buildSchedulers(
       },
     );
   };
-  const drains = Array.from({ length: config.MAX_CONCURRENCY }, buildDrain);
+  // Of the MAX_CONCURRENCY drains, the first RESERVED_PULL_LANES never claim
+  // initialImport/repair — reserved so webhook/reconcile pulls always have a
+  // lane free even when every other drain is busy on a long import (S40-
+  // style starvation, 2026-07-29). The rest claim everything, unchanged.
+  const drains = Array.from({ length: config.MAX_CONCURRENCY }, (_, index) =>
+    buildDrain(index < config.RESERVED_PULL_LANES),
+  );
 
   // Shared per-resource enqueue-failure logging for the resource sweeps below.
   const onEnqueueError =

--- a/packages/sync/src/config/sync.config.db.test.ts
+++ b/packages/sync/src/config/sync.config.db.test.ts
@@ -26,6 +26,14 @@ describe("Sync service configuration", () => {
       const config = parseSyncConfig(compassConfigWithSync());
       expect(config.PORT).toBe(3010);
       expect(config.MAX_CONCURRENCY).toBe(4);
+      expect(config.RESERVED_PULL_LANES).toBe(1);
+    });
+
+    it("coerces a yaml numeric string reservedPullLanes to a number", () => {
+      const config = parseSyncConfig(
+        compassConfigWithSync({ reservedPullLanes: "2" }),
+      );
+      expect(config.RESERVED_PULL_LANES).toBe(2);
     });
 
     it("accepts an explicit active execution mode", () => {
@@ -150,6 +158,29 @@ describe("Sync service configuration", () => {
       expect(() =>
         parseSyncConfig(compassConfigWithSync({ maxConcurrency: 2.5 })),
       ).toThrow();
+    });
+
+    it("rejects reservedPullLanes equal to maxConcurrency", () => {
+      expect(() =>
+        parseSyncConfig(
+          compassConfigWithSync({ maxConcurrency: 2, reservedPullLanes: 2 }),
+        ),
+      ).toThrow(/reservedPullLanes.*maxConcurrency/i);
+    });
+
+    it("rejects reservedPullLanes greater than maxConcurrency", () => {
+      expect(() =>
+        parseSyncConfig(
+          compassConfigWithSync({ maxConcurrency: 2, reservedPullLanes: 3 }),
+        ),
+      ).toThrow();
+    });
+
+    it("accepts reservedPullLanes strictly below maxConcurrency", () => {
+      const config = parseSyncConfig(
+        compassConfigWithSync({ maxConcurrency: 2, reservedPullLanes: 1 }),
+      );
+      expect(config.RESERVED_PULL_LANES).toBe(1);
     });
   });
 

--- a/packages/sync/src/config/sync.config.ts
+++ b/packages/sync/src/config/sync.config.ts
@@ -13,6 +13,7 @@ import { NodeEnv } from "@core/constants/core.constants";
 
 const SYNC_PORT_DEFAULT = 3010;
 const SYNC_MAX_CONCURRENCY_DEFAULT = 4;
+const SYNC_RESERVED_PULL_LANES_DEFAULT = 1;
 
 export const SyncExecutionModeSchema = z.enum(["passive", "active"]);
 export type SyncExecutionMode = z.infer<typeof SyncExecutionModeSchema>;
@@ -25,38 +26,54 @@ const BooleanFromInput = z
   .union([z.boolean(), z.enum(["true", "false"])])
   .transform((value) => value === true || value === "true");
 
-export const SyncConfigSchema = z.strictObject({
-  NODE_ENV: z.enum(NodeEnv),
-  PORT: PositiveIntFromInput.default(SYNC_PORT_DEFAULT),
-  // Isolated `compass_sync` database URI — never the backend's mongo.uri.
-  MONGO_URI: z.string().trim().min(1),
-  // Shared secret authenticating trusted Compass API -> Sync requests.
-  INTERNAL_AUTH_TOKEN: z.string().trim().min(1),
-  // Public base URL provider OAuth redirects and webhooks resolve against
-  // (e.g. https://staging.compasscalendar.com). Must be a valid URL.
-  CALLBACK_BASE_URL: z.url(),
-  // Where the OAuth callback redirects the browser after connecting. Optional;
-  // the callback falls back to CALLBACK_BASE_URL when it is unset.
-  POST_CONNECT_REDIRECT_URL: z.url().optional(),
-  EXECUTION: SyncExecutionModeSchema.default("passive"),
-  MAX_CONCURRENCY: PositiveIntFromInput.default(SYNC_MAX_CONCURRENCY_DEFAULT),
-  // On when a scoped `compass_sync` database user exists (managed cloud), so
-  // startup verifies it cannot read the API database. Off for a single-database
-  // self-host with no scoped user. Defaults off — enable it deliberately.
-  ENFORCE_LEAST_PRIVILEGE: BooleanFromInput.default(false),
-  // The Compass API's database — the one Sync's least-privilege user must NOT
-  // be able to read. Only consulted when ENFORCE_LEAST_PRIVILEGE is on.
-  COMPASS_API_DATABASE: z.string().trim().min(1).default("prod_calendar"),
-  // Google OAuth client, shared with the Compass API's `google` config section.
-  // Optional: a passive deployment without provider credentials still starts;
-  // the Google adapter refuses to construct when either is absent.
-  GOOGLE_CLIENT_ID: z.string().trim().min(1).optional(),
-  GOOGLE_CLIENT_SECRET: z.string().trim().min(1).optional(),
-  // Optional PostHog credentials for sanitized sync_health_snapshot events.
-  // When absent, the health emitter no-ops (local/dev without analytics).
-  POSTHOG_KEY: z.string().trim().min(1).optional(),
-  POSTHOG_HOST: z.url().optional(),
-});
+export const SyncConfigSchema = z
+  .strictObject({
+    NODE_ENV: z.enum(NodeEnv),
+    PORT: PositiveIntFromInput.default(SYNC_PORT_DEFAULT),
+    // Isolated `compass_sync` database URI — never the backend's mongo.uri.
+    MONGO_URI: z.string().trim().min(1),
+    // Shared secret authenticating trusted Compass API -> Sync requests.
+    INTERNAL_AUTH_TOKEN: z.string().trim().min(1),
+    // Public base URL provider OAuth redirects and webhooks resolve against
+    // (e.g. https://staging.compasscalendar.com). Must be a valid URL.
+    CALLBACK_BASE_URL: z.url(),
+    // Where the OAuth callback redirects the browser after connecting. Optional;
+    // the callback falls back to CALLBACK_BASE_URL when it is unset.
+    POST_CONNECT_REDIRECT_URL: z.url().optional(),
+    EXECUTION: SyncExecutionModeSchema.default("passive"),
+    MAX_CONCURRENCY: PositiveIntFromInput.default(SYNC_MAX_CONCURRENCY_DEFAULT),
+    // How many of MAX_CONCURRENCY's drains never claim initialImport/repair —
+    // reserved for webhook/reconcile pulls, so a wave of long-running imports
+    // (e.g. launch-day signups) can never head-of-line block them behind a
+    // single sequential drain loop (2026-07-29 incident). Must stay below
+    // MAX_CONCURRENCY, checked below, or every drain would be reserved and
+    // imports would never run at all.
+    RESERVED_PULL_LANES: z.coerce
+      .number()
+      .int()
+      .nonnegative()
+      .default(SYNC_RESERVED_PULL_LANES_DEFAULT),
+    // On when a scoped `compass_sync` database user exists (managed cloud), so
+    // startup verifies it cannot read the API database. Off for a single-database
+    // self-host with no scoped user. Defaults off — enable it deliberately.
+    ENFORCE_LEAST_PRIVILEGE: BooleanFromInput.default(false),
+    // The Compass API's database — the one Sync's least-privilege user must NOT
+    // be able to read. Only consulted when ENFORCE_LEAST_PRIVILEGE is on.
+    COMPASS_API_DATABASE: z.string().trim().min(1).default("prod_calendar"),
+    // Google OAuth client, shared with the Compass API's `google` config section.
+    // Optional: a passive deployment without provider credentials still starts;
+    // the Google adapter refuses to construct when either is absent.
+    GOOGLE_CLIENT_ID: z.string().trim().min(1).optional(),
+    GOOGLE_CLIENT_SECRET: z.string().trim().min(1).optional(),
+    // Optional PostHog credentials for sanitized sync_health_snapshot events.
+    // When absent, the health emitter no-ops (local/dev without analytics).
+    POSTHOG_KEY: z.string().trim().min(1).optional(),
+    POSTHOG_HOST: z.url().optional(),
+  })
+  .refine((cfg) => cfg.RESERVED_PULL_LANES < cfg.MAX_CONCURRENCY, {
+    message: "sync.reservedPullLanes must be less than sync.maxConcurrency",
+    path: ["RESERVED_PULL_LANES"],
+  });
 export type SyncConfig = z.infer<typeof SyncConfigSchema>;
 
 export function parseSyncConfig(config: CompassConfig): SyncConfig {
@@ -75,6 +92,7 @@ export function parseSyncConfig(config: CompassConfig): SyncConfig {
     POST_CONNECT_REDIRECT_URL: config.sync.postConnectRedirectUrl || undefined,
     EXECUTION: config.sync.execution,
     MAX_CONCURRENCY: config.sync.maxConcurrency,
+    RESERVED_PULL_LANES: config.sync.reservedPullLanes,
     ENFORCE_LEAST_PRIVILEGE: config.sync.enforceLeastPrivilege,
     COMPASS_API_DATABASE: config.sync.compassApiDatabase,
     // Empty-string (unfilled deploy placeholder) or null coerces to absent.

--- a/packages/sync/src/credentials/credential-custody.service.db.test.ts
+++ b/packages/sync/src/credentials/credential-custody.service.db.test.ts
@@ -113,6 +113,30 @@ describe("CredentialCustody", () => {
     expect(adapter.refreshCalls).toBe(0);
   });
 
+  it("refreshes on the next call after invalidateAccessToken clears the cache", async () => {
+    const connectionId = objectId() as ConnectionId;
+    const adapter = new FakeAdapter({
+      refreshed: {
+        accessToken: "reminted-token",
+        expiresAt: new Date("2026-01-01T01:00:00Z"),
+        grantedScopes: [],
+      },
+    });
+    const custody = new CredentialCustody(repo, adapter, fixedNow);
+    await custody.store(baseCredential(connectionId));
+    await repo.cacheAccessToken(
+      connectionId,
+      "rejected-token",
+      new Date("2026-01-01T01:00:00Z"), // still unexpired by clock skew alone
+    );
+
+    await custody.invalidateAccessToken(connectionId);
+    const token = await custody.getValidAccessToken(connectionId);
+
+    expect(token).toBe("reminted-token");
+    expect(adapter.refreshCalls).toBe(1);
+  });
+
   it("refreshes when the cached token is within the expiry skew window", async () => {
     const connectionId = objectId() as ConnectionId;
     const adapter = new FakeAdapter({

--- a/packages/sync/src/credentials/credential-custody.service.ts
+++ b/packages/sync/src/credentials/credential-custody.service.ts
@@ -71,6 +71,14 @@ export class CredentialCustody {
     await this.credentials.deleteByConnection(connectionId);
   }
 
+  // Clear a cached access token the provider just rejected (401), so the next
+  // getValidAccessToken call is forced to refresh instead of replaying the
+  // same dead token. Without this, every retry of a job that hit a stale
+  // cached token reuses it, burning the whole retry ladder for nothing.
+  async invalidateAccessToken(connectionId: ConnectionId): Promise<void> {
+    await this.credentials.clearCachedAccessToken(connectionId);
+  }
+
   async #resolveAccessToken(connectionId: ConnectionId): Promise<string> {
     const credential = await this.credentials.findByConnection(connectionId);
     if (!credential) {

--- a/packages/sync/src/domain/calendar-import.service.db.test.ts
+++ b/packages/sync/src/domain/calendar-import.service.db.test.ts
@@ -55,6 +55,7 @@ class FakeReader implements ProviderEventReader {
 const tokenSource: AccessTokenSource = {
   getValidAccessToken: async () => "access-token",
   discardRevoked: async () => {},
+  invalidateAccessToken: async () => {},
 };
 
 const schedule = {
@@ -478,6 +479,7 @@ describe("importCalendarEvents", () => {
         throw new Error("token fetch failed");
       },
       discardRevoked: async () => {},
+      invalidateAccessToken: async () => {},
     };
 
     await expect(

--- a/packages/sync/src/domain/calendar-list-sync.service.db.test.ts
+++ b/packages/sync/src/domain/calendar-list-sync.service.db.test.ts
@@ -68,6 +68,7 @@ class FakeDiscovery implements ProviderCalendarAdapter {
 const custody = {
   getValidAccessToken: async () => "access-token",
   discardRevoked: async () => {},
+  invalidateAccessToken: async () => {},
 };
 
 describe("syncCalendarList", () => {

--- a/packages/sync/src/domain/calendar-pull.service.db.test.ts
+++ b/packages/sync/src/domain/calendar-pull.service.db.test.ts
@@ -98,6 +98,7 @@ const page = (
 const tokenSource = {
   getValidAccessToken: async () => "access-token",
   discardRevoked: async () => {},
+  invalidateAccessToken: async () => {},
 };
 
 describe("pullCalendarChanges", () => {

--- a/packages/sync/src/domain/calendar-repair.service.db.test.ts
+++ b/packages/sync/src/domain/calendar-repair.service.db.test.ts
@@ -80,6 +80,7 @@ const page = (
 const tokenSource = {
   getValidAccessToken: async () => "access-token",
   discardRevoked: async () => {},
+  invalidateAccessToken: async () => {},
 };
 
 describe("repairCalendar", () => {
@@ -353,6 +354,7 @@ describe("repairCalendar", () => {
         throw new Error("token fetch failed");
       },
       discardRevoked: async () => {},
+      invalidateAccessToken: async () => {},
     };
 
     await expect(

--- a/packages/sync/src/domain/cloud-command.service.db.test.ts
+++ b/packages/sync/src/domain/cloud-command.service.db.test.ts
@@ -113,6 +113,7 @@ const provider = (writer: ProviderEventWriter) => ({
   custody: {
     getValidAccessToken: async () => "access-token",
     discardRevoked: async () => {},
+    invalidateAccessToken: async () => {},
   },
 });
 

--- a/packages/sync/src/domain/connection-refresh.service.db.test.ts
+++ b/packages/sync/src/domain/connection-refresh.service.db.test.ts
@@ -1,0 +1,69 @@
+import { seedProviderCalendar } from "@sync/__tests__/helpers/fixtures";
+import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
+import { refreshPrincipalCalendars } from "@sync/domain/connection-refresh.service";
+import { type ProviderCalendarRecord } from "@sync/storage/contracts/provider-calendar.contracts";
+import { JobRepository } from "@sync/storage/repositories/job.repository";
+import { ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
+import { SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
+
+const now = () => new Date("2026-08-10T12:00:00.000Z");
+
+describe("refreshPrincipalCalendars (db)", () => {
+  const storage = setupSyncStorage(import.meta.url);
+
+  const deps = () => {
+    const db = storage.db();
+    return {
+      resources: new SyncResourceRepository(db),
+      jobs: new JobRepository(db),
+      calendars: new ProviderCalendarRepository(db),
+    };
+  };
+
+  it("revives a wedged failed repair job for the connection, not just incrementalPull", async () => {
+    const { resources, jobs, calendars } = deps();
+    const calendar: ProviderCalendarRecord =
+      await seedProviderCalendar(calendars);
+    const resource = await resources.ensure({
+      tenantId: calendar.tenantId,
+      principalId: calendar.principalId,
+      connectionId: calendar.connectionId,
+      resourceKind: "events",
+      calendarId: calendar._id,
+    });
+
+    // Seed a failed repair job the same way a real worker would leave one:
+    // enqueue, claim, then exhaust it.
+    const repairEnqueue = {
+      tenantId: resource.tenantId,
+      principalId: resource.principalId,
+      connectionId: resource.connectionId,
+      resourceId: resource._id,
+      commandId: null,
+      kind: "repair" as const,
+      priority: 0,
+      runAfter: now(),
+      coalescingKey: `repair:${resource._id}`,
+    };
+    const repairJob = await jobs.enqueue(repairEnqueue);
+    const claimed = await jobs.claimDueJob("worker-1", now(), 60_000);
+    if (!claimed) throw new Error("expected to claim the seeded repair job");
+    await jobs.fail(claimed._id, "worker-1");
+
+    const tally = await refreshPrincipalCalendars(
+      { resources, jobs },
+      resource.tenantId,
+      resource.principalId,
+      now,
+    );
+
+    expect(tally.requeuedFailed).toBeGreaterThanOrEqual(1);
+    const revived = await jobs.findById(
+      resource.tenantId,
+      resource.principalId,
+      repairJob._id,
+    );
+    expect(revived?.state).toBe("pending");
+    expect(revived?.attempt).toBe(0);
+  });
+});

--- a/packages/sync/src/domain/connection-refresh.service.test.ts
+++ b/packages/sync/src/domain/connection-refresh.service.test.ts
@@ -27,12 +27,13 @@ describe("refreshPrincipalCalendars", () => {
       },
     ];
 
+    const requeueFailedByConnection = mock(async () => 0);
     const tally = await refreshPrincipalCalendars(
       {
         resources: {
           listEventsByPrincipal: mock(async () => resources),
         } as never,
-        jobs: { enqueueUrgent } as never,
+        jobs: { enqueueUrgent, requeueFailedByConnection } as never,
       },
       "t1" as TenantId,
       "p1" as PrincipalId,
@@ -46,6 +47,8 @@ describe("refreshPrincipalCalendars", () => {
       requeuedFailed: 0,
       inFlight: 0,
     });
+    // One call per distinct connection touched, not per resource.
+    expect(requeueFailedByConnection).toHaveBeenCalledTimes(1);
     expect(enqueueUrgent).toHaveBeenCalledTimes(2);
     expect(enqueueUrgent.mock.calls[0]?.[0]).toMatchObject({
       kind: "incrementalPull",
@@ -74,22 +77,25 @@ describe("refreshPrincipalCalendars", () => {
       connectionId: "c1",
     }));
 
+    const requeueFailedByConnection = mock(async () => 2);
     const tally = await refreshPrincipalCalendars(
       {
         resources: {
           listEventsByPrincipal: mock(async () => resources),
         } as never,
-        jobs: { enqueueUrgent } as never,
+        jobs: { enqueueUrgent, requeueFailedByConnection } as never,
       },
       "t1" as TenantId,
       "p1" as PrincipalId,
     );
 
+    // The 2 revived-by-connection non-incrementalPull jobs fold into the same
+    // requeuedFailed tally as the enqueueUrgent-outcome "requeuedFailed": 1.
     expect(tally).toEqual({
       resources: 4,
       created: 1,
       boosted: 1,
-      requeuedFailed: 1,
+      requeuedFailed: 3,
       inFlight: 1,
     });
   });

--- a/packages/sync/src/domain/connection-refresh.service.ts
+++ b/packages/sync/src/domain/connection-refresh.service.ts
@@ -49,6 +49,23 @@ export async function refreshPrincipalCalendars(
     inFlight: 0,
   };
 
+  // Revive every failed job (of any kind) for each connection this refresh
+  // touches, not just the incrementalPull rows enqueueUrgent below revives via
+  // coalescing key. Otherwise a wedged calendarListSync/initialImport/repair/
+  // subscriptionMaintain row stays stuck even after the user asks to refresh.
+  const connectionIds = [...new Set(resources.map((r) => r.connectionId))];
+  const revivedCounts = await Promise.all(
+    connectionIds.map((connectionId) =>
+      deps.jobs.requeueFailedByConnection(
+        tenantId,
+        principalId,
+        connectionId,
+        runAfter,
+      ),
+    ),
+  );
+  tally.requeuedFailed += revivedCounts.reduce((sum, n) => sum + n, 0);
+
   const outcomes = await Promise.all(
     resources.map(async (resource) => {
       const enqueue: JobEnqueue = {

--- a/packages/sync/src/domain/provider-command.service.db.test.ts
+++ b/packages/sync/src/domain/provider-command.service.db.test.ts
@@ -83,12 +83,14 @@ class FakeWriter implements ProviderEventWriter {
 const tokenSource = (token = "access-token"): AccessTokenSource => ({
   getValidAccessToken: async () => token,
   discardRevoked: async () => {},
+  invalidateAccessToken: async () => {},
 });
 const failingTokenSource = (error: unknown): AccessTokenSource => ({
   getValidAccessToken: async () => {
     throw error;
   },
   discardRevoked: async () => {},
+  invalidateAccessToken: async () => {},
 });
 
 // Minimal auth adapter for CredentialCustody in the revoked-grant cases.

--- a/packages/sync/src/domain/provider-command.service.ts
+++ b/packages/sync/src/domain/provider-command.service.ts
@@ -56,6 +56,7 @@ import { type SyncResourceRepository } from "@sync/storage/repositories/sync-res
 export interface AccessTokenSource {
   getValidAccessToken(connectionId: ConnectionId): Promise<string>;
   discardRevoked(connectionId: ConnectionId): Promise<void>;
+  invalidateAccessToken(connectionId: ConnectionId): Promise<void>;
 }
 
 export interface ProviderMutationDeps {

--- a/packages/sync/src/domain/stale-command-retry.service.db.test.ts
+++ b/packages/sync/src/domain/stale-command-retry.service.db.test.ts
@@ -52,6 +52,7 @@ class FakeDeleteWriter implements ProviderEventWriter {
 const tokenSource = () => ({
   getValidAccessToken: async () => "access-token",
   discardRevoked: async () => {},
+  invalidateAccessToken: async () => {},
 });
 
 describe("retryStaleCommands", () => {

--- a/packages/sync/src/domain/subscription-maintenance.service.db.test.ts
+++ b/packages/sync/src/domain/subscription-maintenance.service.db.test.ts
@@ -76,6 +76,7 @@ class FakeNotifications implements ProviderNotificationAdapter {
 const custody = {
   getValidAccessToken: async () => "access-token",
   discardRevoked: async () => {},
+  invalidateAccessToken: async () => {},
 };
 
 describe("maintainSubscription", () => {
@@ -304,6 +305,7 @@ describe("maintainSubscription", () => {
       discardRevoked: async (id: ConnectionId) => {
         await credentials.deleteByConnection(id);
       },
+      invalidateAccessToken: async () => {},
     };
     const notifications = new FakeNotifications({
       watchError: new ProviderNotificationError("authorizationRevoked", "gone"),

--- a/packages/sync/src/domain/sync-job-dispatch.service.db.test.ts
+++ b/packages/sync/src/domain/sync-job-dispatch.service.db.test.ts
@@ -97,6 +97,7 @@ class FakeReader implements ProviderEventReader {
 const tokenSource = {
   getValidAccessToken: async () => "access-token",
   discardRevoked: async () => {},
+  invalidateAccessToken: async () => {},
 };
 
 // A notification adapter that records watch calls and returns a fixed channel,
@@ -442,6 +443,7 @@ describe("dispatchSyncJob", () => {
       discardRevoked: async (connectionId) => {
         discarded.push(connectionId);
       },
+      invalidateAccessToken: async () => {},
     };
 
     const outcome = await dispatchSyncJob(
@@ -472,6 +474,7 @@ describe("dispatchSyncJob", () => {
       discardRevoked: async (connectionId) => {
         discarded.push(connectionId);
       },
+      invalidateAccessToken: async () => {},
     };
 
     await expect(
@@ -482,6 +485,31 @@ describe("dispatchSyncJob", () => {
       ),
     ).rejects.toThrow(ProviderAuthError);
     expect(discarded).toEqual([]);
+  });
+
+  it("invalidates the cached access token and rethrows on a rejected 401 read", async () => {
+    const calendar = await seedCalendar();
+    const resource = await seedResource(calendar, "cursor-0");
+    const reader = new FakeReader(
+      [],
+      new ProviderEventReadError("authExpired", "Google rejected the token"),
+    );
+    const invalidated: string[] = [];
+    const authExpiredCustody: SyncJobDispatchDeps["custody"] = {
+      ...tokenSource,
+      invalidateAccessToken: async (connectionId) => {
+        invalidated.push(connectionId);
+      },
+    };
+
+    await expect(
+      dispatchSyncJob(
+        deps(reader, authExpiredCustody),
+        jobFor(resource, "incrementalPull"),
+        now,
+      ),
+    ).rejects.toThrow(ProviderEventReadError);
+    expect(invalidated).toEqual([calendar.connectionId]);
   });
 
   it("drops a job whose resource no longer exists", async () => {

--- a/packages/sync/src/domain/sync-job-dispatch.service.ts
+++ b/packages/sync/src/domain/sync-job-dispatch.service.ts
@@ -110,6 +110,21 @@ export async function dispatchSyncJob(
       };
     }
 
+    // The provider rejected the cached access token (401). Invalidate it so
+    // the retry that the worker's generic catch schedules mints a fresh token
+    // instead of replaying the same rejected one — otherwise every attempt in
+    // the retry ladder fails the same way and the job dead-letters even though
+    // a fresh token would have worked. If the refresh itself then fails with
+    // authorizationRevoked, that surfaces as ProviderAuthError on the next
+    // attempt and is handled by the branch above.
+    if (
+      error instanceof ProviderEventReadError &&
+      error.reason === "authExpired"
+    ) {
+      await deps.custody.invalidateAccessToken(job.connectionId);
+      throw error;
+    }
+
     // A DURABLE read rejection: Google answered with a 4xx that is not 410
     // (cursor expired) or 429 (rate limited) — a calendar deleted out from under
     // us, access revoked for it, or a permanently rejected id. Retrying cannot

--- a/packages/sync/src/domain/sync-job-worker.service.db.test.ts
+++ b/packages/sync/src/domain/sync-job-worker.service.db.test.ts
@@ -235,6 +235,26 @@ describe("SyncJobWorker", () => {
     expect(outcome).toBe("idle");
   });
 
+  it("passes excludeKinds through to claimDueJob, leaving an excluded due job untouched", async () => {
+    const calendar = await seedCalendar();
+    const resource = await seedResource(calendar, null);
+    const job = await enqueue(resource, "initialImport");
+    const reservedWorker = new SyncJobWorker(deps(new FakeReader([])), OWNER, {
+      now,
+      excludeKinds: ["initialImport"],
+    });
+
+    const outcome = await reservedWorker.runOnce();
+
+    expect(outcome).toBe("idle");
+    const after = await jobs.findById(
+      resource.tenantId,
+      resource.principalId,
+      job._id,
+    );
+    expect(after?.state).toBe("pending");
+  });
+
   it("completes an applied incremental pull, removing the job", async () => {
     const calendar = await seedCalendar();
     const resource = await seedResource(calendar, "cursor-0");

--- a/packages/sync/src/domain/sync-job-worker.service.db.test.ts
+++ b/packages/sync/src/domain/sync-job-worker.service.db.test.ts
@@ -345,6 +345,44 @@ describe("SyncJobWorker", () => {
     expect(after?.leaseOwner).toBeNull();
   });
 
+  it("does not call onFail while a transient failure still has retries left", async () => {
+    const calendar = await seedCalendar();
+    const resource = await seedResource(calendar, "cursor-0");
+    await enqueue(resource, "incrementalPull");
+    const failed: JobRecord[] = [];
+    const worker = new SyncJobWorker(
+      deps(
+        new FakeReader([], new ProviderEventReadError("transient", "flaky")),
+      ),
+      OWNER,
+      { now, maxAttempts: 5, onFail: (j) => failed.push(j) },
+    );
+
+    await worker.runOnce();
+
+    expect(failed).toHaveLength(0);
+  });
+
+  it("calls onFail exactly once, with the job, on the exhausting attempt", async () => {
+    const calendar = await seedCalendar();
+    const resource = await seedResource(calendar, "cursor-0");
+    const job = await enqueue(resource, "incrementalPull");
+    const failed: JobRecord[] = [];
+    // maxAttempts: 1 means the first (attempt 1) transient failure is terminal.
+    const worker = new SyncJobWorker(
+      deps(
+        new FakeReader([], new ProviderEventReadError("transient", "flaky")),
+      ),
+      OWNER,
+      { now, maxAttempts: 1, onFail: (j) => failed.push(j) },
+    );
+
+    await worker.runOnce();
+
+    expect(failed).toHaveLength(1);
+    expect(failed[0]?._id).toEqual(job._id);
+  });
+
   it("keeps a failed job's coalescing key so enqueue does not replace it", async () => {
     const calendar = await seedCalendar();
     const resource = await seedResource(calendar, "cursor-0");

--- a/packages/sync/src/domain/sync-job-worker.service.db.test.ts
+++ b/packages/sync/src/domain/sync-job-worker.service.db.test.ts
@@ -89,6 +89,7 @@ class FakeReader implements ProviderEventReader {
 const tokenSource = {
   getValidAccessToken: async () => "access-token",
   discardRevoked: async () => {},
+  invalidateAccessToken: async () => {},
 };
 
 describe("SyncJobWorker", () => {

--- a/packages/sync/src/domain/sync-job-worker.service.ts
+++ b/packages/sync/src/domain/sync-job-worker.service.ts
@@ -47,6 +47,12 @@ export interface SyncJobWorkerOptions {
   // invisible drop path made a mass credential problem look like a dead sweep
   // (2026-07-29) — surface them.
   onDrop?: (job: JobRecord, reason: string) => void;
+  // Called when a job exhausts its retries and settles into a terminal
+  // failure (before the fail() write). Unlike onError (fires every attempt),
+  // this fires exactly once, on the exhausting attempt — the signal worth
+  // alerting on, since the job is now wedged until an operator or a manual
+  // refresh revives it.
+  onFail?: (job: JobRecord) => void;
 }
 
 const DEFAULT_LEASE_MS = 5 * 60_000;
@@ -103,6 +109,7 @@ export class SyncJobWorker {
   readonly #now: () => Date;
   readonly #onError: (error: unknown, job: JobRecord) => void;
   readonly #onDrop: (job: JobRecord, reason: string) => void;
+  readonly #onFail: (job: JobRecord) => void;
 
   constructor(
     deps: SyncJobWorkerDeps,
@@ -124,6 +131,7 @@ export class SyncJobWorker {
     this.#now = options.now ?? (() => new Date());
     this.#onError = options.onError ?? (() => {});
     this.#onDrop = options.onDrop ?? (() => {});
+    this.#onFail = options.onFail ?? (() => {});
   }
 
   // Claim and process at most one due job. Returns "idle" when nothing is due.
@@ -224,6 +232,7 @@ export class SyncJobWorker {
   // be unlimited retries by another name).
   async #settleFailure(job: JobRecord): Promise<void> {
     if (job.attempt >= this.#maxAttempts) {
+      this.#onFail(job);
       await this.#deps.jobs.fail(job._id, this.#owner);
       return;
     }

--- a/packages/sync/src/domain/sync-job-worker.service.ts
+++ b/packages/sync/src/domain/sync-job-worker.service.ts
@@ -53,6 +53,11 @@ export interface SyncJobWorkerOptions {
   // alerting on, since the job is now wedged until an operator or a manual
   // refresh revives it.
   onFail?: (job: JobRecord) => void;
+  // Reserve this worker away from the given job kinds — see
+  // JobRepository.claimDueJob. Used to keep a subset of drains claiming only
+  // quick jobs (pulls), so a long initialImport/repair elsewhere can never
+  // head-of-line block them.
+  excludeKinds?: JobRecord["kind"][];
 }
 
 const DEFAULT_LEASE_MS = 5 * 60_000;
@@ -110,6 +115,7 @@ export class SyncJobWorker {
   readonly #onError: (error: unknown, job: JobRecord) => void;
   readonly #onDrop: (job: JobRecord, reason: string) => void;
   readonly #onFail: (job: JobRecord) => void;
+  readonly #excludeKinds?: JobRecord["kind"][];
 
   constructor(
     deps: SyncJobWorkerDeps,
@@ -132,6 +138,7 @@ export class SyncJobWorker {
     this.#onError = options.onError ?? (() => {});
     this.#onDrop = options.onDrop ?? (() => {});
     this.#onFail = options.onFail ?? (() => {});
+    this.#excludeKinds = options.excludeKinds;
   }
 
   // Claim and process at most one due job. Returns "idle" when nothing is due.
@@ -140,6 +147,7 @@ export class SyncJobWorker {
       this.#owner,
       this.#now(),
       this.#leaseMs,
+      this.#excludeKinds,
     );
     if (!job) return "idle";
     await this.#process(job);

--- a/packages/sync/src/providers/google/google-event-reader.adapter.test.ts
+++ b/packages/sync/src/providers/google/google-event-reader.adapter.test.ts
@@ -232,7 +232,7 @@ describe("GoogleEventReaderAdapter", () => {
     }
   });
 
-  it("maps a 401 to transient (the token can expire mid-job on a long import/repair; the next attempt mints a fresh one)", async () => {
+  it("maps a 401 to authExpired (the caller must invalidate the cached token before retrying)", async () => {
     const api = new FakeEventListApi([], { response: { status: 401 } });
     const { adapter } = adapterWith(api);
 
@@ -241,7 +241,7 @@ describe("GoogleEventReaderAdapter", () => {
         accessToken: "tok",
         calendarId: "primary@google.com",
       }),
-    ).rejects.toMatchObject({ reason: "transient" });
+    ).rejects.toMatchObject({ reason: "authExpired" });
   });
 
   it("maps a quota-shaped 403 to transient, like discovery/watch/write already do", async () => {

--- a/packages/sync/src/providers/google/google-event-reader.adapter.ts
+++ b/packages/sync/src/providers/google/google-event-reader.adapter.ts
@@ -158,23 +158,20 @@ const TRANSIENT_REASONS = [
 ];
 
 // Map a Google events.list failure to a read-error reason. An expired syncToken
-// (410 Gone) forces a full re-import. Retryable: a rate limit or server/network
-// error, a quota-shaped 403, or a 401 - the token that was valid when
-// getValidAccessToken minted it can expire mid-job on a long-running import or
-// repair, and the NEXT attempt mints a fresh one (calendar-import.service.ts /
-// calendar-repair.service.ts each fetch it once at the top of the job).
-// Anything else is an unrecoverable read failure.
+// (410 Gone) forces a full re-import. A 401 means the access token was rejected
+// - it may have expired mid-job on a long-running import or repair, or the
+// cached token may simply be stale - so the caller must invalidate the cached
+// token before retrying; otherwise every retry replays the same rejected
+// token, burns the retry ladder, and dead-letters the job. Also retryable: a
+// rate limit or server/network error, or a quota-shaped 403. Anything else is
+// an unrecoverable read failure.
 function classifyReadError(
   error: unknown,
-): "cursorExpired" | "transient" | "readFailed" {
+): "cursorExpired" | "authExpired" | "transient" | "readFailed" {
   const status = httpStatus(error);
   if (status === 410) return "cursorExpired";
-  if (
-    status === 401 ||
-    status === 429 ||
-    status === undefined ||
-    status >= 500
-  ) {
+  if (status === 401) return "authExpired";
+  if (status === 429 || status === undefined || status >= 500) {
     return "transient";
   }
   if (status === 403) {

--- a/packages/sync/src/providers/provider-event-reader.port.ts
+++ b/packages/sync/src/providers/provider-event-reader.port.ts
@@ -52,11 +52,14 @@ export interface ProviderEventReader {
 
 // Why a page read could not complete. `cursorExpired` (the stored sync token is
 // too old) is not retryable with the same token — the caller must re-import in
-// full. `transient` is a retryable network/provider failure; `readFailed` is an
+// full. `authExpired` is a rejected access token — retryable, but only after
+// the caller invalidates the cached token so the next attempt mints a fresh
+// one. `transient` is a retryable network/provider failure; `readFailed` is an
 // unrecoverable rejection. Distinct from ProviderEventError, which is a
 // per-event normalization failure the reader absorbs into `skipped`.
 export type ProviderEventReadErrorReason =
   | "cursorExpired"
+  | "authExpired"
   | "transient"
   | "readFailed";
 

--- a/packages/sync/src/storage/repositories/credential.repository.ts
+++ b/packages/sync/src/storage/repositories/credential.repository.ts
@@ -81,6 +81,22 @@ export class CredentialRepository {
     return result ? CredentialRecordSchema.parse(result) : null;
   }
 
+  // Clear a cached access token without touching the refresh token, so the
+  // next getValidAccessToken call is forced to mint a fresh one. Used when a
+  // provider rejects the cached token with a 401 mid-job.
+  async clearCachedAccessToken(connectionId: ConnectionId): Promise<void> {
+    await this.collection.updateOne(
+      { _id: connectionId },
+      {
+        $set: {
+          accessToken: null,
+          accessTokenExpiresAt: null,
+          updatedAt: new Date(),
+        },
+      },
+    );
+  }
+
   // Remove a connection's credential (disconnect / account deletion). Returns
   // whether a credential existed to delete.
   async deleteByConnection(connectionId: ConnectionId): Promise<boolean> {

--- a/packages/sync/src/storage/repositories/job.repository.db.test.ts
+++ b/packages/sync/src/storage/repositories/job.repository.db.test.ts
@@ -159,6 +159,67 @@ describe("JobRepository", () => {
       expect(third?.coalescingKey).toBe("bg-older");
     });
 
+    it("excludeKinds skips a due job of an excluded kind and claims another that is due", async () => {
+      await repo.enqueue(
+        enqueue({
+          coalescingKey: "import-due",
+          kind: "initialImport",
+          runAfter: past(2000),
+        }),
+      );
+      await repo.enqueue(
+        enqueue({
+          coalescingKey: "pull-due",
+          kind: "incrementalPull",
+          runAfter: past(1000),
+        }),
+      );
+
+      const claimed = await repo.claimDueJob("reserved-lane", NOW, LEASE_MS, [
+        "initialImport",
+      ]);
+
+      expect(claimed?.coalescingKey).toBe("pull-due");
+      // The excluded job is untouched: still pending, unclaimed.
+      const imports = await db
+        .collection("jobs")
+        .findOne({ coalescingKey: "import-due" });
+      expect(imports?.state).toBe("pending");
+      expect(imports?.leaseOwner).toBeNull();
+    });
+
+    it("excludeKinds returns null rather than claiming an excluded job when nothing else is due", async () => {
+      await repo.enqueue(
+        enqueue({ kind: "initialImport", runAfter: past(1000) }),
+      );
+
+      expect(
+        await repo.claimDueJob("reserved-lane", NOW, LEASE_MS, [
+          "initialImport",
+        ]),
+      ).toBeNull();
+    });
+
+    it("excludeKinds also excludes an expired-lease job of that kind from reclaim", async () => {
+      const created = await repo.enqueue(
+        enqueue({ kind: "repair", runAfter: past(200_000) }),
+      );
+      // Claim well before NOW with a short lease, so the lease has since
+      // expired relative to NOW.
+      await repo.claimDueJob("stalled-worker", past(120_000), 1000);
+
+      const reclaimed = await repo.claimDueJob("reserved-lane", NOW, LEASE_MS, [
+        "repair",
+      ]);
+
+      expect(reclaimed).toBeNull();
+      const stillClaimed = await db
+        .collection("jobs")
+        .findOne({ _id: created._id as never });
+      expect(stillClaimed?.state).toBe("claimed");
+      expect(stillClaimed?.leaseOwner).toBe("stalled-worker");
+    });
+
     it("enqueueUrgent boosts a pending job without pushing back an earlier runAfter", async () => {
       const coalescingKey = "urgent:pending";
       const earlier = past(5000);

--- a/packages/sync/src/storage/repositories/job.repository.db.test.ts
+++ b/packages/sync/src/storage/repositories/job.repository.db.test.ts
@@ -507,6 +507,82 @@ describe("JobRepository", () => {
       });
     });
 
+    it("requeueFailedByConnection revives every failed job kind for the connection", async () => {
+      const connectionId = objectId() as JobEnqueue["connectionId"];
+      const tenantId = objectId() as JobEnqueue["tenantId"];
+      const principalId = objectId() as JobEnqueue["principalId"];
+      const pull = await seedFailed({
+        tenantId,
+        principalId,
+        connectionId,
+        kind: "incrementalPull",
+        coalescingKey: `incrementalPull:${objectId()}`,
+      });
+      const repairJob = await seedFailed({
+        tenantId,
+        principalId,
+        connectionId,
+        kind: "repair",
+        coalescingKey: `repair:${objectId()}`,
+      });
+      // A different connection's failed job must not be touched.
+      const otherConnectionId = objectId() as JobEnqueue["connectionId"];
+      const otherJob = await seedFailed({
+        tenantId,
+        principalId,
+        connectionId: otherConnectionId,
+        kind: "incrementalPull",
+        coalescingKey: `incrementalPull:${objectId()}`,
+      });
+
+      const revivedCount = await repo.requeueFailedByConnection(
+        tenantId,
+        principalId,
+        connectionId,
+        NOW,
+      );
+
+      expect(revivedCount).toBe(2);
+      for (const id of [pull, repairJob]) {
+        const revived = await repo.findByIdUnscoped(id);
+        expect(revived?.state).toBe("pending");
+        expect(revived?.attempt).toBe(0);
+        expect(revived?.leaseOwner).toBeNull();
+        expect(revived?.failureClass).toBeNull();
+        expect(revived?.runAfter).toEqual(NOW);
+      }
+      expect(await repo.findByIdUnscoped(otherJob)).toMatchObject({
+        state: "failed",
+      });
+    });
+
+    it("requeueFailedByConnection leaves pending/claimed jobs alone", async () => {
+      const connectionId = objectId() as JobEnqueue["connectionId"];
+      const tenantId = objectId() as JobEnqueue["tenantId"];
+      const principalId = objectId() as JobEnqueue["principalId"];
+      const pending = await repo.enqueue(
+        enqueue({
+          tenantId,
+          principalId,
+          connectionId,
+          runAfter: past(60 * 60_000),
+          coalescingKey: `repair:${objectId()}`,
+        }),
+      );
+
+      const revivedCount = await repo.requeueFailedByConnection(
+        tenantId,
+        principalId,
+        connectionId,
+        NOW,
+      );
+
+      expect(revivedCount).toBe(0);
+      expect(
+        await repo.findById(tenantId, principalId, pending._id),
+      ).toMatchObject({ state: "pending" });
+    });
+
     it("requeue resets a failed job to pending with a fresh attempt budget", async () => {
       const id = await seedFailed({ runAfter: past(60 * 60_000) });
       expect(await repo.requeue(id, NOW)).toBe(true);

--- a/packages/sync/src/storage/repositories/job.repository.ts
+++ b/packages/sync/src/storage/repositories/job.repository.ts
@@ -486,6 +486,37 @@ export class JobRepository {
     });
   }
 
+  // Revive every failed job for a connection, of any kind — not just the
+  // incrementalPull rows enqueueUrgent's coalescing-key revive already
+  // covers. A manual refresh is the user's explicit signal that the
+  // connection should try again, so a wedged calendarListSync/initialImport/
+  // repair/subscriptionMaintain row should not stay stuck holding its
+  // coalescing key just because it isn't the kind refresh happens to
+  // re-enqueue. Leaves requeuedCount alone, matching enqueueUrgent's revive
+  // arm: that counter is the self-heal sweep's own budget, not a human's.
+  async requeueFailedByConnection(
+    tenantId: TenantId,
+    principalId: PrincipalId,
+    connectionId: ConnectionId,
+    now: Date,
+  ): Promise<number> {
+    const result = await this.collection.updateMany(
+      { tenantId, principalId, connectionId, state: "failed" },
+      {
+        $set: {
+          state: "pending",
+          runAfter: now,
+          attempt: 0,
+          leaseOwner: null,
+          leaseExpiresAt: null,
+          failureClass: null,
+        },
+        $currentDate: { updatedAt: true },
+      },
+    );
+    return result.modifiedCount;
+  }
+
   // Operator tooling only — looks up by id without tenant/principal scope.
   // Prefer findById(tenantId, principalId, id) for request-path reads.
   async findByIdUnscoped(id: SyncJobId): Promise<JobRecord | null> {

--- a/packages/sync/src/storage/repositories/job.repository.ts
+++ b/packages/sync/src/storage/repositories/job.repository.ts
@@ -230,10 +230,16 @@ export class JobRepository {
   // restart burst). Sort is `{runAfter:1}` so oldest-due wins within a rung.
   // findOneAndUpdate stays atomic per arm, so two workers still never both
   // win the same job. Returns null when no job is due.
+  // excludeKinds reserves this lane away from the given job kinds — a light
+  // lane that claims only quick jobs, so a long initialImport/repair claimed
+  // by another lane can never head-of-line block it. Applied to all three
+  // claim arms, including the expired-lease reclaim arm, so a light lane
+  // never adopts a stalled long-running job either.
   async claimDueJob(
     owner: string,
     now: Date,
     leaseDurationMs: number,
+    excludeKinds?: JobRecord["kind"][],
   ): Promise<JobRecord | null> {
     const leaseExpiresAt = new Date(now.getTime() + leaseDurationMs);
     const claimUpdate = {
@@ -245,6 +251,10 @@ export class JobRepository {
       sort: { runAfter: 1 as const },
       returnDocument: "after" as const,
     };
+    const kindFilter =
+      excludeKinds && excludeKinds.length > 0
+        ? { kind: { $nin: excludeKinds } }
+        : {};
 
     for (const filter of [
       { state: "claimed" as const, leaseExpiresAt: { $lt: now } },
@@ -256,7 +266,7 @@ export class JobRepository {
       { state: "pending" as const, runAfter: { $lte: now } },
     ]) {
       const claimed = await this.collection.findOneAndUpdate(
-        filter,
+        { ...filter, ...kindFilter },
         claimUpdate,
         claimOpts,
       );

--- a/self-host/compass.example.yaml
+++ b/self-host/compass.example.yaml
@@ -59,6 +59,7 @@ sync:
   cloudMutationMode: enabled # enabled (default) | maintenance — maintenance rejects cloud edits / connect with typed MAINTENANCE
   execution: active
   maxConcurrency: 4
+  # reservedPullLanes: 1 # of maxConcurrency, how many drains never claim initialImport/repair — keeps pulls from starving behind a wave of long imports. Must stay < maxConcurrency.
   enforceLeastPrivilege: false # true only where a scoped compass_sync database user exists (managed cloud)
   compassApiDatabase: prod_calendar # API database the least-privilege check must be denied access to
 # Public OAuth/webhook paths (via Caddy → sync): /sync/google, /sync/notifications/google


### PR DESCRIPTION
## Summary
- Break the 401 retry loop: classify Google 401s as `authExpired` (not `transient`) and invalidate the cached access token before the worker's retry replays it, instead of burning the whole retry ladder on the same rejected token and dead-lettering the job.
- Surface terminal job failure: emit `sync_job_terminal_failure` to PostHog (alertable) when a job exhausts its retries; manual connection refresh now revives failed jobs of *any* kind (`requeueFailedByConnection`), not just `incrementalPull` via the existing coalescing-key revive.
- Reserve drain lanes: new `RESERVED_PULL_LANES` config knob keeps a subset of job-queue drains from ever claiming `initialImport`/`repair`, so a wave of launch-day signups can't starve webhook/reconcile pulls behind long-running imports.

## Test plan
- [x] `bun run type-check` clean
- [x] `bun test:sync` — 884/884 pass
- [x] `bun run test:core` — 549/549 pass
- [x] Targeted new tests: 401→authExpired classification, token-invalidate-then-refresh, dispatch retry rethrow, worker `onFail` hook, `requeueFailedByConnection` (job-repo + connection-refresh db tests), `claimDueJob` `excludeKinds` (including expired-lease reclaim), `RESERVED_PULL_LANES` config validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)