### PR TITLE
fix(backend,sync): launch hardening for durable errors and writes

### DIFF
--- a/docs/backend/backend-error-handling.md
+++ b/docs/backend/backend-error-handling.md
@@ -5,11 +5,20 @@ Compass uses typed operational errors plus a centralized Express error handler.
 ## Principles
 
 - Minimize the number of `try/catch` blocks in the code.
+- Never return non-HTTP statuses such as `Status.UNSURE` (600) on live paths.
+- Event mutation routes use the `EventMutationError` envelope
+  (`code` / `message` / `retryable`). Unknown/programmer errors are
+  **non-retryable 500** — only true Sync/provider failures stay retryable
+  `PROVIDER_FAILURE`.
+- Sync proxy failures on calendar/auth reads use `throwSyncProxyFailure` /
+  `unwrapSyncResult` (503/502), never `GenericError.NotSure`.
 
 ## Source Files
 
 - `packages/backend/src/common/errors/handlers/error.handler.ts`
 - `packages/backend/src/common/errors/handlers/error.express.handler.ts`
+- `packages/backend/src/common/services/sync-service/sync-proxy-error.ts`
+- `packages/backend/src/event/event.error.ts`
 - feature error metadata files under `packages/backend/src/common/errors/**`
 - `packages/core/src/errors/errors.base.ts`
 
@@ -20,7 +29,12 @@ Preferred backend pattern:
 1. define reusable error metadata in the relevant feature file
 2. create a `BaseError` through `error(...)`
 3. let controller/service code throw that error
-4. let centralized Express handling turn it into the client payload
+4. let centralized Express handling (`res.promise` → `handleExpressError`) turn it into the client payload
+
+Event mutation controllers may catch locally and call `toEventMutationError`
+so the strict `{ code, message, retryable }` envelope is preserved. User
+controllers return JSON via `toClientErrorPayload` (or `{ code, message }` for
+unexpected errors) rather than empty bodies.
 
 Example:
 
@@ -28,7 +42,7 @@ Example:
 import { AuthError } from "@backend/common/errors/auth/auth.errors";
 import { error } from "@backend/common/errors/handlers/error.handler";
 
-throw error(AuthError.MissingRefreshToken, "Google connection required");
+throw error(AuthError.SyncConnectionUnavailable, "Could not reach sync");
 ```
 
 ## Client Payload Rules
@@ -39,13 +53,15 @@ For `BaseError`, backend responses are intentionally small:
 - `message`: safe user-facing description
 - `code`: optional stable machine-readable identifier for frontend branching
 
+Event mutations use `{ code, message, retryable }` instead.
+
 Internal details such as stack traces and operational flags stay server-side.
 
 ## Unexpected Error Rules
 
-- non-`BaseError` values are routed through `handleExpressError(...)`
-- Google API errors get special handling for revoked tokens, invalid values, and full-sync recovery
-- programmer errors can terminate the process after logging
+- non-`BaseError` values are routed through `handleExpressError(...)` when using `res.promise`
+- Sync client failures map to 502/503 (or typed mutation codes) — never HTTP 600
+- programmer errors can terminate the process after logging when `isOperational` is false
 
 ## Guidance
 

--- a/docs/development/performance-baselines.md
+++ b/docs/development/performance-baselines.md
@@ -9,20 +9,20 @@ performance now, with its own test suite.
 
 ## Native parallel test suite timings (Bun 1.3.14)
 
-Recorded on 2026-07-22 after removing the Jest compat shim and switching to
-`bun test --parallel` with package preloads (`test-mongo-env.ts` for
-mongo-backed packages). **Web is an exception:** `test:web` runs sequentially
-in one process (MSW/jsdom + `--isolate` constraint — see
-`docs/development/testing-playbook.md#web-native-parallel-future--blocked`).
-Local macOS, mongodb-memory-server.
+Recorded on 2026-08-12 on the cloud agent VM after launch-hardening work
+(stale create retry, provider-write ladder extract, USER collection cleanup,
+SSE `waitForNoEvent`). Use `bun test:sync:fast` / `bun test:backend:fast` for
+Mongo-free iteration; full suites remain the durability gate.
 
 | Script | Tests | Time |
 | --- | --- | --- |
-| `bun run test:core` | 496 / 496 | ~0.5s |
-| `bun run test:web` | 1319 / 1319 | ~14–17s (sequential, one process) |
-| `bun run test:backend:fast` | 353 / 353 | ~3s |
-| `bun run test:sync` | 505 / 505 | ~31s |
-| `bun run test:scripts` | 40 / 40 | ~2s |
+| `bun run test:core` | (see package) | ~0.5s |
+| `bun run test:web` | (sequential; see testing-playbook) | ~14–17s |
+| `bun run test:backend:fast` | 248 / 248 | ~1.6s |
+| `bun run test:backend` | 303 / 304 (1 skip) | ~3.4s |
+| `bun run test:sync:fast` | 321 / 321 | ~0.6s |
+| `bun run test:sync` | 893 / 893 | ~13–14s |
+| `bun run test:scripts` | (see package) | ~2s |
 
 ## Regression rule
 

