### PR TITLE
fix(dev): fill sync.* config placeholders in backend bootstrap

### DIFF
--- a/.cursor/bootstrap-backend.sh
+++ b/.cursor/bootstrap-backend.sh
@@ -19,6 +19,8 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT"
 
 MONGO_URI="${MONGO_URI:-mongodb://localhost:27017/dev_calendar?replicaSet=rs0}"
+# Sync uses an isolated database on the same local replica set.
+SYNC_MONGO_URI="${SYNC_MONGO_URI:-mongodb://localhost:27017/compass_sync?replicaSet=rs0}"
 
 # 1. compass.yaml -----------------------------------------------------------
 if [ ! -f compass.yaml ]; then
@@ -28,9 +30,13 @@ if [ ! -f compass.yaml ]; then
     -e "s#REPLACE_WITH_COMPASS_TOKEN#${COMPASS_TOKEN:-local-dev-compass-token}#" \
     -e "s#REPLACE_WITH_SUPERTOKENS_URI#${SUPERTOKENS_URI:-http://localhost:3567}#" \
     -e "s#REPLACE_WITH_SUPERTOKENS_KEY#${SUPERTOKENS_KEY:-local-dev-supertokens-key}#" \
+    -e "s#REPLACE_WITH_SYNC_INTERNAL_AUTH_TOKEN#${SYNC_INTERNAL_AUTH_TOKEN:-local-dev-sync-internal-auth-token}#" \
     compass.yaml
   # Replace the whole mongo.uri line (the example ships an Atlas placeholder).
   sed -i "s#^  uri: mongodb.*#  uri: ${MONGO_URI//#/\\#}#" compass.yaml
+  # The sync service needs an isolated database on the same local replica set.
+  # Replace the sync.mongoUri line (the example ships an Atlas placeholder).
+  sed -i "s#^  mongoUri: mongodb.*#  mongoUri: ${SYNC_MONGO_URI//#/\\#}#" compass.yaml
 
   if [ -n "${GOOGLE_CLIENT_ID:-}" ] && [ -n "${GOOGLE_CLIENT_SECRET:-}" ]; then
     echo "[bootstrap] enabling Google integration from environment"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,15 +126,22 @@ everything runs through Bun, so that mismatch is not a blocker.
   chromium`. Axe "incomplete" results are logged, not failures (see
   `docs/development/testing-playbook.md`).
 - Backend: run `bash .cursor/bootstrap-backend.sh` once to write a working
-  `compass.yaml` and install/start a single-node MongoDB replica set, then
-  `bun run dev:backend` (serves http://localhost:3000/api). The script is
-  idempotent and reads `SUPERTOKENS_URI`, `SUPERTOKENS_KEY`, `GOOGLE_CLIENT_ID`,
-  and `GOOGLE_CLIENT_SECRET` from the environment when set (otherwise dummy
-  local auth values, Google disabled). Non-obvious: the backend uses
-  transactions, so Mongo must be a replica set and `mongo.uri` must include
-  `replicaSet=...` — a standalone `mongod` will not work. `GET /api/health`
-  returning `200 {"status":"ok"}` confirms the backend is up and Mongo is
-  reachable.
+ `compass.yaml` and install/start a single-node MongoDB replica set, then
+ `bun run dev:backend` (serves http://localhost:3000/api). The script is
+ idempotent and reads `SUPERTOKENS_URI`, `SUPERTOKENS_KEY`, `GOOGLE_CLIENT_ID`,
+ `GOOGLE_CLIENT_SECRET`, `SYNC_MONGO_URI`, and `SYNC_INTERNAL_AUTH_TOKEN` from
+ the environment when set (otherwise dummy local values, Google disabled). The
+ required `sync.*` config block is filled with local defaults — `sync.mongoUri`
+ points at an isolated `compass_sync` database on the same local replica set.
+ Non-obvious: the backend uses transactions, so Mongo must be a replica set and
+ both `mongo.uri` and `sync.mongoUri` must include `replicaSet=...` — a
+ standalone `mongod` will not work. `GET /api/health` returning
+ `200 {"status":"ok"}` confirms the backend is up and Mongo is reachable.
+- The Sync service (`bun run dev:sync`) is a separate, optional process. When it
+ is not running, the backend logs recurring
+ `app:sse.sync-change-feed: Sync global change-feed poll failed: unavailable`
+ warnings — these are expected and harmless for core event CRUD work; only start
+ `dev:sync` when working on Google sync/SSE.
 - Auth/login and real Google Calendar sync are gated on external services not
   provisioned by default: a SuperTokens instance and Google OAuth. Provide them
   as environment secrets so `bootstrap-backend.sh` wires them into


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

While setting up the development environment I found that `.cursor/bootstrap-backend.sh` was stale relative to the current `compass.example.yaml`. The example config now ships a required `sync:` block with `REPLACE_WITH_SYNC_MONGO_PASSWORD` and `REPLACE_WITH_SYNC_INTERNAL_AUTH_TOKEN` placeholders, but the bootstrap script only filled the older `backend`, `supertokens`, and `mongo.uri` values. The config validator (`packages/core/src/config/compass.config.ts`) rejects any remaining `REPLACE_WITH_` value, so both `bun run dev:web` and `bun run dev:backend` aborted at startup with:

```
Compass config file /workspace/compass.yaml contains unfilled placeholder values.
Replace the following fields with real values:
  - sync.mongoUri
  - sync.internalAuthToken
