### PR TITLE
fix(web): commit event duplicates immediately instead of opening the form

### DIFF
--- a/packages/web/src/events/grid-event-draft.adapter.ts
+++ b/packages/web/src/events/grid-event-draft.adapter.ts
@@ -128,7 +128,7 @@ export function editGridEventDraft(
 export function duplicateGridEventDraft(
   event: Event,
   calendars: Calendar[],
-): GridEventDraft | null {
+): Extract<GridEventDraft, { kind: "create" }> | null {
   const schedule = gridScheduleFromEvent(event);
   if (!schedule) return null;
 

--- a/packages/web/src/events/mutations/duplicate-event.test.ts
+++ b/packages/web/src/events/mutations/duplicate-event.test.ts
@@ -1,0 +1,115 @@
+import {
+  type Calendar,
+  getCalendarCapabilities,
+} from "@core/types/calendar.contracts";
+import { type CalendarId } from "@core/types/domain-primitives";
+import { type Event } from "@core/types/event.contracts";
+import { type CreateEventInput } from "@core/types/event-command.contracts";
+import { commitDuplicateEvent } from "@web/events/mutations/duplicate-event";
+import { expect, mock, test } from "bun:test";
+
+const createMock = () => mock((_input: CreateEventInput) => {});
+
+const timedEvent = {
+  id: "0123456789abcdef01234567",
+  calendarId: "0123456789abcdef76543210",
+  content: { kind: "details" as const, title: "Focus", description: "" },
+  schedule: {
+    kind: "timed" as const,
+    start: "2026-07-11T09:00:00-06:00",
+    end: "2026-07-11T10:00:00-06:00",
+    timeZone: "America/Denver",
+  },
+  recurrence: { kind: "single" as const },
+  createdAt: "2026-07-01T00:00:00.000Z",
+  updatedAt: null,
+} as unknown as Event;
+
+const seriesEvent = {
+  ...(timedEvent as object),
+  id: "0123456789abcdef01234598",
+  recurrence: {
+    kind: "series" as const,
+    rules: ["RRULE:FREQ=WEEKLY;BYDAY=MO,TU,WE"],
+  },
+} as unknown as Event;
+
+const writableCalendar = {
+  id: timedEvent.calendarId,
+  capabilities: getCalendarCapabilities("owner"),
+} as unknown as Calendar;
+
+const readOnlyCalendar = {
+  id: timedEvent.calendarId,
+  capabilities: getCalendarCapabilities("reader"),
+} as unknown as Calendar;
+
+const defaultWritableCalendarId = "0123456789abcdefdddddddd" as CalendarId;
+const defaultWritableCalendar = {
+  id: defaultWritableCalendarId,
+  capabilities: getCalendarCapabilities("owner"),
+} as unknown as Calendar;
+
+test("commits with the source event's calendar when it's still writable", () => {
+  const create = createMock();
+
+  const committed = commitDuplicateEvent({
+    source: timedEvent,
+    calendars: [writableCalendar],
+    defaultCalendarId: undefined,
+    create,
+  });
+
+  expect(committed).toBe(true);
+  expect(create).toHaveBeenCalledTimes(1);
+  const [input] = create.mock.calls[0];
+  expect(input.calendarId).toBe(timedEvent.calendarId);
+  expect(input.content.title).toBe("Focus");
+  expect(input.id).toBeTruthy();
+});
+
+test("falls back to the default target calendar when the source calendar is read-only", () => {
+  const create = createMock();
+
+  const committed = commitDuplicateEvent({
+    source: timedEvent,
+    calendars: [readOnlyCalendar, defaultWritableCalendar],
+    defaultCalendarId: defaultWritableCalendarId,
+    create,
+  });
+
+  expect(committed).toBe(true);
+  const [input] = create.mock.calls[0];
+  expect(input.calendarId).toBe(defaultWritableCalendarId);
+});
+
+test("does not commit when no writable calendar can be resolved", () => {
+  const create = createMock();
+
+  const committed = commitDuplicateEvent({
+    source: timedEvent,
+    calendars: [readOnlyCalendar],
+    defaultCalendarId: undefined,
+    create,
+  });
+
+  expect(committed).toBe(false);
+  expect(create).not.toHaveBeenCalled();
+});
+
+test("preserves series rules on the duplicate", () => {
+  const create = createMock();
+
+  commitDuplicateEvent({
+    source: seriesEvent,
+    calendars: [writableCalendar],
+    defaultCalendarId: undefined,
+    create,
+  });
+
+  const [input] = create.mock.calls[0];
+  expect(input.recurrence).toEqual({
+    kind: "series",
+    rules: ["RRULE:FREQ=WEEKLY;BYDAY=MO,TU,WE"],
+  });
+});

--- a/packages/web/src/events/mutations/duplicate-event.ts
+++ b/packages/web/src/events/mutations/duplicate-event.ts
@@ -1,0 +1,54 @@
+import { type Calendar } from "@core/types/calendar.contracts";
+import { type CalendarId, EventIdSchema } from "@core/types/domain-primitives";
+import { type Event } from "@core/types/event.contracts";
+import { focusCalendarEventElement } from "@web/common/utils/event/event.util";
+import { createObjectIdString } from "@web/common/utils/id/object-id.util";
+import {
+  duplicateGridEventDraft,
+  parseGridEventDraft,
+} from "@web/events/grid-event-draft.adapter";
+import { type EventMutations } from "@web/events/mutations/useEventMutations";
+
+/**
+ * Duplicates `source` as a saved event in one commit, skipping the create
+ * draft/form entirely: every field is already filled in, so the form would
+ * only be a step to dismiss. Focuses the new card so Shift+Arrow can
+ * reposition it immediately, and undo (Mod+Z) covers the whole thing since
+ * `create` records its own undo entry.
+ *
+ * Returns false when no writable calendar can be resolved (duplicating from
+ * a read-only calendar with no default target) - the one case that still
+ * needs the form, so the caller can fall back to opening it.
+ */
+export function commitDuplicateEvent({
+  source,
+  calendars,
+  defaultCalendarId,
+  create,
+}: {
+  source: Event;
+  calendars: Calendar[];
+  defaultCalendarId: CalendarId | undefined;
+  create: EventMutations["create"];
+}): boolean {
+  const draft = duplicateGridEventDraft(source, calendars);
+  if (!draft) return false;
+
+  const calendarId = draft.values.calendarId ?? defaultCalendarId ?? null;
+  if (!calendarId) return false;
+
+  const parsed = parseGridEventDraft({
+    ...draft,
+    values: { ...draft.values, calendarId },
+  });
+  if (!parsed.ok || parsed.mode !== "create") return false;
+
+  const id = EventIdSchema.parse(createObjectIdString());
+
+  create(
+    { ...parsed.input, id },
+    { onOptimisticApplied: () => focusCalendarEventElement(id) },
+  );
+
+  return true;
+}

--- a/packages/web/src/grid/shortcuts/useGridEventEditShortcuts.ts
+++ b/packages/web/src/grid/shortcuts/useGridEventEditShortcuts.ts
@@ -6,6 +6,7 @@ import {
   isGridEventInteractionReadOnly,
   useCalendarLookup,
 } from "@web/calendars/useCalendarLookup";
+import { useDefaultTargetCalendar } from "@web/calendars/useDefaultTargetCalendar";
 import { ID_SIDEBAR } from "@web/common/constants/web.constants";
 import { type GridEvent } from "@web/common/types/web.event.types";
 import { getVisibleGridStartMinute } from "@web/common/utils/draft/draft.util";
@@ -25,6 +26,7 @@ import {
   isEventFormKeyboardTarget,
 } from "@web/common/utils/form/form.util";
 import { duplicateGridEventDraft } from "@web/events/grid-event-draft.adapter";
+import { commitDuplicateEvent } from "@web/events/mutations/duplicate-event";
 import {
   type EventMutationDependencies,
   useEventMutations,
@@ -119,8 +121,10 @@ export function useGridEventEditShortcuts({
 }) {
   const calendarLookup = useCalendarLookup();
   const { data: calendars } = useCalendarsQuery();
+  const defaultCalendar = useDefaultTargetCalendar(calendars ?? []);
   const queryClient = useQueryClient();
-  const { delete: deleteEvent } = useEventMutations(dependencies);
+  const { create: createEvent, delete: deleteEvent } =
+    useEventMutations(dependencies);
   const updateEvent = useUpdateEvent(dependencies);
 
   // Focused only (no hover/first-visible fallback): edit actions must
@@ -176,11 +180,23 @@ export function useGridEventEditShortcuts({
     const sourceEvent = findEventInCache(queryClient, gridEvent._id);
     if (!sourceEvent) return;
 
-    const duplicate = duplicateGridEventDraft(sourceEvent, calendars ?? []);
-    if (!duplicate) return;
+    const committed = commitDuplicateEvent({
+      source: sourceEvent,
+      calendars: calendars ?? [],
+      defaultCalendarId: defaultCalendar?.id,
+      create: createEvent,
+    });
 
     keyboardEvent.preventDefault();
     keyboardEvent.stopPropagation();
+
+    if (committed) return;
+
+    // No writable calendar could be resolved for the copy - fall back to
+    // the create-draft form so the user can pick one.
+    const duplicate = duplicateGridEventDraft(sourceEvent, calendars ?? []);
+    if (!duplicate) return;
+
     draftActions.startGridDraft({ activity: "gridClick", draft: duplicate });
     draftActions.setFormOpen(true);
   };

--- a/packages/web/src/views/Day/hooks/shortcuts/useDayEventNudgeShortcuts.test.tsx
+++ b/packages/web/src/views/Day/hooks/shortcuts/useDayEventNudgeShortcuts.test.tsx
@@ -10,9 +10,11 @@ import {
   waitFor,
 } from "@web/__tests__/__mocks__/mock.render";
 import { toNormalizedEventQueryData } from "@web/__tests__/utils/event-query-test-data";
+import { createMockCalendar } from "@web/__tests__/utils/factories/calendar.factory";
 import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
 import { pressKey } from "@web/__tests__/utils/keyboard.test.util";
 import { createCompassQueryClient } from "@web/api/query-client";
+import { calendarQueryKeys } from "@web/calendars/calendar.query";
 import { ID_EVENT_FORM, ID_SIDEBAR } from "@web/common/constants/web.constants";
 import { type GridEvent } from "@web/common/types/web.event.types";
 import { getBrowserTimeZone } from "@web/common/utils/datetime/web.date.util";
@@ -136,6 +138,9 @@ const renderEditShortcuts = ({
     }),
     toNormalizedEventQueryData(contracts),
   );
+  queryClient.setQueryData(calendarQueryKeys.all, [
+    createMockCalendar({ id: timedEventContract.calendarId }),
+  ]);
   const repository: EventRepository = {
     list: async () => [],
     create: async () => timedEventContract,
@@ -188,6 +193,14 @@ const getDeleteMutation = (
     .getMutationCache()
     .getAll()
     .find((mutation) => mutation.options.mutationKey?.[2] === "delete");
+
+const getCreateMutation = (
+  queryClient: ReturnType<typeof createCompassQueryClient>,
+) =>
+  queryClient
+    .getMutationCache()
+    .getAll()
+    .find((mutation) => mutation.options.mutationKey?.[2] === "create");
 
 beforeEach(() => {
   HotkeyManager.resetInstance();
@@ -420,17 +433,22 @@ describe("useDayEventNudgeShortcuts", () => {
 
   it("duplicates the focused calendar event with Mod+D", () => {
     focusCalendarTarget(TIMED_EVENT_ID, "timed");
-    renderEditShortcuts();
+    const { queryClient } = renderEditShortcuts();
 
     pressKey("d", {
       keyDownInit: { ctrlKey: true },
       keyUpInit: { ctrlKey: true },
     });
 
+    const { input } = getCreateMutation(queryClient)?.state.variables as {
+      input: { calendarId: string; content: { title: string } };
+    };
+    expect(input.calendarId).toBe(timedEventContract.calendarId);
+    expect(input.content.title).toBe("Timed event");
+
     const state = useDraftStore.getState();
-    expect(state.status?.isFormOpen).toBe(true);
-    expect(state.gridDraft?.kind).toBe("create");
-    expect(state.gridDraft?.values.title).toBe("Timed event");
+    expect(state.status?.isFormOpen).toBe(false);
+    expect(state.gridDraft).toBeNull();
   });
 
   it("focuses the chronologically next event with ArrowDown", () => {

--- a/packages/web/src/views/Forms/hooks/useDuplicateEvent.ts
+++ b/packages/web/src/views/Forms/hooks/useDuplicateEvent.ts
@@ -1,31 +1,47 @@
 import { useCallback } from "react";
 import { useCalendarsQuery } from "@web/calendars/calendar.query";
+import { useDefaultTargetCalendar } from "@web/calendars/useDefaultTargetCalendar";
 import { duplicateGridEventDraft } from "@web/events/grid-event-draft.adapter";
+import { commitDuplicateEvent } from "@web/events/mutations/duplicate-event";
+import { useEventMutations } from "@web/events/mutations/useEventMutations";
 import { useEventById } from "@web/events/queries/useEventById";
 import { draftActions } from "@web/events/stores/draft.store";
-import { useCloseEventForm } from "@web/views/Forms/hooks/useCloseEventForm";
 
 /**
- * Opens a create draft based on an existing event (preserves series rules).
+ * Duplicates an existing event as a new saved event (preserves series
+ * rules). Falls back to opening a create draft only when no writable
+ * calendar can be resolved for the copy.
  */
 export function useDuplicateEvent(_id: string) {
   const event = useEventById(_id);
-  const onClose = useCloseEventForm();
   const { data: calendars } = useCalendarsQuery();
+  const defaultCalendar = useDefaultTargetCalendar(calendars ?? []);
+  const { create } = useEventMutations();
 
   const duplicateEvent = useCallback(() => {
     if (!event) return;
 
+    // Discards directly (not useCloseEventForm) - that hook's
+    // refocus-to-source-event would race commitDuplicateEvent's own
+    // focus-the-new-card call, and either the fallback below opens a new
+    // form (making a refocus pointless) or the commit succeeds and owns
+    // focus itself.
+    draftActions.discard();
+
+    const committed = commitDuplicateEvent({
+      source: event,
+      calendars: calendars ?? [],
+      defaultCalendarId: defaultCalendar?.id,
+      create,
+    });
+    if (committed) return;
+
     const duplicate = duplicateGridEventDraft(event, calendars ?? []);
     if (!duplicate) return;
 
-    onClose();
-
-    // The duplicated draft renders into the grid and its card attaches the
-    // floating reference, so the form anchors itself once mounted.
     draftActions.startGridDraft({ activity: "gridClick", draft: duplicate });
     draftActions.setFormOpen(true);
-  }, [calendars, event, onClose]);
+  }, [calendars, create, defaultCalendar?.id, event]);
 
   return duplicateEvent;
 }

--- a/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcutOwner.test.tsx
+++ b/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcutOwner.test.tsx
@@ -383,17 +383,26 @@ describe("useWeekShortcutOwner calendar event targeting", () => {
   it("duplicates the focused calendar event with Mod+D", () => {
     const button = addCalendarTarget();
     button.focus();
-    renderShortcuts();
+    const { queryClient } = renderShortcuts();
 
     pressKey("d", {
       keyDownInit: { ctrlKey: true },
       keyUpInit: { ctrlKey: true },
     });
 
+    const created = queryClient
+      .getMutationCache()
+      .getAll()
+      .find((mutation) => mutation.options.mutationKey?.[2] === "create");
+    const { input } = created?.state.variables as {
+      input: { calendarId: string; content: { title: string } };
+    };
+    expect(input.calendarId).toBe(editableEvent.calendarId);
+    expect(input.content.title).toBe("Editable event");
+
     const state = useDraftStore.getState();
-    expect(state.status?.isFormOpen).toBe(true);
-    expect(state.gridDraft?.kind).toBe("create");
-    expect(state.gridDraft?.values.title).toBe("Editable event");
+    expect(state.status?.isFormOpen).toBe(false);
+    expect(state.gridDraft).toBeNull();
   });
 
   it("keeps ArrowDown on the same day when a later event exists that day", () => {


### PR DESCRIPTION
## Summary

Duplicating an event (Mod+D on a focused grid event, right-click > Duplicate, or the event form's action menu) previously created a grid draft with an identical time slot to the source and force-opened the edit form — even though every field was already filled in. Two problems followed: the draft rendered directly on top of the source with no visual distinction, and the form was an unwanted extra step.

Duplication now commits the copy immediately as a real saved event through the existing optimistic `create` mutation, skips the draft/form entirely, and focuses the new card so Shift+Arrow can reposition it right away. It's undoable via the existing Mod+Z stack. Saved events already participate in the app's overlap "deck" layout (`grid/layout/timed-deck.layout.ts`), so the duplicate and original become visually distinguishable as a side effect of no longer being drafts — no new layout code needed.

Falls back to the old draft/form path only when no writable calendar can be resolved for the copy (duplicating from a read-only calendar with no default target calendar set).

## Simplicity

- New logic lives in one shared helper (`commitDuplicateEvent` in `events/mutations/duplicate-event.ts`) called from both the grid keyboard shortcut and the form/context-menu hook, rather than duplicating the commit sequence.
- Reused the existing `duplicateGridEventDraft` adapter, `parseGridEventDraft`, and the `create` mutation as-is — no new mutation or store.
- Narrowed `duplicateGridEventDraft`'s return type to `Extract<GridEventDraft, { kind: "create" }> | null` so the new helper doesn't need a redundant runtime `kind` guard just to satisfy the discriminated union.
- A `/simplify` pass (4 parallel review angles: reuse, simplification, efficiency, altitude) found nothing else worth changing at this diff's scope; a couple of lower-value suggestions (extracting a 3-line calendarId-fallback pattern shared with `useSaveEventForm`, and lazily reading the default-target-calendar hook) were skipped as not worth the added abstraction/API surface for a negligible cost.

## Automated validation

Manually verified in a live browser dev server (`bun dev:web`, anon/local session):
- Focused-event Mod+D creates a real second event immediately, no form opens, the two events fan visually via the deck layout.
- Focus lands on the new duplicate; Shift+Arrow nudges only the new card (verified schedule updates, e.g. 12–1 PM → 12:15–1:15 PM).
- Two Mod+Z presses cleanly undo the nudge then the create, leaving only the original.
- Re-tested the exact race condition a review round flagged: opening the form by clicking an event (title input focused), then Mod+D from inside the form — focus correctly lands on the new duplicate's card, not the source, and the form closes with no console errors.
- No new console/network errors introduced (only pre-existing `ERR_CONNECTION_REFUSED` noise from the backend not running in this dev-only session).

## Independent review

Two independent read-only review rounds via `feature-dev:code-reviewer`, plus a 4-angle `/simplify` pass:
- Round 1 confirmed one real issue: an uncoordinated focus race between `useCloseEventForm`'s refocus-to-source-event and the new commit's focus-the-new-card call, reachable via the form's own Duplicate action. Fixed by having `useDuplicateEvent` discard the closed form's draft directly (`draftActions.discard()`) instead of going through `useCloseEventForm`, since the commit path owns focus itself once it succeeds.
- `/simplify` found and fixed one dead branch (a `draft.kind !== "create"` runtime check that could never be false) by narrowing the adapter's return type instead; three other findings (a small duplicated calendarId-fallback pattern, an unconditional-hook efficiency nit, and a broader `useCloseEventForm` API redesign suggestion) were judged not worth the added scope/risk and skipped with reasoning.
- Round 2 (fresh reviewer, full final diff) specifically re-verified the type-narrowing change is sound at all call sites and that the `draftActions.discard()` swap drops no other side effect — no findings.

## Test plan

- `bun run type-check` — clean
- `bun run lint` — clean (13 pre-existing warnings elsewhere, none in touched files)
- `TZ=UTC NODE_ENV=test bun test src/events/mutations/duplicate-event.test.ts src/views/Day/hooks/shortcuts/useDayEventNudgeShortcuts.test.tsx src/views/Forms/EventForm/EventForm.test.tsx src/components/ContextMenu/ContextMenuItems.test.tsx src/events/grid-event-draft.adapter.test.ts` (run from `packages/web`) — 107 pass, 0 fail