--- a/e2e/onboarding/first-run.spec.ts
+++ b/e2e/onboarding/first-run.spec.ts
@@ -8,7 +8,9 @@ import {
 
 // Most E2E coverage skips onboarding to keep the calendar tests focused. This
 // spec deliberately starts with empty browser storage so a new user's path is
-// exercised end to end.
+// exercised end to end. Shortcut Showcase itself is covered in
+// shortcut-showcase.spec.ts — here we skip it so sample events and create
+// persistence remain the focus.
 test.use({ storageState: { cookies: [], origins: [] } });
 test.use({ viewport: { width: 1600, height: 900 } });
 
@@ -23,6 +25,13 @@ test("welcomes a first-time user and seeds sample events", async ({ page }) => {
   await welcomeDialog.getByRole("button", { name: "Start Now" }).click();
   await expect(welcomeDialog).toBeHidden();
 
+  const showcase = page.getByRole("region", { name: "Shortcut practice" });
+  await expect(showcase).toContainText("Create with the keyboard");
+  await page.keyboard.press("Escape");
+  await expect(showcase).toContainText("Skip the shortcuts?");
+  await showcase.getByRole("button", { name: "Skip anyway" }).click();
+  await expect(showcase).toHaveCount(0);
+
   await expect(
     page.getByText(/Sample events to help you explore/i),
   ).toBeVisible();
@@ -36,5 +45,8 @@ test("welcomes a first-time user and seeds sample events", async ({ page }) => {
 
   await page.reload({ waitUntil: "domcontentloaded" });
   await expect(welcomeDialog).toBeHidden();
+  await expect(
+    page.getByRole("region", { name: "Shortcut practice" }),
+  ).toHaveCount(0);
   await expectTimedEventVisible(page, title);
 });

--- a/packages/backend/src/__tests__/drivers/base.driver.ts
+++ b/packages/backend/src/__tests__/drivers/base.driver.ts
@@ -79,6 +79,12 @@ export class BaseDriver {
   openSSEStream(user?: { userId: string; sessionId?: string }): {
     close: () => void;
     waitForEvent: (eventName: string, timeoutMs?: number) => Promise<unknown>;
+    /**
+     * Resolves once a short event-loop settle passes with no matching event.
+     * Prefer this over a fixed multi-hundred-ms timeout when asserting that a
+     * publish did not fan out to this stream.
+     */
+    waitForNoEvent: (eventName: string, settleMs?: number) => Promise<void>;
   } {
     if (!this.serverUri) throw new Error("did you forget to call `listen`?");
 
@@ -183,6 +189,32 @@ export class BaseDriver {
             clearTimeout(timer);
             resolve(data);
           });
+          eventListeners.set(eventName, listeners);
+        }),
+      waitForNoEvent: (eventName: string, settleMs = 40) =>
+        new Promise((resolve, reject) => {
+          if ((pendingEvents.get(eventName)?.length ?? 0) > 0) {
+            reject(
+              new Error(`Unexpected SSE event already queued: ${eventName}`),
+            );
+            return;
+          }
+
+          const timer = setTimeout(() => {
+            const listeners = eventListeners.get(eventName) ?? [];
+            eventListeners.set(
+              eventName,
+              listeners.filter((cb) => cb !== onEvent),
+            );
+            resolve();
+          }, settleMs);
+
+          const onEvent = () => {
+            clearTimeout(timer);
+            reject(new Error(`Unexpected SSE event: ${eventName}`));
+          };
+          const listeners = eventListeners.get(eventName) ?? [];
+          listeners.push(onEvent);
           eventListeners.set(eventName, listeners);
         }),
     };

--- a/packages/backend/src/__tests__/helpers/mock.db.setup.ts
+++ b/packages/backend/src/__tests__/helpers/mock.db.setup.ts
@@ -1,5 +1,4 @@
 import { enterTestFileUrl } from "@backend/__tests__/helpers/test-file-context";
-import { Collections } from "@backend/common/constants/collections";
 import mongoService from "@backend/common/services/mongo.service";
 import { createHash } from "node:crypto";
 
@@ -37,15 +36,7 @@ export async function setupTestDb(testFileUrl: string): Promise<void> {
 export async function cleanupCollections(): Promise<void> {
   const collections = await mongoService.db.collections();
 
-  const SKIP_COLLECTIONS = [Collections.USER];
-
-  const selectedCollections = collections.filter(
-    (collection) => !SKIP_COLLECTIONS.includes(collection.collectionName),
-  );
-
-  await Promise.all(
-    selectedCollections.map((collection) => collection.deleteMany({})),
-  );
+  await Promise.all(collections.map((collection) => collection.deleteMany({})));
 }
 
 export async function cleanupTestDb(): Promise<void> {

--- a/packages/backend/src/auth/middleware/auth.middleware.test.ts
+++ b/packages/backend/src/auth/middleware/auth.middleware.test.ts
@@ -1,0 +1,46 @@
+import { type NextFunction, type Request, type Response } from "express";
+import { NodeEnv } from "@core/constants/core.constants";
+import { Status } from "@core/errors/status.codes";
+import authMiddleware from "@backend/auth/middleware/auth.middleware";
+import { CONFIG } from "@backend/common/constants/config.constants";
+import { afterEach, describe, expect, it, mock } from "bun:test";
+
+describe("auth.middleware verifyIsDev", () => {
+  const originalNodeEnv = CONFIG.NODE_ENV;
+
+  afterEach(() => {
+    CONFIG.NODE_ENV = originalNodeEnv;
+  });
+
+  const mockRes = () => {
+    const json = mock();
+    const res = {
+      status: mock().mockReturnThis(),
+      json,
+    } as unknown as Response;
+    return { res, json };
+  };
+
+  it("returns 403 and does not call next in production", () => {
+    CONFIG.NODE_ENV = NodeEnv.Production;
+    const { res, json } = mockRes();
+    const next = mock() as NextFunction;
+
+    authMiddleware.verifyIsDev({} as Request, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(Status.FORBIDDEN);
+    expect(json).toHaveBeenCalled();
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("calls next in development", () => {
+    CONFIG.NODE_ENV = NodeEnv.Development;
+    const { res } = mockRes();
+    const next = mock() as NextFunction;
+
+    authMiddleware.verifyIsDev({} as Request, res, next);
+
+    expect(res.status).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/backend/src/auth/middleware/auth.middleware.ts
+++ b/packages/backend/src/auth/middleware/auth.middleware.ts
@@ -1,15 +1,19 @@
 import { type NextFunction, type Request, type Response } from "express";
 import { Status } from "@core/errors/status.codes";
-import { IS_DEV } from "@backend/common/constants/config.constants";
+import { isDev } from "@core/util/env.util";
+import { CONFIG } from "@backend/common/constants/config.constants";
 import { AuthError } from "@backend/common/errors/auth/auth.errors";
 import { error } from "@backend/common/errors/handlers/error.handler";
 
 class AuthMiddleware {
   verifyIsDev = (_req: Request, res: Response, next: NextFunction) => {
-    if (!IS_DEV) {
+    // Read NODE_ENV from CONFIG each call so production never falls through
+    // to next() after a 403 (and so tests can flip CONFIG.NODE_ENV).
+    if (!isDev(CONFIG.NODE_ENV)) {
       res
         .status(Status.FORBIDDEN)
         .json({ error: error(AuthError.DevOnly, "Request Failed") });
+      return;
     }
     next();
   };

--- a/packages/backend/src/auth/services/google/google.auth.service.ts
+++ b/packages/backend/src/auth/services/google/google.auth.service.ts
@@ -122,25 +122,27 @@ async function googleSignup(
 ) {
   const session = await mongoService.startSession();
 
-  const user = await session.withTransaction(async (transactionSession) => {
-    const cUser = await userService.upsertUserFromAuth(
-      {
-        userId,
-        email: gUser.email ?? "",
-        name: gUser.name || undefined,
-        locale: gUser.locale || undefined,
-        google: {
-          googleId: gUser.sub ?? "",
-          picture: gUser.picture || "not provided",
+  try {
+    return await session.withTransaction(async (transactionSession) => {
+      const cUser = await userService.upsertUserFromAuth(
+        {
+          userId,
+          email: gUser.email ?? "",
+          name: gUser.name || undefined,
+          locale: gUser.locale || undefined,
+          google: {
+            googleId: gUser.sub ?? "",
+            picture: gUser.picture || "not provided",
+          },
         },
-      },
-      transactionSession,
-    );
+        transactionSession,
+      );
 
-    return { cUserId: cUser.user.userId, refreshToken };
-  });
-
-  return user;
+      return { cUserId: cUser.user.userId, refreshToken };
+    });
+  } finally {
+    await session.endSession();
+  }
 }
 
 async function repairGoogleConnection(

--- a/packages/backend/src/billing/services/billing.service.ts
+++ b/packages/backend/src/billing/services/billing.service.ts
@@ -39,21 +39,12 @@ class BillingService {
   /**
    * Starts a trial once per user; a second call is a no-op that just
    * returns the existing state, so retried/duplicate CTA clicks can never
-   * push the trial window out further.
+   * push the trial window out further. Uses a conditional update so two
+   * concurrent POSTs cannot both write a new trialStartedAt.
    */
   startTrial = async (userId: string): Promise<BillingStatusResponse> => {
-    const user = await mongoService.user.findOne({
-      _id: mongoService.objectId(userId),
-    });
-    if (!user) {
-      throw new Error("User not found");
-    }
-
+    const _id = mongoService.objectId(userId);
     const now = new Date();
-
-    if (user.billing?.trialStartedAt) {
-      return deriveBillingStatus(user.billing, now);
-    }
 
     const trialEndsAt = new Date(now);
     trialEndsAt.setDate(
@@ -66,12 +57,28 @@ class BillingService {
       trialEndsAt,
     };
 
-    await mongoService.user.updateOne(
-      { _id: mongoService.objectId(userId) },
+    const result = await mongoService.user.findOneAndUpdate(
+      {
+        _id,
+        $or: [
+          { "billing.trialStartedAt": { $exists: false } },
+          { "billing.trialStartedAt": null },
+        ],
+      },
       { $set: { billing } },
+      { returnDocument: "after" },
     );
 
-    return deriveBillingStatus(billing, now);
+    if (result) {
+      return deriveBillingStatus(result.billing, now);
+    }
+
+    const user = await mongoService.user.findOne({ _id });
+    if (!user) {
+      throw new Error("User not found");
+    }
+
+    return deriveBillingStatus(user.billing, now);
   };
 
   getStatus = async (userId: string): Promise<BillingStatusResponse> => {

--- a/packages/backend/src/calendar/controllers/calendar.controller.ts
+++ b/packages/backend/src/calendar/controllers/calendar.controller.ts
@@ -15,6 +15,7 @@ import { GenericError } from "@backend/common/errors/generic/generic.errors";
 import { error } from "@backend/common/errors/handlers/error.handler";
 import { syncCalendarsToBrowser } from "@backend/common/services/sync-service/calendar-list.translation";
 import { toSyncPrincipal } from "@backend/common/services/sync-service/sync-principal";
+import { throwSyncProxyFailure } from "@backend/common/services/sync-service/sync-proxy-error";
 import { getSyncServiceClient } from "@backend/common/services/sync-service/sync-service.factory";
 import { type Res_Promise } from "@backend/common/types/express.types";
 
@@ -76,14 +77,14 @@ const listCalendarsFromSync = async (
     client.listConnections(principal),
   ]);
   if (!calendarsResult.ok) {
-    throw error(
-      GenericError.NotSure,
+    throwSyncProxyFailure(
+      calendarsResult.error.kind,
       `Failed to list calendars from sync (${calendarsResult.error.kind})`,
     );
   }
   if (!connectionsResult.ok) {
-    throw error(
-      GenericError.NotSure,
+    throwSyncProxyFailure(
+      connectionsResult.error.kind,
       `Failed to list connections from sync (${connectionsResult.error.kind})`,
     );
   }
@@ -124,8 +125,8 @@ const getAvailabilityFromSync = async (
         purpose: "display",
       });
       if (!result.ok) {
-        throw error(
-          GenericError.NotSure,
+        throwSyncProxyFailure(
+          result.error.kind,
           `Failed to query availability from sync (${result.error.kind})`,
         );
       }

--- a/packages/backend/src/common/errors/generic/generic.errors.ts
+++ b/packages/backend/src/common/errors/generic/generic.errors.ts
@@ -22,17 +22,19 @@ export const GenericError: GenericErrors = {
   },
   NotImplemented: {
     description: "Not implemented yet",
-    status: Status.UNSURE,
+    status: Status.NOT_IMPLEMENTED,
     isOperational: true,
   },
+  // Prefer typed Sync/auth/event errors on live paths. Kept as a last-resort
+  // operational 500 — never Status.UNSURE (600), which is not a real HTTP status.
   NotSure: {
     description: "Not sure why error occurred. See logs",
-    status: Status.UNSURE,
+    status: Status.INTERNAL_SERVER,
     isOperational: true,
   },
   OperationTimeout: {
     description: "Operation timed out",
-    status: Status.UNSURE,
+    status: Status.GATEWAY_TIMEOUT,
     isOperational: true,
   },
 };

--- a/packages/backend/src/common/services/sync-service/sync-proxy-error.test.ts
+++ b/packages/backend/src/common/services/sync-service/sync-proxy-error.test.ts
@@ -1,0 +1,67 @@
+import { BaseError } from "@core/errors/errors.base";
+import { Status } from "@core/errors/status.codes";
+import {
+  throwSyncCommandSubmitFailure,
+  throwSyncProxyFailure,
+} from "@backend/common/services/sync-service/sync-proxy-error";
+import {
+  EventMutationException,
+  toEventMutationError,
+} from "@backend/event/event.error";
+import { describe, expect, it } from "bun:test";
+
+describe("toEventMutationError", () => {
+  it("keeps PROVIDER_FAILURE retryable for typed mutation failures", () => {
+    const mapped = toEventMutationError(
+      new EventMutationException("PROVIDER_FAILURE", "provider blip"),
+    );
+    expect(mapped.status).toBe(502);
+    expect(mapped.body.retryable).toBe(true);
+  });
+
+  it("maps unknown errors to non-retryable 500", () => {
+    const mapped = toEventMutationError(new Error("boom"));
+    expect(mapped.status).toBe(Status.INTERNAL_SERVER);
+    expect(mapped.body).toEqual({
+      code: "PROVIDER_FAILURE",
+      message: "boom",
+      retryable: false,
+    });
+  });
+});
+
+describe("sync-proxy-error", () => {
+  it("maps unavailable Sync reads to 503, never 600", () => {
+    try {
+      throwSyncProxyFailure("unavailable", "calendars down");
+      throw new Error("expected throw");
+    } catch (e) {
+      expect(e).toBeInstanceOf(BaseError);
+      expect((e as BaseError).statusCode).toBe(Status.SERVICE_UNAVAILABLE);
+      expect((e as BaseError).statusCode).not.toBe(Status.UNSURE);
+    }
+  });
+
+  it("maps unexpected Sync reads to 502, never 600", () => {
+    try {
+      throwSyncProxyFailure("unexpectedStatus", "weird status");
+      throw new Error("expected throw");
+    } catch (e) {
+      expect(e).toBeInstanceOf(BaseError);
+      expect((e as BaseError).statusCode).toBe(Status.BAD_GATEWAY);
+      expect((e as BaseError).statusCode).not.toBe(Status.UNSURE);
+    }
+  });
+
+  it("maps command submit timeout to retryable PROVIDER_FAILURE", () => {
+    try {
+      throwSyncCommandSubmitFailure("timeout", "timeout");
+      throw new Error("expected throw");
+    } catch (e) {
+      expect(e).toBeInstanceOf(EventMutationException);
+      const mapped = toEventMutationError(e);
+      expect(mapped.status).toBe(502);
+      expect(mapped.body.retryable).toBe(true);
+    }
+  });
+});

--- a/packages/backend/src/common/services/sync-service/sync-proxy-error.test.ts
+++ b/packages/backend/src/common/services/sync-service/sync-proxy-error.test.ts
@@ -55,7 +55,7 @@ describe("sync-proxy-error", () => {
 
   it("maps command submit timeout to retryable PROVIDER_FAILURE", () => {
     try {
-      throwSyncCommandSubmitFailure("timeout", "timeout");
+      throwSyncCommandSubmitFailure("timeout");
       throw new Error("expected throw");
     } catch (e) {
       expect(e).toBeInstanceOf(EventMutationException);

--- a/packages/backend/src/common/services/sync-service/sync-proxy-error.ts
+++ b/packages/backend/src/common/services/sync-service/sync-proxy-error.ts
@@ -1,0 +1,51 @@
+import { Status } from "@core/errors/status.codes";
+import { AuthError } from "@backend/common/errors/auth/auth.errors";
+import { error } from "@backend/common/errors/handlers/error.handler";
+import { type SyncClientErrorKind } from "@backend/common/services/sync-service/sync-service.client";
+import { eventMutationError } from "@backend/event/event.error";
+
+/**
+ * Map a failed Sync HTTP call on a read/proxy route into a real HTTP status.
+ * Never returns Status.UNSURE (600). Timeout/unavailable → 503; other Sync
+ * failures → 502. Clients get a retryable service error without Sync-internal
+ * details leaking beyond the kind already in `userMessage`.
+ */
+export function throwSyncProxyFailure(
+  kind: SyncClientErrorKind,
+  userMessage: string,
+): never {
+  if (kind === "timeout" || kind === "unavailable") {
+    throw error(AuthError.SyncConnectionUnavailable, userMessage);
+  }
+  throw error(
+    {
+      description: "Sync service returned an unexpected failure",
+      status: Status.BAD_GATEWAY,
+      isOperational: true,
+      code: "SYNC_PROXY_FAILURE",
+    },
+    userMessage,
+  );
+}
+
+/**
+ * Map a failed Sync command submit on an event mutation route. Timeout and
+ * unavailable stay PROVIDER_FAILURE (retryable 502) because Sync may already
+ * have applied the write. Other kinds are also PROVIDER_FAILURE so clients
+ * never see GenericError.NotSure / HTTP 600.
+ */
+export function throwSyncCommandSubmitFailure(
+  kind: SyncClientErrorKind,
+  detail: string,
+): never {
+  if (kind === "timeout" || kind === "unavailable") {
+    throw eventMutationError(
+      "PROVIDER_FAILURE",
+      `Sync command ${kind}; the mutation may already be applied`,
+    );
+  }
+  throw eventMutationError(
+    "PROVIDER_FAILURE",
+    `Failed to submit command to sync (${detail})`,
+  );
+}

--- a/packages/backend/src/common/services/sync-service/sync-proxy-error.ts
+++ b/packages/backend/src/common/services/sync-service/sync-proxy-error.ts
@@ -4,12 +4,8 @@ import { error } from "@backend/common/errors/handlers/error.handler";
 import { type SyncClientErrorKind } from "@backend/common/services/sync-service/sync-service.client";
 import { eventMutationError } from "@backend/event/event.error";
 
-/**
- * Map a failed Sync HTTP call on a read/proxy route into a real HTTP status.
- * Never returns Status.UNSURE (600). Timeout/unavailable → 503; other Sync
- * failures → 502. Clients get a retryable service error without Sync-internal
- * details leaking beyond the kind already in `userMessage`.
- */
+// Map a failed Sync HTTP call on a read/proxy route into a real HTTP status.
+// Never Status.UNSURE (600). Timeout/unavailable → 503; other failures → 502.
 export function throwSyncProxyFailure(
   kind: SyncClientErrorKind,
   userMessage: string,
@@ -28,24 +24,15 @@ export function throwSyncProxyFailure(
   );
 }
 
-/**
- * Map a failed Sync command submit on an event mutation route. Timeout and
- * unavailable stay PROVIDER_FAILURE (retryable 502) because Sync may already
- * have applied the write. Other kinds are also PROVIDER_FAILURE so clients
- * never see GenericError.NotSure / HTTP 600.
- */
+// Map a failed Sync command submit. Always PROVIDER_FAILURE so clients never
+// see GenericError.NotSure / HTTP 600. Timeout/unavailable stay retryable
+// because Sync may already have applied the write.
 export function throwSyncCommandSubmitFailure(
   kind: SyncClientErrorKind,
-  detail: string,
 ): never {
-  if (kind === "timeout" || kind === "unavailable") {
-    throw eventMutationError(
-      "PROVIDER_FAILURE",
-      `Sync command ${kind}; the mutation may already be applied`,
-    );
-  }
-  throw eventMutationError(
-    "PROVIDER_FAILURE",
-    `Failed to submit command to sync (${detail})`,
-  );
+  const message =
+    kind === "timeout" || kind === "unavailable"
+      ? `Sync command ${kind}; the mutation may already be applied`
+      : `Failed to submit command to sync (${kind})`;
+  throw eventMutationError("PROVIDER_FAILURE", message);
 }

--- a/packages/backend/src/common/services/sync-service/sync-service.client.ts
+++ b/packages/backend/src/common/services/sync-service/sync-service.client.ts
@@ -559,12 +559,11 @@ function statusToKind(status: number): SyncClientErrorKind {
   if (status === 400) return "badRequest";
   if (status === 404) return "notFound";
   if (status === 409) return "conflict";
+  // unexpectedStatus -> Sync proxy 502 (never Status.UNSURE / HTTP 600).
   // 429 is sync's own internal rate limiter (internal-http.ts), tripped
   // easily under normal-ish load (a shared 300/min bucket for the whole
   // backend). Treated the same as 503: a retryable service-busy state, not
-  // an unexpected condition - previously this fell through to
-  // unexpectedStatus -> GenericError.NotSure, whose Status.UNSURE (600) is
-  // not a real HTTP status and reads as an unretryable mystery to the caller.
+  // an unexpected condition.
   if (status === 429 || status === 503) return "unavailable";
   return "unexpectedStatus";
 }

--- a/packages/backend/src/event/controllers/event.controller.test.ts
+++ b/packages/backend/src/event/controllers/event.controller.test.ts
@@ -387,4 +387,29 @@ describe("EventController", () => {
       retryable: true,
     });
   });
+
+  it("rejects delete-all when the session user does not match :userId", async () => {
+    const deleteSpy = spyOn(
+      (await import("@backend/event/services/event.service")).default,
+      "deleteAllByUser",
+    );
+    const { res, json } = jsonRes();
+    const sessionUser = objectId();
+    const otherUser = objectId();
+
+    await eventController.deleteAllByUser(
+      sessionReq(sessionUser, { params: { userId: otherUser } }),
+      res,
+    );
+
+    expect(deleteSpy).not.toHaveBeenCalled();
+    expect((res.status as ReturnType<typeof mock>).mock.calls[0]?.[0]).toBe(
+      Status.BAD_REQUEST,
+    );
+    expect(json).toHaveBeenCalledWith({
+      code: "INVALID_INPUT",
+      message: "Cannot delete events for another user",
+      retryable: false,
+    });
+  });
 });

--- a/packages/backend/src/event/controllers/event.controller.ts
+++ b/packages/backend/src/event/controllers/event.controller.ts
@@ -204,14 +204,14 @@ const submitCommandOrThrow = async (
   }
   // Backstop for invariant 1 ("every write resolves definitively"): a
   // command that is still pending/applying/reconciling has NOT actually
-  // applied anywhere. Nothing re-dispatches a stranded pending command (see
-  // ProviderWriteUnavailableError's docblock in cloud-command.service.ts), so
-  // returning success here would let the caller believe the write landed
-  // while it silently never did — the client optimistically applies the
-  // change, then a later refetch reverts it with no error ever shown. Every
-  // known path that could leave a command non-terminal already throws
-  // explicitly instead (ProviderWriteUnavailableError, failCloud); this is
-  // the safety net for any path that doesn't, today or in the future.
+  // applied anywhere. Sync's stale-command retry sweep revisits
+  // create/update/delete after the stale window, but this request must not
+  // report success while the command is still non-terminal — the client
+  // would optimistically apply the change, then a later refetch could
+  // revert it with no error ever shown. Every known path that could leave a
+  // command non-terminal already throws explicitly instead
+  // (ProviderWriteUnavailableError, failCloud); this is the safety net for
+  // any path that doesn't, today or in the future.
   if (outcome.state !== "confirmed") {
     throw eventMutationError(
       "PROVIDER_FAILURE",

--- a/packages/backend/src/event/controllers/event.controller.ts
+++ b/packages/backend/src/event/controllers/event.controller.ts
@@ -21,8 +21,6 @@ import {
   SyncEventCalendarIdSchema,
 } from "@core/types/sync/event.contracts";
 import calendarService from "@backend/calendar/services/calendar.service";
-import { GenericError } from "@backend/common/errors/generic/generic.errors";
-import { error } from "@backend/common/errors/handlers/error.handler";
 import { assertCloudMutationsAllowed } from "@backend/common/services/sync-service/cloud-mutation-mode";
 import {
   toCreateSubmitRequest,
@@ -31,6 +29,7 @@ import {
 } from "@backend/common/services/sync-service/event-command.translation";
 import { syncEventInstanceToBrowser } from "@backend/common/services/sync-service/event-list.translation";
 import { toSyncPrincipal } from "@backend/common/services/sync-service/sync-principal";
+import { throwSyncCommandSubmitFailure } from "@backend/common/services/sync-service/sync-proxy-error";
 import { type SyncServiceClient } from "@backend/common/services/sync-service/sync-service.client";
 import { getSyncServiceClient } from "@backend/common/services/sync-service/sync-service.factory";
 import {
@@ -193,19 +192,7 @@ const submitCommandOrThrow = async (
     // Timeout/unavailable can mean Sync already accepted (or finished) the
     // mutation — especially provider deletes, which run inline. Do not fall
     // back to legacy; surface a retryable provider failure instead.
-    if (
-      result.error.kind === "timeout" ||
-      result.error.kind === "unavailable"
-    ) {
-      throw eventMutationError(
-        "PROVIDER_FAILURE",
-        `Sync command ${result.error.kind}; the mutation may already be applied`,
-      );
-    }
-    throw error(
-      GenericError.NotSure,
-      `Failed to submit command to sync (${result.error.kind})`,
-    );
+    throwSyncCommandSubmitFailure(result.error.kind, result.error.kind);
   }
 
   const { outcome } = result.value.command;
@@ -338,6 +325,15 @@ class EventController {
   deleteAllByUser = async (req: SessionRequest, res: Response) => {
     try {
       const userToRemove = req.params["userId"] as string;
+      const sessionUserId = req.session?.getUserId();
+      // Defense in depth: even while verifyIsDev gates this route, never let
+      // a session wipe another user's events.
+      if (!sessionUserId || sessionUserId !== userToRemove) {
+        throw eventMutationError(
+          "INVALID_INPUT",
+          "Cannot delete events for another user",
+        );
+      }
       const result = await eventService.deleteAllByUser(userToRemove);
 
       res.status(Status.OK).json(result);

--- a/packages/backend/src/event/controllers/event.controller.ts
+++ b/packages/backend/src/event/controllers/event.controller.ts
@@ -192,7 +192,7 @@ const submitCommandOrThrow = async (
     // Timeout/unavailable can mean Sync already accepted (or finished) the
     // mutation — especially provider deletes, which run inline. Do not fall
     // back to legacy; surface a retryable provider failure instead.
-    throwSyncCommandSubmitFailure(result.error.kind, result.error.kind);
+    throwSyncCommandSubmitFailure(result.error.kind);
   }
 
   const { outcome } = result.value.command;

--- a/packages/backend/src/event/event.error.ts
+++ b/packages/backend/src/event/event.error.ts
@@ -114,9 +114,11 @@ export const toEventMutationError = (
     };
   }
 
+  // Programmer bugs and unexpected throws are not provider outages — never
+  // advertise them as retryable or clients will hammer the same broken path.
   const message = e instanceof Error ? e.message : "Unexpected error";
   return {
     status: Status.INTERNAL_SERVER,
-    body: { code: "PROVIDER_FAILURE", message, retryable: true },
+    body: { code: "PROVIDER_FAILURE", message, retryable: false },
   };
 };

--- a/packages/backend/src/servers/sse/sse.server.test.ts
+++ b/packages/backend/src/servers/sse/sse.server.test.ts
@@ -102,9 +102,6 @@ describe("SSE Server", () => {
         streamA.waitForEvent("userMetadataChanged", 2000),
       ).resolves.toBeDefined();
 
-      // Register a second listener on tab A BEFORE tab B connects.
-      const spuriousReplay = streamA.waitForEvent("userMetadataChanged", 300);
-
       // Tab B opens for the same user — should only replay to tab B.
       const streamB = baseDriver.openSSEStream({ userId });
       await expect(
@@ -112,7 +109,9 @@ describe("SSE Server", () => {
       ).resolves.toBeDefined();
 
       // Tab A must NOT receive a second userMetadataChanged.
-      await expect(spuriousReplay).rejects.toThrow("Timeout");
+      await expect(
+        streamA.waitForNoEvent("userMetadataChanged"),
+      ).resolves.toBeUndefined();
 
       streamA.close();
       streamB.close();
@@ -125,8 +124,6 @@ describe("SSE Server", () => {
       const stream = baseDriver.openSSEStream({ userId });
       await stream.waitForEvent("userMetadataChanged", 2000);
 
-      const eventPromise = stream.waitForEvent("eventsChanged", 300);
-
       const { sseServer } = await import("./sse.server");
       sseServer.publishEventsChanged(otherUserId, {
         calendarId: new ObjectId().toHexString() as CalendarId,
@@ -134,7 +131,9 @@ describe("SSE Server", () => {
         reason: "reconciled",
       });
 
-      await expect(eventPromise).rejects.toThrow("Timeout");
+      await expect(
+        stream.waitForNoEvent("eventsChanged"),
+      ).resolves.toBeUndefined();
 
       stream.close();
     });

--- a/packages/backend/src/user/controllers/user.controller.ts
+++ b/packages/backend/src/user/controllers/user.controller.ts
@@ -4,6 +4,7 @@ import { Status } from "@core/errors/status.codes";
 import { Logger } from "@core/logger/winston.logger";
 import { zObjectId } from "@core/types/type.utils";
 import { type UserMetadata, type UserProfile } from "@core/types/user.types";
+import { toClientErrorPayload } from "@backend/common/errors/handlers/error.handler";
 import { type SReqBody } from "@backend/common/types/express.types";
 import userService from "@backend/user/services/user.service";
 import userMetadataService from "@backend/user/services/user-metadata.service";
@@ -11,10 +12,22 @@ import { type Summary_Delete } from "@backend/user/types/user.types";
 
 const logger = Logger("app:user.controller");
 
+const sendUserError = (res: Response, e: unknown) => {
+  if (e instanceof BaseError) {
+    res.status(e.statusCode).json(toClientErrorPayload(e));
+    return;
+  }
+  const message = e instanceof Error ? e.message : "Unexpected error";
+  res.status(Status.INTERNAL_SERVER).json({
+    code: "INTERNAL_ERROR",
+    message,
+  });
+};
+
 class UserController {
   getProfile = async (
     req: Request<never, UserProfile, never, never>,
-    res: Response<UserProfile>,
+    res: Response,
   ) => {
     try {
       const user = zObjectId.parse(req.session?.getUserId());
@@ -22,16 +35,12 @@ class UserController {
 
       res.status(Status.OK).json(profile);
     } catch (e) {
-      if (e instanceof BaseError) {
-        res.status(e.statusCode).send();
-        return;
-      }
-      res.status(Status.INTERNAL_SERVER).send();
+      sendUserError(res, e);
     }
   };
   deleteAccount = async (
     req: Request<never, Summary_Delete, never, never>,
-    res: Response<Summary_Delete>,
+    res: Response,
   ) => {
     try {
       // Session-derived only: a user may never delete anyone but themselves.
@@ -59,17 +68,13 @@ class UserController {
 
       res.status(Status.OK).json(summary);
     } catch (e) {
-      if (e instanceof BaseError) {
-        res.status(e.statusCode).send();
-        return;
-      }
-      res.status(Status.INTERNAL_SERVER).send();
+      sendUserError(res, e);
     }
   };
 
   getMetadata = async (
     req: Request<never, UserMetadata, never, never>,
-    res: Response<UserMetadata>,
+    res: Response,
   ) => {
     try {
       const user = zObjectId.parse(req.session?.getUserId());
@@ -79,18 +84,11 @@ class UserController {
 
       res.status(Status.OK).json(metadata);
     } catch (e) {
-      if (e instanceof BaseError) {
-        res.status(e.statusCode).send();
-        return;
-      }
-      res.status(Status.INTERNAL_SERVER).send();
+      sendUserError(res, e);
     }
   };
 
-  updateMetadata = async (
-    req: SReqBody<UserMetadata>,
-    res: Response<UserMetadata>,
-  ) => {
+  updateMetadata = async (req: SReqBody<UserMetadata>, res: Response) => {
     try {
       const user = zObjectId.parse(req.session?.getUserId());
 
@@ -101,11 +99,7 @@ class UserController {
 
       res.status(Status.OK).json(metadata);
     } catch (e) {
-      if (e instanceof BaseError) {
-        res.status(e.statusCode).send();
-        return;
-      }
-      res.status(Status.INTERNAL_SERVER).send();
+      sendUserError(res, e);
     }
   };
 }

--- a/packages/backend/src/user/services/user.service.ts
+++ b/packages/backend/src/user/services/user.service.ts
@@ -177,26 +177,33 @@ class UserService {
       await supertokensUserCleanupService.resolveByExternalUserId(userId);
     const session = await mongoService.startSession();
 
-    await session.withTransaction(async (session) => {
-      const user = await mongoService.user.findOne({ _id }, { session });
+    try {
+      await session.withTransaction(async (session) => {
+        const user = await mongoService.user.findOne({ _id }, { session });
 
-      if (!user) {
-        logger.warn(`User(${userId}) not found while deleting compass data`);
-      }
+        if (!user) {
+          logger.warn(`User(${userId}) not found while deleting compass data`);
+        }
 
-      // Events first: they are reachable only through the calendars that own
-      // them, so deleting the calendars first would leave nothing to find them
-      // by.
-      const events = await eventService.deleteAllByUser(userId, session);
-      summary.events = events.deletedCount;
+        // Events first: they are reachable only through the calendars that own
+        // them, so deleting the calendars first would leave nothing to find them
+        // by.
+        const events = await eventService.deleteAllByUser(userId, session);
+        summary.events = events.deletedCount;
 
-      const calendars = await calendarService.deleteAllByUser(userId, session);
-      summary.calendars = calendars.deletedCount;
+        const calendars = await calendarService.deleteAllByUser(
+          userId,
+          session,
+        );
+        summary.calendars = calendars.deletedCount;
 
-      // delete user
-      const userDel = await mongoService.user.deleteOne({ _id }, { session });
-      summary.user = userDel.deletedCount;
-    });
+        // delete user
+        const userDel = await mongoService.user.deleteOne({ _id }, { session });
+        summary.user = userDel.deletedCount;
+      });
+    } finally {
+      await session.endSession();
+    }
 
     const { sessionsRevoked } =
       await compassAuthService.revokeSessionsByUser(userId);

--- a/packages/sync/src/app.ts
+++ b/packages/sync/src/app.ts
@@ -650,11 +650,10 @@ function buildSchedulers(
       },
     },
     {
-      // Self-heal sweep for the OTHER kind of stuck work: a cloud-targeted
-      // update/delete command that hit a transient provider failure
-      // mid-execute. Those run inline from the HTTP request (not as a job),
-      // and nothing else ever revisits a command left nonterminal that way -
-      // see stale-command-retry.service.ts. Looks BACK, like
+      // Self-heal sweep for stuck inline cloud commands (create/update/delete)
+      // that hit a transient provider failure mid-execute. Those run inline from
+      // the HTTP request (not as a job); this sweep revisits them after the
+      // stale window — see stale-command-retry.service.ts. Looks BACK, like
       // reconcile/failedJobRequeue.
       name: "staleCommandRetry",
       windowMs: -STALE_COMMAND_RETRY_AFTER_MS,

--- a/packages/sync/src/domain/calendar-import.service.db.test.ts
+++ b/packages/sync/src/domain/calendar-import.service.db.test.ts
@@ -5,7 +5,7 @@ import {
   type CalendarImportDeps,
   importCalendarEvents,
 } from "@sync/domain/calendar-import.service";
-import { type AccessTokenSource } from "@sync/domain/provider-command.service";
+import { type AccessTokenSource } from "@sync/domain/provider-write-ladder";
 import {
   type ProviderEvent,
   type ProviderEventRead,

--- a/packages/sync/src/domain/calendar-import.service.ts
+++ b/packages/sync/src/domain/calendar-import.service.ts
@@ -1,7 +1,7 @@
 import { toColorLabelMap } from "@sync/domain/color-label-map";
 import { syncHorizon } from "@sync/domain/horizon";
-import { type AccessTokenSource } from "@sync/domain/provider-command.service";
 import { ProviderPageApplier } from "@sync/domain/provider-page-applier";
+import { type AccessTokenSource } from "@sync/domain/provider-write-ladder";
 import {
   type EventWindow,
   type ProviderEventReader,

--- a/packages/sync/src/domain/calendar-list-sync.service.ts
+++ b/packages/sync/src/domain/calendar-list-sync.service.ts
@@ -1,5 +1,5 @@
 import { type ProviderCalendarSourceId } from "@core/types/sync/identity.contracts";
-import { type AccessTokenSource } from "@sync/domain/provider-command.service";
+import { type AccessTokenSource } from "@sync/domain/provider-write-ladder";
 import {
   type ProviderCalendarAdapter,
   ProviderCalendarError,

--- a/packages/sync/src/domain/calendar-pull.service.ts
+++ b/packages/sync/src/domain/calendar-pull.service.ts
@@ -1,6 +1,6 @@
 import { toColorLabelMap } from "@sync/domain/color-label-map";
-import { type AccessTokenSource } from "@sync/domain/provider-command.service";
 import { ProviderPageApplier } from "@sync/domain/provider-page-applier";
+import { type AccessTokenSource } from "@sync/domain/provider-write-ladder";
 import { type ProviderEventCancellation } from "@sync/providers/provider-event.port";
 import {
   ProviderEventReadError,

--- a/packages/sync/src/domain/calendar-repair.service.ts
+++ b/packages/sync/src/domain/calendar-repair.service.ts
@@ -1,6 +1,6 @@
 import { toColorLabelMap } from "@sync/domain/color-label-map";
-import { type AccessTokenSource } from "@sync/domain/provider-command.service";
 import { ProviderPageApplier } from "@sync/domain/provider-page-applier";
+import { type AccessTokenSource } from "@sync/domain/provider-write-ladder";
 import { type ProviderEventReader } from "@sync/providers/provider-event-reader.port";
 import { type ProviderCalendarRecord } from "@sync/storage/contracts/provider-calendar.contracts";
 import { type SyncResourceRecord } from "@sync/storage/contracts/sync-resource.contracts";

--- a/packages/sync/src/domain/cloud-command.service.ts
+++ b/packages/sync/src/domain/cloud-command.service.ts
@@ -50,9 +50,10 @@ import { type ProviderCalendarRepository } from "@sync/storage/repositories/prov
 import { type SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
 
 // A provider-targeted write arrived while provider work is unavailable
-// (execution is passive, or no provider is configured). Nothing re-dispatches a
-// pending command, so accepting it would strand the write permanently while the
-// caller believes it succeeded. Callers surface this as a retryable 503.
+// (execution is passive, or no provider is configured). Accepting it as
+// pending without a self-heal path would strand the write while the caller
+// believes it succeeded — so the request is refused. The stale-command retry
+// sweep revisits create/update/delete once provider work is available again.
 //
 // Production hit exactly that on 2026-07-29: routing was flipped to Sync while
 // the sync process was still passive, and creates returned 200 with the event
@@ -169,47 +170,14 @@ export async function submitCloudCommand(
 
   // A create whose target calendar is a connected provider calendar must go to
   // the provider, not be confirmed as a local cloud event. Execute it now when
-  // provider work is enabled; otherwise leave it pending for a later execution.
-  // A calendar id that resolves to no provider calendar is a Compass cloud
-  // calendar, so it is applied locally below.
-  const providerCalendar = await deps.calendars.findById(
-    command.tenantId,
-    command.principalId,
-    command.input.calendarId as ProviderCalendarId,
-  );
-  if (providerCalendar) {
-    if (deps.execution === "active" && deps.provider) {
-      return finish(
-        await executeProviderCreate(
-          {
-            commands: deps.commands,
-            events: deps.events,
-            occurrences: deps.occurrences,
-            resources: deps.resources,
-            writer: deps.provider.writer,
-            custody: deps.provider.custody,
-          },
-          command,
-          providerCalendar,
-          now,
-        ),
-      );
-    }
-    // Nothing else ever picks this command up: no scheduled work re-dispatches
-    // a pending command, so returning it here would strand the write forever
-    // while the caller sees success. Refuse instead, so the caller can retry
-    // once provider work is enabled.
-    throw new ProviderWriteUnavailableError();
-  }
-
-  const record = buildCloudEventRecord(command, now());
-  await deps.events.put(record);
-  await reprojectOccurrences(deps.occurrences, record, now);
-  return finish(await confirmCloud(deps, command));
+  // provider work is enabled; otherwise refuse (stale-command sweep retries
+  // once execution is active). A calendar id that resolves to no provider
+  // calendar is a Compass cloud calendar, so it is applied locally.
+  return finish(await applyCloudCreateOrProvider(deps, command, now));
 }
 
-// Re-run an already-submitted, still-nonterminal update/delete command
-// through the same routing applyCloudMutation used the first time (dedupe by
+// Re-run an already-submitted, still-nonterminal create/update/delete command
+// through the same routing the original request used (dedupe by
 // idempotencyKey does not apply here — the command already exists). For the
 // stale-command retry sweep: a transient provider failure mid-execute leaves
 // the command exactly as it was (see provider-command.service.ts's per-kind
@@ -239,7 +207,67 @@ export async function retryCloudMutation(
   if (superseded) {
     return failCloud(deps, command, "versionConflict");
   }
+  if (command.input.kind === "create") {
+    return applyCloudCreateOrProvider(deps, command, now);
+  }
   return applyCloudMutation(deps, command, now);
+}
+
+async function applyCloudCreateOrProvider(
+  deps: CloudCommandDeps,
+  command: CommandRecord,
+  now: () => Date,
+): Promise<CommandRecord> {
+  if (command.input.kind !== "create") {
+    throw new Error("applyCloudCreateOrProvider requires a create command");
+  }
+  const providerCalendar = await deps.calendars.findById(
+    command.tenantId,
+    command.principalId,
+    command.input.calendarId as ProviderCalendarId,
+  );
+  if (providerCalendar) {
+    if (deps.execution === "active" && deps.provider) {
+      return executeProviderCreate(
+        {
+          commands: deps.commands,
+          events: deps.events,
+          occurrences: deps.occurrences,
+          resources: deps.resources,
+          writer: deps.provider.writer,
+          custody: deps.provider.custody,
+        },
+        command,
+        providerCalendar,
+        now,
+      );
+    }
+    throw new ProviderWriteUnavailableError();
+  }
+  return applyCloudCreate(deps, command, now);
+}
+
+async function applyCloudCreate(
+  deps: CloudCommandDeps,
+  command: CommandRecord,
+  now: () => Date,
+): Promise<CommandRecord> {
+  if (command.input.kind !== "create") {
+    throw new Error("applyCloudCreate requires a create command");
+  }
+  // Idempotent: a crash after the event write but before confirm leaves the
+  // command pending with the event already present — confirm without rewriting.
+  const existing = await deps.events.findById(
+    command.tenantId,
+    command.principalId,
+    command.eventId,
+  );
+  if (!existing) {
+    const record = buildCloudEventRecord(command, now());
+    await deps.events.put(record);
+    await reprojectOccurrences(deps.occurrences, record, now);
+  }
+  return confirmCloud(deps, command);
 }
 
 // Apply a cloud-only update or delete to an existing event. Only single,

--- a/packages/sync/src/domain/cloud-command.service.ts
+++ b/packages/sync/src/domain/cloud-command.service.ts
@@ -255,18 +255,20 @@ async function applyCloudCreate(
   if (command.input.kind !== "create") {
     throw new Error("applyCloudCreate requires a create command");
   }
-  // Idempotent: a crash after the event write but before confirm leaves the
-  // command pending with the event already present — confirm without rewriting.
-  const existing = await deps.events.findById(
+  // Idempotent: a crash after the event write (or after put but before
+  // occurrence projection) leaves the command pending with the event already
+  // present. Always reproject before confirm so a retry never confirms a
+  // create that is invisible to range/busy reads.
+  let record = await deps.events.findById(
     command.tenantId,
     command.principalId,
     command.eventId,
   );
-  if (!existing) {
-    const record = buildCloudEventRecord(command, now());
+  if (!record) {
+    record = buildCloudEventRecord(command, now());
     await deps.events.put(record);
-    await reprojectOccurrences(deps.occurrences, record, now);
   }
+  await reprojectOccurrences(deps.occurrences, record, now);
   return confirmCloud(deps, command);
 }
 

--- a/packages/sync/src/domain/provider-command.service.db.test.ts
+++ b/packages/sync/src/domain/provider-command.service.db.test.ts
@@ -12,7 +12,6 @@ import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
 import { CredentialCustody } from "@sync/credentials/credential-custody.service";
 import { truncateRulesBefore } from "@sync/domain/occurrence-projection";
 import {
-  type AccessTokenSource,
   executeProviderCreate,
   executeProviderDelete,
   executeProviderOccurrenceDelete,
@@ -22,6 +21,7 @@ import {
   executeProviderSeriesUpdate,
   executeProviderUpdate,
 } from "@sync/domain/provider-command.service";
+import { type AccessTokenSource } from "@sync/domain/provider-write-ladder";
 import { reprojectOccurrences } from "@sync/domain/reproject";
 import {
   type ProviderAuthAdapter,

--- a/packages/sync/src/domain/provider-command.service.ts
+++ b/packages/sync/src/domain/provider-command.service.ts
@@ -350,12 +350,7 @@ export async function executeProviderUpdate(
   );
   if (!fetchResult.ok) {
     if (fetchResult.stop.kind === "pending") return command;
-    return failCommand(
-      deps,
-      command,
-      fetchResult.stop.reason,
-      connectionId,
-    );
+    return failCommand(deps, command, fetchResult.stop.reason, connectionId);
   }
   const current =
     fetchResult.value?.kind === "event" ? fetchResult.value : null;
@@ -397,12 +392,7 @@ export async function executeProviderUpdate(
   );
   if (!patchResult.ok) {
     if (patchResult.stop.kind === "pending") return command;
-    return failCommand(
-      deps,
-      command,
-      patchResult.stop.reason,
-      connectionId,
-    );
+    return failCommand(deps, command, patchResult.stop.reason, connectionId);
   }
   const result = patchResult.value;
 
@@ -516,12 +506,7 @@ export async function executeProviderSeriesUpdate(
   );
   if (!fetchResult.ok) {
     if (fetchResult.stop.kind === "pending") return command;
-    return failCommand(
-      deps,
-      command,
-      fetchResult.stop.reason,
-      connectionId,
-    );
+    return failCommand(deps, command, fetchResult.stop.reason, connectionId);
   }
   const current =
     fetchResult.value?.kind === "event" ? fetchResult.value : null;
@@ -563,12 +548,7 @@ export async function executeProviderSeriesUpdate(
   );
   if (!patchResult.ok) {
     if (patchResult.stop.kind === "pending") return command;
-    return failCommand(
-      deps,
-      command,
-      patchResult.stop.reason,
-      connectionId,
-    );
+    return failCommand(deps, command, patchResult.stop.reason, connectionId);
   }
   const result = patchResult.value;
 
@@ -1096,12 +1076,7 @@ export async function executeProviderSeriesFollowingDelete(
   );
   if (!fetchResult.ok) {
     if (fetchResult.stop.kind === "pending") return command;
-    return failCommand(
-      deps,
-      command,
-      fetchResult.stop.reason,
-      connectionId,
-    );
+    return failCommand(deps, command, fetchResult.stop.reason, connectionId);
   }
   const current =
     fetchResult.value?.kind === "event" ? fetchResult.value : null;
@@ -1254,12 +1229,7 @@ export async function executeProviderSeriesFollowingUpdate(
   );
   if (!fetchResult.ok) {
     if (fetchResult.stop.kind === "pending") return command;
-    return failCommand(
-      deps,
-      command,
-      fetchResult.stop.reason,
-      connectionId,
-    );
+    return failCommand(deps, command, fetchResult.stop.reason, connectionId);
   }
   const current =
     fetchResult.value?.kind === "event" ? fetchResult.value : null;

--- a/packages/sync/src/domain/provider-command.service.ts
+++ b/packages/sync/src/domain/provider-command.service.ts
@@ -609,32 +609,34 @@ async function commitProviderSeriesUpdate(
   for (const exception of discarded) {
     const exceptionProviderEventId = exception.providerEventId;
     if (exceptionProviderEventId) {
-      const alignResult = await runProviderWrite(() =>
-        convertsToSingle
-          ? deps.writer.deleteEvent({
-              accessToken: provider.accessToken,
-              calendarId: provider.calendarId,
-              providerEventId: exceptionProviderEventId,
-              expectedVersion: null,
-              invitation: input.invitation,
-            })
-          : deps.writer.patchEvent({
-              // Revert the override into the edited series without cancelling
-              // the occurrence. Delete would mark the instance cancelled at Google.
-              accessToken: provider.accessToken,
-              calendarId: provider.calendarId,
-              providerEventId: exceptionProviderEventId,
-              expectedVersion: null,
-              content,
-              schedule: occurrenceScheduleAfterSeriesEdit(
-                master.schedule,
-                input.schedule,
-                exceptionInstant(exception),
-              ),
-              recurrence: { kind: "instance" },
-              invitation: input.invitation,
-            }),
-      );
+      const alignResult = await runProviderWrite(async () => {
+        if (convertsToSingle) {
+          await deps.writer.deleteEvent({
+            accessToken: provider.accessToken,
+            calendarId: provider.calendarId,
+            providerEventId: exceptionProviderEventId,
+            expectedVersion: null,
+            invitation: input.invitation,
+          });
+          return;
+        }
+        await deps.writer.patchEvent({
+          // Revert the override into the edited series without cancelling
+          // the occurrence. Delete would mark the instance cancelled at Google.
+          accessToken: provider.accessToken,
+          calendarId: provider.calendarId,
+          providerEventId: exceptionProviderEventId,
+          expectedVersion: null,
+          content,
+          schedule: occurrenceScheduleAfterSeriesEdit(
+            master.schedule,
+            input.schedule,
+            exceptionInstant(exception),
+          ),
+          recurrence: { kind: "instance" },
+          invitation: input.invitation,
+        });
+      });
       if (!alignResult.ok) {
         if (alignResult.stop.kind === "pending") return command;
         if (convertsToSingle) {

--- a/packages/sync/src/domain/provider-command.service.ts
+++ b/packages/sync/src/domain/provider-command.service.ts
@@ -33,7 +33,6 @@ import {
   remainderMasterId,
   reprojectMaster,
 } from "@sync/domain/series-exception";
-import { ProviderAuthError } from "@sync/providers/provider-auth.port";
 import { type ProviderEvent } from "@sync/providers/provider-event.port";
 import {
   type ProviderEventWriter,
@@ -50,14 +49,13 @@ import { type EventRepository } from "@sync/storage/repositories/event.repositor
 import { type EventOccurrenceRepository } from "@sync/storage/repositories/event-occurrence.repository";
 import { type SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
 
-// The slice of credential custody the executor needs — a valid access token for
-// a connection, plus discard of a provider-invalidated grant. Narrow so tests
-// pass a plain fake; CredentialCustody satisfies it structurally.
-export interface AccessTokenSource {
-  getValidAccessToken(connectionId: ConnectionId): Promise<string>;
-  discardRevoked(connectionId: ConnectionId): Promise<void>;
-  invalidateAccessToken(connectionId: ConnectionId): Promise<void>;
-}
+export type { AccessTokenSource } from "@sync/domain/provider-write-ladder";
+
+import {
+  type AccessTokenSource,
+  resolveAccessToken,
+  runProviderWrite,
+} from "@sync/domain/provider-write-ladder";
 
 export interface ProviderMutationDeps {
   commands: CommandRepository;
@@ -96,29 +94,28 @@ export async function executeProviderCreate(
   }
   const { input } = command;
 
-  let accessToken: string;
-  try {
-    accessToken = await deps.custody.getValidAccessToken(calendar.connectionId);
-  } catch (error) {
+  const tokenResult = await resolveAccessToken(
+    deps.custody,
+    calendar.connectionId,
+  );
+  if (!tokenResult.ok) {
     // A transient refresh failure is retryable, so leave the command pending; a
     // revoked or missing credential is terminal.
-    if (
-      error instanceof ProviderAuthError &&
-      error.reason === "refreshFailed"
-    ) {
-      return command;
-    }
+    if (tokenResult.stop.kind === "pending") return command;
     return failCommand(
       deps,
       command,
-      "authorizationRevoked",
+      tokenResult.stop.reason,
       calendar.connectionId,
     );
   }
+  const { accessToken } = tokenResult;
 
-  let result: ProviderWriteResult;
-  try {
-    result = await deps.writer.createEvent({
+  // Transient failures are safe to retry — the deterministic id keeps the
+  // eventual retry idempotent. Every other reason is terminal and maps
+  // straight to a command failure class.
+  const writeResult = await runProviderWrite(() =>
+    deps.writer.createEvent({
       accessToken,
       calendarId: calendar.providerCalendarId,
       providerEventId: command.eventId,
@@ -126,17 +123,18 @@ export async function executeProviderCreate(
       schedule: input.schedule,
       recurrence: toProviderWriteRecurrence(input.recurrence),
       invitation: input.invitation,
-    });
-  } catch (error) {
-    if (error instanceof ProviderWriteError) {
-      // Transient failures are safe to retry — the deterministic id keeps the
-      // eventual retry idempotent. Every other reason is terminal and maps
-      // straight to a command failure class.
-      if (error.reason === "transient") return command;
-      return failCommand(deps, command, error.reason, calendar.connectionId);
-    }
-    throw error;
+    }),
+  );
+  if (!writeResult.ok) {
+    if (writeResult.stop.kind === "pending") return command;
+    return failCommand(
+      deps,
+      command,
+      writeResult.stop.reason,
+      calendar.connectionId,
+    );
   }
+  const result = writeResult.value;
 
   // Commit the provider identity to the canonical event and project its
   // occurrences, then confirm. Both run before confirmation, so a crash leaves
@@ -330,18 +328,12 @@ export async function executeProviderUpdate(
   const providerEventId = event.providerEventId;
   const connectionId = event.connectionId;
 
-  let accessToken: string;
-  try {
-    accessToken = await deps.custody.getValidAccessToken(connectionId);
-  } catch (error) {
-    if (
-      error instanceof ProviderAuthError &&
-      error.reason === "refreshFailed"
-    ) {
-      return command;
-    }
-    return failCommand(deps, command, "authorizationRevoked", connectionId);
+  const tokenResult = await resolveAccessToken(deps.custody, connectionId);
+  if (!tokenResult.ok) {
+    if (tokenResult.stop.kind === "pending") return command;
+    return failCommand(deps, command, tokenResult.stop.reason, connectionId);
   }
+  const { accessToken } = tokenResult;
 
   const location = {
     accessToken,
@@ -351,19 +343,22 @@ export async function executeProviderUpdate(
 
   // Fetch current provider state to detect a replay (our edit already landed)
   // and to learn the version to commit.
-  let current: ProviderEvent | null;
-  try {
-    const read = await deps.writer.fetchEvent(location);
-    // A cancellation read means the event no longer exists as a content event —
-    // there is nothing to update.
-    current = read?.kind === "event" ? read : null;
-  } catch (error) {
-    if (error instanceof ProviderWriteError) {
-      if (error.reason === "transient") return command;
-      return failCommand(deps, command, error.reason, connectionId);
-    }
-    throw error;
+  // A cancellation read means the event no longer exists as a content event —
+  // there is nothing to update.
+  const fetchResult = await runProviderWrite(() =>
+    deps.writer.fetchEvent(location),
+  );
+  if (!fetchResult.ok) {
+    if (fetchResult.stop.kind === "pending") return command;
+    return failCommand(
+      deps,
+      command,
+      fetchResult.stop.reason,
+      connectionId,
+    );
   }
+  const current =
+    fetchResult.value?.kind === "event" ? fetchResult.value : null;
   if (!current) {
     return failCommand(deps, command, "permanentProviderError", connectionId);
   }
@@ -390,23 +385,26 @@ export async function executeProviderUpdate(
     );
   }
 
-  let result: ProviderWriteResult;
-  try {
-    result = await deps.writer.patchEvent({
+  const patchResult = await runProviderWrite(() =>
+    deps.writer.patchEvent({
       ...location,
       expectedVersion: command.expectedVersion,
       content,
       schedule: input.schedule,
       recurrence: intendedRecurrence,
       invitation: input.invitation,
-    });
-  } catch (error) {
-    if (error instanceof ProviderWriteError) {
-      if (error.reason === "transient") return command;
-      return failCommand(deps, command, error.reason, connectionId);
-    }
-    throw error;
+    }),
+  );
+  if (!patchResult.ok) {
+    if (patchResult.stop.kind === "pending") return command;
+    return failCommand(
+      deps,
+      command,
+      patchResult.stop.reason,
+      connectionId,
+    );
   }
+  const result = patchResult.value;
 
   return commitProviderUpdate(
     deps,
@@ -498,18 +496,12 @@ export async function executeProviderSeriesUpdate(
   const providerEventId = master.providerEventId;
   const intendedRecurrence = intendedSeriesRecurrence(input.recurrence, master);
 
-  let accessToken: string;
-  try {
-    accessToken = await deps.custody.getValidAccessToken(connectionId);
-  } catch (error) {
-    if (
-      error instanceof ProviderAuthError &&
-      error.reason === "refreshFailed"
-    ) {
-      return command;
-    }
-    return failCommand(deps, command, "authorizationRevoked", connectionId);
+  const tokenResult = await resolveAccessToken(deps.custody, connectionId);
+  if (!tokenResult.ok) {
+    if (tokenResult.stop.kind === "pending") return command;
+    return failCommand(deps, command, tokenResult.stop.reason, connectionId);
   }
+  const { accessToken } = tokenResult;
 
   const location = {
     accessToken,
@@ -519,17 +511,20 @@ export async function executeProviderSeriesUpdate(
 
   // Fetch the master's current provider state to detect a replay and learn the
   // version to commit. A cancellation read means the series no longer exists.
-  let current: ProviderEvent | null;
-  try {
-    const read = await deps.writer.fetchEvent(location);
-    current = read?.kind === "event" ? read : null;
-  } catch (error) {
-    if (error instanceof ProviderWriteError) {
-      if (error.reason === "transient") return command;
-      return failCommand(deps, command, error.reason, connectionId);
-    }
-    throw error;
+  const fetchResult = await runProviderWrite(() =>
+    deps.writer.fetchEvent(location),
+  );
+  if (!fetchResult.ok) {
+    if (fetchResult.stop.kind === "pending") return command;
+    return failCommand(
+      deps,
+      command,
+      fetchResult.stop.reason,
+      connectionId,
+    );
   }
+  const current =
+    fetchResult.value?.kind === "event" ? fetchResult.value : null;
   if (!current) {
     return failCommand(deps, command, "permanentProviderError", connectionId);
   }
@@ -556,23 +551,26 @@ export async function executeProviderSeriesUpdate(
     );
   }
 
-  let result: ProviderWriteResult;
-  try {
-    result = await deps.writer.patchEvent({
+  const patchResult = await runProviderWrite(() =>
+    deps.writer.patchEvent({
       ...location,
       expectedVersion: command.expectedVersion,
       content,
       schedule: input.schedule,
       recurrence: intendedRecurrence,
       invitation: input.invitation,
-    });
-  } catch (error) {
-    if (error instanceof ProviderWriteError) {
-      if (error.reason === "transient") return command;
-      return failCommand(deps, command, error.reason, connectionId);
-    }
-    throw error;
+    }),
+  );
+  if (!patchResult.ok) {
+    if (patchResult.stop.kind === "pending") return command;
+    return failCommand(
+      deps,
+      command,
+      patchResult.stop.reason,
+      connectionId,
+    );
   }
+  const result = patchResult.value;
 
   return commitProviderSeriesUpdate(
     deps,
@@ -787,18 +785,12 @@ export async function executeProviderOccurrenceUpdate(
   const connectionId = master.connectionId;
   const seriesProviderEventId = master.providerEventId;
 
-  let accessToken: string;
-  try {
-    accessToken = await deps.custody.getValidAccessToken(connectionId);
-  } catch (error) {
-    if (
-      error instanceof ProviderAuthError &&
-      error.reason === "refreshFailed"
-    ) {
-      return command;
-    }
-    return failCommand(deps, command, "authorizationRevoked", connectionId);
+  const tokenResult = await resolveAccessToken(deps.custody, connectionId);
+  if (!tokenResult.ok) {
+    if (tokenResult.stop.kind === "pending") return command;
+    return failCommand(deps, command, tokenResult.stop.reason, connectionId);
   }
+  const { accessToken } = tokenResult;
 
   let instance: ProviderEvent | null;
   try {
@@ -964,18 +956,12 @@ export async function executeProviderOccurrenceDelete(
   const connectionId = master.connectionId;
   const seriesProviderEventId = master.providerEventId;
 
-  let accessToken: string;
-  try {
-    accessToken = await deps.custody.getValidAccessToken(connectionId);
-  } catch (error) {
-    if (
-      error instanceof ProviderAuthError &&
-      error.reason === "refreshFailed"
-    ) {
-      return command;
-    }
-    return failCommand(deps, command, "authorizationRevoked", connectionId);
+  const tokenResult = await resolveAccessToken(deps.custody, connectionId);
+  if (!tokenResult.ok) {
+    if (tokenResult.stop.kind === "pending") return command;
+    return failCommand(deps, command, tokenResult.stop.reason, connectionId);
   }
+  const { accessToken } = tokenResult;
 
   let instance: ProviderEvent | null;
   try {
@@ -1090,18 +1076,12 @@ export async function executeProviderSeriesFollowingDelete(
     return executeProviderDelete(deps, command, master, calendar, now);
   }
 
-  let accessToken: string;
-  try {
-    accessToken = await deps.custody.getValidAccessToken(connectionId);
-  } catch (error) {
-    if (
-      error instanceof ProviderAuthError &&
-      error.reason === "refreshFailed"
-    ) {
-      return command;
-    }
-    return failCommand(deps, command, "authorizationRevoked", connectionId);
+  const tokenResult = await resolveAccessToken(deps.custody, connectionId);
+  if (!tokenResult.ok) {
+    if (tokenResult.stop.kind === "pending") return command;
+    return failCommand(deps, command, tokenResult.stop.reason, connectionId);
   }
+  const { accessToken } = tokenResult;
 
   await deleteFollowingExceptions(deps, command, master._id, splitAt);
   const truncatedRules = truncateRulesBefore(master.recurrence.rules, splitAt);
@@ -1111,17 +1091,20 @@ export async function executeProviderSeriesFollowingDelete(
     providerEventId,
   };
 
-  let current: ProviderEvent | null;
-  try {
-    const read = await deps.writer.fetchEvent(location);
-    current = read?.kind === "event" ? read : null;
-  } catch (error) {
-    if (error instanceof ProviderWriteError) {
-      if (error.reason === "transient") return command;
-      return failCommand(deps, command, error.reason, connectionId);
-    }
-    throw error;
+  const fetchResult = await runProviderWrite(() =>
+    deps.writer.fetchEvent(location),
+  );
+  if (!fetchResult.ok) {
+    if (fetchResult.stop.kind === "pending") return command;
+    return failCommand(
+      deps,
+      command,
+      fetchResult.stop.reason,
+      connectionId,
+    );
   }
+  const current =
+    fetchResult.value?.kind === "event" ? fetchResult.value : null;
   if (!current) {
     return failCommand(deps, command, "permanentProviderError", connectionId);
   }
@@ -1248,18 +1231,12 @@ export async function executeProviderSeriesFollowingUpdate(
     return executeProviderSeriesUpdate(deps, command, master, calendar, now);
   }
 
-  let accessToken: string;
-  try {
-    accessToken = await deps.custody.getValidAccessToken(connectionId);
-  } catch (error) {
-    if (
-      error instanceof ProviderAuthError &&
-      error.reason === "refreshFailed"
-    ) {
-      return command;
-    }
-    return failCommand(deps, command, "authorizationRevoked", connectionId);
+  const tokenResult = await resolveAccessToken(deps.custody, connectionId);
+  if (!tokenResult.ok) {
+    if (tokenResult.stop.kind === "pending") return command;
+    return failCommand(deps, command, tokenResult.stop.reason, connectionId);
   }
+  const { accessToken } = tokenResult;
 
   // Truncate the original master first — same ordering as the cloud path:
   // the worst transient state between this step and the remainder create
@@ -1272,17 +1249,20 @@ export async function executeProviderSeriesFollowingUpdate(
     providerEventId,
   };
 
-  let current: ProviderEvent | null;
-  try {
-    const read = await deps.writer.fetchEvent(originalLocation);
-    current = read?.kind === "event" ? read : null;
-  } catch (error) {
-    if (error instanceof ProviderWriteError) {
-      if (error.reason === "transient") return command;
-      return failCommand(deps, command, error.reason, connectionId);
-    }
-    throw error;
+  const fetchResult = await runProviderWrite(() =>
+    deps.writer.fetchEvent(originalLocation),
+  );
+  if (!fetchResult.ok) {
+    if (fetchResult.stop.kind === "pending") return command;
+    return failCommand(
+      deps,
+      command,
+      fetchResult.stop.reason,
+      connectionId,
+    );
   }
+  const current =
+    fetchResult.value?.kind === "event" ? fetchResult.value : null;
   if (!current) {
     return failCommand(deps, command, "permanentProviderError", connectionId);
   }
@@ -1577,28 +1557,25 @@ export async function executeProviderDelete(
     return confirmDeletion(deps, command);
   }
 
-  let accessToken: string;
-  try {
-    accessToken = await deps.custody.getValidAccessToken(connectionId);
-  } catch (error) {
-    if (
-      error instanceof ProviderAuthError &&
-      error.reason === "refreshFailed"
-    ) {
-      return command;
-    }
+  const tokenResult = await resolveAccessToken(deps.custody, connectionId);
+  if (!tokenResult.ok) {
+    if (tokenResult.stop.kind === "pending") return command;
     return revertAndFail(
       deps,
       command,
       event,
-      "authorizationRevoked",
+      tokenResult.stop.reason,
       connectionId,
       now,
     );
   }
+  const { accessToken } = tokenResult;
 
-  try {
-    await deps.writer.deleteEvent({
+  // Transient: keep the event deletionPending (visibly deleting) and retry.
+  // Terminal: the delete failed, so restore the event to active rather than
+  // leaving it stuck showing "deleting".
+  const deleteResult = await runProviderWrite(() =>
+    deps.writer.deleteEvent({
       accessToken,
       calendarId: calendar.providerCalendarId,
       providerEventId,
@@ -1606,23 +1583,18 @@ export async function executeProviderDelete(
       // unrelated external change never blocks it.
       expectedVersion: null,
       invitation: input.invitation,
-    });
-  } catch (error) {
-    if (error instanceof ProviderWriteError) {
-      // Transient: keep the event deletionPending (visibly deleting) and retry.
-      if (error.reason === "transient") return command;
-      // Terminal: the delete failed, so restore the event to active rather than
-      // leaving it stuck showing "deleting".
-      return revertAndFail(
-        deps,
-        command,
-        event,
-        error.reason,
-        connectionId,
-        now,
-      );
-    }
-    throw error;
+    }),
+  );
+  if (!deleteResult.ok) {
+    if (deleteResult.stop.kind === "pending") return command;
+    return revertAndFail(
+      deps,
+      command,
+      event,
+      deleteResult.stop.reason,
+      connectionId,
+      now,
+    );
   }
 
   // The provider confirmed the deletion. Write the content-free tombstone first

--- a/packages/sync/src/domain/provider-command.service.ts
+++ b/packages/sync/src/domain/provider-command.service.ts
@@ -25,6 +25,11 @@ import {
   stripRuleBounds,
   truncateRulesBefore,
 } from "@sync/domain/occurrence-projection";
+import {
+  type AccessTokenSource,
+  resolveAccessToken,
+  runProviderWrite,
+} from "@sync/domain/provider-write-ladder";
 import { reprojectOccurrences } from "@sync/domain/reproject";
 import {
   deleteFollowingExceptions,
@@ -36,7 +41,6 @@ import {
 import { type ProviderEvent } from "@sync/providers/provider-event.port";
 import {
   type ProviderEventWriter,
-  ProviderWriteError,
   type ProviderWriteRecurrence,
   type ProviderWriteResult,
 } from "@sync/providers/provider-event-writer.port";
@@ -48,14 +52,6 @@ import { type DeletionMarkerRepository } from "@sync/storage/repositories/deleti
 import { type EventRepository } from "@sync/storage/repositories/event.repository";
 import { type EventOccurrenceRepository } from "@sync/storage/repositories/event-occurrence.repository";
 import { type SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
-
-export type { AccessTokenSource } from "@sync/domain/provider-write-ladder";
-
-import {
-  type AccessTokenSource,
-  resolveAccessToken,
-  runProviderWrite,
-} from "@sync/domain/provider-write-ladder";
 
 export interface ProviderMutationDeps {
   commands: CommandRepository;
@@ -203,39 +199,31 @@ async function resolveFailedOverrideAlign(
     connectionId: ConnectionId;
   },
   providerEventId: string,
-  patchError: ProviderWriteError,
+  reason: SyncCommandFailureReason,
 ): Promise<CommandRecord | null> {
-  if (patchError.reason === "transient") return command;
-  if (patchError.reason !== "permanentProviderError") {
-    return failCommand(deps, command, patchError.reason, provider.connectionId);
+  if (reason !== "permanentProviderError") {
+    return failCommand(deps, command, reason, provider.connectionId);
   }
-  try {
-    const read = await deps.writer.fetchEvent({
+  const fetchResult = await runProviderWrite(() =>
+    deps.writer.fetchEvent({
       accessToken: provider.accessToken,
       calendarId: provider.calendarId,
       providerEventId: providerEventId as ProviderEventId,
-    });
-    if (read?.kind === "event") {
-      return failCommand(
-        deps,
-        command,
-        patchError.reason,
-        provider.connectionId,
-      );
-    }
-    return null;
-  } catch (fetchError) {
-    if (fetchError instanceof ProviderWriteError) {
-      if (fetchError.reason === "transient") return command;
-      return failCommand(
-        deps,
-        command,
-        fetchError.reason,
-        provider.connectionId,
-      );
-    }
-    throw fetchError;
+    }),
+  );
+  if (!fetchResult.ok) {
+    if (fetchResult.stop.kind === "pending") return command;
+    return failCommand(
+      deps,
+      command,
+      fetchResult.stop.reason,
+      provider.connectionId,
+    );
   }
+  if (fetchResult.value?.kind === "event") {
+    return failCommand(deps, command, reason, provider.connectionId);
+  }
+  return null;
 }
 
 // Build the canonical event for a provider-linked create: same shape as a cloud
@@ -619,42 +607,41 @@ async function commitProviderSeriesUpdate(
   // Align or remove discarded overrides at Google first, then clear local
   // copies. Kept cancelled tombstones are not touched at the provider.
   for (const exception of discarded) {
-    if (exception.providerEventId) {
-      try {
+    const exceptionProviderEventId = exception.providerEventId;
+    if (exceptionProviderEventId) {
+      const alignResult = await runProviderWrite(() =>
+        convertsToSingle
+          ? deps.writer.deleteEvent({
+              accessToken: provider.accessToken,
+              calendarId: provider.calendarId,
+              providerEventId: exceptionProviderEventId,
+              expectedVersion: null,
+              invitation: input.invitation,
+            })
+          : deps.writer.patchEvent({
+              // Revert the override into the edited series without cancelling
+              // the occurrence. Delete would mark the instance cancelled at Google.
+              accessToken: provider.accessToken,
+              calendarId: provider.calendarId,
+              providerEventId: exceptionProviderEventId,
+              expectedVersion: null,
+              content,
+              schedule: occurrenceScheduleAfterSeriesEdit(
+                master.schedule,
+                input.schedule,
+                exceptionInstant(exception),
+              ),
+              recurrence: { kind: "instance" },
+              invitation: input.invitation,
+            }),
+      );
+      if (!alignResult.ok) {
+        if (alignResult.stop.kind === "pending") return command;
         if (convertsToSingle) {
-          await deps.writer.deleteEvent({
-            accessToken: provider.accessToken,
-            calendarId: provider.calendarId,
-            providerEventId: exception.providerEventId,
-            expectedVersion: null,
-            invitation: input.invitation,
-          });
-        } else {
-          // Revert the override into the edited series without cancelling the
-          // occurrence. Delete would mark the instance cancelled at Google.
-          await deps.writer.patchEvent({
-            accessToken: provider.accessToken,
-            calendarId: provider.calendarId,
-            providerEventId: exception.providerEventId,
-            expectedVersion: null,
-            content,
-            schedule: occurrenceScheduleAfterSeriesEdit(
-              master.schedule,
-              input.schedule,
-              exceptionInstant(exception),
-            ),
-            recurrence: { kind: "instance" },
-            invitation: input.invitation,
-          });
-        }
-      } catch (error) {
-        if (!(error instanceof ProviderWriteError)) throw error;
-        if (convertsToSingle) {
-          if (error.reason === "transient") return command;
           return failCommand(
             deps,
             command,
-            error.reason,
+            alignResult.stop.reason,
             provider.connectionId,
           );
         }
@@ -662,8 +649,8 @@ async function commitProviderSeriesUpdate(
           deps,
           command,
           provider,
-          exception.providerEventId,
-          error,
+          exceptionProviderEventId,
+          alignResult.stop.reason,
         );
         if (stop) return stop;
       }
@@ -772,23 +759,28 @@ export async function executeProviderOccurrenceUpdate(
   }
   const { accessToken } = tokenResult;
 
-  let instance: ProviderEvent | null;
-  try {
-    const read = await deps.writer.fetchInstanceAt({
+  const fetchInstanceResult = await runProviderWrite(() =>
+    deps.writer.fetchInstanceAt({
       accessToken,
       calendarId: calendar.providerCalendarId,
       seriesProviderEventId,
       originalStartAt: recurrenceId,
       scheduleKind: master.schedule.kind,
-    });
-    instance = read?.kind === "event" ? read : null;
-  } catch (error) {
-    if (error instanceof ProviderWriteError) {
-      if (error.reason === "transient") return command;
-      return failCommand(deps, command, error.reason, connectionId);
-    }
-    throw error;
+    }),
+  );
+  if (!fetchInstanceResult.ok) {
+    if (fetchInstanceResult.stop.kind === "pending") return command;
+    return failCommand(
+      deps,
+      command,
+      fetchInstanceResult.stop.reason,
+      connectionId,
+    );
   }
+  const instance =
+    fetchInstanceResult.value?.kind === "event"
+      ? fetchInstanceResult.value
+      : null;
   // No live instance to override: never materialized at that instant, or
   // already cancelled at the provider (see the deferred-gap note above).
   if (!instance) {
@@ -824,23 +816,21 @@ export async function executeProviderOccurrenceUpdate(
     );
   }
 
-  let result: ProviderWriteResult;
-  try {
-    result = await deps.writer.patchEvent({
+  const patchResult = await runProviderWrite(() =>
+    deps.writer.patchEvent({
       ...location,
       expectedVersion: command.expectedVersion,
       content,
       schedule: input.schedule,
       recurrence: { kind: "instance" },
       invitation: input.invitation,
-    });
-  } catch (error) {
-    if (error instanceof ProviderWriteError) {
-      if (error.reason === "transient") return command;
-      return failCommand(deps, command, error.reason, connectionId);
-    }
-    throw error;
+    }),
+  );
+  if (!patchResult.ok) {
+    if (patchResult.stop.kind === "pending") return command;
+    return failCommand(deps, command, patchResult.stop.reason, connectionId);
   }
+  const result = patchResult.value;
 
   return commitProviderOccurrenceUpdate(
     deps,
@@ -943,27 +933,32 @@ export async function executeProviderOccurrenceDelete(
   }
   const { accessToken } = tokenResult;
 
-  let instance: ProviderEvent | null;
-  try {
-    const read = await deps.writer.fetchInstanceAt({
+  const fetchInstanceResult = await runProviderWrite(() =>
+    deps.writer.fetchInstanceAt({
       accessToken,
       calendarId: calendar.providerCalendarId,
       seriesProviderEventId,
       originalStartAt: recurrenceId,
       scheduleKind: master.schedule.kind,
-    });
-    instance = read?.kind === "event" ? read : null;
-  } catch (error) {
-    if (error instanceof ProviderWriteError) {
-      if (error.reason === "transient") return command;
-      return failCommand(deps, command, error.reason, connectionId);
-    }
-    throw error;
+    }),
+  );
+  if (!fetchInstanceResult.ok) {
+    if (fetchInstanceResult.stop.kind === "pending") return command;
+    return failCommand(
+      deps,
+      command,
+      fetchInstanceResult.stop.reason,
+      connectionId,
+    );
   }
+  const instance =
+    fetchInstanceResult.value?.kind === "event"
+      ? fetchInstanceResult.value
+      : null;
 
   if (instance) {
-    try {
-      await deps.writer.deleteEvent({
+    const deleteResult = await runProviderWrite(() =>
+      deps.writer.deleteEvent({
         accessToken,
         calendarId: calendar.providerCalendarId,
         providerEventId: instance.providerEventId,
@@ -971,13 +966,11 @@ export async function executeProviderOccurrenceDelete(
         // one instance is not conditioned on its version.
         expectedVersion: null,
         invitation: input.invitation,
-      });
-    } catch (error) {
-      if (error instanceof ProviderWriteError) {
-        if (error.reason === "transient") return command;
-        return failCommand(deps, command, error.reason, connectionId);
-      }
-      throw error;
+      }),
+    );
+    if (!deleteResult.ok) {
+      if (deleteResult.stop.kind === "pending") return command;
+      return failCommand(deps, command, deleteResult.stop.reason, connectionId);
     }
   }
 
@@ -1106,23 +1099,21 @@ export async function executeProviderSeriesFollowingDelete(
     );
   }
 
-  let result: ProviderWriteResult;
-  try {
-    result = await deps.writer.patchEvent({
+  const patchResult = await runProviderWrite(() =>
+    deps.writer.patchEvent({
       ...location,
       expectedVersion: command.expectedVersion,
       content: master.content,
       schedule: master.schedule,
       recurrence: truncateRecurrence,
       invitation: input.invitation,
-    });
-  } catch (error) {
-    if (error instanceof ProviderWriteError) {
-      if (error.reason === "transient") return command;
-      return failCommand(deps, command, error.reason, connectionId);
-    }
-    throw error;
+    }),
+  );
+  if (!patchResult.ok) {
+    if (patchResult.stop.kind === "pending") return command;
+    return failCommand(deps, command, patchResult.stop.reason, connectionId);
   }
+  const result = patchResult.value;
 
   return commitProviderSeriesFollowingDelete(
     deps,
@@ -1252,24 +1243,26 @@ export async function executeProviderSeriesFollowingUpdate(
   ) {
     originalVersion = current.providerVersion;
   } else {
-    let truncateResult: ProviderWriteResult;
-    try {
-      truncateResult = await deps.writer.patchEvent({
+    const truncateResult = await runProviderWrite(() =>
+      deps.writer.patchEvent({
         ...originalLocation,
         expectedVersion: command.expectedVersion,
         content: master.content,
         schedule: master.schedule,
         recurrence: truncateRecurrence,
         invitation: input.invitation,
-      });
-    } catch (error) {
-      if (error instanceof ProviderWriteError) {
-        if (error.reason === "transient") return command;
-        return failCommand(deps, command, error.reason, connectionId);
-      }
-      throw error;
+      }),
+    );
+    if (!truncateResult.ok) {
+      if (truncateResult.stop.kind === "pending") return command;
+      return failCommand(
+        deps,
+        command,
+        truncateResult.stop.reason,
+        connectionId,
+      );
     }
-    originalVersion = truncateResult.providerVersion;
+    originalVersion = truncateResult.value.providerVersion;
   }
 
   const truncated: EventRecord = {
@@ -1300,9 +1293,8 @@ export async function executeProviderSeriesFollowingUpdate(
   );
   const remainderContent = mergeUpdateContent(master.content, input.content);
 
-  let createResult: ProviderWriteResult;
-  try {
-    createResult = await deps.writer.createEvent({
+  const createResultAttempt = await runProviderWrite(() =>
+    deps.writer.createEvent({
       accessToken,
       calendarId: calendar.providerCalendarId,
       providerEventId: remainderId,
@@ -1310,14 +1302,18 @@ export async function executeProviderSeriesFollowingUpdate(
       schedule: input.schedule,
       recurrence: remainderRecurrence,
       invitation: input.invitation,
-    });
-  } catch (error) {
-    if (error instanceof ProviderWriteError) {
-      if (error.reason === "transient") return command;
-      return failCommand(deps, command, error.reason, connectionId);
-    }
-    throw error;
+    }),
+  );
+  if (!createResultAttempt.ok) {
+    if (createResultAttempt.stop.kind === "pending") return command;
+    return failCommand(
+      deps,
+      command,
+      createResultAttempt.stop.reason,
+      connectionId,
+    );
   }
+  const createResult = createResultAttempt.value;
 
   const remainder: EventRecord = {
     ...master,

--- a/packages/sync/src/domain/provider-write-ladder.test.ts
+++ b/packages/sync/src/domain/provider-write-ladder.test.ts
@@ -1,0 +1,89 @@
+import { type ConnectionId } from "@core/types/sync/identity.contracts";
+import {
+  type AccessTokenSource,
+  resolveAccessToken,
+  runProviderWrite,
+} from "@sync/domain/provider-write-ladder";
+import { ProviderAuthError } from "@sync/providers/provider-auth.port";
+import { ProviderWriteError } from "@sync/providers/provider-event-writer.port";
+import { describe, expect, it } from "bun:test";
+
+const connectionId = "507f1f77bcf86cd799439011" as ConnectionId;
+
+describe("resolveAccessToken", () => {
+  it("returns the token on success", async () => {
+    const custody: AccessTokenSource = {
+      getValidAccessToken: async () => "tok",
+      discardRevoked: async () => {},
+      invalidateAccessToken: async () => {},
+    };
+    await expect(resolveAccessToken(custody, connectionId)).resolves.toEqual({
+      ok: true,
+      accessToken: "tok",
+    });
+  });
+
+  it("maps refreshFailed to pending", async () => {
+    const custody: AccessTokenSource = {
+      getValidAccessToken: async () => {
+        throw new ProviderAuthError("refreshFailed", "blip");
+      },
+      discardRevoked: async () => {},
+      invalidateAccessToken: async () => {},
+    };
+    await expect(resolveAccessToken(custody, connectionId)).resolves.toEqual({
+      ok: false,
+      stop: { kind: "pending" },
+    });
+  });
+
+  it("maps other auth failures to authorizationRevoked", async () => {
+    const custody: AccessTokenSource = {
+      getValidAccessToken: async () => {
+        throw new ProviderAuthError("authorizationRevoked", "gone");
+      },
+      discardRevoked: async () => {},
+      invalidateAccessToken: async () => {},
+    };
+    await expect(resolveAccessToken(custody, connectionId)).resolves.toEqual({
+      ok: false,
+      stop: { kind: "failed", reason: "authorizationRevoked" },
+    });
+  });
+});
+
+describe("runProviderWrite", () => {
+  it("returns the value on success", async () => {
+    await expect(runProviderWrite(async () => 42)).resolves.toEqual({
+      ok: true,
+      value: 42,
+    });
+  });
+
+  it("maps transient ProviderWriteError to pending", async () => {
+    await expect(
+      runProviderWrite(async () => {
+        throw new ProviderWriteError("transient", "blip");
+      }),
+    ).resolves.toEqual({ ok: false, stop: { kind: "pending" } });
+  });
+
+  it("maps permanent ProviderWriteError to failed with that reason", async () => {
+    await expect(
+      runProviderWrite(async () => {
+        throw new ProviderWriteError("permanentProviderError", "missing");
+      }),
+    ).resolves.toEqual({
+      ok: false,
+      stop: { kind: "failed", reason: "permanentProviderError" },
+    });
+  });
+
+  it("rethrows unexpected errors", async () => {
+    await expect(
+      runProviderWrite(async () => {
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+  });
+});

--- a/packages/sync/src/domain/provider-write-ladder.ts
+++ b/packages/sync/src/domain/provider-write-ladder.ts
@@ -1,0 +1,76 @@
+import { type SyncCommandFailureReason } from "@core/types/sync/command.contracts";
+import { type ConnectionId } from "@core/types/sync/identity.contracts";
+import { ProviderAuthError } from "@sync/providers/provider-auth.port";
+import { ProviderWriteError } from "@sync/providers/provider-event-writer.port";
+
+// The slice of credential custody the executor needs — a valid access token for
+// a connection, plus discard of a provider-invalidated grant. Narrow so tests
+// pass a plain fake; CredentialCustody satisfies it structurally.
+export interface AccessTokenSource {
+  getValidAccessToken(connectionId: ConnectionId): Promise<string>;
+  discardRevoked(connectionId: ConnectionId): Promise<void>;
+  invalidateAccessToken(connectionId: ConnectionId): Promise<void>;
+}
+
+/**
+ * Shared classification for the auth + provider-write ladders duplicated across
+ * provider-command executors. Callers decide how to turn a stop into a command
+ * outcome (failCommand vs revertAndFail vs return pending).
+ */
+export type ProviderWriteStop =
+  | { kind: "pending" }
+  | { kind: "failed"; reason: SyncCommandFailureReason };
+
+export type AccessTokenResult =
+  | { ok: true; accessToken: string }
+  | { ok: false; stop: ProviderWriteStop };
+
+export type ProviderWriteAttempt<T> =
+  | { ok: true; value: T }
+  | { ok: false; stop: ProviderWriteStop };
+
+/**
+ * Resolve a valid access token. Transient refresh failures leave the command
+ * pending; revoked/missing credentials are terminal authorizationRevoked.
+ */
+export async function resolveAccessToken(
+  custody: AccessTokenSource,
+  connectionId: ConnectionId,
+): Promise<AccessTokenResult> {
+  try {
+    const accessToken = await custody.getValidAccessToken(connectionId);
+    return { ok: true, accessToken };
+  } catch (error) {
+    if (
+      error instanceof ProviderAuthError &&
+      error.reason === "refreshFailed"
+    ) {
+      return { ok: false, stop: { kind: "pending" } };
+    }
+    return {
+      ok: false,
+      stop: { kind: "failed", reason: "authorizationRevoked" },
+    };
+  }
+}
+
+/**
+ * Run a provider write/read that throws ProviderWriteError. Transient → pending;
+ * other ProviderWriteError reasons → failed with that reason; anything else
+ * rethrows (programmer / unexpected).
+ */
+export async function runProviderWrite<T>(
+  attempt: () => Promise<T>,
+): Promise<ProviderWriteAttempt<T>> {
+  try {
+    return { ok: true, value: await attempt() };
+  } catch (error) {
+    if (error instanceof ProviderWriteError) {
+      if (error.reason === "transient") {
+        return { ok: false, stop: { kind: "pending" } };
+      }
+      return { ok: false, stop: { kind: "failed", reason: error.reason } };
+    }
+    throw error;
+  }
+}

--- a/packages/sync/src/domain/provider-write-ladder.ts
+++ b/packages/sync/src/domain/provider-write-ladder.ts
@@ -3,20 +3,16 @@ import { type ConnectionId } from "@core/types/sync/identity.contracts";
 import { ProviderAuthError } from "@sync/providers/provider-auth.port";
 import { ProviderWriteError } from "@sync/providers/provider-event-writer.port";
 
-// The slice of credential custody the executor needs — a valid access token for
-// a connection, plus discard of a provider-invalidated grant. Narrow so tests
-// pass a plain fake; CredentialCustody satisfies it structurally.
+// Narrow custody slice so tests can pass a plain fake; CredentialCustody
+// satisfies it structurally.
 export interface AccessTokenSource {
   getValidAccessToken(connectionId: ConnectionId): Promise<string>;
   discardRevoked(connectionId: ConnectionId): Promise<void>;
   invalidateAccessToken(connectionId: ConnectionId): Promise<void>;
 }
 
-/**
- * Shared classification for the auth + provider-write ladders duplicated across
- * provider-command executors. Callers decide how to turn a stop into a command
- * outcome (failCommand vs revertAndFail vs return pending).
- */
+// Callers decide how to turn a stop into a command outcome (failCommand vs
+// revertAndFail vs return pending).
 export type ProviderWriteStop =
   | { kind: "pending" }
   | { kind: "failed"; reason: SyncCommandFailureReason };
@@ -29,10 +25,7 @@ export type ProviderWriteAttempt<T> =
   | { ok: true; value: T }
   | { ok: false; stop: ProviderWriteStop };
 
-/**
- * Resolve a valid access token. Transient refresh failures leave the command
- * pending; revoked/missing credentials are terminal authorizationRevoked.
- */
+// Transient refresh → pending; revoked/missing → authorizationRevoked.
 export async function resolveAccessToken(
   custody: AccessTokenSource,
   connectionId: ConnectionId,
@@ -54,11 +47,7 @@ export async function resolveAccessToken(
   }
 }
 
-/**
- * Run a provider write/read that throws ProviderWriteError. Transient → pending;
- * other ProviderWriteError reasons → failed with that reason; anything else
- * rethrows (programmer / unexpected).
- */
+// Transient ProviderWriteError → pending; other reasons → failed; else rethrow.
 export async function runProviderWrite<T>(
   attempt: () => Promise<T>,
 ): Promise<ProviderWriteAttempt<T>> {

--- a/packages/sync/src/domain/stale-command-retry.service.db.test.ts
+++ b/packages/sync/src/domain/stale-command-retry.service.db.test.ts
@@ -12,15 +12,18 @@ import { submitCloudCommand } from "@sync/domain/cloud-command.service";
 import { retryStaleCommands } from "@sync/domain/stale-command-retry.service";
 import { type ProviderEvent } from "@sync/providers/provider-event.port";
 import {
+  type ProviderCreateInput,
   type ProviderDeleteInput,
   type ProviderEventWriter,
   ProviderWriteError,
+  type ProviderWriteResult,
 } from "@sync/providers/provider-event-writer.port";
 import { CommandRepository } from "@sync/storage/repositories/command.repository";
 import { DeletionMarkerRepository } from "@sync/storage/repositories/deletion-marker.repository";
 import { EventRepository } from "@sync/storage/repositories/event.repository";
 import { EventOccurrenceRepository } from "@sync/storage/repositories/event-occurrence.repository";
 import { ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
+import { SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
 import { type SyncMongoService } from "@sync/storage/sync-mongo.service";
 import { beforeEach, describe, expect, it } from "bun:test";
 
@@ -49,6 +52,33 @@ class FakeDeleteWriter implements ProviderEventWriter {
   }
 }
 
+class FakeCreateWriter implements ProviderEventWriter {
+  readonly provider = "google" as const;
+  createError: Error | null = null;
+  createCalls: ProviderCreateInput[] = [];
+  result: ProviderWriteResult = {
+    providerEventId: "g-created-1",
+    providerVersion: "etag-created",
+  };
+  async createEvent(input: ProviderCreateInput): Promise<ProviderWriteResult> {
+    this.createCalls.push(input);
+    if (this.createError) throw this.createError;
+    return this.result;
+  }
+  async deleteEvent(): Promise<never> {
+    throw new Error("unused");
+  }
+  async patchEvent(): Promise<never> {
+    throw new Error("unused");
+  }
+  async fetchEvent(): Promise<ProviderEvent | null> {
+    return null;
+  }
+  async fetchInstanceAt(): Promise<ProviderEvent | null> {
+    return null;
+  }
+}
+
 const tokenSource = () => ({
   getValidAccessToken: async () => "access-token",
   discardRevoked: async () => {},
@@ -62,6 +92,7 @@ describe("retryStaleCommands", () => {
   let occurrences: EventOccurrenceRepository;
   let calendars: ProviderCalendarRepository;
   let markers: DeletionMarkerRepository;
+  let resources: SyncResourceRepository;
 
   const now = () => new Date("2026-07-10T00:00:00.000Z");
   // CommandRepository.submit() stamps createdAt/updatedAt with the real wall
@@ -76,6 +107,17 @@ describe("retryStaleCommands", () => {
     end: "2026-07-14T10:00:00-06:00",
     timeZone: "America/Denver",
   };
+
+  const baseDeps = (writer: ProviderEventWriter) => ({
+    commands,
+    events,
+    calendars,
+    occurrences,
+    resources,
+    markers,
+    execution: "active" as const,
+    provider: { writer, custody: tokenSource() },
+  });
 
   // Seed a provider-linked event stuck deletionPending, plus its still-pending
   // delete command - the state a transient provider failure leaves behind
@@ -135,6 +177,44 @@ describe("retryStaleCommands", () => {
     return { tenantId, principalId, calendar, event, command };
   };
 
+  // Seed a still-pending create against a provider calendar — the state a
+  // transient Google blip leaves behind (executeProviderCreate returns the
+  // command unchanged; no event row yet).
+  const seedStuckCreate = async () => {
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
+    const connectionId = objectId() as ConnectionId;
+    const calendar = await seedProviderCalendar(calendars, {
+      tenantId,
+      principalId,
+      connectionId,
+    });
+    const eventId = objectId() as EventId;
+    const { record: command } = await commands.submit({
+      tenantId,
+      principalId,
+      idempotencyKey: `idem-${objectId()}` as IdempotencyKey,
+      eventId,
+      input: {
+        kind: "create",
+        calendarId: calendar._id,
+        invitation: "none",
+        content: {
+          title: "New",
+          description: "",
+          location: null,
+          organizer: null,
+          attendees: [],
+          conference: null,
+        },
+        schedule,
+        recurrence: { kind: "single" },
+      } as never,
+      expectedVersion: null,
+    });
+    return { tenantId, principalId, calendar, eventId, command };
+  };
+
   beforeEach(() => {
     mongo = storage.mongo();
     commands = new CommandRepository(mongo.db);
@@ -142,6 +222,7 @@ describe("retryStaleCommands", () => {
     occurrences = new EventOccurrenceRepository(mongo.db, mongo.client);
     calendars = new ProviderCalendarRepository(mongo.db);
     markers = new DeletionMarkerRepository(mongo.db);
+    resources = new SyncResourceRepository(mongo.db);
   });
 
   it("finishes a delete that failed transiently on the first attempt", async () => {
@@ -149,19 +230,7 @@ describe("retryStaleCommands", () => {
     expect(command.outcome.state).toBe("pending");
     const writer = new FakeDeleteWriter();
 
-    const result = await retryStaleCommands(
-      {
-        commands,
-        events,
-        calendars,
-        occurrences,
-        markers,
-        execution: "active",
-        provider: { writer, custody: tokenSource() },
-      },
-      before(),
-      now,
-    );
+    const result = await retryStaleCommands(baseDeps(writer), before(), now);
 
     expect(result).toEqual({ attempted: 1, stillStale: 0 });
     expect(writer.deleteCalls).toHaveLength(1);
@@ -170,24 +239,39 @@ describe("retryStaleCommands", () => {
     expect(await events.findById(tenantId, principalId, event._id)).toBeNull();
   });
 
+  it("finishes a create that failed transiently on the first attempt", async () => {
+    const { tenantId, principalId, eventId, command } = await seedStuckCreate();
+    expect(command.outcome.state).toBe("pending");
+    const writer = new FakeCreateWriter();
+
+    const result = await retryStaleCommands(baseDeps(writer), before(), now);
+
+    expect(result).toEqual({ attempted: 1, stillStale: 0 });
+    expect(writer.createCalls).toHaveLength(1);
+    const stored = await commands.findById(tenantId, principalId, command._id);
+    expect(stored?.outcome.state).toBe("confirmed");
+    const event = await events.findById(tenantId, principalId, eventId);
+    expect(event?.providerEventId).toBe("g-created-1");
+  });
+
+  it("leaves a create pending and reports it still stale on a repeated transient failure", async () => {
+    const { tenantId, principalId, command } = await seedStuckCreate();
+    const writer = new FakeCreateWriter();
+    writer.createError = new ProviderWriteError("transient", "blip again");
+
+    const result = await retryStaleCommands(baseDeps(writer), before(), now);
+
+    expect(result).toEqual({ attempted: 1, stillStale: 1 });
+    const stored = await commands.findById(tenantId, principalId, command._id);
+    expect(stored?.outcome.state).toBe("pending");
+  });
+
   it("leaves the command pending and reports it still stale on a repeated transient failure", async () => {
     const { tenantId, principalId, command } = await seedStuckDelete();
     const writer = new FakeDeleteWriter();
     writer.deleteError = new ProviderWriteError("transient", "blip again");
 
-    const result = await retryStaleCommands(
-      {
-        commands,
-        events,
-        calendars,
-        occurrences,
-        markers,
-        execution: "active",
-        provider: { writer, custody: tokenSource() },
-      },
-      before(),
-      now,
-    );
+    const result = await retryStaleCommands(baseDeps(writer), before(), now);
 
     expect(result).toEqual({ attempted: 1, stillStale: 1 });
     const stored = await commands.findById(tenantId, principalId, command._id);
@@ -199,15 +283,7 @@ describe("retryStaleCommands", () => {
     const writer = new FakeDeleteWriter();
 
     const result = await retryStaleCommands(
-      {
-        commands,
-        events,
-        calendars,
-        occurrences,
-        markers,
-        execution: "active",
-        provider: { writer, custody: tokenSource() },
-      },
+      baseDeps(writer),
       // Cutoff before the command's updatedAt: not stale yet.
       notYetStale(),
       now,
@@ -223,15 +299,10 @@ describe("retryStaleCommands", () => {
 
     const result = await retryStaleCommands(
       {
-        commands,
-        events,
-        calendars,
-        occurrences,
-        markers,
+        ...baseDeps(writer),
         // Provider work unavailable: dispatchProviderDelete throws
         // ProviderWriteUnavailableError before ever calling the writer.
         execution: "passive",
-        provider: { writer, custody: tokenSource() },
       },
       before(),
       now,
@@ -265,13 +336,7 @@ describe("retryStaleCommands", () => {
 
     const result = await retryStaleCommands(
       {
-        commands,
-        events,
-        calendars,
-        occurrences,
-        markers,
-        execution: "active",
-        provider: { writer, custody: tokenSource() },
+        ...baseDeps(writer),
         onRetryError: (error, commandId) =>
           onRetryErrorCalls.push({ error, commandId }),
       },
@@ -380,15 +445,7 @@ describe("retryStaleCommands", () => {
 
     // The user's follow-up edit B->C is submitted and applied normally.
     const { command: laterCommand } = await submitCloudCommand(
-      {
-        commands,
-        events,
-        calendars,
-        occurrences,
-        markers,
-        execution: "active",
-        provider: { writer: new FakeDeleteWriter(), custody: tokenSource() },
-      },
+      baseDeps(new FakeDeleteWriter()),
       updateTo("C"),
       now,
     );
@@ -398,15 +455,7 @@ describe("retryStaleCommands", () => {
     ).toBe("C");
 
     const result = await retryStaleCommands(
-      {
-        commands,
-        events,
-        calendars,
-        occurrences,
-        markers,
-        execution: "active",
-        provider: { writer: new FakeDeleteWriter(), custody: tokenSource() },
-      },
+      baseDeps(new FakeDeleteWriter()),
       before(),
       now,
     );

--- a/packages/sync/src/domain/stale-command-retry.service.ts
+++ b/packages/sync/src/domain/stale-command-retry.service.ts
@@ -23,19 +23,22 @@ export interface StaleCommandRetryResult {
 }
 
 // The kinds executed inline and synchronously from the command HTTP request
-// (see cloud-command.service.ts's applyCloudMutation): a transient provider
-// failure mid-execute there returns the command unchanged, and no job or
-// worker ever revisits it. Without this sweep, an event can sit visibly
-// "deleting" or reflecting a half-applied update forever after one blip.
+// (see cloud-command.service.ts's applyCloudMutation / create path): a
+// transient provider failure mid-execute there returns the command unchanged,
+// and no job worker revisits it. Without this sweep, an event can sit visibly
+// "creating"/"deleting" or reflecting a half-applied update forever after one
+// blip.
 const RETRYABLE_KINDS: readonly SyncCommandInput["kind"][] = [
+  "create",
   "update",
   "delete",
 ];
 
 // The self-heal sweep for commands stuck nonterminal (pending/applying/
 // reconciling) past the stale window. Re-runs the exact same routing logic
-// the original request used (retryCloudMutation -> applyCloudMutation), so a
-// command that recovers converges exactly as it would have inline.
+// the original request used (retryCloudMutation -> applyCloudMutation /
+// create path), so a command that recovers converges exactly as it would
+// have inline.
 // retryCloudMutation itself refuses to reapply a command superseded by a
 // later one for the same event (failing it as versionConflict instead) - a
 // stale command that just sat pending for the retry window is not

--- a/packages/sync/src/domain/subscription-maintenance.service.ts
+++ b/packages/sync/src/domain/subscription-maintenance.service.ts
@@ -1,4 +1,4 @@
-import { type AccessTokenSource } from "@sync/domain/provider-command.service";
+import { type AccessTokenSource } from "@sync/domain/provider-write-ladder";
 import {
   type ProviderNotificationAdapter,
   ProviderNotificationError,

--- a/packages/sync/src/domain/sync-job-dispatch.service.ts
+++ b/packages/sync/src/domain/sync-job-dispatch.service.ts
@@ -2,7 +2,7 @@ import { importCalendarEvents } from "@sync/domain/calendar-import.service";
 import { syncCalendarList } from "@sync/domain/calendar-list-sync.service";
 import { pullCalendarChanges } from "@sync/domain/calendar-pull.service";
 import { repairCalendar } from "@sync/domain/calendar-repair.service";
-import { type AccessTokenSource } from "@sync/domain/provider-command.service";
+import { type AccessTokenSource } from "@sync/domain/provider-write-ladder";
 import { maintainSubscription } from "@sync/domain/subscription-maintenance.service";
 import { ProviderAuthError } from "@sync/providers/provider-auth.port";
 import {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Pre-launch hardening for backend and sync ahead of Aug 14: close the production `verifyIsDev` fall-through, unify Sync→API error envelopes, self-heal stranded create commands, collapse duplicated provider-write ladders, and speed up / de-flake Mongo-backed tests.

## What changed and why

1. **Dev route gate** — `verifyIsDev` returns after 403 (no `next()`); `delete-all` requires session user match.
2. **Error envelopes** — Sync proxy failures map to 502/503 (never HTTP 600); unknown mutation errors are non-retryable 500; user routes return JSON bodies.
3. **Write durability** — stale-command retry includes creates with a real create retry path that always reprojects occurrences; backend Mongo sessions always `endSession()`; `startTrial` uses a conditional update.
4. **Provider write ladders** — shared `resolveAccessToken` / `runProviderWrite` across provider-command executors.
5. **Tests** — USER collection cleaned between DB tests; SSE `waitForNoEvent`; performance baselines refreshed.

## Simplification

- Finished migrating remaining `ProviderWriteError` catch blocks onto `runProviderWrite`.
- Collapsed `throwSyncCommandSubmitFailure` to a single-arg helper.
- Dropped the `AccessTokenSource` re-export; consumers import from `provider-write-ladder`.

## Validation

- `bun test:backend:fast` — 248 pass
- `bun test:backend` — 303 pass, 1 skip
- `bun test:sync:fast` — 321 pass
- `bun test:sync` (provider-command + stale-command-retry) — 59+ pass
- `bun type-check` — pass
- `bun lint` — pass (pre-existing warnings only)
- Independent review: fixed create-retry occurrence reproject gap

## Residual risk

- Google adopt / account-purge outbox saga still deferred.
- Onboarding e2e on earlier push failed once (form open / shortcut showcase); unrelated to backend/sync paths in this PR — monitoring latest CI.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-33252301-70eb-4b2e-bd25-44b18232c83e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-33252301-70eb-4b2e-bd25-44b18232c83e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

