### PR TITLE
ci: run e2e on pushes to main

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -8,13 +8,27 @@ on:
       - ".gitignore"
       - "**/*.md"
       - "docs/**"
+  # Merge commits are never tested as merged, and nothing re-runs afterward,
+  # so a red e2e used to land on main and hide until the next PR opened.
+  # Scoped to main on purpose: a full Playwright run per feature-branch
+  # commit costs real minutes and adds no signal the PR run does not have.
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - ".gitignore"
+      - "**/*.md"
+      - "docs/**"
 
 permissions:
   contents: read
 
 concurrency:
   group: e2e-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  # Superseding a PR push is fine, but two merges landing close together must
+  # not cancel the first main run: a cancelled run reads as "not red" and
+  # would recreate the blind spot this trigger exists to close.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   e2e:


### PR DESCRIPTION
Closes the blind spot behind the red-main incident fixed in #2763 and #2764.

`test-e2e.yml` triggered only on `pull_request`, so:
- a merge commit was never tested as merged, and
- nothing re-ran e2e on `main` afterward.

#2761 merged with a failing `e2e` job and `main` stayed red invisibly until someone happened to open the next PR. `gh pr checks 2761` still shows `e2e fail` today.

## Changes

**`push` trigger on `main`.** `test-unit.yml` already has a push trigger, so this only brings e2e in line with the existing pattern. One deliberate difference: `test-unit.yml`'s push has no branch filter and runs on every branch, while this is scoped to `main` — a full Playwright run per feature-branch commit costs real minutes and adds no signal the `pull_request` run does not already provide. Same `paths-ignore` as the PR trigger.

**`cancel-in-progress` is now `pull_request`-only.** Superseding an in-flight PR run is what you want. Cancelling a `main` run is not: if two merges land close together, the first commit's run would be cancelled, and a cancelled run reads as "not red" — recreating the exact blind spot this trigger exists to close. The concurrency group already separates PR runs (`github.event.pull_request.number`) from main pushes (`github.ref`), so PR and main runs never contend.

## Cost

One extra ~2 minute e2e run per merge to `main`. That is the deliberate trade: it is what would have caught #2761 at merge time instead of one PR later.

## Verification

Parsed the workflow to confirm the triggers and the templated `cancel-in-progress` resolve as intended:

```
"on": { "pull_request": {branches: [main], ...}, "push": {branches: [main], ...} }
"concurrency": { group: "e2e-${{ ... }}", cancel-in-progress: "${{ github.event_name == 'pull_request' }}" }
```

The trigger itself can only be fully verified once this is on `main` — the push event fires on merge, so this PR's own merge is the first real exercise of it.