### PR TITLE
fix(web): calendar-colored event focus chrome

### DIFF
--- a/packages/web/src/calendars/calendarCardIdentity.test.tsx
+++ b/packages/web/src/calendars/calendarCardIdentity.test.tsx
@@ -10,6 +10,7 @@ import { createStoreWrapper } from "@web/__tests__/render-with-store";
 import { calendarQueryKeys } from "@web/calendars/calendar.query";
 import {
   resolveCalendarCardIdentity,
+  resolveCalendarFocusColor,
   useCalendarLookup,
 } from "@web/calendars/useCalendarLookup";
 import { type GridEvent } from "@web/common/types/web.event.types";
@@ -63,12 +64,14 @@ const makeGridEvent = (overrides: Partial<GridEvent> = {}): GridEvent =>
 function TimedCardWithResolvedIdentity({ event }: { event: GridEvent }) {
   const lookup = useCalendarLookup();
   const calendarIdentity = resolveCalendarCardIdentity(lookup, event);
+  const focusColor = resolveCalendarFocusColor(lookup, event);
 
   return (
     <TimedEventCard
       calendarIdentity={calendarIdentity}
       displayMode="saved"
       event={event}
+      focusColor={focusColor}
       motionMode="idle"
       position={POSITION}
     />
@@ -78,11 +81,13 @@ function TimedCardWithResolvedIdentity({ event }: { event: GridEvent }) {
 function AllDayCardWithResolvedIdentity({ event }: { event: GridEvent }) {
   const lookup = useCalendarLookup();
   const calendarIdentity = resolveCalendarCardIdentity(lookup, event);
+  const focusColor = resolveCalendarFocusColor(lookup, event);
 
   return (
     <AllDayEventCard
       calendarIdentity={calendarIdentity}
       event={event}
+      focusColor={focusColor}
       isPlaceholder={false}
       position={POSITION}
     />
@@ -167,5 +172,54 @@ describe("Calendar identity on event cards", () => {
 
     const card = screen.getByRole("button", { name: /Team sync/ });
     expect(card.getAttribute("aria-label")).not.toMatch(/calendar$/);
+  });
+});
+
+describe("resolveCalendarFocusColor", () => {
+  it("returns the calendar color for a single-calendar account", () => {
+    const only = makeCalendar({ backgroundColor: "#9e9e9e" });
+    const lookup = new Map([[only.id, only]]);
+
+    expect(resolveCalendarFocusColor(lookup, { calendarId: only.id })).toBe(
+      "#9e9e9e",
+    );
+  });
+
+  it("returns the calendar color when multiple calendars are active", () => {
+    const work = makeCalendar({ backgroundColor: "#3b82f6" });
+    const personal = makeCalendar({ backgroundColor: "#ef4444" });
+    const lookup = new Map([
+      [work.id, work],
+      [personal.id, personal],
+    ]);
+
+    expect(resolveCalendarFocusColor(lookup, { calendarId: personal.id })).toBe(
+      "#ef4444",
+    );
+  });
+
+  it("returns null when the calendar is missing or the event has no calendarId", () => {
+    const work = makeCalendar();
+    const lookup = new Map([[work.id, work]]);
+
+    expect(resolveCalendarFocusColor(lookup, { calendarId: null })).toBeNull();
+    expect(
+      resolveCalendarFocusColor(lookup, {
+        calendarId: CalendarIdSchema.parse(createObjectIdString()),
+      }),
+    ).toBeNull();
+  });
+
+  it("sets --event-focus-color from the calendar on a single-calendar timed card", () => {
+    const onlyCalendar = makeCalendar({ backgroundColor: "#616161" });
+    const event = makeGridEvent({ calendarId: onlyCalendar.id });
+
+    renderWithCalendars(<TimedCardWithResolvedIdentity event={event} />, [
+      onlyCalendar,
+    ]);
+
+    const card = screen.getByRole("button", { name: /Team sync/ });
+    expect(card.style.getPropertyValue("--event-focus-color")).toBe("#616161");
+    expect(card.className).not.toContain("ring-accent");
   });
 });

--- a/packages/web/src/calendars/useCalendarLookup.ts
+++ b/packages/web/src/calendars/useCalendarLookup.ts
@@ -107,6 +107,22 @@ export function resolveCalendarCardIdentity(
 }
 
 /**
+ * Calendar color for event focus chrome (whole-card outline + start/end edge
+ * indicators). Unlike {@link resolveCalendarCardIdentity}, this is not gated
+ * on multi-calendar — a single-calendar account still needs a calendar-colored
+ * focus line so cards never introduce a third theme-accent color.
+ */
+export function resolveCalendarFocusColor(
+  lookup: ReadonlyMap<CalendarId, Calendar>,
+  event: { calendarId?: CalendarId | null },
+): string | null {
+  const { calendarId } = event;
+  if (!calendarId) return null;
+
+  return lookup.get(calendarId)?.backgroundColor ?? null;
+}
+
+/**
  * Grid-only content flags that force read-only treatment regardless of
  * calendar write capability (passed as the `isBusy` argument to
  * {@link isEventReadOnly}).

--- a/packages/web/src/grid/components/AllDayEventCard.tsx
+++ b/packages/web/src/grid/components/AllDayEventCard.tsx
@@ -17,6 +17,8 @@ import { type GridEvent } from "@web/common/types/web.event.types";
 import {
   calendarAccentAccessibleSuffix,
   calendarAccentStyle,
+  eventEdgeFocusShadow,
+  eventFocusColor,
 } from "@web/grid/components/calendar-accent.util";
 import { EVENT_RESIZE_HANDLE_ATTRIBUTE } from "@web/grid/interaction/dom";
 import {
@@ -32,6 +34,8 @@ export interface AllDayEventCardProps {
   /** Resolved by a list-level useCalendarLookup call, not fetched here. */
   calendarIdentity?: CalendarCardIdentity | null;
   event: GridEvent;
+  /** Calendar backgroundColor for focus chrome; null falls back to --text. */
+  focusColor?: string | null;
   interactionAttributes?: Record<string, string | undefined>;
   isPlaceholder: boolean;
   onEventKeyDown?: (event: GridEvent) => void;
@@ -50,6 +54,7 @@ const AllDayEventCardBase = (
   {
     calendarIdentity = null,
     event,
+    focusColor = null,
     interactionAttributes,
     isPlaceholder,
     onEventKeyDown,
@@ -87,15 +92,23 @@ const AllDayEventCardBase = (
   // drop the title below 4.5:1.
   const titleColor = theme.getContrastText(bgColor);
 
+  const focusedEdge = useEdgeFocusStore(selectEdgeForEvent(event._id));
+  const focusColorCss = eventFocusColor(focusColor);
+  const edgeFocusShadow = focusedEdge
+    ? eventEdgeFocusShadow(focusedEdge, "horizontal", focusColorCss)
+    : undefined;
+
   const eventStyle = {
     "--event-bg": bgColor,
     "--event-hover-bg": hoverBgColor,
+    "--event-focus-color": focusColorCss,
     height: position.height,
     left: position.left,
     opacity: isPlaceholder ? 0.5 : undefined,
     top: position.top,
     width: position.width,
     zIndex: position.zIndex ?? ZIndex.LAYER_1,
+    boxShadow: edgeFocusShadow,
   } as CSSProperties;
 
   const showResizeCursor = !isPlaceholder;
@@ -115,7 +128,6 @@ const AllDayEventCardBase = (
   // Fill stays a flat neutral color; the accent + this suffix are the only
   // calendar signal, and the name (never color alone) is what makes it
   // accessible (A9).
-  const focusedEdge = useEdgeFocusStore(selectEdgeForEvent(event._id));
   const edgeFocusSuffix =
     focusedEdge === "startDate"
       ? ", editing start date"
@@ -132,16 +144,22 @@ const AllDayEventCardBase = (
     <div
       {...interactionAttributes}
       aria-label={accessibleLabel}
+      data-edge-focus={focusedEdge ?? undefined}
       ref={ref}
       role="button"
       tabIndex={0}
       className={cn(
-        "absolute min-h-2.5 select-none overflow-hidden rounded-xs bg-(--event-bg) pr-0.75 pl-1.25 transition-[background-color,filter] duration-260 ease-[cubic-bezier(0.16,1,0.3,1)] hover:bg-(--event-hover-bg) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 focus-visible:ring-offset-background",
+        "absolute min-h-2.5 select-none overflow-hidden rounded-xs bg-(--event-bg) pr-0.75 pl-1.25 transition-[background-color,filter] duration-260 ease-[cubic-bezier(0.16,1,0.3,1)] hover:bg-(--event-hover-bg)",
         {
           "hover:cursor-pointer": !isPlaceholder,
           "outline outline-dashed outline-1 outline-text-muted/50":
             event.isDemo,
         },
+        // Outside outline (not an accent ring) so titles stay readable.
+        // Suppress while an edge is focused — only the outer edge line shows.
+        focusedEdge
+          ? "focus-visible:outline-none"
+          : "focus-visible:outline-(--event-focus-color) focus-visible:outline-2 focus-visible:outline-offset-2",
       )}
       style={eventStyle}
       onKeyDown={(e: KeyboardEvent<HTMLDivElement>) => {
@@ -167,17 +185,6 @@ const AllDayEventCardBase = (
           aria-hidden="true"
           className="absolute inset-y-0 left-0 w-[3px]"
           style={calendarAccentStyle(calendarIdentity)}
-        />
-      )}
-      {focusedEdge && (
-        <div
-          aria-hidden="true"
-          className={cn(
-            "absolute inset-y-0 w-[3px] rounded-full bg-accent",
-            focusedEdge === "startDate" ? "left-0" : "right-0",
-          )}
-          data-edge-focus={focusedEdge}
-          style={{ zIndex: ZIndex.LAYER_4 }}
         />
       )}
       <div

--- a/packages/web/src/grid/components/AllDayEventCard.tsx
+++ b/packages/web/src/grid/components/AllDayEventCard.tsx
@@ -19,6 +19,7 @@ import {
   calendarAccentStyle,
   eventEdgeFocusShadow,
   eventFocusColor,
+  eventFocusOutlineClass,
 } from "@web/grid/components/calendar-accent.util";
 import { EVENT_RESIZE_HANDLE_ATTRIBUTE } from "@web/grid/interaction/dom";
 import {
@@ -155,11 +156,7 @@ const AllDayEventCardBase = (
           "outline outline-dashed outline-1 outline-text-muted/50":
             event.isDemo,
         },
-        // Outside outline (not an accent ring) so titles stay readable.
-        // Suppress while an edge is focused — only the outer edge line shows.
-        focusedEdge
-          ? "focus-visible:outline-none"
-          : "focus-visible:outline-(--event-focus-color) focus-visible:outline-2 focus-visible:outline-offset-2",
+        eventFocusOutlineClass(focusedEdge),
       )}
       style={eventStyle}
       onKeyDown={(e: KeyboardEvent<HTMLDivElement>) => {

--- a/packages/web/src/grid/components/EventCard.test.tsx
+++ b/packages/web/src/grid/components/EventCard.test.tsx
@@ -467,7 +467,7 @@ describe("EventCard", () => {
           startDate: "2099-01-15T09:00:00.000Z",
           endDate: "2099-01-15T10:00:00.000Z",
         })}
-        focusColor="#9e9e9e"
+        focusColor="#616161"
         motionMode="idle"
         position={position}
       />,
@@ -476,7 +476,7 @@ describe("EventCard", () => {
     const card = screen.getByRole("button", {
       name: "Timed event: Planning block, 9 - 10 AM",
     });
-    expect(card.style.getPropertyValue("--event-focus-color")).toBe("#9e9e9e");
+    expect(card.style.getPropertyValue("--event-focus-color")).toBe("#616161");
     expect(card.className).not.toContain("ring-accent");
     expect(card.className).toContain(
       "focus-visible:outline-(--event-focus-color)",
@@ -531,7 +531,7 @@ describe("EventCard", () => {
       <TimedEventCard
         displayMode="saved"
         event={event}
-        focusColor="#9e9e9e"
+        focusColor="#616161"
         motionMode="idle"
         position={{ ...position, height: COMPACT_EVENT_MAX_HEIGHT }}
       />,
@@ -541,7 +541,7 @@ describe("EventCard", () => {
     const card = screen.getByRole("button", { name: /Do drops/ });
     expect(card).toHaveAttribute("data-edge-focus", "startDate");
     // Outside shadow, not an inset accent bar covering the title.
-    expect(card.style.boxShadow).toContain("0 -3px 0 0 #9e9e9e");
+    expect(card.style.boxShadow).toContain("0 -3px 0 0 #616161");
     expect(card.querySelector("[data-edge-focus]")).toBeNull();
   });
 

--- a/packages/web/src/grid/components/EventCard.test.tsx
+++ b/packages/web/src/grid/components/EventCard.test.tsx
@@ -2,11 +2,16 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { getEventPalette } from "@web/common/styles/theme.util";
 import { type GridEvent } from "@web/common/types/web.event.types";
 import {
+  COMPACT_EVENT_MAX_HEIGHT,
   GRID_EVENT_TITLE_COMPACT_FONT_SIZE,
   GRID_EVENT_TITLE_COMPACT_LINE_HEIGHT,
   GRID_EVENT_TITLE_FONT_SIZE,
 } from "@web/grid/grid.constants";
-import { describe, expect, it, mock } from "bun:test";
+import {
+  initialEdgeFocusState,
+  useEdgeFocusStore,
+} from "@web/grid/shortcuts/edge-focus.store";
+import { afterEach, describe, expect, it, mock } from "bun:test";
 import "@testing-library/jest-dom";
 
 import { AllDayEventCard } from "./AllDayEventCard";
@@ -40,6 +45,10 @@ const position = {
 };
 
 describe("EventCard", () => {
+  afterEach(() => {
+    useEdgeFocusStore.setState(initialEdgeFocusState, true);
+  });
+
   it("renders timed event details, interaction attributes, and resize handles", () => {
     const onEventMouseDown = mock();
     const onScalerMouseDown = mock();
@@ -448,5 +457,119 @@ describe("EventCard", () => {
         name: "Recurring All-day event: Planning block",
       }),
     ).toBeInTheDocument();
+  });
+
+  it("uses calendar-colored focus chrome instead of the theme accent ring", () => {
+    render(
+      <TimedEventCard
+        displayMode="saved"
+        event={createEvent({
+          startDate: "2099-01-15T09:00:00.000Z",
+          endDate: "2099-01-15T10:00:00.000Z",
+        })}
+        focusColor="#9e9e9e"
+        motionMode="idle"
+        position={position}
+      />,
+    );
+
+    const card = screen.getByRole("button", {
+      name: "Timed event: Planning block, 9 - 10 AM",
+    });
+    expect(card.style.getPropertyValue("--event-focus-color")).toBe("#9e9e9e");
+    expect(card.className).not.toContain("ring-accent");
+    expect(card.className).toContain(
+      "focus-visible:outline-(--event-focus-color)",
+    );
+    expect(card.className).toContain("focus-visible:outline-2");
+  });
+
+  it("paints start/end edge focus outside the card with the calendar color", () => {
+    const event = createEvent({
+      startDate: "2099-01-15T09:00:00.000Z",
+      endDate: "2099-01-15T10:00:00.000Z",
+    });
+    useEdgeFocusStore.setState({
+      eventId: event._id!,
+      edge: "startDate",
+      announcement: "Editing start time",
+    });
+
+    render(
+      <TimedEventCard
+        displayMode="saved"
+        event={event}
+        focusColor="#616161"
+        motionMode="idle"
+        position={position}
+      />,
+    );
+
+    const card = screen.getByRole("button", {
+      name: /editing start time/,
+    });
+    expect(card).toHaveAttribute("data-edge-focus", "startDate");
+    expect(card.style.boxShadow).toContain("0 -3px 0 0 #616161");
+    expect(card.className).toContain("focus-visible:outline-none");
+    expect(card.className).not.toContain("ring-accent");
+    expect(card.className).not.toContain("bg-accent");
+  });
+
+  it("keeps a short timed title readable while an edge is focused", () => {
+    const event = createEvent({
+      startDate: "2099-01-15T09:00:00.000Z",
+      endDate: "2099-01-15T09:15:00.000Z",
+      title: "Do drops",
+    });
+    useEdgeFocusStore.setState({
+      eventId: event._id!,
+      edge: "startDate",
+      announcement: "Editing start time",
+    });
+
+    render(
+      <TimedEventCard
+        displayMode="saved"
+        event={event}
+        focusColor="#9e9e9e"
+        motionMode="idle"
+        position={{ ...position, height: COMPACT_EVENT_MAX_HEIGHT }}
+      />,
+    );
+
+    expect(screen.getByText("Do drops")).toBeInTheDocument();
+    const card = screen.getByRole("button", { name: /Do drops/ });
+    expect(card).toHaveAttribute("data-edge-focus", "startDate");
+    // Outside shadow, not an inset accent bar covering the title.
+    expect(card.style.boxShadow).toContain("0 -3px 0 0 #9e9e9e");
+    expect(card.querySelector("[data-edge-focus]")).toBeNull();
+  });
+
+  it("paints all-day edge focus with the calendar color on the left/right", () => {
+    const event = createEvent({
+      isAllDay: true,
+      title: "Conference",
+    });
+    useEdgeFocusStore.setState({
+      eventId: event._id!,
+      edge: "endDate",
+      announcement: "Editing end time",
+    });
+
+    render(
+      <AllDayEventCard
+        event={event}
+        focusColor="#3b82f6"
+        isPlaceholder={false}
+        position={position}
+      />,
+    );
+
+    const card = screen.getByRole("button", {
+      name: /editing end date/,
+    });
+    expect(card).toHaveAttribute("data-edge-focus", "endDate");
+    expect(card.style.boxShadow).toContain("3px 0 0 0 #3b82f6");
+    expect(card.className).not.toContain("ring-accent");
   });
 });

--- a/packages/web/src/grid/components/TimedEventCard.tsx
+++ b/packages/web/src/grid/components/TimedEventCard.tsx
@@ -22,6 +22,7 @@ import {
   calendarAccentStyle,
   eventEdgeFocusShadow,
   eventFocusColor,
+  eventFocusOutlineClass,
 } from "@web/grid/components/calendar-accent.util";
 import {
   COMPACT_EVENT_MAX_HEIGHT,
@@ -279,11 +280,7 @@ const TimedEventCardBase = (
         "absolute min-h-2.5 select-none overflow-hidden rounded-xs pr-0.75 pl-1.25 transition-[background-color,filter] duration-[260ms] ease-[cubic-bezier(0.16,1,0.3,1)]",
         "bg-(--event-bg) hover:bg-(--event-hover-bg)",
         "hover:cursor-pointer",
-        // Outside outline (not an accent ring) so short titles stay readable.
-        // Suppress while an edge is focused — only the outer edge line shows.
-        focusedEdge
-          ? "focus-visible:outline-none"
-          : "focus-visible:outline-(--event-focus-color) focus-visible:outline-2 focus-visible:outline-offset-2",
+        eventFocusOutlineClass(focusedEdge),
         event.isDemo &&
           "outline outline-dashed outline-1 outline-text-muted/50",
       )}

--- a/packages/web/src/grid/components/TimedEventCard.tsx
+++ b/packages/web/src/grid/components/TimedEventCard.tsx
@@ -20,6 +20,8 @@ import { getLineClamp } from "@web/common/utils/grid/grid.util";
 import {
   calendarAccentAccessibleSuffix,
   calendarAccentStyle,
+  eventEdgeFocusShadow,
+  eventFocusColor,
 } from "@web/grid/components/calendar-accent.util";
 import {
   COMPACT_EVENT_MAX_HEIGHT,
@@ -60,6 +62,8 @@ interface TimedEventCardProps {
   calendarIdentity?: CalendarCardIdentity | null;
   displayMode: "draft" | "placeholder" | "saved";
   event: GridEvent;
+  /** Calendar backgroundColor for focus chrome; null falls back to --text. */
+  focusColor?: string | null;
   interactionAttributes?: Record<string, string | undefined>;
   isSelected?: boolean;
   motionMode: "dragging" | "idle" | "resizing";
@@ -83,6 +87,7 @@ const TimedEventCardBase = (
     calendarIdentity = null,
     displayMode,
     event,
+    focusColor = null,
     interactionAttributes,
     isSelected = false,
     motionMode,
@@ -153,6 +158,13 @@ const TimedEventCardBase = (
   // with a background halo so the ring stays visible on dark default fills.
   const selectedBoxShadow =
     "0 0 0 1px var(--background), 0 0 0 3px color-mix(in srgb, var(--text) 70%, transparent)";
+  const focusedEdge = useEdgeFocusStore(selectEdgeForEvent(event._id));
+  const focusColorCss = eventFocusColor(focusColor);
+  // Edge focus paints outside the card (box-shadow) so short titles stay
+  // readable — an inset accent bar used to cover the top of compact events.
+  const edgeFocusShadow = focusedEdge
+    ? eventEdgeFocusShadow(focusedEdge, "vertical", focusColorCss)
+    : undefined;
 
   const bgColor = (() => {
     if (isDraft) return baseColor;
@@ -160,11 +172,10 @@ const TimedEventCardBase = (
     if (isInPast) return pastColor;
     return baseColor;
   })();
-  const eventBoxShadow = isSelected
-    ? boxShadow
-      ? `${selectedBoxShadow}, ${boxShadow}`
-      : selectedBoxShadow
-    : boxShadow;
+  const eventBoxShadow =
+    [isSelected ? selectedBoxShadow : null, boxShadow, edgeFocusShadow]
+      .filter(Boolean)
+      .join(", ") || undefined;
 
   // isInPast is excluded here (falls through to bgColor, i.e. pastColor) so
   // a past event stays dimmed on hover instead of snapping to full brightness.
@@ -180,6 +191,7 @@ const TimedEventCardBase = (
   const eventStyle = {
     "--event-bg": bgColor,
     "--event-hover-bg": hoverBgColor,
+    "--event-focus-color": focusColorCss,
     height: position.height || 0,
     left: position.left,
     opacity: isPlaceholder ? 0.5 : undefined,
@@ -191,7 +203,6 @@ const TimedEventCardBase = (
   } as CSSProperties;
 
   const isCompactEvent = position.height <= COMPACT_EVENT_MAX_HEIGHT;
-  const focusedEdge = useEdgeFocusStore(selectEdgeForEvent(event._id));
 
   const titleStyle: CSSProperties = {
     fontSize: isCompactEvent
@@ -260,13 +271,19 @@ const TimedEventCardBase = (
     <div
       {...interactionAttributes}
       aria-label={accessibleLabel}
+      data-edge-focus={focusedEdge ?? undefined}
       ref={ref}
       role="button"
       tabIndex={0}
       className={cn(
-        "absolute min-h-2.5 select-none overflow-hidden rounded-xs pr-0.75 pl-1.25 transition-[background-color,filter] duration-[260ms] ease-[cubic-bezier(0.16,1,0.3,1)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 focus-visible:ring-offset-background",
+        "absolute min-h-2.5 select-none overflow-hidden rounded-xs pr-0.75 pl-1.25 transition-[background-color,filter] duration-[260ms] ease-[cubic-bezier(0.16,1,0.3,1)]",
         "bg-(--event-bg) hover:bg-(--event-hover-bg)",
         "hover:cursor-pointer",
+        // Outside outline (not an accent ring) so short titles stay readable.
+        // Suppress while an edge is focused — only the outer edge line shows.
+        focusedEdge
+          ? "focus-visible:outline-none"
+          : "focus-visible:outline-(--event-focus-color) focus-visible:outline-2 focus-visible:outline-offset-2",
         event.isDemo &&
           "outline outline-dashed outline-1 outline-text-muted/50",
       )}
@@ -302,17 +319,6 @@ const TimedEventCardBase = (
           aria-hidden="true"
           className="absolute inset-y-0 left-0 w-[3px]"
           style={calendarAccentStyle(calendarIdentity)}
-        />
-      )}
-      {focusedEdge && (
-        <div
-          aria-hidden="true"
-          className={cn(
-            "absolute inset-x-0 h-[3px] rounded-full bg-accent",
-            focusedEdge === "startDate" ? "top-0" : "bottom-0",
-          )}
-          data-edge-focus={focusedEdge}
-          style={{ zIndex: ZIndex.LAYER_4 }}
         />
       )}
       <div

--- a/packages/web/src/grid/components/calendar-accent.util.test.ts
+++ b/packages/web/src/grid/components/calendar-accent.util.test.ts
@@ -1,6 +1,8 @@
 import {
   calendarAccentAccessibleSuffix,
   calendarAccentStyle,
+  eventEdgeFocusShadow,
+  eventFocusColor,
 } from "./calendar-accent.util";
 import { describe, expect, it } from "bun:test";
 
@@ -51,5 +53,36 @@ describe("calendarAccentAccessibleSuffix", () => {
         },
       }),
     ).toBe(", Work calendar, also on ahab@gmail.com");
+  });
+});
+
+describe("eventFocusColor", () => {
+  it("uses the calendar color when present", () => {
+    expect(eventFocusColor("#9e9e9e")).toBe("#9e9e9e");
+  });
+
+  it("falls back to --text when no calendar color is available", () => {
+    expect(eventFocusColor(null)).toBe("var(--text)");
+    expect(eventFocusColor(undefined)).toBe("var(--text)");
+  });
+});
+
+describe("eventEdgeFocusShadow", () => {
+  it("paints outside the timed card for start and end edges", () => {
+    expect(eventEdgeFocusShadow("startDate", "vertical", "#9e9e9e")).toBe(
+      "0 -3px 0 0 #9e9e9e",
+    );
+    expect(eventEdgeFocusShadow("endDate", "vertical", "#9e9e9e")).toBe(
+      "0 3px 0 0 #9e9e9e",
+    );
+  });
+
+  it("paints outside the all-day card for start and end edges", () => {
+    expect(eventEdgeFocusShadow("startDate", "horizontal", "#3b82f6")).toBe(
+      "-3px 0 0 0 #3b82f6",
+    );
+    expect(eventEdgeFocusShadow("endDate", "horizontal", "#3b82f6")).toBe(
+      "3px 0 0 0 #3b82f6",
+    );
   });
 });

--- a/packages/web/src/grid/components/calendar-accent.util.test.ts
+++ b/packages/web/src/grid/components/calendar-accent.util.test.ts
@@ -3,6 +3,7 @@ import {
   calendarAccentStyle,
   eventEdgeFocusShadow,
   eventFocusColor,
+  eventFocusOutlineClass,
 } from "./calendar-accent.util";
 import { describe, expect, it } from "bun:test";
 
@@ -57,13 +58,34 @@ describe("calendarAccentAccessibleSuffix", () => {
 });
 
 describe("eventFocusColor", () => {
-  it("uses the calendar color when present", () => {
-    expect(eventFocusColor("#9e9e9e")).toBe("#9e9e9e");
+  it("uses the calendar color when it contrasts with the page", () => {
+    expect(eventFocusColor("#616161")).toBe("#616161");
   });
 
   it("falls back to --text when no calendar color is available", () => {
     expect(eventFocusColor(null)).toBe("var(--text)");
     expect(eventFocusColor(undefined)).toBe("var(--text)");
+  });
+
+  it("falls back to --text for near-white or low-contrast calendar colors", () => {
+    // Local/anonymous calendar uses #ffffff — invisible on the light page.
+    expect(eventFocusColor("#ffffff")).toBe("var(--text)");
+    // Common Google gray fails 3:1 on light paper.
+    expect(eventFocusColor("#9e9e9e")).toBe("var(--text)");
+  });
+});
+
+describe("eventFocusOutlineClass", () => {
+  it("suppresses the whole-card outline while an edge is focused", () => {
+    expect(eventFocusOutlineClass("startDate")).toBe(
+      "focus-visible:outline-none",
+    );
+  });
+
+  it("uses the calendar focus color outline when no edge is focused", () => {
+    expect(eventFocusOutlineClass(null)).toBe(
+      "focus-visible:outline-(--event-focus-color) focus-visible:outline-2 focus-visible:outline-offset-2",
+    );
   });
 });
 

--- a/packages/web/src/grid/components/calendar-accent.util.ts
+++ b/packages/web/src/grid/components/calendar-accent.util.ts
@@ -1,4 +1,5 @@
 import { type CalendarCardIdentity } from "@web/calendars/useCalendarLookup";
+import { readability } from "@web/common/styles/color.utils";
 
 /**
  * The accent fill for a card's identity strip: this calendar's color, or a
@@ -34,12 +35,36 @@ export function calendarAccentAccessibleSuffix(
     : calendarSuffix;
 }
 
+// Light-theme page paper (`--background` under `.theme-light-beach`). Calendar
+// colors that fail 3:1 here (local #fff, pale pastels) vanish as outside focus
+// chrome on light mode.
+const LIGHT_PAGE_PAPER = "#f3eee2";
+const MIN_FOCUS_CONTRAST = 3;
+
 /**
- * CSS color for event focus chrome. Falls back to `--text` (same family as
- * the selected ring) so cards never introduce a third theme-accent color.
+ * CSS color for event focus chrome. Falls back to `--text` when no calendar
+ * color is available, or when that color is too light to read against the
+ * page (same family as the selected ring) so cards never introduce a third
+ * theme-accent color and never lose a visible focus indicator.
  */
 export function eventFocusColor(focusColor: string | null | undefined): string {
-  return focusColor ?? "var(--text)";
+  if (!focusColor) return "var(--text)";
+  if (readability(focusColor, LIGHT_PAGE_PAPER) < MIN_FOCUS_CONTRAST) {
+    return "var(--text)";
+  }
+  return focusColor;
+}
+
+/**
+ * Whole-card focus outline classes. Suppressed while an edge is focused so
+ * only the outer edge line shows (short titles stay readable).
+ */
+export function eventFocusOutlineClass(
+  focusedEdge: "startDate" | "endDate" | null,
+): string {
+  return focusedEdge
+    ? "focus-visible:outline-none"
+    : "focus-visible:outline-(--event-focus-color) focus-visible:outline-2 focus-visible:outline-offset-2";
 }
 
 /**

--- a/packages/web/src/grid/components/calendar-accent.util.ts
+++ b/packages/web/src/grid/components/calendar-accent.util.ts
@@ -33,3 +33,28 @@ export function calendarAccentAccessibleSuffix(
     ? `${calendarSuffix}, also on ${identity.otherAccount.accountEmail}`
     : calendarSuffix;
 }
+
+/**
+ * CSS color for event focus chrome. Falls back to `--text` (same family as
+ * the selected ring) so cards never introduce a third theme-accent color.
+ */
+export function eventFocusColor(focusColor: string | null | undefined): string {
+  return focusColor ?? "var(--text)";
+}
+
+/**
+ * Outer box-shadow line for start/end edge focus. Drawn outside the card so
+ * short-event titles stay readable (unlike an inset accent bar).
+ */
+export function eventEdgeFocusShadow(
+  edge: "startDate" | "endDate",
+  axis: "horizontal" | "vertical",
+  color: string,
+): string {
+  if (axis === "vertical") {
+    // Timed cards: start = top, end = bottom.
+    return edge === "startDate" ? `0 -3px 0 0 ${color}` : `0 3px 0 0 ${color}`;
+  }
+  // All-day cards: start = left, end = right.
+  return edge === "startDate" ? `-3px 0 0 0 ${color}` : `3px 0 0 0 ${color}`;
+}

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarEventCards.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarEventCards.tsx
@@ -25,6 +25,7 @@ interface DayEventCardProps {
   calendarIdentity?: CalendarCardIdentity | null;
   columnIndex: number;
   event: GridEvent;
+  focusColor?: string | null;
   isActiveDraft: boolean;
   isPlaceholder: boolean;
   isReadOnly: boolean;
@@ -41,6 +42,7 @@ export const DayAllDayCalendarEvent = ({
   calendarIdentity = null,
   columnIndex,
   event,
+  focusColor = null,
   isActiveDraft,
   isPlaceholder,
   isReadOnly,
@@ -91,6 +93,7 @@ export const DayAllDayCalendarEvent = ({
     <AllDayEventCard
       calendarIdentity={calendarIdentity}
       event={event}
+      focusColor={focusColor}
       interactionAttributes={interactionAttributes}
       isPlaceholder={isPlaceholder}
       onEventKeyDown={onOpenEvent}
@@ -111,6 +114,7 @@ export const DayTimedCalendarEvent = ({
   columnIndex,
   deckLayout,
   event,
+  focusColor = null,
   isActiveDraft,
   isPlaceholder,
   isReadOnly,
@@ -178,6 +182,7 @@ export const DayTimedCalendarEvent = ({
       calendarIdentity={calendarIdentity}
       displayMode={isPlaceholder ? "placeholder" : "saved"}
       event={event}
+      focusColor={focusColor}
       interactionAttributes={interactionAttributes}
       isSelected={isActiveDraft}
       motionMode="idle"

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarEventLayers.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarEventLayers.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import {
   isGridEventInteractionReadOnly,
   resolveCalendarCardIdentity,
+  resolveCalendarFocusColor,
   useCalendarLookup,
 } from "@web/calendars/useCalendarLookup";
 import {
@@ -73,6 +74,7 @@ export const DayCalendarAllDayEventsLayer = ({
           calendarIdentity={resolveCalendarCardIdentity(calendarLookup, event)}
           columnIndex={getCalendarColumnIndex(event)}
           event={event}
+          focusColor={resolveCalendarFocusColor(calendarLookup, event)}
           isActiveDraft={isActiveDraftEvent(event, draft, savedEventIds)}
           isPlaceholder={isDraftOnlyEvent(event, draft, savedEventIds)}
           isReadOnly={isGridEventInteractionReadOnly(calendarLookup, event)}
@@ -130,6 +132,7 @@ export const DayCalendarTimedEventsLayer = ({
           columnIndex={getCalendarColumnIndex(event)}
           deckLayout={deckLayout}
           event={event}
+          focusColor={resolveCalendarFocusColor(calendarLookup, event)}
           isActiveDraft={isActiveDraftEvent(event, draft, savedEventIds)}
           isPlaceholder={isDraftOnlyEvent(event, draft, savedEventIds)}
           isReadOnly={isGridEventInteractionReadOnly(calendarLookup, event)}

--- a/packages/web/src/views/Week/components/Draft/grid/GridDraft.tsx
+++ b/packages/web/src/views/Week/components/Draft/grid/GridDraft.tsx
@@ -1,8 +1,4 @@
 import { type FC, type MouseEvent } from "react";
-import {
-  resolveCalendarFocusColor,
-  useCalendarLookup,
-} from "@web/calendars/useCalendarLookup";
 import { type PartialMouseEvent } from "@web/common/types/util.types";
 import { type GridEvent as GridEventEntity } from "@web/common/types/web.event.types";
 import {
@@ -101,17 +97,12 @@ export const GridDraft: FC<Props> = ({
     handleGridDraftClick,
     isMultiDayTimedDraft ? () => {} : handleDrag,
   );
-  const calendarLookup = useCalendarLookup();
 
   if (!draft || !draftAsGridEvent) return null;
 
   const allDayDraftEvent = rendersInAllDayRow
     ? (activeAllDayDraftEvent ?? draftToAllDayRowGridEvent(draft))
     : draftAsGridEvent;
-  const draftFocusColor = resolveCalendarFocusColor(
-    calendarLookup,
-    allDayDraftEvent,
-  );
 
   const draftEventType = rendersInAllDayRow ? "all-day" : "timed";
   // `data-grid-event-surface` lets post-close focus restore skip this portal
@@ -135,7 +126,6 @@ export const GridDraft: FC<Props> = ({
         <GridEvent
           displayMode="draft"
           event={preview}
-          focusColor={resolveCalendarFocusColor(calendarLookup, preview)}
           interactionAttributes={
             preview._id
               ? getWeekInteractionTargetAttributes({
@@ -153,7 +143,6 @@ export const GridDraft: FC<Props> = ({
       {rendersInAllDayRow ? (
         <AllDayEventMemo
           event={allDayDraftEvent}
-          focusColor={draftFocusColor}
           interactionAttributes={draftInteractionAttributes}
           isPlaceholder={false}
           key={`draft-${draftAsGridEvent._id}`}
@@ -177,7 +166,6 @@ export const GridDraft: FC<Props> = ({
           deckLayout={deckLayout}
           displayMode="draft"
           event={draftAsGridEvent}
-          focusColor={draftFocusColor}
           interactionAttributes={draftInteractionAttributes}
           key={`draft-${draftAsGridEvent._id}`}
           measurements={measurements}

--- a/packages/web/src/views/Week/components/Draft/grid/GridDraft.tsx
+++ b/packages/web/src/views/Week/components/Draft/grid/GridDraft.tsx
@@ -1,4 +1,8 @@
 import { type FC, type MouseEvent } from "react";
+import {
+  resolveCalendarFocusColor,
+  useCalendarLookup,
+} from "@web/calendars/useCalendarLookup";
 import { type PartialMouseEvent } from "@web/common/types/util.types";
 import { type GridEvent as GridEventEntity } from "@web/common/types/web.event.types";
 import {
@@ -97,12 +101,17 @@ export const GridDraft: FC<Props> = ({
     handleGridDraftClick,
     isMultiDayTimedDraft ? () => {} : handleDrag,
   );
+  const calendarLookup = useCalendarLookup();
 
   if (!draft || !draftAsGridEvent) return null;
 
   const allDayDraftEvent = rendersInAllDayRow
     ? (activeAllDayDraftEvent ?? draftToAllDayRowGridEvent(draft))
     : draftAsGridEvent;
+  const draftFocusColor = resolveCalendarFocusColor(
+    calendarLookup,
+    allDayDraftEvent,
+  );
 
   const draftEventType = rendersInAllDayRow ? "all-day" : "timed";
   // `data-grid-event-surface` lets post-close focus restore skip this portal
@@ -126,6 +135,7 @@ export const GridDraft: FC<Props> = ({
         <GridEvent
           displayMode="draft"
           event={preview}
+          focusColor={resolveCalendarFocusColor(calendarLookup, preview)}
           interactionAttributes={
             preview._id
               ? getWeekInteractionTargetAttributes({
@@ -143,6 +153,7 @@ export const GridDraft: FC<Props> = ({
       {rendersInAllDayRow ? (
         <AllDayEventMemo
           event={allDayDraftEvent}
+          focusColor={draftFocusColor}
           interactionAttributes={draftInteractionAttributes}
           isPlaceholder={false}
           key={`draft-${draftAsGridEvent._id}`}
@@ -166,6 +177,7 @@ export const GridDraft: FC<Props> = ({
           deckLayout={deckLayout}
           displayMode="draft"
           event={draftAsGridEvent}
+          focusColor={draftFocusColor}
           interactionAttributes={draftInteractionAttributes}
           key={`draft-${draftAsGridEvent._id}`}
           measurements={measurements}

--- a/packages/web/src/views/Week/components/Event/Grid/GridEvent/GridEvent.tsx
+++ b/packages/web/src/views/Week/components/Event/Grid/GridEvent/GridEvent.tsx
@@ -25,6 +25,7 @@ interface Props {
   deckLayout?: TimedDeckLayout | null;
   displayMode: GridEventDisplayMode;
   event: GridEventEntity;
+  focusColor?: string | null;
   interactionAttributes?: Record<string, string | undefined>;
   measurements: Measurements_Grid;
   motionMode?: GridEventMotionMode;
@@ -47,6 +48,7 @@ const GridEventBase = (
     deckLayout = null,
     displayMode,
     event: _event,
+    focusColor = null,
     interactionAttributes,
     measurements,
     motionMode = "idle",
@@ -135,6 +137,7 @@ const GridEventBase = (
       calendarIdentity={calendarIdentity}
       displayMode={displayMode}
       event={event}
+      focusColor={focusColor}
       onFocus={isDeck ? () => setIsFocused(true) : undefined}
       interactionAttributes={interactionAttributes}
       motionMode={motionMode}
@@ -154,6 +157,7 @@ export const GridEventMemo = memo(GridEvent, (prev, next) => {
     prev.displayMode === next.displayMode &&
     prev.deckLayout === next.deckLayout &&
     prev.event === next.event &&
+    prev.focusColor === next.focusColor &&
     prev.interactionAttributes === next.interactionAttributes &&
     prev.measurements === next.measurements &&
     prev.motionMode === next.motionMode &&

--- a/packages/web/src/views/Week/components/Grid/AllDayRow/AllDayEvent.tsx
+++ b/packages/web/src/views/Week/components/Grid/AllDayRow/AllDayEvent.tsx
@@ -10,6 +10,7 @@ import { type WeekProps } from "@web/views/Week/hooks/useWeek";
 interface Props {
   calendarIdentity?: CalendarCardIdentity | null;
   event: GridEvent;
+  focusColor?: string | null;
   interactionAttributes?: Record<string, string | undefined>;
   isPlaceholder: boolean;
   measurements: Measurements_Grid;
@@ -27,6 +28,7 @@ const AllDayEventBase = (
   {
     calendarIdentity = null,
     event,
+    focusColor = null,
     interactionAttributes,
     isPlaceholder,
     measurements,
@@ -62,6 +64,7 @@ const AllDayEventBase = (
     <AllDayEventCard
       calendarIdentity={calendarIdentity}
       event={event}
+      focusColor={focusColor}
       interactionAttributes={interactionAttributes}
       isPlaceholder={isPlaceholder}
       onEventKeyDown={onKeyDown}
@@ -79,6 +82,7 @@ export const AllDayEventMemo = memo(AllDayEvent, (prev, next) => {
   return (
     prev.calendarIdentity === next.calendarIdentity &&
     prev.event === next.event &&
+    prev.focusColor === next.focusColor &&
     prev.interactionAttributes === next.interactionAttributes &&
     prev.isPlaceholder === next.isPlaceholder &&
     prev.measurements === next.measurements &&

--- a/packages/web/src/views/Week/components/Grid/AllDayRow/AllDayEvents.tsx
+++ b/packages/web/src/views/Week/components/Grid/AllDayRow/AllDayEvents.tsx
@@ -3,6 +3,7 @@ import {
   type CalendarCardIdentity,
   isGridEventInteractionReadOnly,
   resolveCalendarCardIdentity,
+  resolveCalendarFocusColor,
   useCalendarLookup,
 } from "@web/calendars/useCalendarLookup";
 import { ID_GRID_EVENTS_ALLDAY } from "@web/common/constants/web.constants";
@@ -71,6 +72,7 @@ export const AllDayEvents = ({
       visibleAllDayEvents.map((event) => ({
         event,
         calendarIdentity: resolveCalendarCardIdentity(calendarLookup, event),
+        focusColor: resolveCalendarFocusColor(calendarLookup, event),
         // Read-only (unwritable calendar or busy content) events never
         // attach interaction attributes/registration below, so the drag/
         // resize engine can't find them as a target - blocked before any
@@ -90,7 +92,7 @@ export const AllDayEvents = ({
     >
       {!isLoadingWeekView &&
         visibleAllDayEventsWithIdentity.map(
-          ({ event, calendarIdentity, isReadOnly }) => {
+          ({ event, calendarIdentity, focusColor, isReadOnly }) => {
             const isPlaceholder = event._id === draftId;
             // Never overlay timed draft dates onto a multi-day timed display
             // bar — that would replace YYYY-MM-DD span dates with datetimes.
@@ -103,11 +105,15 @@ export const AllDayEvents = ({
             const identityForDisplay = isPlaceholder
               ? resolveCalendarCardIdentity(calendarLookup, eventForDisplay)
               : calendarIdentity;
+            const focusColorForDisplay = isPlaceholder
+              ? resolveCalendarFocusColor(calendarLookup, eventForDisplay)
+              : focusColor;
 
             return (
               <AllDayEventItem
                 calendarIdentity={identityForDisplay}
                 event={eventForDisplay}
+                focusColor={focusColorForDisplay}
                 isPlaceholder={isPlaceholder}
                 isReadOnly={isReadOnly}
                 key={event._id}
@@ -126,6 +132,7 @@ export const AllDayEvents = ({
 interface AllDayEventItemProps {
   calendarIdentity: CalendarCardIdentity | null;
   event: GridEvent;
+  focusColor: string | null;
   isPlaceholder: boolean;
   isReadOnly: boolean;
   measurements: Measurements_Grid;
@@ -137,6 +144,7 @@ interface AllDayEventItemProps {
 const AllDayEventItem = ({
   calendarIdentity,
   event,
+  focusColor,
   isPlaceholder,
   isReadOnly,
   measurements,
@@ -180,6 +188,7 @@ const AllDayEventItem = ({
     <AllDayEventMemo
       calendarIdentity={calendarIdentity}
       event={event}
+      focusColor={focusColor}
       interactionAttributes={interactionAttributes}
       isPlaceholder={isPlaceholder}
       measurements={measurements}

--- a/packages/web/src/views/Week/components/Grid/MainGrid/MainGridEvents.tsx
+++ b/packages/web/src/views/Week/components/Grid/MainGrid/MainGridEvents.tsx
@@ -3,6 +3,7 @@ import {
   type CalendarCardIdentity,
   isGridEventInteractionReadOnly,
   resolveCalendarCardIdentity,
+  resolveCalendarFocusColor,
   useCalendarLookup,
 } from "@web/calendars/useCalendarLookup";
 import { ID_GRID_EVENTS_TIMED } from "@web/common/constants/web.constants";
@@ -95,6 +96,7 @@ export const MainGridEvents = ({ measurements, weekProps }: Props) => {
           calendarLookup,
           item.event,
         ),
+        focusColor: resolveCalendarFocusColor(calendarLookup, item.event),
         // Read-only (unwritable calendar or busy content) events never
         // attach interaction attributes/registration below, so the drag/
         // resize engine can't find them as a target - blocked before any
@@ -111,7 +113,7 @@ export const MainGridEvents = ({ measurements, weekProps }: Props) => {
     <div id={ID_GRID_EVENTS_TIMED}>
       {!isLoadingWeekView &&
         timedEventItemsWithIdentity.map(
-          ({ deckLayout, event, calendarIdentity, isReadOnly }) => {
+          ({ deckLayout, event, calendarIdentity, focusColor, isReadOnly }) => {
             const isPlaceholder = event._id === draftId;
             const eventForDisplay = mergeGridEventWithDraftOverlay(
               event,
@@ -123,12 +125,16 @@ export const MainGridEvents = ({ measurements, weekProps }: Props) => {
             const identityForDisplay = isPlaceholder
               ? resolveCalendarCardIdentity(calendarLookup, eventForDisplay)
               : calendarIdentity;
+            const focusColorForDisplay = isPlaceholder
+              ? resolveCalendarFocusColor(calendarLookup, eventForDisplay)
+              : focusColor;
 
             return (
               <MainGridEventItem
                 calendarIdentity={identityForDisplay}
                 deckLayout={deckLayout}
                 event={eventForDisplay}
+                focusColor={focusColorForDisplay}
                 isPlaceholder={isPlaceholder}
                 isReadOnly={isReadOnly}
                 key={`initial-${event._id}`}
@@ -148,6 +154,7 @@ interface MainGridEventItemProps {
   calendarIdentity: CalendarCardIdentity | null;
   deckLayout: TimedDeckLayout | null;
   event: GridEvent;
+  focusColor: string | null;
   isPlaceholder: boolean;
   isReadOnly: boolean;
   measurements: Measurements_Grid;
@@ -160,6 +167,7 @@ const MainGridEventItem = ({
   calendarIdentity,
   deckLayout,
   event,
+  focusColor,
   isPlaceholder,
   isReadOnly,
   measurements,
@@ -205,6 +213,7 @@ const MainGridEventItem = ({
       deckLayout={deckLayout}
       displayMode={isPlaceholder ? "placeholder" : "saved"}
       event={event}
+      focusColor={focusColor}
       interactionAttributes={interactionAttributes}
       measurements={measurements}
       onEventKeyDown={isReadOnly ? onOpenReadOnlyDetails : onEventKeyDown}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Event keyboard focus and start/end edge focus no longer use theme `--accent`. They use the owning calendar’s `backgroundColor` (when it has ≥3:1 contrast against the light page), drawn outside the card so short titles stay readable. Each event stays at two colors: fill + calendar (or `--text` when calendar color would vanish).

## Simplicity

- Shared `eventFocusColor` / `eventFocusOutlineClass` / `eventEdgeFocusShadow` helpers so Timed and AllDay cards stay in sync
- Removed a QueryClient-coupled lookup from `GridDraft`; drafts keep the `--text` focus fallback without new provider requirements
- Contrast fallback for light calendar colors (local `#fff`, pale Google grays) instead of speculative theme-branching

## Automated validation

- Browser at http://localhost:9080 (anonymous): created “Focus check”, focused card, Tab-cycled whole → start → end
  - Whole focus: calendar/`--text` outline, not accent blue; title readable
  - Edge focus: outside 3px shadow; sidebar announced start/end; title readable
  - Console: expected `/api/config` refused with no backend; no UI errors
- Focused web tests: EventCard, calendar-accent util, calendarCardIdentity, GridDraft — 45 pass
- `bun run lint` — no new errors (pre-existing warnings only)

## Independent review

Fresh read-only review found one confirmed High: local `#ffffff` calendar focus invisible on light theme. Fixed by falling back to `--text` when calendar color fails 3:1 against light page paper. No other confirmed findings.

## Test plan

- `bun test:web` on EventCard, calendar-accent.util, calendarCardIdentity, GridDraft
- `bun run lint`
- Manual keyboard focus + Tab edge cycle on localhost:9080
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bc287eae-0e40-424a-a7d3-b36680348374?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bc287eae-0e40-424a-a7d3-b36680348374&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

