### PR TITLE
fix(web): make onboarding shortcuts easier to follow

### DIFF
--- a/packages/web/src/auth/posthog/track.ts
+++ b/packages/web/src/auth/posthog/track.ts
@@ -13,7 +13,7 @@ export type ProductEvent =
   | "shortcut_showcase_step_redone"
   | "shortcut_showcase_skipped"
   | "shortcut_showcase_finished"
-  | "shortcut_showcase_assist_shown"
+  | "shortcut_showcase_assist_used"
   | "checklist_shown"
   | "checklist_item_completed"
   | "checklist_dismissed"

--- a/packages/web/src/components/OnboardingChecklist/OnboardingChecklist.tsx
+++ b/packages/web/src/components/OnboardingChecklist/OnboardingChecklist.tsx
@@ -62,7 +62,7 @@ const ChecklistCard: FC = () => {
           <>
             <div className="mb-2 flex items-center justify-between">
               <span className="font-semibold text-sm">
-                Practice on real events
+                Practice on sample events
               </span>
               <span className="text-text-muted text-xs">
                 {doneCount}/{CHECKLIST_ITEMS.length}
@@ -103,15 +103,17 @@ const ChecklistCard: FC = () => {
                 return (
                   <li key={item.id} className="flex items-center gap-2">
                     {item.id === "signUp" && !isComplete ? (
+                      // The exit of the flow, so it reads as a real CTA
+                      // rather than one more thing to check off.
                       <button
                         type="button"
-                        className="c-focus-ring flex w-full items-center gap-2 rounded-md text-left hover:bg-surface-overlay"
+                        className="c-focus-ring mt-1 inline-flex w-full items-center justify-center rounded-3xl bg-accent px-4 py-1.5 font-medium text-on-accent text-xs transition-all hover:brightness-110"
                         onClick={() => {
                           track("signup_started", { source: "checklist" });
                           openModal("signUp");
                         }}
                       >
-                        {row}
+                        {item.label}
                       </button>
                     ) : (
                       row

--- a/packages/web/src/components/OnboardingChecklist/OnboardingChecklist.tsx
+++ b/packages/web/src/components/OnboardingChecklist/OnboardingChecklist.tsx
@@ -71,9 +71,29 @@ const ChecklistCard: FC = () => {
             <ul className="flex flex-col gap-1.5">
               {CHECKLIST_ITEMS.map((item) => {
                 const isComplete = Boolean(completed[item.id]);
+
+                // The exit of the flow, so it reads as a real CTA rather
+                // than one more thing to check off.
+                if (item.id === "signUp" && !isComplete) {
+                  return (
+                    <li key={item.id} className="mt-1">
+                      <button
+                        type="button"
+                        className="c-focus-ring inline-flex w-full items-center justify-center rounded-3xl bg-accent px-4 py-1.5 font-medium text-on-accent text-xs transition-all hover:brightness-110"
+                        onClick={() => {
+                          track("signup_started", { source: "checklist" });
+                          openModal("signUp");
+                        }}
+                      >
+                        {item.label}
+                      </button>
+                    </li>
+                  );
+                }
+
                 const keycaps = "keycaps" in item ? item.keycaps : undefined;
-                const row = (
-                  <>
+                return (
+                  <li key={item.id} className="flex items-center gap-2">
                     {isComplete ? (
                       <CheckCircleIcon
                         className="shrink-0 text-accent"
@@ -97,26 +117,6 @@ const ChecklistCard: FC = () => {
                     </span>
                     {keycaps && !isComplete && (
                       <ShortcutKeys className="ml-auto" keys={[...keycaps]} />
-                    )}
-                  </>
-                );
-                return (
-                  <li key={item.id} className="flex items-center gap-2">
-                    {item.id === "signUp" && !isComplete ? (
-                      // The exit of the flow, so it reads as a real CTA
-                      // rather than one more thing to check off.
-                      <button
-                        type="button"
-                        className="c-focus-ring mt-1 inline-flex w-full items-center justify-center rounded-3xl bg-accent px-4 py-1.5 font-medium text-on-accent text-xs transition-all hover:brightness-110"
-                        onClick={() => {
-                          track("signup_started", { source: "checklist" });
-                          openModal("signUp");
-                        }}
-                      >
-                        {item.label}
-                      </button>
-                    ) : (
-                      row
                     )}
                   </li>
                 );

--- a/packages/web/src/components/OnboardingChecklist/checklist.items.ts
+++ b/packages/web/src/components/OnboardingChecklist/checklist.items.ts
@@ -24,7 +24,7 @@ export const CHECKLIST_ITEMS = [
   },
   {
     id: "placeDraft",
-    label: "Drop a new event on the grid",
+    label: "Place a new event on the grid",
     keycaps: KEYMAP.moveEvent.keycaps,
   },
   { id: "undo", label: "Undo a change", keycaps: KEYMAP.undo.keycaps },

--- a/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.test.tsx
+++ b/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.test.tsx
@@ -116,6 +116,56 @@ describe("ShortcutShowcase", () => {
     ).toBe("true");
   });
 
+  it("offers 'Do it for me' from the first step, and swaps it out at graduation", async () => {
+    const user = userEvent.setup();
+    render(<ShortcutShowcase />);
+    act(() => shortcutShowcaseActions.start());
+
+    // No idle wait or failed attempt required: the way out is always offered.
+    await user.click(screen.getByRole("button", { name: "Do it for me" }));
+    expect(currentStepId()).toBe("save");
+
+    act(() =>
+      useShortcutShowcaseStore.setState({
+        stepIndex: SHOWCASE_STEP_IDS.indexOf("graduation"),
+      }),
+    );
+    expect(screen.queryByRole("button", { name: "Do it for me" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Enter Compass" })).toBeTruthy();
+  });
+
+  it("shows the stretch hint one phase at a time: Tab, then Shift+Arrow", async () => {
+    const user = userEvent.setup();
+    render(<ShortcutShowcase />);
+    act(() =>
+      useShortcutShowcaseStore.setState({
+        isActive: true,
+        stepIndex: SHOWCASE_STEP_IDS.indexOf("resizeEdge"),
+      }),
+    );
+
+    // Phase one: only the key that moves focus onto the end time.
+    expect(screen.getByTestId("tab-icon")).toBeTruthy();
+    expect(screen.queryByTestId("shift-icon")).toBeNull();
+    expect(screen.queryByTestId("arrowdown-icon")).toBeNull();
+
+    pressKey("Tab");
+
+    // Phase two: the end edge has focus, so the chord replaces Tab.
+    expect(screen.queryByTestId("tab-icon")).toBeNull();
+    expect(screen.getByTestId("shift-icon")).toBeTruthy();
+    expect(screen.getByTestId("arrowdown-icon")).toBeTruthy();
+
+    // Leaving and returning re-seeds the start edge, so the lesson restarts
+    // at phase one rather than stranding the user on the chord.
+    pressKey("ArrowDown", { shiftKey: true });
+    expect(currentStepId()).toBe("placeDraft");
+    await user.click(screen.getByRole("button", { name: "Previous" }));
+    expect(currentStepId()).toBe("resizeEdge");
+    expect(screen.getByTestId("tab-icon")).toBeTruthy();
+    expect(screen.queryByTestId("shift-icon")).toBeNull();
+  });
+
   it("Escape confirms once, lesson keys fall through, second Escape skips", () => {
     render(<ShortcutShowcase />);
     act(() => shortcutShowcaseActions.start());

--- a/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.test.tsx
+++ b/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.test.tsx
@@ -3,7 +3,10 @@ import userEvent from "@testing-library/user-event";
 import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
 import { persistentBrowserStore } from "@web/common/storage/browser-key-value.store";
 import { ShortcutShowcase } from "@web/components/ShortcutShowcase/ShortcutShowcase";
-import { SHOWCASE_STEP_IDS } from "@web/components/ShortcutShowcase/showcase.steps";
+import {
+  SHOWCASE_STEP_IDS,
+  type ShowcaseStepId,
+} from "@web/components/ShortcutShowcase/showcase.steps";
 import {
   initialShortcutShowcaseState,
   shortcutShowcaseActions,
@@ -22,6 +25,16 @@ const pressKey = (key: string, init: KeyboardEventInit = {}) => {
 
 const currentStepId = () =>
   SHOWCASE_STEP_IDS[useShortcutShowcaseStore.getState().stepIndex];
+
+/** Jumps straight to a lesson; there is no store action for an arbitrary step. */
+const showStep = (id: ShowcaseStepId) => {
+  act(() =>
+    useShortcutShowcaseStore.setState({
+      isActive: true,
+      stepIndex: SHOWCASE_STEP_IDS.indexOf(id),
+    }),
+  );
+};
 
 describe("ShortcutShowcase", () => {
   beforeEach(() => {
@@ -125,11 +138,7 @@ describe("ShortcutShowcase", () => {
     await user.click(screen.getByRole("button", { name: "Do it for me" }));
     expect(currentStepId()).toBe("save");
 
-    act(() =>
-      useShortcutShowcaseStore.setState({
-        stepIndex: SHOWCASE_STEP_IDS.indexOf("graduation"),
-      }),
-    );
+    showStep("graduation");
     expect(screen.queryByRole("button", { name: "Do it for me" })).toBeNull();
     expect(screen.getByRole("button", { name: "Enter Compass" })).toBeTruthy();
   });
@@ -137,12 +146,7 @@ describe("ShortcutShowcase", () => {
   it("shows the stretch hint one phase at a time: Tab, then Shift+Arrow", async () => {
     const user = userEvent.setup();
     render(<ShortcutShowcase />);
-    act(() =>
-      useShortcutShowcaseStore.setState({
-        isActive: true,
-        stepIndex: SHOWCASE_STEP_IDS.indexOf("resizeEdge"),
-      }),
-    );
+    showStep("resizeEdge");
 
     // Phase one: only the key that moves focus onto the end time.
     expect(screen.getByTestId("tab-icon")).toBeTruthy();

--- a/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.tsx
+++ b/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.tsx
@@ -8,7 +8,6 @@ import {
 } from "react";
 import { track } from "@web/auth/posthog/track";
 import { Z_INDEX_MODAL } from "@web/common/constants/web.constants";
-import { isEditableKeyboardTarget } from "@web/common/utils/form/form.util";
 import { PracticeCalendar } from "@web/components/ShortcutShowcase/PracticeCalendar";
 import {
   clearFocus,
@@ -34,7 +33,6 @@ import {
 import {
   getShowcaseStep,
   SHOWCASE_STEP_IDS,
-  type ShowcaseStepId,
 } from "@web/components/ShortcutShowcase/showcase.steps";
 import {
   selectShowcaseActive,
@@ -55,52 +53,12 @@ const TEXT_BUTTON_CLASS =
 const PRIMARY_BUTTON_CLASS =
   "c-button c-button-primary rounded-full px-4 py-1.5 text-xs";
 
-const ASSIST_IDLE_MS = 15_000;
-const ASSIST_ATTEMPT_THRESHOLD = 2;
-
 const ARROW_DIRECTIONS: Record<string, PracticeDirection> = {
   ArrowUp: "up",
   ArrowDown: "down",
   ArrowLeft: "left",
   ArrowRight: "right",
 };
-
-/** "Show me" fallback, ported from the retired tour's assist hook. */
-function useShowcaseAssist(stepId: ShowcaseStepId): boolean {
-  const [isVisible, setIsVisible] = useState(false);
-  const attemptsRef = useRef(0);
-  const revealedRef = useRef(false);
-
-  useEffect(() => {
-    setIsVisible(false);
-    attemptsRef.current = 0;
-    revealedRef.current = false;
-    if (stepId === "graduation") return;
-
-    const reveal = () => {
-      if (revealedRef.current) return;
-      revealedRef.current = true;
-      setIsVisible(true);
-      track("shortcut_showcase_assist_shown", { step: stepId });
-    };
-
-    const idleTimer = window.setTimeout(reveal, ASSIST_IDLE_MS);
-    const onKeyDown = (event: KeyboardEvent) => {
-      // Typing a title is progress, not a failed attempt at the shortcut.
-      if (isEditableKeyboardTarget(event)) return;
-      attemptsRef.current += 1;
-      if (attemptsRef.current >= ASSIST_ATTEMPT_THRESHOLD) reveal();
-    };
-
-    document.addEventListener("keydown", onKeyDown);
-    return () => {
-      window.clearTimeout(idleTimer);
-      document.removeEventListener("keydown", onKeyDown);
-    };
-  }, [stepId]);
-
-  return isVisible;
-}
 
 /**
  * Full-screen practice arena shown before a new user ever sees the real
@@ -115,7 +73,6 @@ const ShowcaseTakeover: FC = () => {
   );
   const stepId = stepIdAt(stepIndex);
   const step = getShowcaseStep(stepId);
-  const isAssistVisible = useShowcaseAssist(stepId);
 
   // The takeover owns the keyboard: silence every real app handler
   // (useAppShortcut, the e-sequence, bare-letter s/h) while it is up.
@@ -390,7 +347,9 @@ const ShowcaseTakeover: FC = () => {
     return () => document.removeEventListener("keydown", onKeyDown, true);
   }, [apply]);
 
-  const showMe = () => {
+  // Performs the lesson's action on the practice board, then moves on.
+  const doItForMe = () => {
+    track("shortcut_showcase_assist_used", { step: stepId });
     switch (stepId) {
       case "create":
         apply(createDraft);
@@ -435,7 +394,7 @@ const ShowcaseTakeover: FC = () => {
         apply((state) => (state.hardcoreOn ? state : toggleHardcore(state)));
         break;
       case "graduation":
-        shortcutShowcaseActions.finish();
+        // Unreachable: graduation renders "Enter Compass" instead.
         return;
     }
     advance();
@@ -493,7 +452,17 @@ const ShowcaseTakeover: FC = () => {
               </div>
               <h2 className="font-semibold text-lg text-text">{step.title}</h2>
               <p className="text-sm text-text-muted">{step.body}</p>
-              {step.keycaps && <ShortcutKeys keys={[...step.keycaps]} />}
+              {step.keycaps && (
+                <ShortcutKeys
+                  keys={
+                    // Tab first, then the stretch chord once the end edge has
+                    // focus, so the row never reads as one three-key press.
+                    stepId === "resizeEdge" && practice.edge === "end"
+                      ? ["Shift", "ArrowDown"]
+                      : [...step.keycaps]
+                  }
+                />
+              )}
               <div className="flex items-center gap-2 pt-2">
                 {stepId === "graduation" ? (
                   <button
@@ -504,15 +473,13 @@ const ShowcaseTakeover: FC = () => {
                     Enter Compass
                   </button>
                 ) : (
-                  isAssistVisible && (
-                    <button
-                      type="button"
-                      className={PRIMARY_BUTTON_CLASS}
-                      onClick={showMe}
-                    >
-                      Show me
-                    </button>
-                  )
+                  <button
+                    type="button"
+                    className={PRIMARY_BUTTON_CLASS}
+                    onClick={doItForMe}
+                  >
+                    Do it for me
+                  </button>
                 )}
                 {stepIndex > 0 && stepId !== "graduation" && (
                   <button

--- a/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.tsx
+++ b/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.tsx
@@ -33,6 +33,7 @@ import {
 import {
   getShowcaseStep,
   SHOWCASE_STEP_IDS,
+  STRETCH_KEYCAPS,
 } from "@web/components/ShortcutShowcase/showcase.steps";
 import {
   selectShowcaseActive,
@@ -393,14 +394,15 @@ const ShowcaseTakeover: FC = () => {
       case "hardcore":
         apply((state) => (state.hardcoreOn ? state : toggleHardcore(state)));
         break;
-      case "graduation":
-        // Unreachable: graduation renders "Enter Compass" instead.
-        return;
     }
     advance();
   };
 
   const progressPercent = ((stepIndex + 1) / SHOWCASE_STEP_IDS.length) * 100;
+  // The stretch lesson teaches Tab first, then the chord, so it hints one
+  // press at a time rather than showing all three keys at once.
+  const isStretchPhase = stepId === "resizeEdge" && practice.edge === "end";
+  const keycaps = isStretchPhase ? STRETCH_KEYCAPS : step.keycaps;
 
   return (
     <section
@@ -452,17 +454,7 @@ const ShowcaseTakeover: FC = () => {
               </div>
               <h2 className="font-semibold text-lg text-text">{step.title}</h2>
               <p className="text-sm text-text-muted">{step.body}</p>
-              {step.keycaps && (
-                <ShortcutKeys
-                  keys={
-                    // Tab first, then the stretch chord once the end edge has
-                    // focus, so the row never reads as one three-key press.
-                    stepId === "resizeEdge" && practice.edge === "end"
-                      ? ["Shift", "ArrowDown"]
-                      : [...step.keycaps]
-                  }
-                />
-              )}
+              {keycaps && <ShortcutKeys keys={[...keycaps]} />}
               <div className="flex items-center gap-2 pt-2">
                 {stepId === "graduation" ? (
                   <button

--- a/packages/web/src/components/ShortcutShowcase/showcase.steps.ts
+++ b/packages/web/src/components/ShortcutShowcase/showcase.steps.ts
@@ -1,4 +1,8 @@
+import { detectPlatform } from "@tanstack/react-hotkeys";
 import { KEYMAP } from "@web/shortcuts/keymap";
+
+// Prose has no keycap chips to expand "Mod" into, so spell the real key out.
+const MOD_KEY = detectPlatform() === "mac" ? "Cmd" : "Ctrl";
 
 /**
  * Single source of truth for showcase step order. Every shortcut concept the
@@ -33,8 +37,7 @@ export type ShowcaseStep = {
 
 /**
  * Keycaps reference KEYMAP so a remap updates the hints automatically;
- * keymap.test.ts pins the 1:1 cases. Direction-specific arrows in combined
- * hints stay literal because they demonstrate one direction of a family.
+ * keymap.test.ts pins the 1:1 cases.
  */
 const STEP_CONTENT: Record<ShowcaseStepId, Omit<ShowcaseStep, "id">> = {
   create: {
@@ -68,18 +71,20 @@ const STEP_CONTENT: Record<ShowcaseStepId, Omit<ShowcaseStep, "id">> = {
     keycaps: KEYMAP.moveEvent.keycaps,
   },
   resizeEdge: {
+    // Two phases: the hint swaps to Shift+Arrow once the end edge has focus,
+    // so the keycaps here only cover the first press.
     title: "Stretch the end time",
-    body: "Press Tab to focus the event's end time, then hold Shift and press an arrow to stretch it. The start stays put.",
-    keycaps: [...KEYMAP.edgeFocus.keycaps, "Shift", "ArrowDown"],
+    body: "Press Tab to focus the event's end time, then hold Shift and press the up or down arrow to stretch it. The start stays put.",
+    keycaps: KEYMAP.edgeFocus.keycaps,
   },
   placeDraft: {
     title: "Place a block anywhere",
-    body: "With nothing focused, hold Shift and press an arrow key to drop a new block right on the grid.",
+    body: "With nothing focused, hold Shift and press an arrow key to place a new block right on the grid.",
     keycaps: KEYMAP.moveEvent.keycaps,
   },
   undoRedo: {
     title: "Never stress a mistake",
-    body: "Press Mod+Z to undo your last change, then Mod+Shift+Z to bring it back.",
+    body: `Press ${MOD_KEY}+Z to undo your last change, then ${MOD_KEY}+Shift+Z to bring it back.`,
     keycaps: KEYMAP.undo.keycaps,
   },
   hardcore: {

--- a/packages/web/src/components/ShortcutShowcase/showcase.steps.ts
+++ b/packages/web/src/components/ShortcutShowcase/showcase.steps.ts
@@ -36,6 +36,14 @@ export type ShowcaseStep = {
 };
 
 /**
+ * Second half of the resizeEdge lesson, swapped in once the end edge has
+ * focus so the row never reads as one three-key press. Stretching reuses the
+ * Shift+Arrow family bound by KEYMAP.moveEvent; the arrow stays literal
+ * because it demonstrates one direction, and only up/down stretch.
+ */
+export const STRETCH_KEYCAPS: readonly string[] = ["Shift", "ArrowDown"];
+
+/**
  * Keycaps reference KEYMAP so a remap updates the hints automatically;
  * keymap.test.ts pins the 1:1 cases.
  */

--- a/packages/web/src/shortcuts/keymap.test.ts
+++ b/packages/web/src/shortcuts/keymap.test.ts
@@ -77,6 +77,9 @@ describe("keymap ↔ showcase hint parity", () => {
     expect(getShowcaseStep("editTitle").keycaps).toBe(KEYMAP.editTitle.keycaps);
     expect(getShowcaseStep("eventJump").keycaps).toBe(KEYMAP.eventJump.keycaps);
     expect(getShowcaseStep("moveEvent").keycaps).toBe(KEYMAP.moveEvent.keycaps);
+    expect(getShowcaseStep("resizeEdge").keycaps).toBe(
+      KEYMAP.edgeFocus.keycaps,
+    );
     expect(getShowcaseStep("placeDraft").keycaps).toBe(
       KEYMAP.moveEvent.keycaps,
     );


### PR DESCRIPTION
## Summary

First-run walkthrough surfaced several points of confusion in the Shortcut Showcase and the post-showcase practice checklist. This fixes them:

- **The assist button is always available and says what it does.** It previously appeared only after 15 seconds idle or 2 stray keypresses, so its arrival read as arbitrary, and "Show me" did not convey that clicking it performs the action and advances the step. The `useShowcaseAssist` hook (idle timer + document keydown listener) is gone; the button now renders on every step except `graduation` and is labelled "Do it for me".
- **Step 7 teaches the stretch in two phases.** It was the only step that flattened a sequence and a chord into one keycap row (`Tab Shift ArrowDown`), which reads as a single three-key press. The row now shows `Tab` alone until the practice board's end edge has focus, then swaps to `Shift` + arrow. Body copy also names the up/down arrows, since left/right do not stretch.
- **No more "Mod" in prose.** Keycap chips were already platform-aware, but step 9's sentence leaked the raw hotkey token. It now resolves to Cmd or Ctrl.
- **Copy fixes.** The practice events are unsaved and anonymous, so the checklist is "Practice on sample events", not "real events". "Drop a new event on the grid" becomes "Place a new event on the grid" (nothing is being dropped from anywhere); same verb fixed in step 8's body.
- **The sign-up row looks clickable.** It was already a button but styled identically to the read-only checklist rows; it is now an accent pill matching the welcome modal's sign-up CTA.

Analytics: `shortcut_showcase_assist_shown` is replaced by `shortcut_showcase_assist_used { step }`, which fires on click rather than on reveal. Any insight built on the old event needs repointing. Worth stating as a deliberate trade: the old event was the only signal for "which step do people get stuck on", since it fired on the idle/failed-attempt inference. The new one measures a decision to hand the step over instead. If the struggle signal turns out to matter, time-on-step is derivable from the existing `shortcut_showcase_step_completed` events rather than by restoring the hook.

## Simplicity

The change deletes the `useShowcaseAssist` hook entirely (two constants, a 15s timer, a document keydown listener, three refs, and a state variable) rather than adding a config flag to it, so it removes per-keystroke work rather than adding any. No `useEffect`, `useRef`, or `useState` was added.

A second commit (`refactor(web): tidy the onboarding hint and checklist rendering`) applied the cleanup pass:

- The phase condition is a named `isStretchPhase` binding above the return instead of a ternary buried in a JSX prop.
- The phase-two keycaps moved into `showcase.steps.ts` as `STRETCH_KEYCAPS`, next to the rest of the lesson content, carrying the note that explains why that arrow stays literal: stretching reuses the Shift+Arrow family that `KEYMAP.moveEvent` binds, and the arrow demonstrates one direction of it. (I checked whether the resize chord deserved its own `KEYMAP` entry; it does not, because the real handler binds `KEYMAP.moveEvent.hotkeys.*` for both moving an event and stretching a focused edge. Inventing an entry would have been fiction.)
- The `doItForMe` switch lost its unreachable `graduation` arm. Falling through to `advance()` is equivalent, since `advance()` calls `finish()` on the last step.
- The checklist's sign-up CTA is an early return, so the row fragment is no longer built and thrown away for that item, and the list item owns its spacing instead of the button.
- The tests share one `showStep()` helper instead of two spellings of the same setup.

The two-phase hint deliberately does not become a general per-step phase model. Keeping the swap in the component preserves the reference identity that `keymap.test.ts` asserts between step keycaps and `KEYMAP`, and `resizeEdge` was added to that parity list now that its declared keycaps are a pure `KEYMAP.edgeFocus` reference rather than a hand-built array.

Two cleanup findings were considered and skipped:

- **Building the CTA from `c-button c-button-primary`.** That utility hardcodes `h-11`, too tall for the compact checklist card, so adopting it means overriding the height it exists to set. The pill instead matches the app's established compact-CTA recipe used by `WelcomeModal`, `AnonymousCalendarRow`, `CalendarListHeader`, and `TasksRemovalNotice`. Worth noting the real cost: those compact pills hover with `brightness-110` while `c-button-primary` hovers with `bg-accent-hover`, so a change to the accent-hover token will not reach any of them. That divergence predates this PR and deserves its own pass rather than a sixth variant here.
- **Interleaving keycaps into step prose** (the `ShortcutTipPart` model that `shortcut-tips.data.ts` already uses). That would let step 9 render real chips inside the sentence and drop `MOD_KEY` entirely, but it reshapes how every step body renders, which is well outside this change.

## Automated validation

Full browser walkthrough of all 11 showcase steps plus the checklist on the local dev server:

- "Do it for me" is present on step 1 with no idle wait, and on every subsequent step; clicking it performs the lesson action and advances. The three-button footer (Do it for me / Previous / Skip) does not crowd.
- Step 7 shows only the `Tab` chip on entry; pressing Tab swaps the row to `Shift` + down-arrow. Body reads "the up or down arrow".
- Step 9 body renders "Press Cmd+Z ... then Cmd+Shift+Z" on macOS.
- Step 11 shows only "Enter Compass", with no assist button.
- After graduating: checklist header reads "Practice on sample events", the item reads "Place a new event on the grid", undo shows the Cmd chip, and the sign-up row renders as a filled accent pill. Clicking it opens the sign-up modal.
- Console showed no errors attributable to this change.

Regression-guard check: temporarily reverting the phased-hint conditional makes the new `ShortcutShowcase` test fail, then restoring it makes it pass, confirming the test protects real behavior rather than asserting a tautology.

After the refactor commit, the showcase was walked again in the browser from the welcome modal through step 7, confirming the hint still shows `Tab` alone and swaps to `Shift` + down-arrow on Tab, and the checklist card still renders identically.

## Independent review

A fresh read-only reviewer was run against the final two-commit diff, given the worktree, base ref, task intent, and `AGENTS.md`, but not the implementing agent's conclusions. It was pointed specifically at the refactor commit, since that restructured code after the first commit had already been validated.

**Result: no confirmed defects.** It independently reached the same conclusions I verified by hand on the two paths worth worrying about:

- `keycaps` can never be truthy for a step that declares none. `isStretchPhase` requires `stepId === "resizeEdge"`, which does have keycaps, so `graduation` still renders no chip row.
- Dropping the unreachable `graduation` arm from the assist handler is not just safe but restores the original semantics: falling through to `advance()` calls `finish()` on the last step, which is exactly what that arm used to do.

It also confirmed the checklist's `ul`/`li` structure and the sign-up button's accessible name survive the restructure, that `showStep()` does not mask a regression (the component depends only on `isActive`/`stepIndex`, and `beforeEach` already resets what `start()` would), and that the keymap parity assertion is still truthful about the phase it covers.

An earlier reviewer on the first commit was likewise clean. Separately, a four-angle cleanup pass (reuse, simplification, efficiency, altitude) produced the refactor commit above; its two remaining findings are the ones recorded as skipped under Simplicity.

## Test plan

```
bun run test:web          # 2188 pass, 0 fail
bun run type-check        # clean
bun run lint              # 11 pre-existing warnings, none in changed files
bun run verify            # all checks passed (includes a11y e2e, 7 passed)
bunx playwright test e2e/onboarding/   # 3 passed
```

Two tests added to `ShortcutShowcase.test.tsx`: the assist button's immediate availability and graduation swap, and the two-phase keycap hint.
