### PR TITLE
fix(web): close the practice title editor before the next lesson key

### DIFF
--- a/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.tsx
+++ b/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.tsx
@@ -1,4 +1,11 @@
-import { type FC, useCallback, useEffect, useRef, useState } from "react";
+import {
+  type FC,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 import { track } from "@web/auth/posthog/track";
 import { Z_INDEX_MODAL } from "@web/common/constants/web.constants";
 import { isEditableKeyboardTarget } from "@web/common/utils/form/form.util";
@@ -147,8 +154,12 @@ const ShowcaseTakeover: FC = () => {
 
   // Step-entry effects: snapshot for Back, then stage the board so the
   // taught keystroke lands (mirrors the tour's enterDentistMission trick).
+  // Layout, not passive: a step advances from inside a keydown handler, so a
+  // passive effect would run after the browser is free to deliver the next
+  // keystroke. The lesson key would then land in a title editor this effect
+  // has not closed yet (silently appending to the title instead of teaching).
   // biome-ignore lint/correctness/useExhaustiveDependencies: runs per step change by design
-  useEffect(() => {
+  useLayoutEffect(() => {
     entrySnapshotsRef.current[stepIndex] ??= practiceRef.current;
     undoDoneRef.current = false;
 


### PR DESCRIPTION
`shortcut-showcase.spec.ts` fails in CI at `expect(showcase).toContainText("Reschedule in a keystroke")` and usually passes locally. It is a real race in the showcase, not a flaky assertion.

- The `editTitle` step opens the practice title editor and advances the step in the same keydown.
- The step-entry effect closes that lingering editor, but it was a **passive** `useEffect`. React commits the DOM (so the next step's text is already visible and assertable) and flushes the effect later.
- Any keystroke delivered inside that window lands in the still-mounted `<input>`.

Probing the live page at that instant produced both outcomes across runs on one machine: `input: false` (editor closed, `s` flashed the jump chips) and `input: true, inputValue: "Breakfast with Sams"` — the lesson `s` silently appended to the event title. A loaded CI worker lost the flush race consistently.

Fix: run the step-entry effect as a `useLayoutEffect`. Step advances originate in a discrete keydown, so React renders and flushes layout effects before the browser can deliver the next key, closing the gap by construction rather than by timing. This is user-facing, not just a test fix: a fast real user corrupted a title the same way. Step staging (`focusFallback`/`setEdge`/`clearFocus`) now also happens before paint, so no frame shows the unstaged board.

## Scope note

This PR originally also taught `first-run.spec.ts` to dismiss the showcase. #2763 landed that same fix in parallel while this was in review, so the rebase drops mine in favor of main's (which additionally asserts the confirm text and post-reload absence). What remains here is the product fix, which #2763 does not include.

## Verification

- `bunx playwright test --repeat-each=6 --workers=1 e2e/onboarding` on the rebased tree — 18 passed
- Before the change, `shortcut-showcase.spec.ts:41` reproduced locally on unmodified `origin/main`
- Full `bun run test:e2e` with CI env vars — 31 passed
- `bun run type-check`, `bun run lint` clean; `bun test ./src/components/ShortcutShowcase` — 23 passed

## Worth doing next: run e2e on pushes to main

The deeper problem is that a red e2e can land and stay invisible: `test-e2e.yml` triggers only on `pull_request` targeting `main`, so a merge commit is never tested as merged and nothing re-runs afterward. #2761 merged with `e2e fail` and main stayed red until the next PR. Adding

```yaml
on:
  push:
    branches: [main]
```

would have caught it at merge time. Left out here to keep this PR to the fix, and because the extra run per merge is a CI-cost call worth making deliberately.