```

This PR:
- Fills `sync.mongoUri` (an isolated `compass_sync` database on the same local single-node replica set) and `sync.internalAuthToken` in `bootstrap-backend.sh`, reading optional `SYNC_MONGO_URI` / `SYNC_INTERNAL_AUTH_TOKEN` env overrides with safe local defaults.
- Documents the new env vars, the `sync.mongoUri` replica-set requirement, and the expected/harmless `sync-change-feed ... unavailable` warnings (logged when the optional `dev:sync` service isn't running) under `## Cursor Cloud specific instructions` in `AGENTS.md`.

No application code changed; `compass.yaml` remains gitignored.

## Simplicity

Minimal: two additional `sed` substitutions plus one default variable, mirroring the existing pattern in the script. Documentation updates only in `AGENTS.md`.

## Automated validation

- `bun lint` — passes (12 pre-existing warnings, exit 0).
- `bun test:core` — 549 pass.
- `bun test:web` — 2173 pass.
- `bun test:backend` — 300 pass, 1 skip (in-memory Mongo auto-started).
- `bun run dev:backend` — `GET /api/health` returns `200 {"status":"ok"}` with Mongo connected.
- `bun run dev:web` — serves http://localhost:9080 (HTTP 200).
- Manual: created a calendar event "Hello World Compass" in the web UI (anonymous/IndexedDB mode); it persists on the grid.

<a href="https://cursor.com/agents/bc-229f29b5-1f9c-4229-9810-5f40289bc8fa/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcompass_create_event_hello_world.mp4"><img src="https://cursor.com/artifacts/c/art-0addab4b-8522-4843-a820-a8efe73db3b4" alt="compass_create_event_hello_world.mp4" /></a>

![Hello World Compass event on the calendar](https://cursor.com/artifacts/c/art-daa55114-a2be-4d07-b98b-5638f346d9f1)

## Independent review

Verified fresh-path bootstrap fills all `sync.*` placeholders (only commented google/email/posthog placeholders remain, which the validator ignores) and that re-running the script is idempotent (leaves an existing `compass.yaml` untouched).

## Test plan

```
bun install
bun lint
bun test:core
bun test:web
bun test:backend
bash .cursor/bootstrap-backend.sh
bun run dev:backend   # curl -s localhost:3000/api/health -> {"status":"ok"}
bun run dev:web       # http://localhost:9080 -> 200
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-229f29b5-1f9c-4229-9810-5f40289bc8fa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-229f29b5-1f9c-4229-9810-5f40289bc8fa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

