### PR TITLE
fix(backend,sync): ride out transient mongo health blips

### DIFF
--- a/packages/backend/src/common/services/mongo.service.ts
+++ b/packages/backend/src/common/services/mongo.service.ts
@@ -11,6 +11,7 @@ import {
 import { NodeEnv } from "@core/constants/core.constants";
 import { Logger } from "@core/logger/winston.logger";
 import { type Schema_User } from "@core/types/user.types";
+import { isTransientMongoNetworkError } from "@core/util/mongo-network-error.util";
 import { type CalendarRecord } from "@backend/calendar/calendar.record";
 import { Collections } from "@backend/common/constants/collections";
 import { CONFIG } from "@backend/common/constants/config.constants";
@@ -69,6 +70,12 @@ class MongoService {
   }
 
   private onError(error: Error): void {
+    // Client "error" events include brief Atlas/DNS blips; warn those so they
+    // do not open PostHog exception alerts. Unexpected client errors still page.
+    if (isTransientMongoNetworkError(error)) {
+      logger.warn(error.message, error);
+      return;
+    }
     logger.error(error.message, error);
   }
 

--- a/packages/backend/src/health/controllers/health.controller.db.test.ts
+++ b/packages/backend/src/health/controllers/health.controller.db.test.ts
@@ -106,6 +106,57 @@ describe("HealthController", () => {
       }
     });
 
