### PR TITLE
feat(web): map e then c to color, e then a to account

### DIFF
--- a/docs/acceptance/shortcuts.md
+++ b/docs/acceptance/shortcuts.md
@@ -70,7 +70,8 @@ Helpful notes:
 | `E` then `S`                | Day view  | Edit focused event start time     |
 | `E` then `E`                | Day view  | Edit focused event end time       |
 | `E` then `R`                | Day view  | Edit focused event recurrence     |
-| `E` then `C`                | Day view  | Edit focused event calendar       |
+| `E` then `A`                | Day view  | Edit focused event account        |
+| `E` then `C`                | Day view  | Edit focused event color          |
 | `Cmd+D` / `Ctrl+D`          | Day view  | Duplicate focused event           |
 | `Shift+ArrowLeft`           | Day view  | Move focused event to previous day |
 | `Shift+ArrowRight`          | Day view  | Move focused event to next day    |
@@ -93,7 +94,8 @@ Helpful notes:
 | `E` then `S`                | Week view | Edit focused event start time     |
 | `E` then `E`                | Week view | Edit focused event end time       |
 | `E` then `R`                | Week view | Edit focused event recurrence     |
-| `E` then `C`                | Week view | Edit focused event calendar       |
+| `E` then `A`                | Week view | Edit focused event account        |
+| `E` then `C`                | Week view | Edit focused event color          |
 | `Cmd+D` / `Ctrl+D`          | Week view | Duplicate focused event           |
 | `Shift+ArrowLeft`           | Week view | Move focused event to previous day |
 | `Shift+ArrowRight`          | Week view | Move focused event to next day    |
@@ -294,7 +296,7 @@ Pressing Delete while an event is focused in the Day or Week grid deletes it —
 
 ### UX
 
-With a grid event focused and no form field being typed in, pressing `E` then `T` within a short window opens that event's form (if needed) and places the caret in the title. The same `E`-prefix pattern targets description (`D`), start (`S`), end (`E`), recurrence (`R`), and calendar (`C`).
+With a grid event focused and no form field being typed in, pressing `E` then `T` within a short window opens that event's form (if needed) and places the caret in the title. The same `E`-prefix pattern targets description (`D`), start (`S`), end (`E`), recurrence (`R`), account (`A`), and color (`C`).
 
 ### Steps
 

--- a/docs/acceptance/shortcuts.md
+++ b/docs/acceptance/shortcuts.md
@@ -399,5 +399,5 @@ If time is limited, run these checks before shipping shortcut-related changes:
 11. Arrow keys reposition an open draft in both Day and Week view.
 12. With a focused event and no draft open, ArrowUp/ArrowDown move focus to the previous/next event chronologically.
 13. Cmd+D / Ctrl+D duplicates a focused event in Day and Week view.
-14. With a focused event, `E` then `T` opens the form with the title focused; bare `E` alone does nothing.
+14. With a focused event, `E` then `T` opens the form with the title focused; `E` then `A` / `C` jump to account / color; bare `E` alone does nothing.
 15. Pressing `S` shows event jump chips; a day letter + digit focuses that event; Shift+Tab does not show chips. `H` toggles Hardcore Mode.

