### PR TITLE
fix: multi-account sync disappearing calendar and stuck import

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,7 @@ Internal documentation for engineers and agents working in the Compass repo.
 
 - [Repo Architecture](./architecture/repo-architecture.md)
 - [Event Domain Model](./architecture/event-domain-model.md)
+- [Multi-account Sync](./architecture/multi-account-sync.md)
 - [Glossary](./architecture/glossary.md)
 
 ## Development And Operations

--- a/docs/architecture/multi-account-sync.md
+++ b/docs/architecture/multi-account-sync.md
@@ -1,0 +1,61 @@
+# Multi-account sync invariants
+
+These rules keep Compass's per-account Google sync state honest after
+email/password signup plus "Add account", reconnect, and missed SSE.
+
+Zustand remains the store for user metadata. The failure mode was refresh
+discipline, not the store; migrating metadata to react-query would touch
+dozens of consumers (auth, sidebar, settings, SSE handlers, and the
+`__COMPASS_E2E_STORE__` Playwright bridge) to fix a problem four files own.
+Calendars live in react-query and connections in zustand; refetching both
+unconditionally on the same signals keeps them from diverging.
+
+## 1. Push on every transition
+
+`refreshConnectionState` is the only writer of derived connection state. On
+change it persists the new state and appends a `kind: "connection"`
+invalidation. The backend SSE bridge fans those invalidations out as
+`calendarsChanged`.
+
+Any new job kind or route that changes state-derivation evidence (bootstrap
+flags, cursors, credentials, calendar-list discovery, durable read failures)
+must end by calling `refreshConnectionState` with the invalidations
+repository. Do not grow a second push channel. Delete the dormant
+`importProgress` invalidation kind and caller-less
+`sseServer.publishUserMetadata` in a follow-up cleanup rather than adding
+another path.
+
+At dispatch time the completing job is still claimed, so derivation often
+lands on `catchingUp` first. That is still a change from `importing`, so the
+invalidation fires, the client refetches, and the read-path refresh after the
+job settles lands `healthy`.
+
+## 2. Pull reconciliation, unconditionally cheap
+
+Force-refresh metadata on every SSE signal, on stream open/reopen, and on
+tab focus — regardless of connection state — plus a 20s poll while any
+**single** connection is `connecting` / `importing` / `catchingUp`.
+
+The sync `GET /connections` read path re-derives state, so every metadata
+pull is also a server-side reconciliation. The UI self-heals even with SSE
+fully dead. Concurrent `force` refreshes chain onto one trailing fetch;
+an epoch counter drops stale writes.
+
+Do not gate metadata reconciliation on HEALTHY/ATTENTION. That gate is only
+for the provider Refresh enqueue.
+
+## 3. Per-account attribution
+
+User-visible status hangs off one connection, never the precedence-collapsed
+aggregate. A stuck account must not pin an unattributed banner (or disable
+reconciliation) for all accounts.
+
+- The local Compass calendar is its own sidebar section (the signed-in
+  user's email) once any Google account exists. It stays visible and
+  toggleable. LCV1/LCV2 still exclude it as a create target.
+- A connected-but-still-importing account keeps its section header with
+  zero calendars so "Adding your calendar…" attributes to that account.
+- Day view columns are active+visible calendars, matching Week.
+
+Follow-up candidate: `SidebarStatusBar` names the account when more than one
+connection exists.

--- a/packages/backend/src/auth/services/google/google.auth.service.test.ts
+++ b/packages/backend/src/auth/services/google/google.auth.service.test.ts
@@ -193,6 +193,33 @@ describe("handleGoogleAuth", () => {
       expect(googleAuthService.googleSignup).not.toHaveBeenCalled();
       expect(adoptCalls).toHaveLength(0);
     });
+
+    it("does not create a user when an existing session would otherwise SIGNUP", async () => {
+      const success: GoogleSignInSuccess = {
+        providerUser: makeProviderUser(),
+        oAuthTokens: makeOAuthTokens(),
+        createdNewRecipeUser: true,
+        recipeUserId: faker.database.mongodbObjectId(),
+        loginMethodsLength: 1,
+      };
+
+      mockDetermineGoogleAuthMode.mockResolvedValue(
+        makeDecision({ authMode: "SIGNUP" }),
+      );
+
+      await expect(
+        googleAuthService.handleGoogleAuth(success, {
+          hasExistingSession: true,
+        }),
+      ).rejects.toMatchObject({
+        result:
+          "You're already signed in — use Settings → Add account to connect this Google account.",
+        code: "GOOGLE_SIGNIN_WHILE_AUTHENTICATED",
+      });
+
+      expect(googleAuthService.googleSignup).not.toHaveBeenCalled();
+      expect(adoptCalls).toHaveLength(0);
+    });
   });
 
   describe("SIGNIN path", () => {

--- a/packages/backend/src/auth/services/google/google.auth.service.ts
+++ b/packages/backend/src/auth/services/google/google.auth.service.ts
@@ -202,7 +202,10 @@ async function adoptConnection(
   );
 }
 
-async function handleGoogleAuth(success: GoogleSignInSuccess): Promise<void> {
+async function handleGoogleAuth(
+  success: GoogleSignInSuccess,
+  options?: { hasExistingSession?: boolean },
+): Promise<void> {
   const {
     providerUser,
     oAuthTokens,
@@ -237,6 +240,12 @@ async function handleGoogleAuth(success: GoogleSignInSuccess): Promise<void> {
 
   switch (decision.authMode) {
     case "SIGNUP": {
+      if (options?.hasExistingSession) {
+        throw error(
+          AuthError.GoogleSignInWhileAuthenticated,
+          "You're already signed in — use Settings → Add account to connect this Google account.",
+        );
+      }
       const isNewUser = createdNewRecipeUser && loginMethodsLength === 1;
       if (!isNewUser) {
         // Edge case: no Compass user found but SuperTokens says not new

--- a/packages/backend/src/common/errors/auth/auth.errors.ts
+++ b/packages/backend/src/common/errors/auth/auth.errors.ts
@@ -8,6 +8,7 @@ interface AuthErrors {
   GoogleNotConfigured: ErrorMetadata;
   GoogleRedirectUriMismatch: ErrorMetadata;
   GoogleRefreshTokenMissing: ErrorMetadata;
+  GoogleSignInWhileAuthenticated: ErrorMetadata;
   InadequatePermissions: ErrorMetadata;
   NoGAuthAccessToken: ErrorMetadata;
   SyncConnectionUnavailable: ErrorMetadata;
@@ -47,6 +48,13 @@ export const AuthError: AuthErrors = {
     code: "GOOGLE_REFRESH_TOKEN_MISSING",
     description:
       "Google did not grant a fresh authorization. Please try again.",
+    status: Status.CONFLICT,
+    isOperational: true,
+  },
+  GoogleSignInWhileAuthenticated: {
+    code: "GOOGLE_SIGNIN_WHILE_AUTHENTICATED",
+    description:
+      "You're already signed in — use Settings → Add account to connect this Google account.",
     status: Status.CONFLICT,
     isOperational: true,
   },

--- a/packages/backend/src/common/middleware/supertokens.middleware.handlers.ts
+++ b/packages/backend/src/common/middleware/supertokens.middleware.handlers.ts
@@ -125,7 +125,9 @@ export async function handleGoogleSignInUp(
     success,
   );
 
-  await googleAuthService.handleGoogleAuth(remapped.success);
+  await googleAuthService.handleGoogleAuth(remapped.success, {
+    hasExistingSession: Boolean(input.session),
+  });
 
   return remapped.response;
 }

--- a/packages/backend/src/common/middleware/supertokens.middleware.test.ts
+++ b/packages/backend/src/common/middleware/supertokens.middleware.test.ts
@@ -1,5 +1,4 @@
 import * as corsLib from "cors";
-import { ObjectId } from "mongodb";
 import superTokensNode from "supertokens-node";
 import Dashboard from "supertokens-node/recipe/dashboard";
 import EmailPassword from "supertokens-node/recipe/emailpassword";
@@ -464,6 +463,42 @@ describe("supertokens.middleware", () => {
       });
       expect(googleAuthService.handleGoogleAuth).toHaveBeenCalledWith(
         successPayload,
+        { hasExistingSession: false },
+      );
+    });
+
+    it("tells handleGoogleAuth when ThirdParty signInUpPOST already has a session", async () => {
+      const responsePayload = { status: "OK" };
+      const successPayload = { providerUser: { id: "u1" } };
+      const existingSession = { getUserId: () => "existing-user" };
+
+      (createGoogleSignInSuccess as Mock).mockReturnValue(successPayload);
+
+      initSupertokens();
+
+      const thirdPartyConfig = getFirstCallArg<{
+        override: {
+          apis: (originalImplementation: {
+            signInUpPOST?: (input: unknown) => Promise<unknown>;
+          }) => {
+            signInUpPOST: (input: unknown) => Promise<unknown>;
+          };
+        };
+      }>(ThirdParty.init);
+
+      const originalImplementation = {
+        signInUpPOST: mock().mockResolvedValue(responsePayload),
+      };
+
+      const overridden = thirdPartyConfig.override.apis(originalImplementation);
+      const input = { session: existingSession, some: "input" };
+
+      await overridden.signInUpPOST(input);
+
+      expect(originalImplementation.signInUpPOST).toHaveBeenCalledWith(input);
+      expect(googleAuthService.handleGoogleAuth).toHaveBeenCalledWith(
+        successPayload,
+        { hasExistingSession: true },
       );
     });
 
@@ -663,6 +698,7 @@ describe("supertokens.middleware", () => {
       expect(createGoogleSignInSuccess).toHaveBeenCalledTimes(2);
       expect(googleAuthService.handleGoogleAuth).toHaveBeenCalledWith(
         expect.objectContaining({ recipeUserId: "compass-user-id" }),
+        { hasExistingSession: false },
       );
     });
 

--- a/packages/scripts/src/commands/audit-connection-identity/audit.db.test.ts
+++ b/packages/scripts/src/commands/audit-connection-identity/audit.db.test.ts
@@ -54,8 +54,6 @@ describe("auditConnectionIdentity (db)", () => {
       capabilities: ["readEvents", "readBusy", "writeEvents"],
       state: "healthy",
       stateReason: null,
-      lastSyncedAt: null,
-      lastHealthyAt: null,
     });
   };
 

--- a/packages/sync/src/app.ts
+++ b/packages/sync/src/app.ts
@@ -441,6 +441,7 @@ function buildSchedulers(
         resources,
         calendars: repos.calendars,
         connections: repos.connections,
+        credentials: repos.credentials,
         discovery: new GoogleCalendarAdapter(),
         commands: repos.commands,
         jobs,

--- a/packages/sync/src/domain/busy-availability.service.db.test.ts
+++ b/packages/sync/src/domain/busy-availability.service.db.test.ts
@@ -54,9 +54,21 @@ describe("computeBusyAvailability", () => {
       capabilities: ["readEvents"],
       state,
       stateReason: null,
-      lastSyncedAt,
-      lastHealthyAt: lastSyncedAt,
     });
+    if (lastSyncedAt !== null) {
+      await connections.updateDerivedState(
+        tenantId,
+        principalId,
+        connection._id,
+        {
+          state,
+          stateReason: null,
+          lastSyncedAt,
+          lastHealthyAt: lastSyncedAt,
+        },
+        NOW,
+      );
+    }
     return connection._id;
   };
 

--- a/packages/sync/src/domain/connection-refresh.service.db.test.ts
+++ b/packages/sync/src/domain/connection-refresh.service.db.test.ts
@@ -1,9 +1,12 @@
 import { seedProviderCalendar } from "@sync/__tests__/helpers/fixtures";
 import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
 import { refreshPrincipalCalendars } from "@sync/domain/connection-refresh.service";
+import { SYNC_COLLECTIONS } from "@sync/storage/collections";
+import { JOB_PRIORITY } from "@sync/storage/contracts/job.contracts";
 import { type ProviderCalendarRecord } from "@sync/storage/contracts/provider-calendar.contracts";
 import { JobRepository } from "@sync/storage/repositories/job.repository";
 import { ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
+import { ProviderConnectionRepository } from "@sync/storage/repositories/provider-connection.repository";
 import { SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
 
 const now = () => new Date("2026-08-10T12:00:00.000Z");
@@ -17,11 +20,12 @@ describe("refreshPrincipalCalendars (db)", () => {
       resources: new SyncResourceRepository(db),
       jobs: new JobRepository(db),
       calendars: new ProviderCalendarRepository(db),
+      connections: new ProviderConnectionRepository(db),
     };
   };
 
   it("revives a wedged failed repair job for the connection, not just incrementalPull", async () => {
-    const { resources, jobs, calendars } = deps();
+    const { resources, jobs, calendars, connections } = deps();
     const calendar: ProviderCalendarRecord =
       await seedProviderCalendar(calendars);
     const resource = await resources.ensure({
@@ -51,7 +55,7 @@ describe("refreshPrincipalCalendars (db)", () => {
     await jobs.fail(claimed._id, "worker-1");
 
     const tally = await refreshPrincipalCalendars(
-      { resources, jobs },
+      { resources, jobs, connections },
       resource.tenantId,
       resource.principalId,
       now,
@@ -65,5 +69,51 @@ describe("refreshPrincipalCalendars (db)", () => {
     );
     expect(revived?.state).toBe("pending");
     expect(revived?.attempt).toBe(0);
+  });
+
+  it("enqueues a coalesced calendarListSync per connection at user priority", async () => {
+    const { resources, jobs, calendars, connections } = deps();
+    const calendar: ProviderCalendarRecord =
+      await seedProviderCalendar(calendars);
+    await resources.ensure({
+      tenantId: calendar.tenantId,
+      principalId: calendar.principalId,
+      connectionId: calendar.connectionId,
+      resourceKind: "events",
+      calendarId: calendar._id,
+    });
+
+    await refreshPrincipalCalendars(
+      { resources, jobs, connections },
+      calendar.tenantId,
+      calendar.principalId,
+      now,
+    );
+
+    const discovery = await storage
+      .db()
+      .collection(SYNC_COLLECTIONS.jobs)
+      .findOne({ coalescingKey: `calendarListSync:${calendar.connectionId}` });
+    expect(discovery).toMatchObject({
+      kind: "calendarListSync",
+      resourceId: null,
+      coalescingKey: `calendarListSync:${calendar.connectionId}`,
+      priority: JOB_PRIORITY.user,
+    });
+
+    await refreshPrincipalCalendars(
+      { resources, jobs, connections },
+      calendar.tenantId,
+      calendar.principalId,
+      now,
+    );
+    expect(
+      await storage
+        .db()
+        .collection(SYNC_COLLECTIONS.jobs)
+        .countDocuments({
+          coalescingKey: `calendarListSync:${calendar.connectionId}`,
+        }),
+    ).toBe(1);
   });
 });

--- a/packages/sync/src/domain/connection-refresh.service.test.ts
+++ b/packages/sync/src/domain/connection-refresh.service.test.ts
@@ -28,12 +28,14 @@ describe("refreshPrincipalCalendars", () => {
     ];
 
     const requeueFailedByConnection = mock(async () => 0);
+    const listByPrincipal = mock(async () => [{ _id: "c1" }]);
     const tally = await refreshPrincipalCalendars(
       {
         resources: {
           listEventsByPrincipal: mock(async () => resources),
         } as never,
         jobs: { enqueueUrgent, requeueFailedByConnection } as never,
+        connections: { listByPrincipal } as never,
       },
       "t1" as TenantId,
       "p1" as PrincipalId,
@@ -49,8 +51,14 @@ describe("refreshPrincipalCalendars", () => {
     });
     // One call per distinct connection touched, not per resource.
     expect(requeueFailedByConnection).toHaveBeenCalledTimes(1);
-    expect(enqueueUrgent).toHaveBeenCalledTimes(2);
+    expect(enqueueUrgent).toHaveBeenCalledTimes(3);
     expect(enqueueUrgent.mock.calls[0]?.[0]).toMatchObject({
+      kind: "calendarListSync",
+      resourceId: null,
+      coalescingKey: "calendarListSync:c1",
+      priority: JOB_PRIORITY.user,
+    });
+    expect(enqueueUrgent.mock.calls[1]?.[0]).toMatchObject({
       kind: "incrementalPull",
       resourceId: "r1",
       coalescingKey: "incrementalPull:r1",
@@ -66,10 +74,12 @@ describe("refreshPrincipalCalendars", () => {
       "inFlight",
     ] as const;
     let i = 0;
-    const enqueueUrgent = mock(async () => ({
-      job: {},
-      outcome: outcomes[i++]!,
-    }));
+    const enqueueUrgent = mock(async (job: { kind: string }) => {
+      if (job.kind === "calendarListSync") {
+        return { job: {}, outcome: "created" as const };
+      }
+      return { job: {}, outcome: outcomes[i++]! };
+    });
     const resources = outcomes.map((id) => ({
       _id: id,
       tenantId: "t1" as TenantId,
@@ -84,6 +94,9 @@ describe("refreshPrincipalCalendars", () => {
           listEventsByPrincipal: mock(async () => resources),
         } as never,
         jobs: { enqueueUrgent, requeueFailedByConnection } as never,
+        connections: {
+          listByPrincipal: mock(async () => [{ _id: "c1" }]),
+        } as never,
       },
       "t1" as TenantId,
       "p1" as PrincipalId,

--- a/packages/sync/src/domain/connection-refresh.service.ts
+++ b/packages/sync/src/domain/connection-refresh.service.ts
@@ -7,11 +7,13 @@ import {
   type JobEnqueue,
 } from "@sync/storage/contracts/job.contracts";
 import { type JobRepository } from "@sync/storage/repositories/job.repository";
+import { type ProviderConnectionRepository } from "@sync/storage/repositories/provider-connection.repository";
 import { type SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
 
 export interface ConnectionRefreshDeps {
   resources: SyncResourceRepository;
   jobs: JobRepository;
+  connections: Pick<ProviderConnectionRepository, "listByPrincipal">;
 }
 
 export type ConnectionRefreshTally = {
@@ -36,10 +38,10 @@ export async function refreshPrincipalCalendars(
   principalId: PrincipalId,
   now: () => Date = () => new Date(),
 ): Promise<ConnectionRefreshTally> {
-  const resources = await deps.resources.listEventsByPrincipal(
-    tenantId,
-    principalId,
-  );
+  const [resources, connectionRecords] = await Promise.all([
+    deps.resources.listEventsByPrincipal(tenantId, principalId),
+    deps.connections.listByPrincipal(tenantId, principalId),
+  ]);
   const runAfter = now();
   const tally: ConnectionRefreshTally = {
     resources: resources.length,
@@ -53,7 +55,15 @@ export async function refreshPrincipalCalendars(
   // touches, not just the incrementalPull rows enqueueUrgent below revives via
   // coalescing key. Otherwise a wedged calendarListSync/initialImport/repair/
   // subscriptionMaintain row stays stuck even after the user asks to refresh.
-  const connectionIds = [...new Set(resources.map((r) => r.connectionId))];
+  // Union connection rows with events-resource owners so a connection whose
+  // calendars have no events resource (the missing-resource trap) still
+  // requeues and re-runs discovery.
+  const connectionIds = [
+    ...new Set([
+      ...connectionRecords.map((connection) => connection._id),
+      ...resources.map((r) => r.connectionId),
+    ]),
+  ];
   const revivedCounts = await Promise.all(
     connectionIds.map((connectionId) =>
       deps.jobs.requeueFailedByConnection(
@@ -65,6 +75,25 @@ export async function refreshPrincipalCalendars(
     ),
   );
   tally.requeuedFailed += revivedCounts.reduce((sum, n) => sum + n, 0);
+
+  // Re-run calendar-list discovery per connection so a Refresh heals
+  // resource-less calendars (discovery creates the missing events resource
+  // and enqueues its import). Coalesced per connection at user priority.
+  await Promise.all(
+    connectionIds.map((connectionId) =>
+      deps.jobs.enqueueUrgent({
+        tenantId,
+        principalId,
+        connectionId,
+        resourceId: null,
+        commandId: null,
+        kind: "calendarListSync",
+        priority: JOB_PRIORITY.user,
+        runAfter,
+        coalescingKey: `calendarListSync:${connectionId}`,
+      }),
+    ),
+  );
 
   const outcomes = await Promise.all(
     resources.map(async (resource) => {

--- a/packages/sync/src/domain/connection-retention.service.db.test.ts
+++ b/packages/sync/src/domain/connection-retention.service.db.test.ts
@@ -82,8 +82,6 @@ describe("purgeExpiredDisconnectedConnections", () => {
       capabilities: ["readEvents"],
       state: "healthy",
       stateReason: null,
-      lastSyncedAt: null,
-      lastHealthyAt: null,
     });
     if (disconnectedAt) {
       await connections.markDisconnected(
@@ -287,8 +285,6 @@ describe("purgeExpiredDisconnectedConnections", () => {
       capabilities: ["readEvents"],
       state: "healthy",
       stateReason: null,
-      lastSyncedAt: null,
-      lastHealthyAt: null,
     });
 
     const purged = await purgeExpiredDisconnectedConnections(

--- a/packages/sync/src/domain/connection-state-refresh.service.db.test.ts
+++ b/packages/sync/src/domain/connection-state-refresh.service.db.test.ts
@@ -47,8 +47,6 @@ describe("refreshConnectionState", () => {
       capabilities: ["readEvents", "readBusy", "writeEvents"],
       state: "importing",
       stateReason: null,
-      lastSyncedAt: null,
-      lastHealthyAt: null,
     });
     await credentials.store({
       connectionId: connection._id,
@@ -422,6 +420,92 @@ describe("refreshConnectionState", () => {
     );
     expect(after.state).toBe("delayed");
     expect(after.stateReason).toBe("workOverdue");
+  });
+
+  it("reports delayed when an active calendar has no events resource and is past the stall window", async () => {
+    const connection = await seedImportingConnection();
+    await calendars.upsertByProviderCalendar({
+      tenantId: connection.tenantId,
+      principalId: connection.principalId,
+      connectionId: connection._id,
+      providerCalendarId: "primary@example.com" as ProviderCalendarSourceId,
+      displayName: "Primary",
+      color: null,
+      active: true,
+      primary: true,
+      accessRole: "owner",
+      capabilities: {
+        canReadEvents: true,
+        canWriteEvents: true,
+        canReadBusy: true,
+        canInviteAttendees: true,
+      },
+    });
+    const listResource = await resources.ensure({
+      tenantId: connection.tenantId,
+      principalId: connection.principalId,
+      connectionId: connection._id,
+      resourceKind: "calendarList",
+      calendarId: null,
+    });
+    await resources.advanceCursor(
+      connection.tenantId,
+      connection.principalId,
+      listResource._id,
+      "list-cursor",
+      new Date(),
+    );
+
+    const stillFresh = await refreshConnectionState(deps(), connection);
+    expect(stillFresh.state).toBe("importing");
+
+    const wellPastOverdue = () =>
+      new Date(Date.now() + BOOTSTRAP_STALLED_AFTER_MS);
+    const after = await refreshConnectionState(
+      deps(),
+      connection,
+      wellPastOverdue,
+    );
+    expect(after.state).toBe("delayed");
+    expect(after.stateReason).toBe("workOverdue");
+  });
+
+  it("keeps importing when an active calendar has no events resource and is still young", async () => {
+    const connection = await seedImportingConnection();
+    await calendars.upsertByProviderCalendar({
+      tenantId: connection.tenantId,
+      principalId: connection.principalId,
+      connectionId: connection._id,
+      providerCalendarId: "primary@example.com" as ProviderCalendarSourceId,
+      displayName: "Primary",
+      color: null,
+      active: true,
+      primary: true,
+      accessRole: "owner",
+      capabilities: {
+        canReadEvents: true,
+        canWriteEvents: true,
+        canReadBusy: true,
+        canInviteAttendees: true,
+      },
+    });
+    const listResource = await resources.ensure({
+      tenantId: connection.tenantId,
+      principalId: connection.principalId,
+      connectionId: connection._id,
+      resourceKind: "calendarList",
+      calendarId: null,
+    });
+    await resources.advanceCursor(
+      connection.tenantId,
+      connection.principalId,
+      listResource._id,
+      "list-cursor",
+      new Date(),
+    );
+
+    const after = await refreshConnectionState(deps(), connection);
+    expect(after.state).toBe("importing");
   });
 
   it("reports catchingUp while a user-requested pull is queued", async () => {

--- a/packages/sync/src/domain/connection-state-refresh.service.ts
+++ b/packages/sync/src/domain/connection-state-refresh.service.ts
@@ -131,10 +131,13 @@ export async function gatherConnectionStateEvidence(
   // this just for taking a while.
   const bootstrapOverdue = activeCalendars.some((c) => {
     const resource = eventsByCalendar.get(c._id);
-    if (!resource || resource.bootstrapState === "ready") return false;
-    return (
-      now.getTime() - resource.updatedAt.getTime() >= BOOTSTRAP_STALLED_AFTER_MS
-    );
+    if (resource?.bootstrapState === "ready") return false;
+    // An active calendar with no events resource used to skip this check
+    // entirely and stay "importing" forever. Fall back to the calendar row's
+    // own updatedAt so a missing resource still trips delayed after the stall
+    // window; Refresh then re-runs calendar-list discovery to heal it.
+    const basis = resource?.updatedAt ?? c.updatedAt;
+    return now.getTime() - basis.getTime() >= BOOTSTRAP_STALLED_AFTER_MS;
   });
 
   // "Last synced" must be as old as the least-recent active calendar. Taking

--- a/packages/sync/src/domain/sync-job-dispatch.service.db.test.ts
+++ b/packages/sync/src/domain/sync-job-dispatch.service.db.test.ts
@@ -27,11 +27,13 @@ import { type ProviderCalendarRecord } from "@sync/storage/contracts/provider-ca
 import { type ProviderConnectionRecord } from "@sync/storage/contracts/provider-connection.contracts";
 import { type SyncResourceRecord } from "@sync/storage/contracts/sync-resource.contracts";
 import { CommandRepository } from "@sync/storage/repositories/command.repository";
+import { CredentialRepository } from "@sync/storage/repositories/credential.repository";
 import { EventRepository } from "@sync/storage/repositories/event.repository";
 import { EventOccurrenceRepository } from "@sync/storage/repositories/event-occurrence.repository";
 import { InvalidationRepository } from "@sync/storage/repositories/invalidation.repository";
 import { JobRepository } from "@sync/storage/repositories/job.repository";
 import { ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
+import { ProviderConnectionRepository } from "@sync/storage/repositories/provider-connection.repository";
 import { SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
 
 const objectId = () => faker.database.mongodbObjectId();
@@ -151,6 +153,7 @@ describe("dispatchSyncJob", () => {
   let commands: CommandRepository;
   let jobs: JobRepository;
   let invalidations: InvalidationRepository;
+  let credentials: CredentialRepository;
   // Dispatch resolves the connection for a calendarListSync job; a test sets what
   // findById returns without seeding a full connection record.
   let stubbedConnection: ProviderConnectionRecord | null;
@@ -163,11 +166,27 @@ describe("dispatchSyncJob", () => {
     commands = new CommandRepository(storage.db());
     jobs = new JobRepository(storage.db());
     invalidations = new InvalidationRepository(storage.db());
+    credentials = new CredentialRepository(storage.db());
     stubbedConnection = null;
   });
 
   const connections = {
     findById: async () => stubbedConnection,
+    updateDerivedState: async (
+      tenantId: ProviderConnectionRecord["tenantId"],
+      principalId: ProviderConnectionRecord["principalId"],
+      id: ProviderConnectionRecord["_id"],
+      fields: {
+        state: ProviderConnectionRecord["state"];
+        stateReason: ProviderConnectionRecord["stateReason"];
+        lastSyncedAt: Date | null;
+        lastHealthyAt: Date | null;
+      },
+      at?: Date,
+    ) => {
+      const real = new ProviderConnectionRepository(storage.db());
+      return real.updateDerivedState(tenantId, principalId, id, fields, at);
+    },
   } as unknown as SyncJobDispatchDeps["connections"];
 
   const deps = (
@@ -181,6 +200,7 @@ describe("dispatchSyncJob", () => {
     resources,
     calendars,
     connections,
+    credentials,
     discovery: discoveryOverride,
     jobs,
     commands,
@@ -729,6 +749,135 @@ describe("dispatchSyncJob", () => {
     );
     expect(saved?.bootstrapState).toBe("ready");
     expect(saved?.subscriptionId).toBeNull();
+  });
+
+  async function seedConnectedCalendar() {
+    const realConnections = new ProviderConnectionRepository(storage.db());
+    const connection = await realConnections.upsertByProviderAccount({
+      tenantId: objectId(),
+      principalId: objectId(),
+      provider: "google",
+      account: {
+        providerAccountId: "acct-1",
+        email: "user@example.com",
+        displayName: "User",
+      },
+      capabilities: ["readEvents", "readBusy", "writeEvents"],
+      state: "importing",
+      stateReason: null,
+    });
+    await credentials.store({
+      connectionId: connection._id,
+      provider: "google",
+      refreshToken: "refresh",
+      scopes: ["https://www.googleapis.com/auth/calendar.events"],
+    });
+    const calendar = await seedProviderCalendar(calendars, {
+      tenantId: connection.tenantId,
+      principalId: connection.principalId,
+      connectionId: connection._id,
+    });
+    const listResource = await resources.ensure({
+      tenantId: connection.tenantId,
+      principalId: connection.principalId,
+      connectionId: connection._id,
+      resourceKind: "calendarList",
+      calendarId: null,
+    });
+    await resources.advanceCursor(
+      connection.tenantId,
+      connection.principalId,
+      listResource._id,
+      "list-cursor",
+      now(),
+    );
+    stubbedConnection = connection;
+    return { connection, calendar };
+  }
+
+  async function connectionInvalidations(principalId: string) {
+    const feed = await storage
+      .db()
+      .collection(SYNC_COLLECTIONS.invalidations)
+      .find({ principalId })
+      .toArray();
+    return feed.filter(
+      (row) =>
+        (row.invalidation as { kind?: string } | undefined)?.kind ===
+        "connection",
+    );
+  }
+
+  it("appends a connection invalidation when bootstrapCatchup completes", async () => {
+    const { connection, calendar } = await seedConnectedCalendar();
+    const resource = await seedResource(calendar, "cursor-1");
+
+    const outcome = await dispatchSyncJob(
+      deps(new FakeReader([page([], "cursor-2")])),
+      jobFor(resource, "bootstrapCatchup"),
+      now,
+    );
+
+    expect(outcome).toEqual({ result: "done" });
+    expect(await connectionInvalidations(connection.principalId)).toHaveLength(
+      1,
+    );
+  });
+
+  it("appends a connection invalidation when subscriptionMaintain completes unsupported", async () => {
+    const { connection, calendar } = await seedConnectedCalendar();
+    const resource = await ensureEventsResource(resources, calendar, {
+      cursor: "cursor-1",
+      bootstrapState: "watching",
+      now,
+    });
+    const refusing = {
+      ...notifications,
+      watchEvents: async () => {
+        throw new ProviderNotificationError(
+          "watchUnsupported",
+          "push not supported for this calendar",
+        );
+      },
+    };
+
+    const outcome = await dispatchSyncJob(
+      deps(new FakeReader([]), tokenSource, refusing),
+      jobFor(resource, "subscriptionMaintain"),
+      now,
+    );
+
+    expect(outcome).toEqual({ result: "done" });
+    expect(await connectionInvalidations(connection.principalId)).toHaveLength(
+      1,
+    );
+  });
+
+  it("does not fail the job when connection-state refresh throws", async () => {
+    const { calendar } = await seedConnectedCalendar();
+    const resource = await seedResource(calendar, "cursor-1");
+    const warnings: string[] = [];
+    const failingDeps: SyncJobDispatchDeps = {
+      ...deps(new FakeReader([page([], "cursor-2")])),
+      connections: {
+        findById: async () => stubbedConnection,
+        updateDerivedState: async () => {
+          throw new Error("derived-state write failed");
+        },
+      } as unknown as SyncJobDispatchDeps["connections"],
+      log: { warn: (message) => warnings.push(message) },
+    };
+
+    const outcome = await dispatchSyncJob(
+      failingDeps,
+      jobFor(resource, "bootstrapCatchup"),
+      now,
+    );
+
+    expect(outcome).toEqual({ result: "done" });
+    expect(warnings.some((message) => message.includes("derived-state"))).toBe(
+      true,
+    );
   });
 
   const calendarListJob = (

--- a/packages/sync/src/domain/sync-job-dispatch.service.ts
+++ b/packages/sync/src/domain/sync-job-dispatch.service.ts
@@ -2,6 +2,7 @@ import { importCalendarEvents } from "@sync/domain/calendar-import.service";
 import { syncCalendarList } from "@sync/domain/calendar-list-sync.service";
 import { pullCalendarChanges } from "@sync/domain/calendar-pull.service";
 import { repairCalendar } from "@sync/domain/calendar-repair.service";
+import { refreshConnectionState } from "@sync/domain/connection-state-refresh.service";
 import { type AccessTokenSource } from "@sync/domain/provider-write-ladder";
 import { maintainSubscription } from "@sync/domain/subscription-maintenance.service";
 import { ProviderAuthError } from "@sync/providers/provider-auth.port";
@@ -22,6 +23,7 @@ import {
 import { type ProviderCalendarRecord } from "@sync/storage/contracts/provider-calendar.contracts";
 import { type SyncResourceRecord } from "@sync/storage/contracts/sync-resource.contracts";
 import { type CommandRepository } from "@sync/storage/repositories/command.repository";
+import { type CredentialRepository } from "@sync/storage/repositories/credential.repository";
 import { type EventRepository } from "@sync/storage/repositories/event.repository";
 import { type EventOccurrenceRepository } from "@sync/storage/repositories/event-occurrence.repository";
 import { type InvalidationRepository } from "@sync/storage/repositories/invalidation.repository";
@@ -38,6 +40,7 @@ export interface SyncJobDispatchDeps {
   // syncCalendarList resolves the connection a calendarListSync job targets,
   // discovers its calendars, and enqueues an initial import per active calendar.
   connections: ProviderConnectionRepository;
+  credentials: CredentialRepository;
   discovery: ProviderCalendarAdapter;
   jobs: JobRepository;
   // pullCalendarChanges consults pending commands before deleting an event.
@@ -334,6 +337,7 @@ async function runSyncJob(
           "ready",
         );
         await appendCalendarInvalidation(deps, calendar, now());
+        await refreshConnectionStateAfterBootstrap(deps, job);
         return { result: "done" };
       }
       if (pull.status === "notImported") {
@@ -394,6 +398,7 @@ async function runSyncJob(
           "ready",
         );
         await appendCalendarInvalidation(deps, calendar, now());
+        await refreshConnectionStateAfterBootstrap(deps, job);
         return { result: "done" };
       }
       if (subscription.status !== "authRevoked") {
@@ -466,6 +471,31 @@ function bootstrapCatchupFollowup(
 
 function needsBootstrapCompletion(resource: SyncResourceRecord): boolean {
   return resource.bootstrapState !== "ready";
+}
+
+// Push derived connection state after bootstrap evidence changes. At dispatch
+// time the current job is still claimed, so derivation lands on catchingUp
+// (still a change from importing → invalidation fires → client refetches →
+// the read-path refresh after the job settles lands healthy). Never fail the
+// job: state refresh is observational, not part of the provider work.
+async function refreshConnectionStateAfterBootstrap(
+  deps: SyncJobDispatchDeps,
+  job: JobRecord,
+): Promise<void> {
+  try {
+    const connection = await deps.connections.findById(
+      job.tenantId,
+      job.principalId,
+      job.connectionId,
+    );
+    if (!connection) return;
+    await refreshConnectionState(deps, connection);
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    deps.log?.warn(
+      `Failed to refresh connection state after bootstrap for connection ${job.connectionId}: ${detail}`,
+    );
+  }
 }
 
 async function appendCalendarInvalidation(

--- a/packages/sync/src/domain/sync-job-worker.service.db.test.ts
+++ b/packages/sync/src/domain/sync-job-worker.service.db.test.ts
@@ -21,6 +21,7 @@ import { type JobRecord } from "@sync/storage/contracts/job.contracts";
 import { type ProviderCalendarRecord } from "@sync/storage/contracts/provider-calendar.contracts";
 import { type SyncResourceRecord } from "@sync/storage/contracts/sync-resource.contracts";
 import { CommandRepository } from "@sync/storage/repositories/command.repository";
+import { CredentialRepository } from "@sync/storage/repositories/credential.repository";
 import { EventRepository } from "@sync/storage/repositories/event.repository";
 import { EventOccurrenceRepository } from "@sync/storage/repositories/event-occurrence.repository";
 import { InvalidationRepository } from "@sync/storage/repositories/invalidation.repository";
@@ -128,6 +129,7 @@ describe("SyncJobWorker", () => {
     resources,
     calendars,
     connections,
+    credentials: new CredentialRepository(storage.db()),
     discovery: discoveryOverride,
     commands,
     jobs,
@@ -600,8 +602,6 @@ describe("SyncJobWorker", () => {
       capabilities: ["readEvents", "readBusy", "writeEvents"],
       state: "importing",
       stateReason: null,
-      lastSyncedAt: null,
-      lastHealthyAt: null,
     });
     const job = await jobs.enqueue({
       tenantId: connection.tenantId,

--- a/packages/sync/src/safety/isolation-matrix.db.test.ts
+++ b/packages/sync/src/safety/isolation-matrix.db.test.ts
@@ -112,8 +112,6 @@ describe("R-SEC-03 isolation matrix", () => {
       capabilities: ["readEvents"],
       state: "healthy",
       stateReason: null,
-      lastSyncedAt: new Date(),
-      lastHealthyAt: new Date(),
     });
     return connection._id;
   };

--- a/packages/sync/src/server/availability.routes.db.test.ts
+++ b/packages/sync/src/server/availability.routes.db.test.ts
@@ -93,8 +93,6 @@ describe("POST /internal/availability/busy", () => {
       capabilities: ["readEvents"],
       state,
       stateReason: null,
-      lastSyncedAt: new Date(),
-      lastHealthyAt: new Date(),
     });
     return c._id;
   };

--- a/packages/sync/src/server/connection.routes.db.test.ts
+++ b/packages/sync/src/server/connection.routes.db.test.ts
@@ -139,8 +139,6 @@ const seedConnection = (
     capabilities: ["readEvents"],
     state: "healthy",
     stateReason: null,
-    lastSyncedAt: null,
-    lastHealthyAt: null,
   });
 
 // Sign like the trusted Compass API would, so the request clears internal auth.
@@ -794,6 +792,19 @@ describe("GET /sync/google", () => {
       principalId,
       "reauth@example.com",
     );
+    const healthyAt = new Date("2026-07-01T00:00:00.000Z");
+    await connections.updateDerivedState(
+      existing.tenantId,
+      existing.principalId,
+      existing._id,
+      {
+        state: "healthy",
+        stateReason: null,
+        lastSyncedAt: healthyAt,
+        lastHealthyAt: healthyAt,
+      },
+      healthyAt,
+    );
     // Google returns the same account the connection is tied to.
     adapter.exchangeResult = {
       ...adapter.exchangeResult,
@@ -817,6 +828,7 @@ describe("GET /sync/google", () => {
     );
     expect(all).toHaveLength(1);
     expect(all[0]._id).toBe(existing._id);
+    expect(all[0].lastHealthyAt).toEqual(healthyAt);
   });
 
   it("refuses and links nothing when reconnect consents with a different account", async () => {

--- a/packages/sync/src/server/connection.routes.ts
+++ b/packages/sync/src/server/connection.routes.ts
@@ -584,7 +584,11 @@ export function registerConnectionRoutes(
       try {
         const repos = syncRepositories(deps.mongo);
         const tally = await refreshPrincipalCalendars(
-          { resources: repos.syncResources, jobs: repos.jobs },
+          {
+            resources: repos.syncResources,
+            jobs: repos.jobs,
+            connections: repos.connections,
+          },
           auth.tenantId,
           auth.principalId,
           () => new Date((deps.now ?? Date.now)()),
@@ -819,8 +823,6 @@ async function linkConnection(
     capabilities: googleCapabilitiesFromScopes(authorization.grantedScopes),
     state: derived.state,
     stateReason: derived.reason,
-    lastSyncedAt: null,
-    lastHealthyAt: null,
   });
 
   try {

--- a/packages/sync/src/server/diagnostic.routes.db.test.ts
+++ b/packages/sync/src/server/diagnostic.routes.db.test.ts
@@ -85,8 +85,6 @@ describe("GET /internal/diagnostics/connections/:diagnosticKey", () => {
       capabilities: ["readEvents"],
       state: "delayed",
       stateReason: null,
-      lastSyncedAt: null,
-      lastHealthyAt: null,
     });
     await calendars.upsertByProviderCalendar({
       tenantId: tenantId as TenantId,

--- a/packages/sync/src/server/principal.routes.db.test.ts
+++ b/packages/sync/src/server/principal.routes.db.test.ts
@@ -95,8 +95,6 @@ const seedConnection = (
     capabilities: ["readEvents"],
     state: "healthy",
     stateReason: null,
-    lastSyncedAt: null,
-    lastHealthyAt: null,
   });
 
 describe("DELETE /internal/principal", () => {

--- a/packages/sync/src/storage/contracts/provider-connection.contracts.ts
+++ b/packages/sync/src/storage/contracts/provider-connection.contracts.ts
@@ -76,8 +76,6 @@ export const ProviderConnectionUpsertSchema = z
     capabilities: ProviderCapabilitySetSchema,
     state: ConnectionStateSchema,
     stateReason: ConnectionStateReasonSchema.nullable(),
-    lastSyncedAt: z.date().nullable(),
-    lastHealthyAt: z.date().nullable(),
   })
   .refine(hasReasonWhenActionRequired, actionRequiredReasonIssue);
 export type ProviderConnectionUpsert = z.infer<

--- a/packages/sync/src/storage/repositories/provider-connection.repository.db.test.ts
+++ b/packages/sync/src/storage/repositories/provider-connection.repository.db.test.ts
@@ -22,8 +22,6 @@ const baseUpsert = (
     capabilities: ["readEvents"],
     state: "importing",
     stateReason: null,
-    lastSyncedAt: null,
-    lastHealthyAt: null,
     ...overrides,
   }) as ProviderConnectionUpsert;
 
@@ -140,6 +138,36 @@ describe("ProviderConnectionRepository", () => {
       "writeEvents",
       "changeNotifications",
     ]);
+  });
+
+  it("keeps prior lastHealthyAt when the same account reconnects", async () => {
+    const tenantId = objectId();
+    const principalId = objectId();
+    const created = await repo.upsertByProviderAccount(
+      baseUpsert({ tenantId, principalId }),
+    );
+    const healthyAt = new Date("2026-07-01T00:00:00.000Z");
+    await repo.updateDerivedState(
+      created.tenantId,
+      created.principalId,
+      created._id,
+      {
+        state: "healthy",
+        stateReason: null,
+        lastSyncedAt: healthyAt,
+        lastHealthyAt: healthyAt,
+      },
+      healthyAt,
+    );
+
+    const reconnected = await repo.upsertByProviderAccount(
+      baseUpsert({ tenantId, principalId, state: "importing" }),
+    );
+
+    expect(reconnected._id).toBe(created._id);
+    expect(reconnected.state).toBe("importing");
+    expect(reconnected.lastHealthyAt).toEqual(healthyAt);
+    expect(reconnected.lastSyncedAt).toEqual(healthyAt);
   });
 
   it("does not leak one principal's connections to another", async () => {

--- a/packages/sync/src/storage/repositories/provider-connection.repository.ts
+++ b/packages/sync/src/storage/repositories/provider-connection.repository.ts
@@ -53,8 +53,6 @@ export class ProviderConnectionRepository {
           capabilities: fields.capabilities,
           state: fields.state,
           stateReason: fields.stateReason,
-          lastSyncedAt: fields.lastSyncedAt,
-          lastHealthyAt: fields.lastHealthyAt,
           // A successful upsert-by-account-identity means the account is live —
           // a create or a reconnect — so clear any prior disconnect evidence.
           // This keeps disconnectedAt and state consistent: an upsert never
@@ -68,6 +66,11 @@ export class ProviderConnectionRepository {
           tenantId: fields.tenantId,
           principalId: fields.principalId,
           provider: fields.provider,
+          // Health timestamps are derived evidence, not link-time facts.
+          // Putting them on $set would clobber lastHealthyAt on reconnect and
+          // make an established account look like a first import.
+          lastSyncedAt: null,
+          lastHealthyAt: null,
           createdAt: now,
         },
       },

--- a/packages/sync/src/telemetry/health-snapshot.service.db.test.ts
+++ b/packages/sync/src/telemetry/health-snapshot.service.db.test.ts
@@ -60,8 +60,6 @@ describe("computeHealthSnapshot", () => {
       capabilities: ["readEvents"],
       state,
       stateReason: state === "actionRequired" ? "authorizationRevoked" : null,
-      lastSyncedAt: null,
-      lastHealthyAt: null,
     });
 
   it("aggregates connection states, jobs, subscriptions, and freshness", async () => {

--- a/packages/web/src/auth/compass/session/SessionProvider.test.tsx
+++ b/packages/web/src/auth/compass/session/SessionProvider.test.tsx
@@ -2,6 +2,7 @@ import { renderHook, waitFor } from "@testing-library/react";
 import { act, useContext } from "react";
 import { session } from "@web/auth/compass/session/Session";
 import { DEFAULT_AUTH_STATE } from "@web/auth/compass/state/auth.state.util";
+import * as userMetadataUtil from "@web/auth/compass/user/util/user-metadata.util";
 import {
   initialUserMetadataState,
   userMetadataActions,
@@ -18,8 +19,13 @@ import {
   spyOn,
 } from "bun:test";
 
-// Create mocks at module level
-const refreshUserMetadata = mock().mockResolvedValue(undefined);
+// spyOn (restorable) rather than mock.module: mock.module leaks process-wide
+// and would replace refreshUserMetadata with a no-op for later files that
+// exercise the real coalescing/fetch path.
+const refreshUserMetadata = spyOn(
+  userMetadataUtil,
+  "refreshUserMetadata",
+).mockResolvedValue(undefined);
 // SSEProvider.test.tsx has its own dedicated test importing the real module —
 // mock.module leaks process-wide across files, so spy on the real module's
 // exports (restorable) instead of mock.module'ing the whole path.
@@ -44,10 +50,6 @@ const subscribeToAuthState = mock();
 const updateAuthState = mock();
 const doesSessionExist = spyOn(session, "doesSessionExist");
 
-mock.module("@web/auth/compass/user/util/user-metadata.util", () => ({
-  refreshUserMetadata,
-}));
-
 mock.module("@web/auth/compass/state/auth.state.util", () => ({
   clearAnonymousCalendarChangeSignUpPrompt,
   clearAuthenticationState,
@@ -68,6 +70,7 @@ const { SessionProvider, sessionInit } =
 
 describe("SessionProvider sessionInit", () => {
   afterAll(() => {
+    refreshUserMetadata.mockRestore();
     openStream.mockRestore();
     closeStream.mockRestore();
     getStream.mockRestore();

--- a/packages/web/src/auth/compass/user/util/user-metadata.util.test.ts
+++ b/packages/web/src/auth/compass/user/util/user-metadata.util.test.ts
@@ -8,7 +8,7 @@ import {
   applyUserMetadataSideEffects,
   refreshUserMetadata,
 } from "./user-metadata.util";
-import { beforeEach, describe, expect, it, spyOn } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
 
 const healthy: UserMetadata = { google: { connectionState: "HEALTHY" } };
 const attention: UserMetadata = { google: { connectionState: "ATTENTION" } };
@@ -70,15 +70,19 @@ describe("applyUserMetadataSideEffects - delayed toast lifecycle", () => {
 });
 
 describe("refreshUserMetadata force coalescing", () => {
+  let get: ReturnType<typeof spyOn> | undefined;
+
+  afterEach(() => {
+    get?.mockRestore();
+    get = undefined;
+  });
+
   it("chains concurrent force calls onto one trailing fetch", async () => {
     // Spy BaseApi.get, not UserApi.getMetadata: other files' mock.module of
     // UserApi can leave this file spying a different object than the util
-    // closed over at first load.
-    const get = spyOn(BaseApi, "get").mockResolvedValue({
-      data: healthy,
-    } as never);
-    await refreshUserMetadata({ force: true });
-    get.mockReset();
+    // closed over at first load. Always restore in afterEach — a leaked spy
+    // would swallow CalendarList's adapter-based error path.
+    get = spyOn(BaseApi, "get");
 
     let resolveFirst!: (value: { data: UserMetadata }) => void;
     const first = new Promise<{ data: UserMetadata }>((resolve) => {
@@ -98,6 +102,5 @@ describe("refreshUserMetadata force coalescing", () => {
     await Promise.all([inFlight, forceA, forceB]);
 
     expect(get).toHaveBeenCalledTimes(2);
-    get.mockRestore();
   });
 });

--- a/packages/web/src/auth/compass/user/util/user-metadata.util.test.ts
+++ b/packages/web/src/auth/compass/user/util/user-metadata.util.test.ts
@@ -1,10 +1,14 @@
 import { type UserMetadata } from "@core/types/user.types";
 import { createTestToastPort } from "@web/__tests__/helpers/web-test-seams";
+import { UserApi } from "@web/api/user.api";
 import { resetGoogleReconnectRequiredForTests } from "@web/auth/google/state/google.reconnect.state";
 import { GOOGLE_DELAYED_TOAST_ID } from "@web/common/constants/toast.constants";
 import { registerToastPort } from "@web/common/utils/toast/toast.port";
-import { applyUserMetadataSideEffects } from "./user-metadata.util";
-import { beforeEach, describe, expect, it } from "bun:test";
+import {
+  applyUserMetadataSideEffects,
+  refreshUserMetadata,
+} from "./user-metadata.util";
+import { beforeEach, describe, expect, it, spyOn } from "bun:test";
 
 const healthy: UserMetadata = { google: { connectionState: "HEALTHY" } };
 const attention: UserMetadata = { google: { connectionState: "ATTENTION" } };
@@ -62,5 +66,27 @@ describe("applyUserMetadataSideEffects - delayed toast lifecycle", () => {
       expect.anything(),
       expect.objectContaining({ toastId: GOOGLE_DELAYED_TOAST_ID }),
     );
+  });
+});
+
+describe("refreshUserMetadata force coalescing", () => {
+  it("chains concurrent force calls onto one trailing fetch", async () => {
+    let resolveFirst!: (value: UserMetadata) => void;
+    const first = new Promise<UserMetadata>((resolve) => {
+      resolveFirst = resolve;
+    });
+    const getMetadata = spyOn(UserApi, "getMetadata")
+      .mockImplementationOnce(() => first)
+      .mockResolvedValue(healthy);
+
+    const inFlight = refreshUserMetadata();
+    const forceA = refreshUserMetadata({ force: true });
+    const forceB = refreshUserMetadata({ force: true });
+
+    resolveFirst(attention);
+    await Promise.all([inFlight, forceA, forceB]);
+
+    expect(getMetadata).toHaveBeenCalledTimes(2);
+    getMetadata.mockRestore();
   });
 });

--- a/packages/web/src/auth/compass/user/util/user-metadata.util.test.ts
+++ b/packages/web/src/auth/compass/user/util/user-metadata.util.test.ts
@@ -1,6 +1,6 @@
 import { type UserMetadata } from "@core/types/user.types";
 import { createTestToastPort } from "@web/__tests__/helpers/web-test-seams";
-import { UserApi } from "@web/api/user.api";
+import { BaseApi } from "@web/api/base/base.api";
 import { resetGoogleReconnectRequiredForTests } from "@web/auth/google/state/google.reconnect.state";
 import { GOOGLE_DELAYED_TOAST_ID } from "@web/common/constants/toast.constants";
 import { registerToastPort } from "@web/common/utils/toast/toast.port";
@@ -71,22 +71,33 @@ describe("applyUserMetadataSideEffects - delayed toast lifecycle", () => {
 
 describe("refreshUserMetadata force coalescing", () => {
   it("chains concurrent force calls onto one trailing fetch", async () => {
-    let resolveFirst!: (value: UserMetadata) => void;
-    const first = new Promise<UserMetadata>((resolve) => {
+    // Spy BaseApi.get, not UserApi.getMetadata: other files' mock.module of
+    // UserApi can leave this file spying a different object than the util
+    // closed over at first load.
+    const get = spyOn(BaseApi, "get").mockResolvedValue({
+      data: healthy,
+    } as never);
+    await refreshUserMetadata({ force: true });
+    get.mockReset();
+
+    let resolveFirst!: (value: { data: UserMetadata }) => void;
+    const first = new Promise<{ data: UserMetadata }>((resolve) => {
       resolveFirst = resolve;
     });
-    const getMetadata = spyOn(UserApi, "getMetadata")
-      .mockImplementationOnce(() => first)
-      .mockResolvedValue(healthy);
+    get
+      .mockImplementationOnce(() => first as never)
+      .mockResolvedValue({
+        data: healthy,
+      } as never);
 
     const inFlight = refreshUserMetadata();
     const forceA = refreshUserMetadata({ force: true });
     const forceB = refreshUserMetadata({ force: true });
 
-    resolveFirst(attention);
+    resolveFirst({ data: attention });
     await Promise.all([inFlight, forceA, forceB]);
 
-    expect(getMetadata).toHaveBeenCalledTimes(2);
-    getMetadata.mockRestore();
+    expect(get).toHaveBeenCalledTimes(2);
+    get.mockRestore();
   });
 });

--- a/packages/web/src/auth/compass/user/util/user-metadata.util.ts
+++ b/packages/web/src/auth/compass/user/util/user-metadata.util.ts
@@ -23,6 +23,7 @@ import {
 
 let refreshUserMetadataRequest: Promise<void> | null = null;
 let hasShownDelayedToastThisLoad = false;
+let metadataFetchEpoch = 0;
 
 /**
  * Keep session reconnect overrides and sticky toasts congruent with the latest
@@ -85,16 +86,19 @@ export const refreshUserMetadata = async (options?: {
       return refreshUserMetadataRequest;
     }
 
-    // The in-flight request predates whatever invalidated the metadata (e.g.
-    // a Google revocation prune), so its response is stale. Let it settle,
-    // then fetch fresh.
+    // Concurrent force calls chain onto one trailing fetch: each waits for
+    // the in-flight request, then `refreshUserMetadata()` without force joins
+    // whichever fetch the first waiter already started. A burst of SSE
+    // signals cannot stampede.
     return refreshUserMetadataRequest.then(() => refreshUserMetadata());
   }
 
   userMetadataActions.setLoading();
+  const epoch = ++metadataFetchEpoch;
 
   refreshUserMetadataRequest = UserApi.getMetadata()
     .then((metadata) => {
+      if (epoch !== metadataFetchEpoch) return;
       userMetadataActions.set(metadata);
       applyUserMetadataSideEffects(metadata);
     })

--- a/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.scope.test.tsx
+++ b/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.scope.test.tsx
@@ -114,4 +114,23 @@ describe("useConnectGoogle account scoping", () => {
 
     beginSpy.mockRestore();
   });
+
+  it("never sends connectionId for a new-account connect, even under RECONNECT_REQUIRED", async () => {
+    const beginSpy = spyOn(AuthApi, "beginGoogleConnection").mockResolvedValue({
+      authorizationUrl: "#consent",
+    });
+
+    const { wrapper } = createStoreWrapper();
+    const { result } = renderHook(
+      () => useConnectGoogle({ newAccount: true }),
+      { wrapper },
+    );
+    act(() => result.current.connect());
+
+    await waitFor(() => {
+      expect(beginSpy).toHaveBeenCalledWith({});
+    });
+
+    beginSpy.mockRestore();
+  });
 });

--- a/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.ts
+++ b/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.ts
@@ -36,6 +36,12 @@ export interface UseConnectGoogleOptions {
    * the precedence-winning one. Omit for the aggregate (whole-user) view.
    */
   connection?: GoogleSyncConnectionSummary | null;
+  /**
+   * Always start a new-account OAuth round-trip (`{}`), even when some other
+   * account is `RECONNECT_REQUIRED`. Settings "Add account" must never bind
+   * to a reconnect.
+   */
+  newAccount?: boolean;
 }
 
 export const useConnectGoogle = (
@@ -124,9 +130,10 @@ export const useConnectGoogle = (
       // from metadata so the wrong account cannot spawn a second.
       try {
         const beginRequest =
-          state === "RECONNECT_REQUIRED" && syncConnection?.id
-            ? { connectionId: syncConnection.id as ConnectionId }
-            : {};
+          options?.newAccount ||
+          !(state === "RECONNECT_REQUIRED" && syncConnection?.id)
+            ? {}
+            : { connectionId: syncConnection.id as ConnectionId };
         const { authorizationUrl } =
           await AuthApi.beginGoogleConnection(beginRequest);
         window.location.assign(authorizationUrl);
@@ -140,7 +147,7 @@ export const useConnectGoogle = (
     };
 
     void start();
-  }, [state, stopConnecting, syncConnection?.id]);
+  }, [options?.newAccount, state, stopConnecting, syncConnection?.id]);
 
   const onRefreshGoogle = useCallback(
     (options?: { silent?: boolean }) => {

--- a/packages/web/src/calendars/calendar.util.test.ts
+++ b/packages/web/src/calendars/calendar.util.test.ts
@@ -449,9 +449,11 @@ describe("groupCalendarsByAccount", () => {
     expect(groups[0]?.calendars).toEqual([work]);
   });
 
-  it("omits a connected account with no calendars yet", () => {
+  it("keeps a connected account with no calendars yet", () => {
     const { groups } = groupCalendarsByAccount([], [connection("old@x.com")]);
 
-    expect(groups).toHaveLength(0);
+    expect(groups).toHaveLength(1);
+    expect(groups[0]?.accountEmail).toBe("old@x.com");
+    expect(groups[0]?.calendars).toEqual([]);
   });
 });

--- a/packages/web/src/calendars/calendar.util.ts
+++ b/packages/web/src/calendars/calendar.util.ts
@@ -119,8 +119,9 @@ export interface AccountGroup {
 /**
  * Bucket calendars by the account they belong to, in connection order, with
  * anything lacking an account email (the local calendar) left ungrouped.
- * Callers render `ungrouped` after the groups, matching {@link
- * compareCalendars}, which sorts accountless calendars last.
+ * Empty groups are kept so a connected-but-still-importing account still
+ * renders its section header. Callers that cannot show an empty optgroup
+ * (the Settings default-calendar select) skip those groups inline.
  */
 export function groupCalendarsByAccount(
   calendars: Calendar[],
@@ -157,9 +158,7 @@ export function groupCalendarsByAccount(
     group.calendars.push(calendar);
   }
 
-  // An account can be connected before its calendars have imported; an empty
-  // section would render a heading with nothing under it.
-  return { groups: groups.filter((g) => g.calendars.length > 0), ungrouped };
+  return { groups, ungrouped };
 }
 
 export interface DefaultTargetCalendarOptions {

--- a/packages/web/src/components/AuthModal/AuthModal.test.tsx
+++ b/packages/web/src/components/AuthModal/AuthModal.test.tsx
@@ -41,7 +41,7 @@ let mockEmailPassword = createTestEmailPasswordPort();
 // afterAll so later files do not inherit this file's unauthenticated default.
 const actualUseSession = (await import("@web/auth/compass/session/useSession"))
   .useSession;
-const isSessionMocked = true;
+let isSessionMocked = true;
 const mockUseSession = mock(() => ({
   authenticated: false,
   userId: undefined as string | undefined,

--- a/packages/web/src/components/AuthModal/AuthModal.test.tsx
+++ b/packages/web/src/components/AuthModal/AuthModal.test.tsx
@@ -18,6 +18,7 @@ import {
   resetEmailPasswordPort,
 } from "@web/auth/compass/hooks/emailpassword.port";
 import { registerUseCompleteAuthenticationForTests } from "@web/auth/compass/hooks/useCompleteAuthentication.registry";
+import { SessionContext } from "@web/auth/compass/session/session.context";
 import { markGoogleAuthNeedsConsentRetry } from "@web/auth/google/authorization/google-authorization.storage";
 import { registerUseStartGoogleAuthorizationForTests } from "@web/auth/google/authorization/useStartGoogleAuthorization";
 import {
@@ -856,6 +857,30 @@ describe("URL Parameter Support", () => {
       expect(
         screen.getByRole("heading", { name: /hey, welcome back/i }),
       ).toBeInTheDocument();
+    });
+  });
+
+  it("ignores ?auth= while a session already exists", async () => {
+    const router = createTestRouter(
+      <SessionContext.Provider
+        value={{ authenticated: true, setAuthenticated: () => {} }}
+      >
+        <AuthModalProvider>
+          <AuthModal />
+        </AuthModalProvider>
+      </SessionContext.Provider>,
+      { initialEntries: ["/?auth=login"] },
+    );
+    render(<RouterProvider router={router} />);
+    await waitForRouterIdle(router);
+
+    expect(
+      screen.queryByRole("heading", { name: /hey, welcome back/i }),
+    ).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(router.state.location.search).not.toEqual(
+        expect.objectContaining({ auth: "login" }),
+      );
     });
   });
 

--- a/packages/web/src/components/AuthModal/AuthModal.test.tsx
+++ b/packages/web/src/components/AuthModal/AuthModal.test.tsx
@@ -18,7 +18,6 @@ import {
   resetEmailPasswordPort,
 } from "@web/auth/compass/hooks/emailpassword.port";
 import { registerUseCompleteAuthenticationForTests } from "@web/auth/compass/hooks/useCompleteAuthentication.registry";
-import { SessionContext } from "@web/auth/compass/session/session.context";
 import { markGoogleAuthNeedsConsentRetry } from "@web/auth/google/authorization/google-authorization.storage";
 import { registerUseStartGoogleAuthorizationForTests } from "@web/auth/google/authorization/useStartGoogleAuthorization";
 import {
@@ -37,6 +36,20 @@ const mockUseStartGoogleAuthorization = mock(() => ({
 }));
 const mockCompleteAuthentication = mock().mockResolvedValue(undefined);
 let mockEmailPassword = createTestEmailPasswordPort();
+
+// mock.module is process-wide. Capture the real hook and flip the flag off in
+// afterAll so later files do not inherit this file's unauthenticated default.
+const actualUseSession = (await import("@web/auth/compass/session/useSession"))
+  .useSession;
+const isSessionMocked = true;
+const mockUseSession = mock(() => ({
+  authenticated: false,
+  userId: undefined as string | undefined,
+}));
+mock.module("@web/auth/compass/session/useSession", () => ({
+  useSession: (...args: Parameters<typeof actualUseSession>) =>
+    isSessionMocked ? mockUseSession(...args) : actualUseSession(...args),
+}));
 
 const { redirectToToday, loadTodayData } = await import("@web/routers/loaders");
 const { ROOT_ROUTES } = await import("@web/common/constants/routes");
@@ -134,6 +147,10 @@ function installAuthModalTestSeams() {
   registerEmailPasswordPort(mockEmailPassword);
   resetGoogleAvailabilityForTests();
   setGoogleAvailabilityForTests("available");
+  mockUseSession.mockReset().mockReturnValue({
+    authenticated: false,
+    userId: undefined,
+  });
 }
 
 describe("AuthModal", () => {
@@ -861,18 +878,11 @@ describe("URL Parameter Support", () => {
   });
 
   it("ignores ?auth= while a session already exists", async () => {
-    const router = createTestRouter(
-      <SessionContext.Provider
-        value={{ authenticated: true, setAuthenticated: () => {} }}
-      >
-        <AuthModalProvider>
-          <AuthModal />
-        </AuthModalProvider>
-      </SessionContext.Provider>,
-      { initialEntries: ["/?auth=login"] },
-    );
-    render(<RouterProvider router={router} />);
-    await waitForRouterIdle(router);
+    mockUseSession.mockReturnValue({
+      authenticated: true,
+      userId: "user-1",
+    });
+    const { router } = await renderWithProviders(<div />, "/?auth=login");
 
     expect(
       screen.queryByRole("heading", { name: /hey, welcome back/i }),
@@ -1071,4 +1081,8 @@ describe("URL Parameter Support", () => {
       ).toBeInTheDocument();
     });
   });
+});
+
+afterAll(() => {
+  isSessionMocked = false;
 });

--- a/packages/web/src/components/AuthModal/hooks/useAuthModal.ts
+++ b/packages/web/src/components/AuthModal/hooks/useAuthModal.ts
@@ -1,5 +1,12 @@
 import { useNavigate, useSearch } from "@tanstack/react-router";
-import { createContext, useCallback, useContext, useMemo } from "react";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+} from "react";
+import { useSession } from "@web/auth/compass/session/useSession";
 
 export type AuthView =
   | "login"
@@ -81,6 +88,7 @@ function getViewFromParam(param: string | undefined): AuthView | null {
 export function useAuthModalState(): AuthModalContextValue {
   const { auth } = useSearch({ from: "__root__" });
   const navigate = useNavigate();
+  const { authenticated } = useSession();
   const view = getViewFromParam(auth);
 
   const setAuthView = useCallback(
@@ -100,14 +108,23 @@ export function useAuthModalState(): AuthModalContextValue {
     [navigate, view],
   );
 
+  useEffect(() => {
+    if (!authenticated || !auth) return;
+    navigate({
+      to: ".",
+      replace: true,
+      search: (prev) => ({ ...prev, auth: undefined }),
+    });
+  }, [authenticated, auth, navigate]);
+
   return useMemo(
     () => ({
-      isOpen: view !== null,
+      isOpen: view !== null && !authenticated,
       currentView: view ?? "login",
       openModal: (nextView: AuthView = "login") => setAuthView(nextView),
       closeModal: () => setAuthView(null),
       setView: (nextView: AuthView) => setAuthView(nextView),
     }),
-    [view, setAuthView],
+    [authenticated, view, setAuthView],
   );
 }

--- a/packages/web/src/components/Settings/SettingsModal.tsx
+++ b/packages/web/src/components/Settings/SettingsModal.tsx
@@ -212,15 +212,17 @@ const DefaultCalendarPicker: FC<DefaultCalendarPickerProps> = ({
         onChange={(e) => setDefaultCalendarId(e.target.value as CalendarId)}
         value={value}
       >
-        {groups.map((group) => (
-          <optgroup key={group.accountEmail} label={group.accountEmail}>
-            {group.calendars.map((calendar) => (
-              <option key={calendar.id} value={calendar.id}>
-                {calendar.name}
-              </option>
-            ))}
-          </optgroup>
-        ))}
+        {groups
+          .filter((group) => group.calendars.length > 0)
+          .map((group) => (
+            <optgroup key={group.accountEmail} label={group.accountEmail}>
+              {group.calendars.map((calendar) => (
+                <option key={calendar.id} value={calendar.id}>
+                  {calendar.name}
+                </option>
+              ))}
+            </optgroup>
+          ))}
         {ungrouped.map((calendar) => (
           <option key={calendar.id} value={calendar.id}>
             {calendar.name}
@@ -244,7 +246,9 @@ const AccountsSection: FC<AccountsSectionProps> = ({
   resolvedDefault,
   setConfirmingId,
 }) => {
-  const { connect, isAvailable, isConnecting } = useConnectGoogle();
+  const { connect, isAvailable, isConnecting } = useConnectGoogle({
+    newAccount: true,
+  });
   const { disconnect, disconnectingId } = useDisconnectGoogleAccount();
 
   return (

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarList.test.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarList.test.tsx
@@ -520,11 +520,7 @@ describe("CalendarList", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("hides the local calendar entirely once any account is connected", () => {
-    // Once connected, the local calendar can no longer gain new events
-    // (LCV1/LCV2) and stops explaining itself the way an account-owned
-    // calendar does - drop the orphan row rather than render it alongside
-    // real accounts (local-calendar-visibility LCV3).
+  it("shows the local calendar under the Compass email section once Google is connected", () => {
     const work = makeCalendar({
       name: "Work",
       accountEmail: "ahab@pequod.com",
@@ -542,7 +538,15 @@ describe("CalendarList", () => {
       ],
     });
 
-    expect(screen.queryByText("Compass")).not.toBeInTheDocument();
+    const compassSection = screen.getByRole("region", {
+      name: `Calendars for ${HEADER_EMAIL}`,
+    });
+    expect(within(compassSection).getByText("Compass")).toBeInTheDocument();
+    expect(
+      within(compassSection).getByRole("button", {
+        name: "Hide Compass calendar",
+      }),
+    ).toBeInTheDocument();
     for (const email of ["ahab@pequod.com", "ahab@gmail.com"]) {
       expect(
         within(
@@ -552,15 +556,42 @@ describe("CalendarList", () => {
     }
   });
 
-  it("un-hides the local calendar once the only connected account disconnects", () => {
-    // ensureLocalCalendar exists precisely so a disconnected user never loses
-    // every writable calendar - the row LCV3 hides must come back the moment
-    // its precondition (a connected account) stops holding, not stay stuck
-    // hidden with no calendar left to show instead. useDisconnectGoogleAccount
-    // calls userMetadataActions.removeConnection synchronously on success,
-    // before its network refetch even resolves - simulate exactly that,
-    // rather than the eventual refetch, since the row must not wait on it
-    // (local-calendar-visibility LCV5).
+  it("keeps the local calendar toggleable after Google is connected", async () => {
+    const work = makeCalendar({
+      name: "Work",
+      accountEmail: "ahab@pequod.com",
+    });
+    const local = makeCalendar({ name: "Compass", provider: "local" });
+
+    const user = userEvent.setup({ delay: null });
+    renderCalendarList([work, local], {
+      connections: [makeConnection("ahab@pequod.com")],
+    });
+
+    const toggle = screen.getByRole("button", {
+      name: "Hide Compass calendar",
+    });
+    expect(toggle).toHaveAttribute("aria-pressed", "true");
+    await user.click(toggle);
+    expect(
+      screen.getByRole("button", { name: "Show Compass calendar" }),
+    ).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("renders a connected account's header even before any calendars have imported", () => {
+    renderCalendarList([], {
+      connections: [makeConnection("ahab@pequod.com")],
+    });
+
+    expect(
+      screen.getByRole("region", { name: "Calendars for ahab@pequod.com" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "ahab@pequod.com" }),
+    ).toBeInTheDocument();
+  });
+
+  it("keeps the local calendar visible after a connected account disconnects", () => {
     const work = makeCalendar({
       name: "Work",
       accountEmail: "ahab@pequod.com",
@@ -570,7 +601,7 @@ describe("CalendarList", () => {
 
     renderCalendarList([work, local], { connections: [onlyConnection] });
 
-    expect(screen.queryByText("Compass")).not.toBeInTheDocument();
+    expect(screen.getByText("Compass")).toBeInTheDocument();
 
     act(() => {
       userMetadataActions.removeConnection(onlyConnection.id);
@@ -612,7 +643,7 @@ describe("CalendarList", () => {
     expect(screen.getByText("Work")).toBeInTheDocument();
   });
 
-  it("keeps the local calendar hidden regardless of account collapse state", async () => {
+  it("keeps the local Compass section visible when Google accounts are collapsed", async () => {
     const work = makeCalendar({
       name: "Work",
       accountEmail: "ahab@pequod.com",
@@ -634,7 +665,7 @@ describe("CalendarList", () => {
     await user.click(screen.getByRole("button", { name: "ahab@pequod.com" }));
     await user.click(screen.getByRole("button", { name: "ahab@gmail.com" }));
 
-    expect(screen.queryByText("Compass")).not.toBeInTheDocument();
+    expect(screen.getByText("Compass")).toBeInTheDocument();
   });
 
   it("renders no placeholder text while calendars are pending, to avoid a layout shift once they load", () => {

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarList.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarList.tsx
@@ -34,7 +34,6 @@ export const CalendarList: FC = () => {
   const accountEmailOrder = useConnectedAccountEmails();
   const collapsedKeys = useCollapsedAccountKeys();
 
-  const hasConnectedAccount = accountEmailOrder.length > 0;
   const isAnonymous = !email;
   // Session expiry already surfaces SessionExpiredToast — don't also show
   // "Couldn't load calendars" / Retry (or a false empty-list story) for it.
@@ -46,21 +45,9 @@ export const CalendarList: FC = () => {
   const calendars = useMemo(
     () =>
       (data ?? [])
-        .filter(
-          (calendar) =>
-            calendar.isActive &&
-            // Once any account is connected, the local calendar can no
-            // longer gain new events (LCV1/LCV2 close off both the ways it
-            // could) and no longer explains itself to the user the way an
-            // account-owned calendar does - drop its orphan row rather than
-            // show it. Gated on connection state, not on the calendar being
-            // empty: nothing can write to it anymore, and prod carries zero
-            // connected users with events already on it (see
-            // local-calendar-visibility LCV3).
-            (!hasConnectedAccount || calendar.provider !== "local"),
-        )
+        .filter((calendar) => calendar.isActive)
         .sort(compareCalendars(accountEmailOrder)),
-    [data, accountEmailOrder, hasConnectedAccount],
+    [data, accountEmailOrder],
   );
   const { groups, ungrouped } = useMemo(
     () => groupCalendarsByAccount(calendars, connections),
@@ -107,7 +94,7 @@ export const CalendarList: FC = () => {
             Retry
           </button>
         </div>
-      ) : calendars.length === 0 ? (
+      ) : calendars.length === 0 && groups.length === 0 ? (
         <p className="text-text-muted text-xs">
           {authenticated && state === "NOT_CONNECTED" && isAvailable
             ? "Connect Google to see your calendars."
@@ -128,22 +115,43 @@ export const CalendarList: FC = () => {
             </section>
           ))}
           {ungrouped.length > 0 ? (
-            <ul className="flex flex-col gap-1.5">
-              {ungrouped.map((calendar) =>
-                isAnonymous ? (
-                  <AnonymousCalendarRow calendar={calendar} key={calendar.id} />
-                ) : (
-                  <CalendarRow
-                    calendar={calendar}
-                    key={calendar.id}
-                    label={
-                      calendar.provider === "local" ? calendar.name : undefined
-                    }
-                    onToggle={toggleCalendarVisibility}
-                  />
-                ),
-              )}
-            </ul>
+            groups.length > 0 && email ? (
+              <section aria-label={`Calendars for ${email}`}>
+                <div className="mb-1.5">
+                  <h2 className="mb-0.5 font-semibold text-sm leading-none">
+                    <span
+                      className="min-w-0 truncate text-text-muted"
+                      translate="no"
+                    >
+                      {email}
+                    </span>
+                  </h2>
+                </div>
+                {renderRows(ungrouped)}
+              </section>
+            ) : (
+              <ul className="flex flex-col gap-1.5">
+                {ungrouped.map((calendar) =>
+                  isAnonymous ? (
+                    <AnonymousCalendarRow
+                      calendar={calendar}
+                      key={calendar.id}
+                    />
+                  ) : (
+                    <CalendarRow
+                      calendar={calendar}
+                      key={calendar.id}
+                      label={
+                        calendar.provider === "local"
+                          ? calendar.name
+                          : undefined
+                      }
+                      onToggle={toggleCalendarVisibility}
+                    />
+                  ),
+                )}
+              </ul>
+            )
           ) : null}
         </div>
       )}

--- a/packages/web/src/sse/hooks/useGcalSSE.factory.ts
+++ b/packages/web/src/sse/hooks/useGcalSSE.factory.ts
@@ -20,7 +20,9 @@ export type GcalSSEDependencies = {
   handleGoogleRevoked: () => void;
   invalidateEventQueries: () => void;
   onServerMessage: OnServerMessage;
-  refreshUserMetadata: () => Promise<unknown> | unknown;
+  refreshUserMetadata: (options?: {
+    force?: boolean;
+  }) => Promise<unknown> | unknown;
   setUserMetadata: (metadata: UserMetadata) => void;
   showErrorToast: (
     message: string | undefined,
@@ -43,7 +45,7 @@ export const createUseGcalSSE = (dependencies: GcalSSEDependencies) => {
       }
 
       if (message.sync.status === "healthy") {
-        void dependencies.refreshUserMetadata();
+        void dependencies.refreshUserMetadata({ force: true });
         return;
       }
 
@@ -55,7 +57,7 @@ export const createUseGcalSSE = (dependencies: GcalSSEDependencies) => {
         return;
       }
 
-      void dependencies.refreshUserMetadata();
+      void dependencies.refreshUserMetadata({ force: true });
 
       if (message.sync.code === "WATCH_REPAIR_FAILED") {
         dependencies.showErrorToast(
@@ -68,14 +70,14 @@ export const createUseGcalSSE = (dependencies: GcalSSEDependencies) => {
     }, []);
 
     const onImportCompleted = useCallback((_message: ImportResultMessage) => {
-      void dependencies.refreshUserMetadata();
+      void dependencies.refreshUserMetadata({ force: true });
       dependencies.invalidateEventQueries();
     }, []);
 
     // Sync connection/calendar invalidations arrive as calendarsChanged. Refetch
     // metadata so IMPORTING → HEALTHY (or RECONNECT/ATTENTION) reaches the UI.
     const onCalendarsChanged = useCallback(() => {
-      void dependencies.refreshUserMetadata();
+      void dependencies.refreshUserMetadata({ force: true });
     }, []);
 
     const onUserMetadataChanged = useCallback(

--- a/packages/web/src/sse/hooks/useSSEConnection.test.tsx
+++ b/packages/web/src/sse/hooks/useSSEConnection.test.tsx
@@ -7,6 +7,7 @@ import { beforeEach, describe, expect, it, mock } from "bun:test";
 
 const mockUseSession = mock();
 const mockUseUser = mock();
+const mockRefreshUserMetadata = mock().mockResolvedValue(undefined);
 const openStream = mock();
 const closeStream = mock();
 let reopenHandler: (() => void) | null = null;
@@ -22,6 +23,9 @@ mock.module("@web/auth/compass/session/useSession", () => ({
 }));
 mock.module("@web/auth/compass/user/hooks/useUser", () => ({
   useUser: mockUseUser,
+}));
+mock.module("@web/auth/compass/user/util/user-metadata.util", () => ({
+  refreshUserMetadata: mockRefreshUserMetadata,
 }));
 mock.module("../client/sse.client", () => ({
   openStream,
@@ -43,6 +47,7 @@ describe("useSSEConnection", () => {
     openStream.mockClear();
     closeStream.mockClear();
     onStreamReopen.mockClear();
+    mockRefreshUserMetadata.mockClear();
     mockUseSession.mockReturnValue({
       authenticated: true,
       setAuthenticated: mock(),
@@ -75,5 +80,6 @@ describe("useSSEConnection", () => {
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: calendarQueryKeys.all,
     });
+    expect(mockRefreshUserMetadata).toHaveBeenCalledWith({ force: true });
   });
 });

--- a/packages/web/src/sse/hooks/useSSEConnection.ts
+++ b/packages/web/src/sse/hooks/useSSEConnection.ts
@@ -2,6 +2,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useEffect } from "react";
 import { useSession } from "@web/auth/compass/session/useSession";
 import { useUser } from "@web/auth/compass/user/hooks/useUser";
+import { refreshUserMetadata } from "@web/auth/compass/user/util/user-metadata.util";
 import { calendarQueryKeys } from "@web/calendars/calendar.query";
 import { eventQueryKeys } from "@web/events/queries/event.query.keys";
 import { closeStream, onStreamReopen, openStream } from "../client/sse.client";
@@ -11,6 +12,15 @@ const invalidateScheduleQueries = (
 ) => {
   void queryClient.invalidateQueries({ queryKey: eventQueryKeys.all });
   void queryClient.invalidateQueries({ queryKey: calendarQueryKeys.all });
+};
+
+const reconcileAfterStreamGap = (
+  queryClient: ReturnType<typeof useQueryClient>,
+) => {
+  invalidateScheduleQueries(queryClient);
+  // A reopened stream means missed invalidations; events+calendars already
+  // refetch, metadata is the third leg.
+  void refreshUserMetadata({ force: true });
 };
 
 export const useSSEConnection = () => {
@@ -26,9 +36,9 @@ export const useSSEConnection = () => {
 
     openStream();
     // Open and native reconnect can both follow a disconnect gap.
-    invalidateScheduleQueries(queryClient);
+    reconcileAfterStreamGap(queryClient);
     return onStreamReopen(() => {
-      invalidateScheduleQueries(queryClient);
+      reconcileAfterStreamGap(queryClient);
     });
   }, [authenticated, userId, queryClient]);
 };

--- a/packages/web/src/sse/hooks/useSyncFocusRefresh.test.ts
+++ b/packages/web/src/sse/hooks/useSyncFocusRefresh.test.ts
@@ -1,10 +1,25 @@
 import { renderHook } from "@testing-library/react";
 import { act } from "react";
 import { type UseConnectGoogleResult } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle.types";
-import { useSyncFocusRefresh } from "@web/sse/hooks/useSyncFocusRefresh";
-import { afterEach, describe, expect, it, mock, setSystemTime } from "bun:test";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  mock,
+  setSystemTime,
+} from "bun:test";
 
 const MIN_HIDDEN_DURATION_MS = 30_000;
+const mockRefreshUserMetadata = mock().mockResolvedValue(undefined);
+
+mock.module("@web/auth/compass/user/util/user-metadata.util", () => ({
+  refreshUserMetadata: mockRefreshUserMetadata,
+}));
+
+const { useSyncFocusRefresh } =
+  require("./useSyncFocusRefresh") as typeof import("./useSyncFocusRefresh");
 
 const fakeConnectGoogle = (
   overrides: Partial<UseConnectGoogleResult> = {},
@@ -32,6 +47,10 @@ describe("useSyncFocusRefresh", () => {
     document.dispatchEvent(new Event("visibilitychange"));
   };
 
+  beforeEach(() => {
+    mockRefreshUserMetadata.mockClear();
+  });
+
   afterEach(() => {
     visibilityState = "visible";
     setSystemTime();
@@ -43,6 +62,7 @@ describe("useSyncFocusRefresh", () => {
 
     expect(refresh).toHaveBeenCalledTimes(1);
     expect(refresh).toHaveBeenCalledWith({ silent: true });
+    expect(mockRefreshUserMetadata).toHaveBeenCalledWith({ force: true });
   });
 
   it("refreshes on mount for an ATTENTION connection", () => {
@@ -54,22 +74,24 @@ describe("useSyncFocusRefresh", () => {
     );
 
     expect(refresh).toHaveBeenCalledTimes(1);
+    expect(mockRefreshUserMetadata).toHaveBeenCalledWith({ force: true });
   });
 
   it.each([
     "NOT_CONNECTED",
     "RECONNECT_REQUIRED",
     "IMPORTING",
-  ] as const)("does not refresh on mount for %s", (state) => {
+  ] as const)("does not provider-refresh on mount for %s", (state) => {
     const refresh = mock();
     renderHook(() =>
       useSyncFocusRefresh(() => fakeConnectGoogle({ refresh, state })),
     );
 
     expect(refresh).not.toHaveBeenCalled();
+    expect(mockRefreshUserMetadata).toHaveBeenCalledWith({ force: true });
   });
 
-  it("does not refresh when Google is unavailable", () => {
+  it("does not provider-refresh when Google is unavailable", () => {
     const refresh = mock();
     renderHook(() =>
       useSyncFocusRefresh(() =>
@@ -78,6 +100,7 @@ describe("useSyncFocusRefresh", () => {
     );
 
     expect(refresh).not.toHaveBeenCalled();
+    expect(mockRefreshUserMetadata).toHaveBeenCalledWith({ force: true });
   });
 
   it("does not retrigger when shared refresh status changes", () => {
@@ -115,6 +138,7 @@ describe("useSyncFocusRefresh", () => {
     const refresh = mock();
     renderHook(() => useSyncFocusRefresh(() => fakeConnectGoogle({ refresh })));
     refresh.mockClear();
+    mockRefreshUserMetadata.mockClear();
 
     act(() => {
       setVisibility("hidden");
@@ -124,6 +148,28 @@ describe("useSyncFocusRefresh", () => {
 
     expect(refresh).toHaveBeenCalledTimes(1);
     expect(refresh).toHaveBeenCalledWith({ silent: true });
+    expect(mockRefreshUserMetadata).toHaveBeenCalledWith({ force: true });
+  });
+
+  it("refreshes metadata but not provider refresh on focus during IMPORTING", () => {
+    setSystemTime(new Date("2026-02-05T00:00:00.000Z"));
+    const refresh = mock();
+    renderHook(() =>
+      useSyncFocusRefresh(() =>
+        fakeConnectGoogle({ refresh, state: "IMPORTING" }),
+      ),
+    );
+    refresh.mockClear();
+    mockRefreshUserMetadata.mockClear();
+
+    act(() => {
+      setVisibility("hidden");
+      setSystemTime(new Date(Date.now() + MIN_HIDDEN_DURATION_MS + 1_000));
+      setVisibility("visible");
+    });
+
+    expect(refresh).not.toHaveBeenCalled();
+    expect(mockRefreshUserMetadata).toHaveBeenCalledWith({ force: true });
   });
 
   it("does not refresh on a short hide", () => {
@@ -131,6 +177,7 @@ describe("useSyncFocusRefresh", () => {
     const refresh = mock();
     renderHook(() => useSyncFocusRefresh(() => fakeConnectGoogle({ refresh })));
     refresh.mockClear();
+    mockRefreshUserMetadata.mockClear();
 
     act(() => {
       setVisibility("hidden");
@@ -139,5 +186,6 @@ describe("useSyncFocusRefresh", () => {
     });
 
     expect(refresh).not.toHaveBeenCalled();
+    expect(mockRefreshUserMetadata).not.toHaveBeenCalled();
   });
 });

--- a/packages/web/src/sse/hooks/useSyncFocusRefresh.ts
+++ b/packages/web/src/sse/hooks/useSyncFocusRefresh.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef } from "react";
+import { refreshUserMetadata } from "@web/auth/compass/user/util/user-metadata.util";
 import { useConnectGoogle } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle";
 import { type UseConnectGoogleResult } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle.types";
 import { useVisibleAfterHidden } from "@web/common/hooks/useVisibleAfterHidden";
@@ -19,8 +20,10 @@ const MIN_HIDDEN_DURATION_MS = 30_000;
  * browser-wide refresh coordinator, so a focus refresh and a manual click
  * share work and status instead of racing each other.
  *
- * No-ops while there's no established connection worth refreshing (not yet
- * connected, reconnect required, or still on the initial import).
+ * Provider refresh no-ops while there's no established connection worth
+ * refreshing (not yet connected, reconnect required, or still on the initial
+ * import). Metadata always reconciles on mount and on visible-after-hidden —
+ * including during IMPORTING, which is exactly when the UI used to get stuck.
  *
  * `useConnectGoogleImpl` is a test seam (default: the real hook) so tests can
  * pass a fake implementation instead of mock.module-ing a hook other files
@@ -30,19 +33,30 @@ export const useSyncFocusRefresh = (
   useConnectGoogleImpl: () => UseConnectGoogleResult = useConnectGoogle,
 ) => {
   const { isAvailable, refresh, state } = useConnectGoogleImpl();
-  const didRefreshOnMount = useRef(false);
+  const didReconcileMetadataOnMount = useRef(false);
+  const didProviderRefreshOnMount = useRef(false);
   const canRefresh =
     isAvailable && (state === "HEALTHY" || state === "ATTENTION");
   const silentRefresh = useCallback(() => refresh({ silent: true }), [refresh]);
+  const reconcileMetadata = useCallback(() => {
+    void refreshUserMetadata({ force: true });
+  }, []);
 
   useEffect(() => {
-    if (!canRefresh || didRefreshOnMount.current) return;
+    if (didReconcileMetadataOnMount.current) return;
+    didReconcileMetadataOnMount.current = true;
+    reconcileMetadata();
+  }, [reconcileMetadata]);
+
+  useEffect(() => {
+    if (!canRefresh || didProviderRefreshOnMount.current) return;
     // Metadata briefly changes the connection state while a refresh is
     // requested. A mount refresh must not run again when that state settles,
     // or every completion enqueues another pull forever.
-    didRefreshOnMount.current = true;
+    didProviderRefreshOnMount.current = true;
     silentRefresh();
   }, [canRefresh, silentRefresh]);
 
   useVisibleAfterHidden(silentRefresh, MIN_HIDDEN_DURATION_MS, canRefresh);
+  useVisibleAfterHidden(reconcileMetadata, MIN_HIDDEN_DURATION_MS, true);
 };

--- a/packages/web/src/sse/hooks/useTransientSyncPolling.test.ts
+++ b/packages/web/src/sse/hooks/useTransientSyncPolling.test.ts
@@ -1,24 +1,9 @@
 import { renderHook } from "@testing-library/react";
 import { act } from "react";
+import * as userMetadataUtil from "@web/auth/compass/user/util/user-metadata.util";
 import { userMetadataActions } from "@web/auth/state/user-metadata.store";
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  mock,
-  spyOn,
-} from "bun:test";
-
-const mockRefreshUserMetadata = mock().mockResolvedValue(undefined);
-
-mock.module("@web/auth/compass/user/util/user-metadata.util", () => ({
-  refreshUserMetadata: mockRefreshUserMetadata,
-}));
-
-const { useTransientSyncPolling } =
-  require("./useTransientSyncPolling") as typeof import("./useTransientSyncPolling");
+import { useTransientSyncPolling } from "./useTransientSyncPolling";
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
 
 const TRANSIENT_POLL_MS = 20_000;
 
@@ -26,27 +11,34 @@ describe("useTransientSyncPolling", () => {
   let intervalCallback: (() => void) | undefined;
   let setIntervalSpy: ReturnType<typeof spyOn>;
   let clearIntervalSpy: ReturnType<typeof spyOn>;
+  let refreshSpy: ReturnType<typeof spyOn>;
 
   beforeEach(() => {
     intervalCallback = undefined;
-    mockRefreshUserMetadata.mockClear();
-    setIntervalSpy = spyOn(window, "setInterval").mockImplementation(((
+    refreshSpy = spyOn(
+      userMetadataUtil,
+      "refreshUserMetadata",
+    ).mockResolvedValue(undefined);
+    setIntervalSpy = spyOn(globalThis, "setInterval").mockImplementation(((
       callback: TimerHandler,
     ) => {
       if (typeof callback === "function") {
         intervalCallback = () => callback();
       }
-      return 1;
-    }) as typeof window.setInterval);
+      return 1 as unknown as ReturnType<typeof setInterval>;
+    }) as unknown as typeof setInterval);
     clearIntervalSpy = spyOn(globalThis, "clearInterval").mockImplementation(
       () => {},
     );
   });
 
   afterEach(() => {
+    refreshSpy.mockRestore();
     setIntervalSpy.mockRestore();
     clearIntervalSpy.mockRestore();
-    userMetadataActions.clear();
+    act(() => {
+      userMetadataActions.clear();
+    });
   });
 
   it("polls metadata while a connection is importing and stops when it settles", () => {
@@ -77,7 +69,7 @@ describe("useTransientSyncPolling", () => {
     act(() => {
       intervalCallback?.();
     });
-    expect(mockRefreshUserMetadata).toHaveBeenCalledWith({ force: true });
+    expect(refreshSpy).toHaveBeenCalledWith({ force: true });
 
     act(() => {
       userMetadataActions.set({
@@ -100,6 +92,7 @@ describe("useTransientSyncPolling", () => {
     hook.rerender();
 
     expect(clearIntervalSpy).toHaveBeenCalled();
+    hook.unmount();
   });
 
   it("does not poll when no connection is transient", () => {
@@ -120,8 +113,9 @@ describe("useTransientSyncPolling", () => {
       },
     });
 
-    renderHook(() => useTransientSyncPolling());
+    const { unmount } = renderHook(() => useTransientSyncPolling());
 
     expect(setIntervalSpy).not.toHaveBeenCalled();
+    unmount();
   });
 });

--- a/packages/web/src/sse/hooks/useTransientSyncPolling.test.ts
+++ b/packages/web/src/sse/hooks/useTransientSyncPolling.test.ts
@@ -30,14 +30,14 @@ describe("useTransientSyncPolling", () => {
   beforeEach(() => {
     intervalCallback = undefined;
     mockRefreshUserMetadata.mockClear();
-    setIntervalSpy = spyOn(globalThis, "setInterval").mockImplementation(((
+    setIntervalSpy = spyOn(window, "setInterval").mockImplementation(((
       callback: TimerHandler,
     ) => {
       if (typeof callback === "function") {
         intervalCallback = () => callback();
       }
-      return 1 as unknown as ReturnType<typeof setInterval>;
-    }) as unknown as typeof setInterval);
+      return 1;
+    }) as typeof window.setInterval);
     clearIntervalSpy = spyOn(globalThis, "clearInterval").mockImplementation(
       () => {},
     );

--- a/packages/web/src/sse/hooks/useTransientSyncPolling.test.ts
+++ b/packages/web/src/sse/hooks/useTransientSyncPolling.test.ts
@@ -1,0 +1,127 @@
+import { renderHook } from "@testing-library/react";
+import { act } from "react";
+import { userMetadataActions } from "@web/auth/state/user-metadata.store";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  mock,
+  spyOn,
+} from "bun:test";
+
+const mockRefreshUserMetadata = mock().mockResolvedValue(undefined);
+
+mock.module("@web/auth/compass/user/util/user-metadata.util", () => ({
+  refreshUserMetadata: mockRefreshUserMetadata,
+}));
+
+const { useTransientSyncPolling } =
+  require("./useTransientSyncPolling") as typeof import("./useTransientSyncPolling");
+
+const TRANSIENT_POLL_MS = 20_000;
+
+describe("useTransientSyncPolling", () => {
+  let intervalCallback: (() => void) | undefined;
+  let setIntervalSpy: ReturnType<typeof spyOn>;
+  let clearIntervalSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    intervalCallback = undefined;
+    mockRefreshUserMetadata.mockClear();
+    setIntervalSpy = spyOn(globalThis, "setInterval").mockImplementation(((
+      callback: TimerHandler,
+    ) => {
+      if (typeof callback === "function") {
+        intervalCallback = () => callback();
+      }
+      return 1 as unknown as ReturnType<typeof setInterval>;
+    }) as unknown as typeof setInterval);
+    clearIntervalSpy = spyOn(globalThis, "clearInterval").mockImplementation(
+      () => {},
+    );
+  });
+
+  afterEach(() => {
+    setIntervalSpy.mockRestore();
+    clearIntervalSpy.mockRestore();
+    userMetadataActions.clear();
+  });
+
+  it("polls metadata while a connection is importing and stops when it settles", () => {
+    userMetadataActions.set({
+      google: {
+        connectionState: "IMPORTING",
+        connections: [
+          {
+            id: "c1",
+            state: "importing",
+            stateReason: null,
+            lastSyncedAt: null,
+            lastHealthyAt: null,
+            accountEmail: "a@example.com",
+            connectionState: "IMPORTING",
+          },
+        ],
+      },
+    });
+
+    const hook = renderHook(() => useTransientSyncPolling());
+
+    expect(setIntervalSpy).toHaveBeenCalledWith(
+      expect.any(Function),
+      TRANSIENT_POLL_MS,
+    );
+
+    act(() => {
+      intervalCallback?.();
+    });
+    expect(mockRefreshUserMetadata).toHaveBeenCalledWith({ force: true });
+
+    act(() => {
+      userMetadataActions.set({
+        google: {
+          connectionState: "HEALTHY",
+          connections: [
+            {
+              id: "c1",
+              state: "healthy",
+              stateReason: null,
+              lastSyncedAt: null,
+              lastHealthyAt: null,
+              accountEmail: "a@example.com",
+              connectionState: "HEALTHY",
+            },
+          ],
+        },
+      });
+    });
+    hook.rerender();
+
+    expect(clearIntervalSpy).toHaveBeenCalled();
+  });
+
+  it("does not poll when no connection is transient", () => {
+    userMetadataActions.set({
+      google: {
+        connectionState: "HEALTHY",
+        connections: [
+          {
+            id: "c1",
+            state: "healthy",
+            stateReason: null,
+            lastSyncedAt: null,
+            lastHealthyAt: null,
+            accountEmail: "a@example.com",
+            connectionState: "HEALTHY",
+          },
+        ],
+      },
+    });
+
+    renderHook(() => useTransientSyncPolling());
+
+    expect(setIntervalSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/sse/hooks/useTransientSyncPolling.ts
+++ b/packages/web/src/sse/hooks/useTransientSyncPolling.ts
@@ -26,9 +26,9 @@ export const useTransientSyncPolling = () => {
 
   useEffect(() => {
     if (!anyTransient) return;
-    const id = window.setInterval(() => {
+    const id = setInterval(() => {
       void refreshUserMetadata({ force: true });
     }, TRANSIENT_POLL_MS);
-    return () => window.clearInterval(id);
+    return () => clearInterval(id);
   }, [anyTransient]);
 };

--- a/packages/web/src/sse/hooks/useTransientSyncPolling.ts
+++ b/packages/web/src/sse/hooks/useTransientSyncPolling.ts
@@ -1,0 +1,34 @@
+import { useEffect } from "react";
+import { refreshUserMetadata } from "@web/auth/compass/user/util/user-metadata.util";
+import {
+  selectGoogleSyncConnections,
+  useUserMetadataStore,
+} from "@web/auth/state/user-metadata.store";
+
+const TRANSIENT_CONNECTION_STATES = new Set([
+  "connecting",
+  "importing",
+  "catchingUp",
+]);
+const TRANSIENT_POLL_MS = 20_000;
+
+/**
+ * While any single connection (not the aggregate) is still connecting,
+ * importing, or catching up, force-refresh metadata every 20s. Each poll is
+ * also a server-side re-derivation because the sync read path refreshes
+ * state. Stops when nothing is transient.
+ */
+export const useTransientSyncPolling = () => {
+  const connections = useUserMetadataStore(selectGoogleSyncConnections);
+  const anyTransient = connections.some((connection) =>
+    TRANSIENT_CONNECTION_STATES.has(connection.state),
+  );
+
+  useEffect(() => {
+    if (!anyTransient) return;
+    const id = window.setInterval(() => {
+      void refreshUserMetadata({ force: true });
+    }, TRANSIENT_POLL_MS);
+    return () => window.clearInterval(id);
+  }, [anyTransient]);
+};

--- a/packages/web/src/sse/provider/SSEProvider.interaction.test.tsx
+++ b/packages/web/src/sse/provider/SSEProvider.interaction.test.tsx
@@ -157,7 +157,7 @@ describe("useGcalSSE", () => {
       // importCompleted alone never clears the override; only metadata that
       // leaves IMPORTING (or an attention/healthy syncStatusChanged) does.
       expect(getGoogleSyncIndicatorOverride()).toBe("syncing");
-      expect(refreshUserMetadata).toHaveBeenCalled();
+      expect(refreshUserMetadata).toHaveBeenCalledWith({ force: true });
       expect(mockInvalidateEventQueries).toHaveBeenCalled();
     });
   });
@@ -170,7 +170,7 @@ describe("useGcalSSE", () => {
     });
 
     await waitFor(() => {
-      expect(refreshUserMetadata).toHaveBeenCalled();
+      expect(refreshUserMetadata).toHaveBeenCalledWith({ force: true });
     });
   });
 
@@ -184,7 +184,7 @@ describe("useGcalSSE", () => {
 
     await waitFor(() => {
       expect(getGoogleSyncIndicatorOverride()).toBe("syncing");
-      expect(refreshUserMetadata).toHaveBeenCalled();
+      expect(refreshUserMetadata).toHaveBeenCalledWith({ force: true });
     });
   });
 

--- a/packages/web/src/sse/provider/SSEProvider.tsx
+++ b/packages/web/src/sse/provider/SSEProvider.tsx
@@ -3,6 +3,7 @@ import { useEventSSE } from "../hooks/useEventSSE";
 import { useGcalSSE } from "../hooks/useGcalSSE";
 import { useSSEConnection } from "../hooks/useSSEConnection";
 import { useSyncFocusRefresh } from "../hooks/useSyncFocusRefresh";
+import { useTransientSyncPolling } from "../hooks/useTransientSyncPolling";
 
 export * from "../client/sse.client";
 
@@ -11,6 +12,7 @@ const SSEProvider = ({ children }: { children: ReactNode }) => {
   useEventSSE();
   useGcalSSE();
   useSyncFocusRefresh();
+  useTransientSyncPolling();
 
   return children;
 };

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.test.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.test.tsx
@@ -15,8 +15,10 @@ import {
   within,
 } from "@web/__tests__/__mocks__/mock.render";
 import { server } from "@web/__tests__/__mocks__/server/mock.server";
+import { createMockConnection } from "@web/__tests__/utils/factories/calendar.factory";
 import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
 import { createCompassQueryClient } from "@web/api/query-client";
+import { userMetadataActions } from "@web/auth/state/user-metadata.store";
 import { calendarQueryKeys } from "@web/calendars/calendar.query";
 import { setCalendarVisibility } from "@web/calendars/calendar-visibility.store";
 import { getLocalCalendarSentinelId } from "@web/calendars/local-calendar.sentinel";
@@ -948,6 +950,45 @@ describe("DayCalendarGrid", () => {
     expect(canCreateDraftOnCalendar(holidays, showError)).toBeFalse();
     expect(showError).toHaveBeenCalledWith(
       "You can't edit the Holidays calendar.",
+    );
+  });
+
+  it("does not create on the local column once a Google account is connected", async () => {
+    const local = makeCalendar("Compass", {
+      id: getLocalCalendarSentinelId(),
+      provider: "local",
+    });
+    const google = makeCalendar("Primary", { isPrimary: true });
+    userMetadataActions.set({
+      google: {
+        connectionState: "HEALTHY",
+        connections: [createMockConnection("ahab@pequod.com")],
+      },
+    });
+    const { user } = renderDayCalendarGrid([local, google]);
+
+    await user.pointer([
+      {
+        coords: { clientX: 90, clientY: 120 },
+        keys: "[MouseLeft>]",
+        target: getTimedSlot(3),
+      },
+      {
+        coords: { clientX: 90, clientY: 120 },
+        keys: "[/MouseLeft]",
+        target: getTimedSlot(3),
+      },
+    ]);
+
+    expect(getDraft()).toBeNull();
+    expect(screen.queryByRole("dialog", { name: "Event form" })).toBeNull();
+
+    const showError = mock();
+    expect(
+      canCreateDraftOnCalendar(local, showError, new Set([google.id])),
+    ).toBeFalse();
+    expect(showError).toHaveBeenCalledWith(
+      "You can't edit the Compass calendar.",
     );
   });
 

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
@@ -12,7 +12,11 @@ import { shouldShowContextualLoadError } from "@web/api/util/api.util";
 import { useConnectGoogle } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle";
 import { isFirstImportInProgress } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle.util";
 import { useCalendarsQuery } from "@web/calendars/calendar.query";
-import { useDefaultTargetCalendar } from "@web/calendars/useDefaultTargetCalendar";
+import { getWritableCalendars } from "@web/calendars/calendar.util";
+import {
+  useConnectedAccountEmails,
+  useDefaultTargetCalendar,
+} from "@web/calendars/useDefaultTargetCalendar";
 import { type GridEvent } from "@web/common/types/web.event.types";
 import { onViewCommand } from "@web/common/utils/dom/view-command-bus";
 import {
@@ -62,8 +66,13 @@ import { useDayTimedDraftCreation } from "./useDayTimedDraftCreation";
 export const canCreateDraftOnCalendar = (
   calendar: Calendar | null,
   showError: (message: string) => unknown = showErrorToast,
+  writableCalendarIds?: ReadonlySet<string>,
 ): boolean => {
-  if (!calendar || calendar.capabilities.canWrite) return true;
+  if (!calendar) return true;
+  const canWrite = writableCalendarIds
+    ? writableCalendarIds.has(calendar.id)
+    : calendar.capabilities.canWrite;
+  if (canWrite) return true;
 
   showError(`You can't edit the ${calendar.name} calendar.`);
   return false;
@@ -80,6 +89,13 @@ export function DayCalendarGrid() {
   // Seed shortcuts with the form's default create target, not day-column order.
   const defaultTargetCalendarId =
     useDefaultTargetCalendar(calendars)?.id ?? null;
+  const accountEmailOrder = useConnectedAccountEmails();
+  const writableCalendarIds = useMemo(() => {
+    const writable = getWritableCalendars(calendars, {
+      hasConnectedAccount: accountEmailOrder.length > 0,
+    });
+    return new Set(writable.map((calendar) => calendar.id));
+  }, [accountEmailOrder.length, calendars]);
   const {
     allDayEvents,
     error: eventsError,
@@ -336,7 +352,9 @@ export function DayCalendarGrid() {
     ) => {
       const calendar = getCalendarAtX(event.clientX);
 
-      if (!canCreateDraftOnCalendar(calendar)) {
+      if (
+        !canCreateDraftOnCalendar(calendar, showErrorToast, writableCalendarIds)
+      ) {
         event.preventDefault();
         event.stopPropagation();
         return;
@@ -344,7 +362,7 @@ export function DayCalendarGrid() {
 
       createDraft(event, calendar?.id ?? null);
     },
-    [getCalendarAtX],
+    [getCalendarAtX, writableCalendarIds],
   );
   const handleAllDayMouseDown = useCallback(
     (event: ReactMouseEvent<HTMLElement>) => {

--- a/packages/web/src/views/Day/components/Calendar/dayCalendarColumns.util.test.ts
+++ b/packages/web/src/views/Day/components/Calendar/dayCalendarColumns.util.test.ts
@@ -27,7 +27,7 @@ function makeCalendar(overrides: Partial<Calendar>): Calendar {
 }
 
 describe("getDayViewCalendars", () => {
-  it("keeps the local calendar when no account is connected", () => {
+  it("keeps the local calendar when it is active and visible", () => {
     const local = makeCalendar({ provider: "local", name: "Compass" });
     const google = makeCalendar({
       provider: "google",
@@ -38,20 +38,7 @@ describe("getDayViewCalendars", () => {
     expect(getDayViewCalendars([local, google])).toEqual([local, google]);
   });
 
-  it("drops the local calendar once an account is connected", () => {
-    const local = makeCalendar({ provider: "local", name: "Compass" });
-    const google = makeCalendar({
-      provider: "google",
-      id: "507f1f77bcf86cd799439012" as Calendar["id"],
-      name: "primary",
-    });
-
-    expect(
-      getDayViewCalendars([local, google], { hasConnectedAccount: true }),
-    ).toEqual([google]);
-  });
-
-  it("falls back to the primary among remaining calendars when none are visible", () => {
+  it("falls back to the primary calendar when none are visible", () => {
     const local = makeCalendar({
       provider: "local",
       name: "Compass",
@@ -72,22 +59,22 @@ describe("getDayViewCalendars", () => {
     });
 
     expect(
-      getDayViewCalendars([local, secondaryGoogle, primaryGoogle], {
-        hasConnectedAccount: true,
-      }),
+      getDayViewCalendars([local, secondaryGoogle, primaryGoogle]),
     ).toEqual([primaryGoogle]);
   });
 
-  it("does not fall back to the local calendar when an account is connected", () => {
+  it("includes a visible local column alongside Google calendars", () => {
     const local = makeCalendar({
       provider: "local",
       name: "Compass",
       isPrimary: true,
-      isVisible: false,
+    });
+    const google = makeCalendar({
+      provider: "google",
+      id: "507f1f77bcf86cd799439012" as Calendar["id"],
+      name: "primary",
     });
 
-    expect(getDayViewCalendars([local], { hasConnectedAccount: true })).toEqual(
-      [],
-    );
+    expect(getDayViewCalendars([local, google])).toEqual([local, google]);
   });
 });

--- a/packages/web/src/views/Day/components/Calendar/dayCalendarColumns.util.ts
+++ b/packages/web/src/views/Day/components/Calendar/dayCalendarColumns.util.ts
@@ -1,37 +1,14 @@
 import { type Calendar } from "@core/types/calendar.contracts";
 
-export interface GetDayViewCalendarsOptions {
-  /**
-   * True once any account is connected. Mirrors the sidebar (LCV3): the local
-   * Compass calendar then drops out of day-view columns so connected users do
-   * not see an orphan empty column they can no longer toggle in the list.
-   * Derive from connection state (e.g. useConnectedAccountEmails().length > 0),
-   * never from calendar rows alone.
-   */
-  hasConnectedAccount?: boolean;
-}
-
-export const getDayViewCalendars = (
-  calendars: Calendar[],
-  options: GetDayViewCalendarsOptions = {},
-): Calendar[] => {
-  const { hasConnectedAccount = false } = options;
+export const getDayViewCalendars = (calendars: Calendar[]): Calendar[] => {
   const eligibleCalendars = calendars.filter(
-    (calendar) =>
-      (!hasConnectedAccount || calendar.provider !== "local") &&
-      calendar.isActive &&
-      calendar.isVisible,
+    (calendar) => calendar.isActive && calendar.isVisible,
   );
 
   if (eligibleCalendars.length > 0) {
     return eligibleCalendars;
   }
 
-  const fallbackCalendars = hasConnectedAccount
-    ? calendars.filter((calendar) => calendar.provider !== "local")
-    : calendars;
-  const primaryCalendar = fallbackCalendars.find(
-    (calendar) => calendar.isPrimary,
-  );
-  return primaryCalendar ? [primaryCalendar] : fallbackCalendars.slice(0, 1);
+  const primaryCalendar = calendars.find((calendar) => calendar.isPrimary);
+  return primaryCalendar ? [primaryCalendar] : calendars.slice(0, 1);
 };

--- a/packages/web/src/views/Day/components/Calendar/useDayCalendarColumns.ts
+++ b/packages/web/src/views/Day/components/Calendar/useDayCalendarColumns.ts
@@ -2,7 +2,6 @@ import { useCallback, useMemo } from "react";
 import { YEAR_MONTH_DAY_FORMAT } from "@core/constants/date.constants";
 import { type Dayjs } from "@core/util/date/dayjs";
 import { useCalendarsQuery } from "@web/calendars/calendar.query";
-import { useConnectedAccountEmails } from "@web/calendars/useDefaultTargetCalendar";
 import { type GridEvent } from "@web/common/types/web.event.types";
 import { isAllDayEventOnDay } from "./dayAllDayRows.util";
 import { getDayViewCalendars } from "./dayCalendarColumns.util";
@@ -17,10 +16,9 @@ export const useDayCalendarColumns = ({
   timedEvents: GridEvent[];
 }) => {
   const { data: calendars = [] } = useCalendarsQuery();
-  const hasConnectedAccount = useConnectedAccountEmails().length > 0;
   const displayedCalendars = useMemo(
-    () => getDayViewCalendars(calendars, { hasConnectedAccount }),
-    [calendars, hasConnectedAccount],
+    () => getDayViewCalendars(calendars),
+    [calendars],
   );
   const calendarColumnIndexById = useMemo(
     () =>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Email/password signup followed by Settings → Add account hid the original Compass calendar and left "Adding your calendar…" stuck. This PR fixes both the UI attribution and the import-state push/pull path, plus a sign-in fork guard.

## Summary

1. **Local calendar vanished.** `CalendarList` hid `provider === "local"` once any Google connection existed (LCV3). That premise is false for email/pw signup → add Google. Day view also dropped local columns while Week kept them. Empty account groups were filtered out, so a just-connected account had no section to hang "Adding your calendar…" on.

2. **Import never converged in the UI.** `importing → healthy` was computed lazily only on sync `GET /connections`. Bootstrap completion did not push a connection invalidation. SSE handlers refreshed metadata without `force`, focus reconciliation was disabled during IMPORTING, and a missing events resource stayed `importing` forever. Reconnect clobbered `lastHealthyAt`, so an established account looked like a first import.

3. **Add account could bind to reconnect.** `useConnectGoogle` pinned `connectionId` whenever any account was `RECONNECT_REQUIRED`, so Settings "Add account" became a reconnect and failed with "Reconnect account does not match the named connection".

4. **Sign-in fork.** An authenticated user hitting the Google sign-in path (`?auth=` → `POST /api/signinup`) with an unrecognized Google account silently created a new Compass user.

**Sync — deterministic import-state convergence**
- Call `refreshConnectionState` after `bootstrapCatchup` and `subscriptionMaintain` unsupported set `bootstrapState` to `ready` (try/catch; never fail the job).
- Missing events resource uses the calendar row's `updatedAt` as the stall basis → `delayed` after `BOOTSTRAP_STALLED_AFTER_MS`.
- Refresh CTA enqueues coalesced `calendarListSync` per connection so discovery heals resource-less calendars.
- `lastSyncedAt` / `lastHealthyAt` move to `$setOnInsert` so reconnect does not clobber them.

**Web — metadata refresh discipline**
- SSE handlers, stream open/reopen, and focus always `refreshUserMetadata({ force: true })`.
- Provider refresh stays gated to HEALTHY/ATTENTION; metadata is not.
- 20s poll while any *single* connection is `connecting` / `importing` / `catchingUp`.
- Concurrent force calls still chain onto one trailing fetch; epoch counter drops stale writes.

**Web — sidebar + Day view**
- Local calendar is its own Compass-email section (no collapse/status/CTA) when Google accounts exist. LCV1/LCV2 still exclude local as a create target (`getWritableCalendars` / `getDefaultTargetCalendar`).
- Empty seeded account groups are kept so importing accounts render a header.
- Day columns are active+visible calendars, matching Week. Click-to-create on a Day column uses the same writable set, so the restored local column is visible and toggleable but not a create target after Google is connected.

**Web — Add account**
- `useConnectGoogle({ newAccount: true })` always begins with `{}`. Settings Accounts section uses it.

**Auth fork guard**
- `?auth=` is ignored (and stripped) while a session exists.
- `handleGoogleAuth` refuses SIGNUP when `input.session` is present: `"You're already signed in — use Settings → Add account to connect this Google account."`

Architecture invariants: `docs/architecture/multi-account-sync.md`.

## Simplicity

Kept zustand for user metadata (refresh discipline, not a store migration). `refreshConnectionState` remains the only derived-state writer. No second SSE push channel. The Day create gate reuses `getWritableCalendars` instead of a new local-exclusion rule.

## Automated validation

- Package tests cover the reported bugs (sidebar local section + toggle, empty importing account header, Day local column visibility, metadata force/poll, reconnect timestamps, bootstrap invalidation, Add-account `newAccount`, `?auth=` while signed in, SIGNUP-under-session).
- Full Google OAuth add-account path was not exercised in this environment (no SuperTokens/Google secrets). Login flows were not run against an incomplete backend, per AGENTS.md.

## Independent review

Confirmed finding fixed: Day click-to-create on the restored local column after Google connect (LCV1/LCV2). Residual: dragging a Google event onto the local Day column can still retarget it; duplicate sidebar headings if Compass email equals a connected Google email; SIGNUP guard runs after SuperTokens `signInUpPOST`.

## Test plan

- `bun test:sync` — 900 pass
- `bun test:web` — 2195 pass, then DayCalendarGrid 31 pass after the create-target fix
- `bun test:backend` — 307 pass, 1 skip
- `bun type-check`
- `bun lint` (pre-existing warnings only)
- GitHub Test + CodeQL on the previous head were green; this head re-runs them
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-58092c33-71a3-4671-b218-4ebf0bfb3714?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-58092c33-71a3-4671-b218-4ebf0bfb3714&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