+    it("should recover from a transient Mongo network blip on ping", async () => {
+      const transient = new Error(
+        "Connection to host:27017 interrupted due to server monitor timeout",
+      );
+      transient.name = "PoolClearedOnNetworkError";
+
+      const pingSpy = spyOn(
+        Object.getPrototypeOf(mongoService.db.admin()),
+        "ping",
+      )
+        .mockImplementationOnce(() => Promise.reject(transient))
+        .mockImplementation(() => Promise.resolve({ ok: 1 }));
+
+      try {
+        const response = await baseDriver
+          .getServer()
+          .get("/api/health")
+          .expect(Status.OK);
+
+        expect(response.body.status).toBe("ok");
+        expect(pingSpy).toHaveBeenCalledTimes(2);
+      } finally {
+        pingSpy.mockRestore();
+      }
+    });
+
+    it("should return 500 after transient Mongo blips exhaust retries", async () => {
+      const transient = new Error("getaddrinfo ESERVFAIL");
+      transient.name = "MongoNetworkError";
+
+      const pingSpy = spyOn(
+        Object.getPrototypeOf(mongoService.db.admin()),
+        "ping",
+      ).mockImplementation(() => Promise.reject(transient));
+
+      try {
+        const response = await baseDriver
+          .getServer()
+          .get("/api/health")
+          .expect(Status.INTERNAL_SERVER);
+
+        expect(response.body).toEqual({
+          status: "error",
+          timestamp: expect.any(String),
+        });
+        expect(pingSpy.mock.calls.length).toBeGreaterThanOrEqual(3);
+      } finally {
+        pingSpy.mockRestore();
+      }
+    });
+
     it("should return consistent response structure", async () => {
       const response = await baseDriver
         .getServer()

--- a/packages/backend/src/health/controllers/health.controller.ts
+++ b/packages/backend/src/health/controllers/health.controller.ts
@@ -1,6 +1,10 @@
 import { type Request, type Response } from "express";
 import { Status } from "@core/errors/status.codes";
 import { Logger } from "@core/logger/winston.logger";
+import {
+  isTransientMongoNetworkError,
+  withTransientMongoRetry,
+} from "@core/util/mongo-network-error.util";
 import mongoService from "@backend/common/services/mongo.service";
 
 interface HealthResponse {
@@ -9,6 +13,12 @@ interface HealthResponse {
 }
 
 const logger = Logger("app:health.controller");
+
+// Ride out brief Atlas/DNS blips without failing the probe on the first
+// interrupted ping. Keep the budget short so load balancers still see a
+// timely answer when Mongo stays down.
+const HEALTH_PING_ATTEMPTS = 3;
+const HEALTH_PING_DELAY_MS = 200;
 
 class HealthController {
   /**
@@ -26,14 +36,24 @@ class HealthController {
     const timestamp = new Date().toISOString();
 
     try {
-      await mongoService.db.admin().ping();
+      await withTransientMongoRetry(() => mongoService.db.admin().ping(), {
+        attempts: HEALTH_PING_ATTEMPTS,
+        delayMs: HEALTH_PING_DELAY_MS,
+      });
 
       res.status(Status.OK).json({
         status: "ok",
         timestamp,
       });
     } catch (error) {
-      logger.error("Database connectivity check failed", error);
+      // Transient network blips are expected on managed Mongo; warn so they
+      // stay in logs/OTel without opening a PostHog exception alert.
+      // Persistent or unexpected failures still page as errors.
+      if (isTransientMongoNetworkError(error)) {
+        logger.warn("Database connectivity check failed", error);
+      } else {
+        logger.error("Database connectivity check failed", error);
+      }
       res.status(Status.INTERNAL_SERVER).json({
         status: "error",
         timestamp,

--- a/packages/backend/src/health/controllers/health.controller.ts
+++ b/packages/backend/src/health/controllers/health.controller.ts
@@ -15,10 +15,11 @@ interface HealthResponse {
 const logger = Logger("app:health.controller");
 
 // Ride out brief Atlas/DNS blips without failing the probe on the first
-// interrupted ping. Keep the budget short so load balancers still see a
-// timely answer when Mongo stays down.
+// interrupted ping. Bound each attempt so retries cannot stack into a
+// multi-minute serverSelectionTimeoutMS wait for load balancers.
 const HEALTH_PING_ATTEMPTS = 3;
 const HEALTH_PING_DELAY_MS = 200;
+const HEALTH_PING_TIMEOUT_MS = 2_500;
 
 class HealthController {
   /**
@@ -36,10 +37,14 @@ class HealthController {
     const timestamp = new Date().toISOString();
 
     try {
-      await withTransientMongoRetry(() => mongoService.db.admin().ping(), {
-        attempts: HEALTH_PING_ATTEMPTS,
-        delayMs: HEALTH_PING_DELAY_MS,
-      });
+      await withTransientMongoRetry(
+        () =>
+          mongoService.db.admin().ping({ timeoutMS: HEALTH_PING_TIMEOUT_MS }),
+        {
+          attempts: HEALTH_PING_ATTEMPTS,
+          delayMs: HEALTH_PING_DELAY_MS,
+        },
+      );
 
       res.status(Status.OK).json({
         status: "ok",

--- a/packages/core/src/util/mongo-network-error.util.test.ts
+++ b/packages/core/src/util/mongo-network-error.util.test.ts
@@ -4,8 +4,8 @@ import {
 } from "./mongo-network-error.util";
 import { describe, expect, it, mock } from "bun:test";
 
-function namedError(name: string, message: string): Error {
-  const error = new Error(message);
+function namedError(name: string, message: string, cause?: Error): Error {
+  const error = new Error(message, cause ? { cause } : undefined);
   error.name = name;
   return error;
 }
@@ -25,11 +25,6 @@ describe("isTransientMongoNetworkError", () => {
         namedError("MongoNetworkError", "getaddrinfo ESERVFAIL"),
       ),
     ).toBe(true);
-    expect(
-      isTransientMongoNetworkError(
-        namedError("MongoServerSelectionError", "Server selection timed out"),
-      ),
-    ).toBe(true);
   });
 
   it("matches DNS and socket blip messages even without a driver name", () => {
@@ -39,6 +34,28 @@ describe("isTransientMongoNetworkError", () => {
     expect(isTransientMongoNetworkError(new Error("read ECONNRESET"))).toBe(
       true,
     );
+  });
+
+  it("matches server selection only when the cause/message is a network blip", () => {
+    expect(
+      isTransientMongoNetworkError(
+        namedError(
+          "MongoServerSelectionError",
+          "Server selection timed out after 30000 ms",
+          namedError("MongoNetworkError", "getaddrinfo ESERVFAIL"),
+        ),
+      ),
+    ).toBe(true);
+
+    // Durable selection failures (allowlist / no primary / etc.) must still page.
+    expect(
+      isTransientMongoNetworkError(
+        namedError(
+          "MongoServerSelectionError",
+          "Server selection timed out after 30000 ms",
+        ),
+      ),
+    ).toBe(false);
   });
 
   it("rejects unrelated failures", () => {

--- a/packages/core/src/util/mongo-network-error.util.test.ts
+++ b/packages/core/src/util/mongo-network-error.util.test.ts
@@ -1,0 +1,106 @@
+import {
+  isTransientMongoNetworkError,
+  withTransientMongoRetry,
+} from "./mongo-network-error.util";
+import { describe, expect, it, mock } from "bun:test";
+
+function namedError(name: string, message: string): Error {
+  const error = new Error(message);
+  error.name = name;
+  return error;
+}
+
+describe("isTransientMongoNetworkError", () => {
+  it("matches Mongo driver network and pool-cleared error names", () => {
+    expect(
+      isTransientMongoNetworkError(
+        namedError(
+          "PoolClearedOnNetworkError",
+          "Connection to host:27017 interrupted due to server monitor timeout",
+        ),
+      ),
+    ).toBe(true);
+    expect(
+      isTransientMongoNetworkError(
+        namedError("MongoNetworkError", "getaddrinfo ESERVFAIL"),
+      ),
+    ).toBe(true);
+    expect(
+      isTransientMongoNetworkError(
+        namedError("MongoServerSelectionError", "Server selection timed out"),
+      ),
+    ).toBe(true);
+  });
+
+  it("matches DNS and socket blip messages even without a driver name", () => {
+    expect(
+      isTransientMongoNetworkError(new Error("getaddrinfo ESERVFAIL foo")),
+    ).toBe(true);
+    expect(isTransientMongoNetworkError(new Error("read ECONNRESET"))).toBe(
+      true,
+    );
+  });
+
+  it("rejects unrelated failures", () => {
+    expect(
+      isTransientMongoNetworkError(new Error("database unavailable")),
+    ).toBe(false);
+    expect(isTransientMongoNetworkError("not an error")).toBe(false);
+    expect(isTransientMongoNetworkError(null)).toBe(false);
+  });
+});
+
+describe("withTransientMongoRetry", () => {
+  it("returns on the first success", async () => {
+    const operation = mock(() => Promise.resolve("ok"));
+    await expect(
+      withTransientMongoRetry(operation, { attempts: 3 }),
+    ).resolves.toBe("ok");
+    expect(operation).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries transient Mongo blips then succeeds", async () => {
+    const sleep = mock((_ms: number) => Promise.resolve());
+    const operation = mock(() => Promise.resolve("ok"));
+    operation
+      .mockImplementationOnce(() =>
+        Promise.reject(
+          namedError("MongoNetworkError", "getaddrinfo ESERVFAIL"),
+        ),
+      )
+      .mockImplementationOnce(() => Promise.resolve("ok"));
+
+    await expect(
+      withTransientMongoRetry(operation, { attempts: 3, delayMs: 10, sleep }),
+    ).resolves.toBe("ok");
+    expect(operation).toHaveBeenCalledTimes(2);
+    expect(sleep).toHaveBeenCalledWith(10);
+  });
+
+  it("does not retry non-transient failures", async () => {
+    const sleep = mock((_ms: number) => Promise.resolve());
+    const failure = new Error("database unavailable");
+    const operation = mock(() => Promise.reject(failure));
+
+    await expect(
+      withTransientMongoRetry(operation, { attempts: 3, delayMs: 10, sleep }),
+    ).rejects.toBe(failure);
+    expect(operation).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it("rethrows the last transient failure after exhausting attempts", async () => {
+    const sleep = mock((_ms: number) => Promise.resolve());
+    const failure = namedError(
+      "PoolClearedOnNetworkError",
+      "Connection interrupted due to server monitor timeout",
+    );
+    const operation = mock(() => Promise.reject(failure));
+
+    await expect(
+      withTransientMongoRetry(operation, { attempts: 3, delayMs: 5, sleep }),
+    ).rejects.toBe(failure);
+    expect(operation).toHaveBeenCalledTimes(3);
+    expect(sleep).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/core/src/util/mongo-network-error.util.test.ts
+++ b/packages/core/src/util/mongo-network-error.util.test.ts
@@ -56,6 +56,11 @@ describe("isTransientMongoNetworkError", () => {
         ),
       ),
     ).toBe(false);
+    expect(
+      isTransientMongoNetworkError(
+        namedError("MongoServerSelectionError", "connection timed out"),
+      ),
+    ).toBe(false);
   });
 
   it("rejects unrelated failures", () => {

--- a/packages/core/src/util/mongo-network-error.util.ts
+++ b/packages/core/src/util/mongo-network-error.util.ts
@@ -1,0 +1,81 @@
+// MongoDB driver / Node DNS failures that usually clear themselves after a
+// brief Atlas/network blip. Matching is name + message based so core stays
+// free of a hard mongodb runtime dependency.
+
+const TRANSIENT_MONGO_ERROR_NAMES = new Set([
+  "MongoNetworkError",
+  "MongoNetworkTimeoutError",
+  "MongoServerSelectionError",
+  "MongoPoolClearedError",
+  "PoolClearedOnNetworkError",
+]);
+
+const TRANSIENT_MONGO_MESSAGE_PATTERNS = [
+  /getaddrinfo\s+ESERVFAIL/i,
+  /getaddrinfo\s+ENOTFOUND/i,
+  /getaddrinfo\s+EAI_AGAIN/i,
+  /\bECONNRESET\b/i,
+  /\bETIMEDOUT\b/i,
+  /\bECONNREFUSED\b/i,
+  /server monitor timeout/i,
+  /interrupted due to server monitor timeout/i,
+  /connection.*(closed|reset|timed?\s*out)/i,
+  /server selection timed?\s*out/i,
+  /no connection available/i,
+  /pool.*cleared/i,
+];
+
+function errorName(error: unknown): string | undefined {
+  if (!(error instanceof Error)) return undefined;
+  return error.name;
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === "string") return error;
+  return "";
+}
+
+export function isTransientMongoNetworkError(error: unknown): boolean {
+  const name = errorName(error);
+  if (name !== undefined && TRANSIENT_MONGO_ERROR_NAMES.has(name)) {
+    return true;
+  }
+
+  const message = errorMessage(error);
+  if (message.length === 0) return false;
+
+  return TRANSIENT_MONGO_MESSAGE_PATTERNS.some((pattern) =>
+    pattern.test(message),
+  );
+}
+
+export async function withTransientMongoRetry<T>(
+  operation: () => Promise<T>,
+  options: {
+    attempts?: number;
+    delayMs?: number;
+    sleep?: (ms: number) => Promise<void>;
+  } = {},
+): Promise<T> {
+  const attempts = options.attempts ?? 3;
+  const delayMs = options.delayMs ?? 250;
+  const sleep =
+    options.sleep ??
+    ((ms: number) => new Promise((resolve) => setTimeout(resolve, ms)));
+
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      return await operation();
+    } catch (error) {
+      lastError = error;
+      const canRetry =
+        attempt < attempts && isTransientMongoNetworkError(error);
+      if (!canRetry) throw error;
+      await sleep(delayMs * attempt);
+    }
+  }
+
+  throw lastError;
+}

--- a/packages/core/src/util/mongo-network-error.util.ts
+++ b/packages/core/src/util/mongo-network-error.util.ts
@@ -1,11 +1,14 @@
 // MongoDB driver / Node DNS failures that usually clear themselves after a
 // brief Atlas/network blip. Matching is name + message based so core stays
 // free of a hard mongodb runtime dependency.
+//
+// Do NOT name-match MongoServerSelectionError alone: the driver also uses it
+// for durable topology/auth/allowlist failures. Those still surface when their
+// cause/message is a network blip (walked below).
 
 const TRANSIENT_MONGO_ERROR_NAMES = new Set([
   "MongoNetworkError",
   "MongoNetworkTimeoutError",
-  "MongoServerSelectionError",
   "MongoPoolClearedError",
   "PoolClearedOnNetworkError",
 ]);
@@ -15,18 +18,31 @@ const TRANSIENT_MONGO_MESSAGE_PATTERNS = [
   /\b(ECONNRESET|ETIMEDOUT|ECONNREFUSED)\b/i,
   /server monitor timeout/i,
   /connection.*(closed|reset|timed?\s*out)/i,
-  /server selection timed?\s*out/i,
   /no connection available/i,
   /pool.*cleared/i,
 ];
 
 export function isTransientMongoNetworkError(error: unknown): boolean {
-  if (!(error instanceof Error)) return false;
-  if (TRANSIENT_MONGO_ERROR_NAMES.has(error.name)) return true;
-  if (error.message.length === 0) return false;
-  return TRANSIENT_MONGO_MESSAGE_PATTERNS.some((pattern) =>
-    pattern.test(error.message),
-  );
+  let current: unknown = error;
+  const seen = new WeakSet<object>();
+
+  while (current instanceof Error) {
+    if (seen.has(current)) break;
+    seen.add(current);
+
+    if (TRANSIENT_MONGO_ERROR_NAMES.has(current.name)) return true;
+    const message = current.message;
+    if (
+      message.length > 0 &&
+      TRANSIENT_MONGO_MESSAGE_PATTERNS.some((pattern) => pattern.test(message))
+    ) {
+      return true;
+    }
+
+    current = current.cause;
+  }
+
+  return false;
 }
 
 export async function withTransientMongoRetry<T>(

--- a/packages/core/src/util/mongo-network-error.util.ts
+++ b/packages/core/src/util/mongo-network-error.util.ts
@@ -11,42 +11,21 @@ const TRANSIENT_MONGO_ERROR_NAMES = new Set([
 ]);
 
 const TRANSIENT_MONGO_MESSAGE_PATTERNS = [
-  /getaddrinfo\s+ESERVFAIL/i,
-  /getaddrinfo\s+ENOTFOUND/i,
-  /getaddrinfo\s+EAI_AGAIN/i,
-  /\bECONNRESET\b/i,
-  /\bETIMEDOUT\b/i,
-  /\bECONNREFUSED\b/i,
+  /getaddrinfo\s+(ESERVFAIL|ENOTFOUND|EAI_AGAIN)/i,
+  /\b(ECONNRESET|ETIMEDOUT|ECONNREFUSED)\b/i,
   /server monitor timeout/i,
-  /interrupted due to server monitor timeout/i,
   /connection.*(closed|reset|timed?\s*out)/i,
   /server selection timed?\s*out/i,
   /no connection available/i,
   /pool.*cleared/i,
 ];
 
-function errorName(error: unknown): string | undefined {
-  if (!(error instanceof Error)) return undefined;
-  return error.name;
-}
-
-function errorMessage(error: unknown): string {
-  if (error instanceof Error) return error.message;
-  if (typeof error === "string") return error;
-  return "";
-}
-
 export function isTransientMongoNetworkError(error: unknown): boolean {
-  const name = errorName(error);
-  if (name !== undefined && TRANSIENT_MONGO_ERROR_NAMES.has(name)) {
-    return true;
-  }
-
-  const message = errorMessage(error);
-  if (message.length === 0) return false;
-
+  if (!(error instanceof Error)) return false;
+  if (TRANSIENT_MONGO_ERROR_NAMES.has(error.name)) return true;
+  if (error.message.length === 0) return false;
   return TRANSIENT_MONGO_MESSAGE_PATTERNS.some((pattern) =>
-    pattern.test(message),
+    pattern.test(error.message),
   );
 }
 
@@ -64,18 +43,16 @@ export async function withTransientMongoRetry<T>(
     options.sleep ??
     ((ms: number) => new Promise((resolve) => setTimeout(resolve, ms)));
 
-  let lastError: unknown;
-  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+  let attempt = 0;
+  while (true) {
+    attempt += 1;
     try {
       return await operation();
     } catch (error) {
-      lastError = error;
-      const canRetry =
-        attempt < attempts && isTransientMongoNetworkError(error);
-      if (!canRetry) throw error;
+      if (attempt >= attempts || !isTransientMongoNetworkError(error)) {
+        throw error;
+      }
       await sleep(delayMs * attempt);
     }
   }
-
-  throw lastError;
 }

--- a/packages/core/src/util/mongo-network-error.util.ts
+++ b/packages/core/src/util/mongo-network-error.util.ts
@@ -17,7 +17,6 @@ const TRANSIENT_MONGO_MESSAGE_PATTERNS = [
   /getaddrinfo\s+(ESERVFAIL|ENOTFOUND|EAI_AGAIN)/i,
   /\b(ECONNRESET|ETIMEDOUT|ECONNREFUSED)\b/i,
   /server monitor timeout/i,
-  /connection.*(closed|reset|timed?\s*out)/i,
   /no connection available/i,
   /pool.*cleared/i,
 ];

--- a/packages/sync/src/app.ts
+++ b/packages/sync/src/app.ts
@@ -7,6 +7,10 @@ import {
   SyncReconcileSweepEventSchema,
 } from "@core/types/sync/health.contracts";
 import {
+  isTransientMongoNetworkError,
+  withTransientMongoRetry,
+} from "@core/util/mongo-network-error.util";
+import {
   createInternalAuthMiddleware,
   createInternalServiceAuthMiddleware,
 } from "@sync/auth/internal-auth";
@@ -340,18 +344,30 @@ function buildHealthSnapshotSweep(
     {
       // SweepScheduler always passes `before`; health ignore it and use now.
       sweep: async () => {
-        await emitHealthSnapshot({
-          deps: { mongo, identity },
-          client,
-        });
+        // A single Atlas/DNS blip must not skip the whole 5-minute gauge.
+        await withTransientMongoRetry(
+          () =>
+            emitHealthSnapshot({
+              deps: { mongo, identity },
+              client,
+            }),
+          { attempts: 3, delayMs: 250 },
+        );
         return 1;
       },
     },
     {
       intervalMs: HEALTH_SNAPSHOT_INTERVAL_MS,
       jitterRatio: 0.05,
-      onError: (error) =>
-        logger.error("Sync health snapshot emit failed", error),
+      onError: (error) => {
+        // Transient Mongo network failures are expected blips; warn so they
+        // stay visible without opening a PostHog exception alert.
+        if (isTransientMongoNetworkError(error)) {
+          logger.warn("Sync health snapshot emit failed", error);
+          return;
+        }
+        logger.error("Sync health snapshot emit failed", error);
+      },
     },
   );
 }

--- a/packages/sync/src/app.ts
+++ b/packages/sync/src/app.ts
@@ -345,13 +345,11 @@ function buildHealthSnapshotSweep(
       // SweepScheduler always passes `before`; health ignore it and use now.
       sweep: async () => {
         // A single Atlas/DNS blip must not skip the whole 5-minute gauge.
-        await withTransientMongoRetry(
-          () =>
-            emitHealthSnapshot({
-              deps: { mongo, identity },
-              client,
-            }),
-          { attempts: 3, delayMs: 250 },
+        await withTransientMongoRetry(() =>
+          emitHealthSnapshot({
+            deps: { mongo, identity },
+            client,
+          }),
         );
         return 1;
       },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Investigated two prod PostHog alerts that fired within ~35s of each other on 2026-08-12 (~21:02–21:03Z):

- `Database connectivity check failed` — `PoolClearedOnNetworkError` / Atlas server monitor timeout on `/api/health`
- `Sync health snapshot emit failed` — `MongoNetworkError` / `getaddrinfo ESERVFAIL` while computing the 5-minute sync health snapshot

Both were a brief correlated Atlas/DNS blip, not a sustained outage. `logger.error` was opening PostHog exception alerts for expected network noise.

This change classifies transient Mongo network/DNS/pool-cleared failures (cause-chain aware; bare `MongoServerSelectionError` / `connection timed out` stay non-transient), retries brief blips on `/api/health` and the sync health-snapshot sweep, bounds each health ping with `timeoutMS`, and logs exhausted transient failures at `warn` (still returns 500 from health when Mongo stays down). Backend Mongo client `error` events use the same warn/error split.

## Simplicity

One shared classifier + retry helper in core; call sites only choose warn vs error. Inlined one-off helpers, tightened message patterns, and avoided a shared logger wrapper across differently worded call sites.

## Automated validation

- `bun test:core -- packages/core/src/util/mongo-network-error.util.test.ts` — 8 pass
- `bun test:backend -- packages/backend/src/health/controllers/health.controller.db.test.ts` — 11 pass (recover + exhausted-retry + warn classification)
- `bun type-check` — pass
- `bun lint` — no new issues from this diff

## Independent review

Bugbot confirmed and fixed:
- over-classifying bare `MongoServerSelectionError` as transient
- health retries stacking into multi-minute `serverSelectionTimeoutMS` waits
- broad `connection timed out` message matching durable selection failures

No remaining confirmed findings after those follow-ups.

## Test plan

- `bun test:core -- packages/core/src/util/mongo-network-error.util.test.ts`
- `bun test:backend -- packages/backend/src/health/controllers/health.controller.db.test.ts`
- `bun type-check`
- `bun lint`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6cc273a1-11c3-4ab9-83c0-cbf5776c7780?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6cc273a1-11c3-4ab9-83c0-cbf5776c7780&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