--- a/packages/web/src/common/utils/form/form.util.test.ts
+++ b/packages/web/src/common/utils/form/form.util.test.ts
@@ -165,6 +165,16 @@ describe("form.util", () => {
       recurrence.appendChild(repeat);
       const calendar = document.createElement("button");
       calendar.id = "event-form-calendar";
+      const color = document.createElement("fieldset");
+      color.id = "event-form-color";
+      const colorSelected = document.createElement("input");
+      colorSelected.type = "radio";
+      colorSelected.name = "event-color";
+      colorSelected.checked = true;
+      const colorOther = document.createElement("input");
+      colorOther.type = "radio";
+      colorOther.name = "event-color";
+      color.append(colorSelected, colorOther);
       form.append(
         title,
         location,
@@ -173,9 +183,19 @@ describe("form.util", () => {
         end,
         recurrence,
         calendar,
+        color,
       );
       document.body.appendChild(form);
-      return { title, location, description, start, end, repeat, calendar };
+      return {
+        title,
+        location,
+        description,
+        start,
+        end,
+        repeat,
+        calendar,
+        colorSelected,
+      };
     };
 
     it("focuses each shipped form field", () => {
@@ -201,6 +221,9 @@ describe("form.util", () => {
 
       expect(focusEventFormField("calendar")).toBe(true);
       expect(document.activeElement).toBe(fields.calendar);
+
+      expect(focusEventFormField("color")).toBe(true);
+      expect(document.activeElement).toBe(fields.colorSelected);
     });
 
     it("falls back to start/end date inputs when time pickers are absent", () => {

--- a/packages/web/src/common/utils/form/form.util.ts
+++ b/packages/web/src/common/utils/form/form.util.ts
@@ -68,8 +68,8 @@ export const focusEventFormField = (field: EventFormFocusField): boolean => {
     case "color":
       // Prefer the selected swatch so arrow keys move from the current color.
       return focusFirstMatch([
-        `${EVENT_FORM_SELECTOR} #event-form-color input[type="radio"]:checked`,
-        `${EVENT_FORM_SELECTOR} #event-form-color input[type="radio"]`,
+        `#event-form-color input[type="radio"]:checked`,
+        `#event-form-color input[type="radio"]`,
       ]);
   }
 };

--- a/packages/web/src/common/utils/form/form.util.ts
+++ b/packages/web/src/common/utils/form/form.util.ts
@@ -9,7 +9,8 @@ export type EventFormFocusField =
   | "start"
   | "end"
   | "recurrence"
-  | "calendar";
+  | "calendar"
+  | "color";
 
 const queryEventFormElement = <T extends Element>(selector: string): T | null =>
   document.querySelector<T>(selector);
@@ -64,6 +65,12 @@ export const focusEventFormField = (field: EventFormFocusField): boolean => {
       ]);
     case "calendar":
       return focusFirstMatch([`#event-form-calendar`]);
+    case "color":
+      // Prefer the selected swatch so arrow keys move from the current color.
+      return focusFirstMatch([
+        `${EVENT_FORM_SELECTOR} #event-form-color input[type="radio"]:checked`,
+        `${EVENT_FORM_SELECTOR} #event-form-color input[type="radio"]`,
+      ]);
   }
 };
 

--- a/packages/web/src/grid/shortcuts/useGridEventFormFieldSequences.ts
+++ b/packages/web/src/grid/shortcuts/useGridEventFormFieldSequences.ts
@@ -29,7 +29,7 @@ const focusFieldAfterPaint = (field: EventFormFocusField) => {
 };
 
 /**
- * `e` (or `Mod+E` while typing) then `t`/`l`/`d`/`s`/`e`/`r`/`c`: open the
+ * `e` (or `Mod+E` while typing) then `t`/`l`/`d`/`s`/`e`/`r`/`a`/`c`: open the
  * focused event's form (if needed) and move caret/focus to the matching field.
  * Shared by Day and Week.
  *

--- a/packages/web/src/shortcuts/data/shortcuts.data.test.ts
+++ b/packages/web/src/shortcuts/data/shortcuts.data.test.ts
@@ -232,8 +232,12 @@ describe("shortcuts.data", () => {
           label: "Edit recurrence",
         });
         expect(shortcuts).toContainEqual({
+          keys: ["e", "a"],
+          label: "Edit account",
+        });
+        expect(shortcuts).toContainEqual({
           keys: ["e", "c"],
-          label: "Edit calendar",
+          label: "Edit color",
         });
       }
     });

--- a/packages/web/src/shortcuts/edit-sequence/EditSequenceMenu.test.tsx
+++ b/packages/web/src/shortcuts/edit-sequence/EditSequenceMenu.test.tsx
@@ -42,10 +42,11 @@ describe("EditSequenceMenu", () => {
       screen.getByRole("status", { hidden: true }).textContent,
     ).toStrictEqual(
       "Edit which field? T for title, L for location, D for description, " +
-        "S for start time, E for end time, R for recurrence, C for calendar. " +
+        "S for start time, E for end time, R for recurrence, A for account, " +
+        "C for color. " +
         "Escape to cancel." +
         "Edit which field?TTitleLLocationDDescriptionSStart timeEEnd time" +
-        "RRecurrenceCCalendarEsc to cancel",
+        "RRecurrenceAAccountCColorEsc to cancel",
     );
   });
 
@@ -61,7 +62,8 @@ describe("EditSequenceMenu", () => {
       "Start time",
       "End time",
       "Recurrence",
-      "Calendar",
+      "Account",
+      "Color",
     ]) {
       expect(menu?.textContent).toContain(label);
     }

--- a/packages/web/src/shortcuts/edit-sequence/edit-sequence.fields.ts
+++ b/packages/web/src/shortcuts/edit-sequence/edit-sequence.fields.ts
@@ -15,7 +15,10 @@ export const EDIT_SEQUENCE_FIELDS = [
   { key: "s", field: "start", label: "Start time" },
   { key: "e", field: "end", label: "End time" },
   { key: "r", field: "recurrence", label: "Recurrence" },
-  { key: "c", field: "calendar", label: "Calendar" },
+  // `a` = account: the calendar picker chooses which calendar/account hosts
+  // the event. `c` = color, so the letter matches the field name users reach for.
+  { key: "a", field: "calendar", label: "Account" },
+  { key: "c", field: "color", label: "Color" },
 ] as const satisfies readonly {
   key: string;
   field: EventFormFocusField;

--- a/packages/web/src/shortcuts/shortcuts.registry.test.ts
+++ b/packages/web/src/shortcuts/shortcuts.registry.test.ts
@@ -105,6 +105,7 @@ describe("shortcuts.registry", () => {
       expect(ids).toContain("edit-focus-end");
       expect(ids).toContain("edit-focus-recurrence");
       expect(ids).toContain("edit-focus-calendar");
+      expect(ids).toContain("edit-focus-color");
     });
 
     it("excludes the in-form leader row when the form is closed and includes it when open", () => {

--- a/packages/web/src/shortcuts/useEditSequenceShortcut.test.tsx
+++ b/packages/web/src/shortcuts/useEditSequenceShortcut.test.tsx
@@ -73,7 +73,8 @@ describe("useEditSequenceShortcut", () => {
         ["s", "start"],
         ["e", "end"],
         ["r", "recurrence"],
-        ["c", "calendar"],
+        ["a", "calendar"],
+        ["c", "color"],
       ] as const;
 
       for (const [second, field] of cases) {

--- a/packages/web/src/views/Forms/EventForm/EventColorPicker/EventColorPicker.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventColorPicker/EventColorPicker.tsx
@@ -16,6 +16,8 @@ export interface EventColorPickerProps {
   /** Radio group name; defaults to `event-color`. Pass a distinct value when
    * more than one picker can mount at once (e.g. form + context menu). */
   name?: string;
+  /** Fieldset id for keyboard focus (edit-sequence `e` then `c`). */
+  id?: string;
 }
 
 const swatchClassName =
@@ -40,8 +42,9 @@ export const EventColorPicker = ({
   value,
   onChange,
   name = "event-color",
+  id,
 }: EventColorPickerProps) => (
-  <fieldset className="m-0 min-w-0 border-0 p-0">
+  <fieldset id={id} className="m-0 min-w-0 border-0 p-0">
     <legend className="sr-only">Event color</legend>
     <div className="flex flex-wrap items-center gap-1.5">
       <ColorSwatch label={eventColorLabel(null)}>

--- a/packages/web/src/views/Forms/EventForm/EventColorPicker/EventColorPicker.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventColorPicker/EventColorPicker.tsx
@@ -16,7 +16,6 @@ export interface EventColorPickerProps {
   /** Radio group name; defaults to `event-color`. Pass a distinct value when
    * more than one picker can mount at once (e.g. form + context menu). */
   name?: string;
-  /** Fieldset id for keyboard focus (edit-sequence `e` then `c`). */
   id?: string;
 }
 

--- a/packages/web/src/views/Forms/EventForm/EventForm.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.test.tsx
@@ -437,7 +437,7 @@ describe("EventForm", () => {
     expect(screen.getByPlaceholderText("Title")).toHaveFocus();
   });
 
-  it("does not crash jumping to the calendar field on an edit draft, where the picker isn't rendered", () => {
+  it("does not crash jumping to the account field on an edit draft, where the picker isn't rendered", () => {
     renderWithStore(
       <WithEditLeader>
         <EventForm
@@ -457,8 +457,35 @@ describe("EventForm", () => {
     act(() => titleField.focus());
 
     dispatchModKey(titleField, "e");
-    expect(() => dispatchKey(titleField, "c")).not.toThrow();
+    expect(() => dispatchKey(titleField, "a")).not.toThrow();
     expect(titleField).toHaveFocus();
+  });
+
+  it("jumps focus to the color picker with Mod+E then C from the title field", () => {
+    renderWithStore(
+      <WithEditLeader>
+        <EventForm
+          draft={createEditDraft()}
+          isDraft={false}
+          isExistingEvent={true}
+          onClose={mock()}
+          onDelete={mock()}
+          onDuplicate={mock()}
+          onSubmit={mock()}
+          setDraft={mock()}
+        />
+      </WithEditLeader>,
+    );
+
+    const titleField = screen.getByPlaceholderText("Title");
+    act(() => titleField.focus());
+
+    dispatchModKey(titleField, "e");
+    dispatchKey(titleField, "c");
+
+    expect(
+      screen.getByRole("radio", { name: "Calendar default" }),
+    ).toHaveFocus();
   });
 
   it("does not jump focus when a bare letter is typed without the Mod+E leader", () => {

--- a/packages/web/src/views/Forms/EventForm/EventForm.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.tsx
@@ -75,6 +75,7 @@ const EVENT_FORM_TITLE_ID = "event-form-title";
 const EVENT_FORM_LOCATION_ID = "event-form-location";
 const EVENT_FORM_DESCRIPTION_ID = "event-form-description";
 const EVENT_FORM_CALENDAR_ID = "event-form-calendar";
+const EVENT_FORM_COLOR_ID = "event-form-color";
 const EVENT_FORM_SCHEDULE_ID = "event-form-schedule";
 const EVENT_FORM_RECURRENCE_ID = "event-form-recurrence";
 
@@ -817,6 +818,7 @@ export const EventForm: React.FC<GridEventFormProps> = memo(
                   </p>
                 )}
                 <EventColorPicker
+                  id={EVENT_FORM_COLOR_ID}
                   value={color}
                   onChange={(next) => patchDraftFields({ color: next })}
                 />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Remap the edit-sequence which-key second keys so they match the fields users reach for:

- `e` then `c` → focus **Color**
- `e` then `a` → focus **Account** (calendar picker; previously on `c`)

## What changed

- Add `color` to `EventFormFocusField` and focus the selected swatch via `#event-form-color`
- Wire an `id` on `EventColorPicker` from the event form
- Update `EDIT_SEQUENCE_FIELDS` (dispatch, which-key menu, shortcuts legend)
- Acceptance docs + unit tests for the remap

## Simplification

- Align color focus selectors with the calendar id pattern (drop redundant form-scoped prefix)
- Drop shortcut-specific JSDoc on the color picker's `id` prop

## Validation

- Focused `bun test:web` (form util, EventForm, edit sequence, shortcuts) — pass
- Manual `/week`: which-key shows `A` Account / `C` Color; `e` `c` focuses a color swatch
- Independent review: fixed the edit-draft test still asserting old `c` → calendar behavior
- CI: watching after ready for review

![Edit which field menu with Account and Color](https://cursor.com/artifacts/c/art-92a020b5-ffac-4982-b72f-194e1a83994e)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-11e778a5-9607-4bd1-bdd5-004ea28400da?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-11e778a5-9607-4bd1-bdd5-004ea28400da&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

