### PR TITLE
style(web): keep welcome modal keycap hints always visible

### DIFF
--- a/packages/web/src/components/WelcomeModal/WelcomeModal.test.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeModal.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createContext } from "react";
 import { type CompassSession } from "@web/auth/compass/session/session.types";
@@ -174,6 +174,19 @@ describe("WelcomeModal", () => {
     expect(questionButton).toHaveAttribute("aria-expanded", "false");
     expect(answer).toHaveAttribute("aria-hidden", "true");
     expect(answer).toHaveAttribute("data-state", "closed");
+  });
+
+  it("shows shortcut keycaps on auth and start actions without hover", () => {
+    render(<WelcomeModal />);
+
+    for (const [name, key] of [
+      ["Sign up", "U"],
+      ["Log in", "I"],
+      ["Start Now", "S"],
+    ] as const) {
+      const hint = within(screen.getByRole("button", { name })).getByText(key);
+      expect(hint.className).not.toMatch(/opacity-0/);
+    }
   });
 
   it("opens sign up with the U shortcut", async () => {

--- a/packages/web/src/components/WelcomeModal/WelcomeModal.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeModal.tsx
@@ -122,22 +122,18 @@ export function WelcomeModal() {
             <button
               type="button"
               onClick={() => handOffToAuth("sign_up")}
-              className="group inline-flex items-center rounded-3xl bg-accent px-4 py-1.5 text-on-accent text-xs transition-all hover:brightness-110"
+              className="inline-flex items-center rounded-3xl bg-accent px-4 py-1.5 text-on-accent text-xs transition-all hover:brightness-110"
             >
               Sign up
-              <ShortcutHint className="ml-2 opacity-0 transition-opacity duration-150 group-hover:opacity-100 group-focus-visible:opacity-100">
-                U
-              </ShortcutHint>
+              <ShortcutHint className="ml-2">U</ShortcutHint>
             </button>
             <button
               type="button"
               onClick={() => handOffToAuth("log_in")}
-              className="group inline-flex items-center rounded-3xl bg-[#c2c6cc] px-4 py-1.5 text-[#1f1f1f] text-xs transition-all hover:bg-[#d1d5da]"
+              className="inline-flex items-center rounded-3xl bg-[#c2c6cc] px-4 py-1.5 text-[#1f1f1f] text-xs transition-all hover:bg-[#d1d5da]"
             >
               Log in
-              <ShortcutHint className="ml-2 opacity-0 transition-opacity duration-150 group-hover:opacity-100 group-focus-visible:opacity-100">
-                I
-              </ShortcutHint>
+              <ShortcutHint className="ml-2">I</ShortcutHint>
             </button>
           </div>
         </div>
@@ -149,12 +145,10 @@ export function WelcomeModal() {
           <button
             type="button"
             onClick={() => dismiss("start_now")}
-            className="group c-button c-button-primary c-button-elevated inline-flex items-center rounded-full px-10"
+            className="c-button c-button-primary c-button-elevated inline-flex items-center rounded-full px-10"
           >
             Start Now
-            <ShortcutHint className="ml-2 opacity-0 transition-opacity duration-150 group-hover:opacity-100 group-focus-visible:opacity-100">
-              S
-            </ShortcutHint>
+            <ShortcutHint className="ml-2">S</ShortcutHint>
           </button>
         </div>
 


### PR DESCRIPTION
## Summary

Welcome modal Sign up / Log in / Start Now keycaps (`U` / `I` / `S`) are always visible, matching the PostHog-style always-on keycap pattern instead of appearing only on hover or focus.

## Simplicity

Removed the opacity toggle and unused `group` classes; no new abstractions.

## Automated validation

- `http://localhost:9083/` after clearing `compass.onboarding.has-seen-welcome`
- Welcome dialog shows keycaps on Sign up (`U`), Log in (`I`), and Start Now (`S`) at rest
- Computed styles: all three hints `opacity: 1` even when only Sign up is focused
- No console errors observed during the check

## Independent review

Fresh diff-first review: no confirmed correctness findings. Accessible names unchanged (`ShortcutHint` remains `aria-hidden`).

## Test plan

- `bun test src/components/WelcomeModal/WelcomeModal.test.tsx` (11 pass)
- `bun run lint` (pass; pre-existing unrelated warnings only)