### PR TITLE
feat(backend,web): require card at trial start via stripe checkout

### DIFF
--- a/.github/workflows/_deploy-environment.yml
+++ b/.github/workflows/_deploy-environment.yml
@@ -94,6 +94,9 @@ jobs:
           SUPERTOKENS_KEY: ${{ secrets.SUPERTOKENS_KEY }}
           SUPERTOKENS_POSTGRES_PASSWORD: ${{ secrets.SUPERTOKENS_POSTGRES_PASSWORD }}
           SUPERTOKENS_URI: ${{ secrets.SUPERTOKENS_URI }}
+          STRIPE_SECRET_KEY: ${{ (inputs.environment == 'production' || inputs.environment == 'staging-cloud') && secrets.STRIPE_SECRET_KEY || '' }}
+          STRIPE_WEBHOOK_SECRET: ${{ (inputs.environment == 'production' || inputs.environment == 'staging-cloud') && secrets.STRIPE_WEBHOOK_SECRET || '' }}
+          STRIPE_PRICE_ID: ${{ (inputs.environment == 'production' || inputs.environment == 'staging-cloud') && secrets.STRIPE_PRICE_ID || '' }}
         run: |
           echo "Deploying Compass ${RELEASE_TAG} (image version: ${IMAGE_VERSION}) to ${{ inputs.environment }}"
           # Only "production" ever runs the production runtime.nodeEnv; every
@@ -180,6 +183,13 @@ jobs:
                 'posthog:' \
                 "  key: \"${POSTHOG_KEY}\"" \
                 "  host: \"${POSTHOG_HOST}\""
+            fi
+            if [ -n "$STRIPE_SECRET_KEY" ] && [ -n "$STRIPE_WEBHOOK_SECRET" ] && [ -n "$STRIPE_PRICE_ID" ]; then
+              printf '%s\n' \
+                'stripe:' \
+                "  secretKey: \"${STRIPE_SECRET_KEY}\"" \
+                "  webhookSecret: \"${STRIPE_WEBHOOK_SECRET}\"" \
+                "  priceId: \"${STRIPE_PRICE_ID}\""
             fi
             printf '%s\n' \
               'sync:' \

--- a/bun.lock
+++ b/bun.lock
@@ -40,6 +40,7 @@
         "lodash": "^4.18.1",
         "mongodb": "^7.2.0",
         "rrule": "^2.7.2",
+        "stripe": "^18.5.0",
         "supertokens-node": "^23.0.1",
         "tslib": "^2.4.0",
         "zod": "^3.25.76",
@@ -1556,6 +1557,8 @@
     "strip-indent": ["strip-indent@3.0.0", "", { "dependencies": { "min-indent": "^1.0.0" } }, "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ=="],
 
     "strip-json-comments": ["strip-json-comments@5.0.3", "", {}, "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw=="],
+
+    "stripe": ["stripe@18.5.0", "", { "dependencies": { "qs": "^6.11.0" }, "peerDependencies": { "@types/node": ">=12.x.x" }, "optionalPeers": ["@types/node"] }, "sha512-Hp+wFiEQtCB0LlNgcFh5uVyKznpDjzyUZ+CNVEf+I3fhlYvh7rZruIg+jOwzJRCpy0ZTPMjlzm7J2/M2N6d+DA=="],
 
     "stylis": ["stylis@4.2.0", "", {}, "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw=="],
 

--- a/compass.example.yaml
+++ b/compass.example.yaml
@@ -41,6 +41,12 @@ supertokens:
 #   key: REPLACE_WITH_POSTHOG_KEY
 #   host: REPLACE_WITH_POSTHOG_HOST
 
+# stripe:
+#   secretKey: REPLACE_WITH_STRIPE_SECRET_KEY # restricted rk_test_... for staging
+#   webhookSecret: REPLACE_WITH_STRIPE_WEBHOOK_SECRET
+#   priceId: REPLACE_WITH_STRIPE_PRICE_ID
+# Omit the whole block for self-host. All three values are required together.
+
 # Compass Sync service — required. The backend exits at startup without
 # serviceUrl/internalAuthToken, and self-host runs Sync by default. mongoUri
 # MUST point at an isolated database/user that cannot read the backend's

--- a/docs/Config/README.md
+++ b/docs/Config/README.md
@@ -98,3 +98,6 @@ database and must not share the backend's database user/data.
 |---|---|---|
 | `posthog.key` | No | PostHog project key injected into the web bundle. |
 | `posthog.host` | No | PostHog host injected into the web bundle. |
+| `stripe.secretKey` | No | Stripe secret (restricted `rk_test_...` on staging). All three Stripe keys are required together; omit the whole `stripe:` block on self-host. |
+| `stripe.webhookSecret` | No | Stripe webhook signing secret. |
+| `stripe.priceId` | No | Stripe Price id for the $8/month plan. |

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@ Internal documentation for engineers and agents working in the Compass repo.
 - Breakpoints, sidebar collapse, or layout at different viewport sizes: [Responsive Layout](./frontend/responsive-layout.md)
 - Local-first or storage behavior: [Offline Storage And Migrations](./features/offline-storage-and-migrations.md)
 - Backend routes and API behavior: [Backend Route Map](./backend/README.md), [Backend Request Flow](./backend/backend-request-flow.md), [Backend Error Handling](./backend/backend-error-handling.md)
+- Trial, pricing, or Stripe: [Billing And Trial](./features/billing.md)
 - A new calendar integration or Google-sync behavior: [Google Sync And SSE Flow](./features/google-sync-and-sse-flow.md), the `packages/sync` domain code directly
 
 ## Architecture And Domain

--- a/docs/backend/README.md
+++ b/docs/backend/README.md
@@ -25,6 +25,7 @@ Backend routes are registered from
 | Config | `packages/backend/src/config/config.routes.config.ts` | Public runtime config used by the web app. |
 | Auth | `packages/backend/src/auth/auth.routes.config.ts` | Compass-owned auth helpers and authenticated Google connect. SuperTokens also mounts recipe routes under `/api`. |
 | User | `packages/backend/src/user/user.routes.config.ts` | Profile and metadata for the active session. |
+| Billing | `packages/backend/src/billing/billing.routes.config.ts` | Session status, Checkout, Billing Portal, and unauthenticated Stripe webhook. Self-host omits Stripe keys and stays fully writable. |
 | Events | `packages/backend/src/event/event.routes.config.ts` | Event CRUD and reorder/delete helpers. |
 | Event stream | `packages/backend/src/events/events.routes.config.ts` | Authenticated SSE stream at `GET /api/events/stream`. |
 | Calendars | `packages/backend/src/calendar/calendar.routes.config.ts` | Calendar list and selection routes. |

--- a/docs/development/cli.md
+++ b/docs/development/cli.md
@@ -15,6 +15,7 @@ Primary file:
 | Command | Implementation | Notes |
 | --- | --- | --- |
 | `bun run cli purge-user --email <address> [--apply] [--out report.json]` | `packages/scripts/src/commands/purge-user.ts` | Deletes one user's API, Sync, and SuperTokens data. Defaults to dry-run. |
+| `bun run cli backfill-billing [--apply] [--batch-size 500] [--cutoff ISO]` | `packages/scripts/src/commands/backfill-billing.ts` | Places existing accounts without billing status onto a 7-day trial. Defaults to dry-run. |
 | `bun run cli purge-corrupt-sync-events [--apply]` | `packages/scripts/src/commands/purge-corrupt-sync-events.ts` | Deletes invalid Sync event documents. Defaults to dry-run. |
 | `bun run cli refresh-connection-states [--apply]` | `packages/scripts/src/commands/refresh-connection-states.ts` | Re-derives Sync connection state. Defaults to dry-run. |
 | `bun run cli manage-failed-jobs <list\|clear\|requeue> …` | `packages/scripts/src/commands/manage-failed-jobs.ts` | Operator tooling for Sync jobs that exhausted the self-heal requeue budget. Defaults to dry-run; pass `--apply` to persist. |

--- a/docs/development/feature-file-map.md
+++ b/docs/development/feature-file-map.md
@@ -97,6 +97,14 @@ the full picture.
 - User metadata service: `packages/backend/src/user/services/user-metadata.service.ts`
 - Mobile waitlist gate (web-only external link): `packages/web/src/components/MobileGate/MobileGate.tsx`
 
+## Billing And Trial
+
+- Shared plan/price copy: `packages/core/src/constants/billing.constants.ts`
+- Anonymous trial clock: `packages/web/src/billing/trial.storage.ts`, `packages/web/src/billing/useTrialStatus.ts`
+- Server access + paid gate: `packages/web/src/billing/useAppAccess.ts`, `packages/web/src/billing/BillingGateModal.tsx`
+- Backend billing: `packages/backend/src/billing`
+- Overview: [Billing And Trial](../features/billing.md)
+
 ## Environment And Infra
 
 - Backend config parsing: `packages/backend/src/common/constants/config.constants.ts`

--- a/docs/features/billing.md
+++ b/docs/features/billing.md
@@ -15,12 +15,17 @@ writes stay open.
 - **Signed up, no card yet:** `awaiting_checkout`, read-only, `BillingGateModal`
   with Subscribe (Stripe Checkout).
 - **Trialing / active / past_due:** writable. `past_due` also shows a banner.
-- **Expired / canceled:** read-only until they subscribe again.
+- **Expired / canceled:** read-only until they subscribe again. A later
+  Checkout does not grant another trial.
+
+There is no `POST /api/billing/trial/start`. A trial only begins through
+Stripe Checkout (`trial_period_days` on the first subscription).
 
 Existing accounts are not grandfathered. `bun run cli backfill-billing` places
-rows without `billing.subscriptionStatus` onto a 7-day trial. Those rows have
-no Stripe subscription id, so they self-expire locally when `trialEndsAt`
-passes.
+rows without `billing.subscriptionStatus` onto a 7-day trial. The default
+`BACKFILL_CUTOFF` is far in the future so every such row is included; set it
+to a past instant to grandfather newer signups. Those rows have no Stripe
+subscription id, so they self-expire locally when `trialEndsAt` passes.
 
 ## Staging
 

--- a/docs/features/billing.md
+++ b/docs/features/billing.md
@@ -1,0 +1,45 @@
+# Billing And Trial
+
+Hosted Compass uses Stripe Checkout (subscription mode, 7-day trial, $8/month)
+and the Stripe Billing Portal. There is no Stripe.js and no publishable key in
+the web bundle.
+
+Self-host installs omit the `stripe:` config block. `/api/config` then reports
+`billing.isConfigured: false`, the web never shows a paid gate, and event
+writes stay open.
+
+## What users see
+
+- **Never signed up:** the existing 7-day anonymous `localStorage` trial and
+  `TrialGateModal`. Unchanged.
+- **Signed up, no card yet:** `awaiting_checkout`, read-only, `BillingGateModal`
+  with Subscribe (Stripe Checkout).
+- **Trialing / active / past_due:** writable. `past_due` also shows a banner.
+- **Expired / canceled:** read-only until they subscribe again.
+
+Existing accounts are not grandfathered. `bun run cli backfill-billing` places
+rows without `billing.subscriptionStatus` onto a 7-day trial. Those rows have
+no Stripe subscription id, so they self-expire locally when `trialEndsAt`
+passes.
+
+## Staging
+
+Set `STRIPE_SECRET_KEY` (restricted `rk_test_...`), `STRIPE_WEBHOOK_SECRET`,
+and `STRIPE_PRICE_ID` on the `staging-cloud` GitHub Environment. Config-only
+deploys need `./compass restart`. Confirm `/api/config` shows
+`billing.isConfigured: true`.
+
+`staging-selfhosted` must not get those secrets — it is the live regression
+that self-host stays writable.
+
+Sales tax (`automatic_tax`) is a Stripe Dashboard decision, not a code one,
+and should be settled before production keys.
+
+## Key files
+
+- Plan/price copy: `packages/core/src/constants/billing.constants.ts`
+- Status derivation: `packages/backend/src/billing/services/billing.service.ts`
+- Checkout / portal: `packages/backend/src/billing/services/stripe.service.ts`
+- Webhook: `packages/backend/src/billing/services/billing.webhook.service.ts`
+- Write guard: `packages/backend/src/billing/billing.guard.ts`
+- Web access: `packages/web/src/billing/useAppAccess.ts`

--- a/docs/self-hosting/README.md
+++ b/docs/self-hosting/README.md
@@ -6,6 +6,8 @@ Start with [Run Compass on a server](./server-guide.md). It walks through a smal
 
 If you only want to run Compass on your own computer, use the normal local development flow with Bun instead of the self-host installer.
 
+Self-host does not require Stripe. Omit the `stripe:` block so billing stays off and every account remains writable. Hosted Compass uses a 7-day trial then $8/month; see [Billing And Trial](../features/billing.md).
+
 ## Compass architecture
 
 When you self-host Compass on a server, you get a stack of small services. Only the public website and API are reachable from your browser. The databases stay private inside Docker.

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -16,6 +16,7 @@
     "mongodb": "^7.2.0",
     "rrule": "^2.7.2",
     "supertokens-node": "^23.0.1",
+    "stripe": "^18.5.0",
     "tslib": "^2.4.0",
     "zod": "^3.25.76"
   },

--- a/packages/backend/src/billing/billing-event.record.ts
+++ b/packages/backend/src/billing/billing-event.record.ts
@@ -1,0 +1,4 @@
+export type BillingEventRecord = {
+  _id: string;
+  receivedAt: Date;
+};

--- a/packages/backend/src/billing/billing.constants.ts
+++ b/packages/backend/src/billing/billing.constants.ts
@@ -1,11 +1,57 @@
+import { BILLING_PLAN } from "@core/constants/billing.constants";
+import { type BillingSubscriptionStatus } from "@core/types/user.types";
+import { CONFIG } from "@backend/common/constants/config.constants";
+
+export { BILLING_PLAN };
+
+export const STRIPE_WEBHOOK_PATH = "/api/billing/webhook/stripe";
+
 /**
- * Placeholder trial/pricing terms, set 2026-08-10 to unblock implementation
- * (see compass-calendar-internal/projects/keyboard-education/03-monetization-trial-checkout.md).
- * Every value here is expected to change in the founder's post-ship pricing
- * sweep -- kept in one module, not scattered literals, so that sweep is a
- * small diff instead of a re-implementation.
+ * Stripe Subscription.Status values for the pinned API version in
+ * stripe.client.ts. A new Stripe status is a type error against
+ * `Stripe.Subscription.Status` there.
  */
-export const BILLING_DEFAULTS = {
-  // Aligned with the client-side anonymous trial clock (packages/web/src/billing/trial.storage.ts).
-  TRIAL_LENGTH_DAYS: 7,
-} as const;
+export type StripeSubscriptionStatus =
+  | "incomplete"
+  | "incomplete_expired"
+  | "trialing"
+  | "active"
+  | "past_due"
+  | "canceled"
+  | "unpaid"
+  | "paused";
+
+export const STRIPE_TO_COMPASS_STATUS: Record<
+  StripeSubscriptionStatus,
+  BillingSubscriptionStatus
+> = {
+  trialing: "trialing",
+  active: "active",
+  past_due: "past_due",
+  incomplete: "awaiting_checkout",
+  incomplete_expired: "expired",
+  canceled: "canceled",
+  unpaid: "expired",
+  paused: "expired",
+};
+
+export const WRITE_ACCESS_BY_STATUS: Record<
+  BillingSubscriptionStatus,
+  boolean
+> = {
+  none: true,
+  awaiting_checkout: false,
+  trialing: true,
+  active: true,
+  past_due: true,
+  canceled: false,
+  expired: false,
+};
+
+export function getStripePriceId(): string {
+  const priceId = CONFIG.STRIPE_PRICE_ID;
+  if (!priceId) {
+    throw new Error("STRIPE_PRICE_ID is not configured");
+  }
+  return priceId;
+}

--- a/packages/backend/src/billing/billing.guard.db.test.ts
+++ b/packages/backend/src/billing/billing.guard.db.test.ts
@@ -1,0 +1,82 @@
+import { type Schema_UserBilling } from "@core/types/user.types";
+import {
+  cleanupCollections,
+  cleanupTestDb,
+  setupTestDb,
+} from "@backend/__tests__/helpers/mock.db.setup";
+import { mockEnv } from "@backend/__tests__/helpers/mock.setup";
+import { assertBillingAllowsWrites } from "@backend/billing/billing.guard";
+import mongoService from "@backend/common/services/mongo.service";
+import { EventMutationException } from "@backend/event/event.error";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "bun:test";
+
+const stripeConfigured = {
+  STRIPE_SECRET_KEY: "rk_test_123",
+  STRIPE_WEBHOOK_SECRET: "whsec_test",
+  STRIPE_PRICE_ID: "price_test",
+};
+
+const insertUser = async (billing?: Schema_UserBilling) => {
+  const userId = mongoService.objectId();
+  await mongoService.user.insertOne({
+    _id: userId,
+    email: `${userId.toString()}@example.com`,
+    name: "Guard User",
+    firstName: "Guard",
+    lastName: "User",
+    locale: "en",
+    ...(billing ? { billing } : {}),
+  });
+  return userId.toString();
+};
+
+describe("assertBillingAllowsWrites", () => {
+  beforeAll(async () => {
+    await setupTestDb(import.meta.url);
+  });
+  beforeEach(cleanupCollections);
+  afterAll(cleanupTestDb);
+
+  it("no-ops when Stripe is unconfigured", async () => {
+    const userId = await insertUser({
+      subscriptionStatus: "awaiting_checkout",
+    });
+    await expect(assertBillingAllowsWrites(userId)).resolves.toBeUndefined();
+  });
+
+  it("allows active and past_due writes when Stripe is configured", async () => {
+    using _env = mockEnv(stripeConfigured);
+    const active = await insertUser({
+      subscriptionStatus: "active",
+      stripeSubscriptionId: "sub_a",
+    });
+    const pastDue = await insertUser({
+      subscriptionStatus: "past_due",
+      stripeSubscriptionId: "sub_p",
+    });
+    await expect(assertBillingAllowsWrites(active)).resolves.toBeUndefined();
+    await expect(assertBillingAllowsWrites(pastDue)).resolves.toBeUndefined();
+  });
+
+  it("rejects awaiting_checkout and expired with BILLING_REQUIRED", async () => {
+    using _env = mockEnv(stripeConfigured);
+    const awaiting = await insertUser({
+      subscriptionStatus: "awaiting_checkout",
+    });
+    const expired = await insertUser({ subscriptionStatus: "expired" });
+
+    await expect(assertBillingAllowsWrites(awaiting)).rejects.toBeInstanceOf(
+      EventMutationException,
+    );
+    await expect(assertBillingAllowsWrites(expired)).rejects.toMatchObject({
+      mutationCode: "BILLING_REQUIRED",
+    });
+  });
+});

--- a/packages/backend/src/billing/billing.guard.ts
+++ b/packages/backend/src/billing/billing.guard.ts
@@ -1,0 +1,27 @@
+import { deriveBillingStatus } from "@backend/billing/services/billing.service";
+import { CONFIG } from "@backend/common/constants/config.constants";
+import { isStripeConfigured } from "@backend/common/constants/config.util";
+import mongoService from "@backend/common/services/mongo.service";
+import { eventMutationError } from "@backend/event/event.error";
+
+/**
+ * Throw BILLING_REQUIRED (403) when the user cannot mutate events.
+ * No-ops when Stripe is unconfigured so self-host stays fully writable.
+ * Lives in controllers, not the shared `/api/event` route chain, so GET
+ * stays open.
+ */
+export async function assertBillingAllowsWrites(userId: string): Promise<void> {
+  if (!isStripeConfigured(CONFIG)) return;
+
+  const user = await mongoService.user.findOne(
+    { _id: mongoService.objectId(userId) },
+    { projection: { billing: 1 } },
+  );
+  const status = deriveBillingStatus(user?.billing, new Date());
+  if (!status.isReadOnly) return;
+
+  throw eventMutationError(
+    "BILLING_REQUIRED",
+    "A paid subscription is required to make changes",
+  );
+}

--- a/packages/backend/src/billing/billing.routes.config.ts
+++ b/packages/backend/src/billing/billing.routes.config.ts
@@ -36,11 +36,6 @@ export class BillingRoutes extends CommonRoutesConfig {
       .get(billingController.getStatus);
 
     this.app
-      .route(`/api/billing/trial/start`)
-      .all(verifySession())
-      .post(sessionWriteLimiter, billingController.startTrial);
-
-    this.app
       .route(`/api/billing/checkout/session`)
       .all(verifySession())
       .post(sessionWriteLimiter, billingController.createCheckoutSession);

--- a/packages/backend/src/billing/billing.routes.config.ts
+++ b/packages/backend/src/billing/billing.routes.config.ts
@@ -1,25 +1,28 @@
 import type express from "express";
 import rateLimit from "express-rate-limit";
 import { verifySession } from "@backend/auth/session/session.middleware";
+import { STRIPE_WEBHOOK_PATH } from "@backend/billing/billing.constants";
+import billingController from "@backend/billing/controllers/billing.controller";
+import billingWebhookController from "@backend/billing/controllers/billing.webhook.controller";
 import { CommonRoutesConfig } from "@backend/common/common.routes.config";
-import billingController from "./controllers/billing.controller";
 
-// A user can only ever start their own trial once (see billing.service's
-// idempotent startTrial), but this still gates the endpoint against a
-// retry storm or scripted abuse the same way any other write route should.
-const startTrialLimiter = rateLimit({
+const sessionWriteLimiter = rateLimit({
   windowMs: 60 * 1000,
   limit: 5,
   standardHeaders: true,
   legacyHeaders: false,
 });
 
+const stripeWebhookLimiter = rateLimit({
+  windowMs: 60_000,
+  limit: 600,
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
 /**
- * Billing Routes Configuration
- *
- * Trial state only today -- no payment collection or Stripe webhooks yet.
- * See compass-calendar-internal/projects/keyboard-education/03-monetization-trial-checkout.md
- * for what remains before this is a real checkout flow.
+ * Billing routes: trial status, Stripe Checkout, Billing Portal, and the
+ * unauthenticated Stripe webhook.
  */
 export class BillingRoutes extends CommonRoutesConfig {
   constructor(app: express.Application) {
@@ -27,28 +30,29 @@ export class BillingRoutes extends CommonRoutesConfig {
   }
 
   configureRoutes(): express.Application {
-    /**
-     * GET /api/billing/status
-     * Returns the current user's trial/subscription status.
-     *
-     * @auth Required - Supertokens session
-     */
     this.app
       .route(`/api/billing/status`)
       .all(verifySession())
       .get(billingController.getStatus);
 
-    /**
-     * POST /api/billing/trial/start
-     * Starts a trial for the current user. Idempotent: a user who already
-     * has one does not get a second, later window.
-     *
-     * @auth Required - Supertokens session
-     */
     this.app
       .route(`/api/billing/trial/start`)
       .all(verifySession())
-      .post(startTrialLimiter, billingController.startTrial);
+      .post(sessionWriteLimiter, billingController.startTrial);
+
+    this.app
+      .route(`/api/billing/checkout/session`)
+      .all(verifySession())
+      .post(sessionWriteLimiter, billingController.createCheckoutSession);
+
+    this.app
+      .route(`/api/billing/portal/session`)
+      .all(verifySession())
+      .post(sessionWriteLimiter, billingController.createPortalSession);
+
+    this.app
+      .route(STRIPE_WEBHOOK_PATH)
+      .post(stripeWebhookLimiter, billingWebhookController.handleStripe);
 
     return this.app;
   }

--- a/packages/backend/src/billing/controllers/billing.controller.test.ts
+++ b/packages/backend/src/billing/controllers/billing.controller.test.ts
@@ -1,0 +1,84 @@
+import { type Request, type Response } from "express";
+import { Status } from "@core/errors/status.codes";
+import { type BillingStatusResponse } from "@core/types/billing.types";
+import billingService from "@backend/billing/services/billing.service";
+import billingController from "./billing.controller";
+import { afterEach, describe, expect, it, mock, spyOn } from "bun:test";
+
+const sessionReq = (userId: string) =>
+  ({
+    session: { getUserId: () => userId },
+  }) as unknown as Request<never, BillingStatusResponse, never, never>;
+
+const jsonRes = () => {
+  const json = mock();
+  const res = {
+    status: mock().mockReturnThis(),
+    json,
+    send: mock().mockReturnThis(),
+  } as unknown as Response;
+  return { res, json };
+};
+
+describe("BillingController", () => {
+  afterEach(() => {
+    mock.restore();
+  });
+
+  it("returns status for the session user", async () => {
+    const status: BillingStatusResponse = {
+      subscriptionStatus: "trialing",
+      trialEndsAt: "2026-08-20T00:00:00.000Z",
+      isReadOnly: false,
+    };
+    spyOn(billingService, "getStatus").mockResolvedValue(status);
+
+    const { res, json } = jsonRes();
+    await billingController.getStatus(
+      sessionReq("507f1f77bcf86cd799439011"),
+      res,
+    );
+
+    expect(billingService.getStatus).toHaveBeenCalledWith(
+      "507f1f77bcf86cd799439011",
+    );
+    expect((res.status as ReturnType<typeof mock>).mock.calls[0]?.[0]).toBe(
+      Status.OK,
+    );
+    expect(json).toHaveBeenCalledWith(status);
+  });
+
+  it("maps a missing user to 404 with a JSON body", async () => {
+    spyOn(billingService, "getStatus").mockRejectedValue(
+      new Error("User not found"),
+    );
+
+    const { res, json } = jsonRes();
+    await billingController.getStatus(
+      sessionReq("507f1f77bcf86cd799439011"),
+      res,
+    );
+
+    expect((res.status as ReturnType<typeof mock>).mock.calls[0]?.[0]).toBe(
+      Status.NOT_FOUND,
+    );
+    expect(json).toHaveBeenCalledWith({ error: "User not found" });
+  });
+
+  it("maps unexpected failures to a logged JSON 500", async () => {
+    spyOn(billingService, "getStatus").mockRejectedValue(
+      new Error("mongo down"),
+    );
+
+    const { res, json } = jsonRes();
+    await billingController.getStatus(
+      sessionReq("507f1f77bcf86cd799439011"),
+      res,
+    );
+
+    expect((res.status as ReturnType<typeof mock>).mock.calls[0]?.[0]).toBe(
+      Status.INTERNAL_SERVER,
+    );
+    expect(json).toHaveBeenCalledWith({ error: "Internal server error" });
+  });
+});

--- a/packages/backend/src/billing/controllers/billing.controller.ts
+++ b/packages/backend/src/billing/controllers/billing.controller.ts
@@ -36,19 +36,6 @@ class BillingController {
     }
   };
 
-  startTrial = async (
-    req: Request<never, BillingStatusResponse, never, never>,
-    res: Response<BillingStatusResponse | { error: string }>,
-  ) => {
-    try {
-      const userId = zObjectId.parse(req.session?.getUserId());
-      const status = await billingService.startTrial(userId.toString());
-      res.status(Status.OK).json(status);
-    } catch (e) {
-      sendBillingError(res, e);
-    }
-  };
-
   createCheckoutSession = async (
     req: Request<never, BillingCheckoutResponse, never, never>,
     res: Response<BillingCheckoutResponse | { error: string }>,

--- a/packages/backend/src/billing/controllers/billing.controller.ts
+++ b/packages/backend/src/billing/controllers/billing.controller.ts
@@ -1,33 +1,79 @@
 import { type Request, type Response } from "express";
 import { Status } from "@core/errors/status.codes";
-import { type BillingStatusResponse } from "@core/types/billing.types";
+import { Logger } from "@core/logger/winston.logger";
+import {
+  type BillingCheckoutResponse,
+  type BillingPortalResponse,
+  type BillingStatusResponse,
+} from "@core/types/billing.types";
 import { zObjectId } from "@core/types/type.utils";
 import billingService from "@backend/billing/services/billing.service";
+import stripeService from "@backend/billing/services/stripe.service";
+
+const logger = Logger("app:billing");
+
+const sendBillingError = (res: Response, e: unknown) => {
+  const message = e instanceof Error ? e.message : "Unexpected error";
+  if (message === "User not found") {
+    res.status(Status.NOT_FOUND).json({ error: "User not found" });
+    return;
+  }
+  logger.error(message, e);
+  res.status(Status.INTERNAL_SERVER).json({ error: "Internal server error" });
+};
 
 class BillingController {
   getStatus = async (
     req: Request<never, BillingStatusResponse, never, never>,
-    res: Response<BillingStatusResponse>,
+    res: Response<BillingStatusResponse | { error: string }>,
   ) => {
     try {
       const userId = zObjectId.parse(req.session?.getUserId());
       const status = await billingService.getStatus(userId.toString());
       res.status(Status.OK).json(status);
-    } catch {
-      res.status(Status.INTERNAL_SERVER).send();
+    } catch (e) {
+      sendBillingError(res, e);
     }
   };
 
   startTrial = async (
     req: Request<never, BillingStatusResponse, never, never>,
-    res: Response<BillingStatusResponse>,
+    res: Response<BillingStatusResponse | { error: string }>,
   ) => {
     try {
       const userId = zObjectId.parse(req.session?.getUserId());
       const status = await billingService.startTrial(userId.toString());
       res.status(Status.OK).json(status);
-    } catch {
-      res.status(Status.INTERNAL_SERVER).send();
+    } catch (e) {
+      sendBillingError(res, e);
+    }
+  };
+
+  createCheckoutSession = async (
+    req: Request<never, BillingCheckoutResponse, never, never>,
+    res: Response<BillingCheckoutResponse | { error: string }>,
+  ) => {
+    try {
+      const userId = zObjectId.parse(req.session?.getUserId());
+      const result = await stripeService.createCheckoutSession(
+        userId.toString(),
+      );
+      res.status(Status.OK).json(result);
+    } catch (e) {
+      sendBillingError(res, e);
+    }
+  };
+
+  createPortalSession = async (
+    req: Request<never, BillingPortalResponse, never, never>,
+    res: Response<BillingPortalResponse | { error: string }>,
+  ) => {
+    try {
+      const userId = zObjectId.parse(req.session?.getUserId());
+      const result = await stripeService.createPortalSession(userId.toString());
+      res.status(Status.OK).json(result);
+    } catch (e) {
+      sendBillingError(res, e);
     }
   };
 }

--- a/packages/backend/src/billing/controllers/billing.webhook.controller.ts
+++ b/packages/backend/src/billing/controllers/billing.webhook.controller.ts
@@ -1,0 +1,50 @@
+import { type Request, type Response } from "express";
+import { Status } from "@core/errors/status.codes";
+import { Logger } from "@core/logger/winston.logger";
+import { processStripeEvent } from "@backend/billing/services/billing.webhook.service";
+import { getStripeClient } from "@backend/billing/services/stripe.client";
+import { CONFIG } from "@backend/common/constants/config.constants";
+import { isStripeConfigured } from "@backend/common/constants/config.util";
+
+const logger = Logger("app:billing.webhook");
+
+class BillingWebhookController {
+  handleStripe = async (req: Request, res: Response) => {
+    if (!isStripeConfigured(CONFIG) || !CONFIG.STRIPE_WEBHOOK_SECRET) {
+      res.status(Status.NOT_FOUND).json({ error: "Stripe is not configured" });
+      return;
+    }
+
+    if (!Buffer.isBuffer(req.body)) {
+      logger.error(
+        "Stripe webhook body was not a Buffer; signature verification cannot run",
+      );
+      res.status(Status.BAD_REQUEST).json({ error: "Invalid webhook payload" });
+      return;
+    }
+
+    const signature = req.headers["stripe-signature"];
+    if (typeof signature !== "string" || signature.length === 0) {
+      res
+        .status(Status.BAD_REQUEST)
+        .json({ error: "Missing Stripe signature" });
+      return;
+    }
+
+    try {
+      const event = getStripeClient().webhooks.constructEvent(
+        req.body,
+        signature,
+        CONFIG.STRIPE_WEBHOOK_SECRET,
+      );
+      await processStripeEvent(event);
+      res.status(Status.OK).json({ received: true });
+    } catch (e) {
+      const message = e instanceof Error ? e.message : "Webhook error";
+      logger.error(message, e);
+      res.status(Status.BAD_REQUEST).json({ error: message });
+    }
+  };
+}
+
+export default new BillingWebhookController();

--- a/packages/backend/src/billing/services/billing.service.db.test.ts
+++ b/packages/backend/src/billing/services/billing.service.db.test.ts
@@ -1,0 +1,77 @@
+import {
+  cleanupCollections,
+  cleanupTestDb,
+  setupTestDb,
+} from "@backend/__tests__/helpers/mock.db.setup";
+import billingService from "@backend/billing/services/billing.service";
+import mongoService from "@backend/common/services/mongo.service";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "bun:test";
+
+describe("BillingService (db)", () => {
+  beforeAll(async () => {
+    await setupTestDb(import.meta.url);
+  });
+  beforeEach(cleanupCollections);
+  afterAll(cleanupTestDb);
+
+  it("starts a trial with field-level $set and preserves Stripe ids", async () => {
+    const userId = mongoService.objectId();
+    await mongoService.user.insertOne({
+      _id: userId,
+      email: "trial@example.com",
+      name: "Trial User",
+      firstName: "Trial",
+      lastName: "User",
+      locale: "en",
+      billing: {
+        subscriptionStatus: "awaiting_checkout",
+        stripeCustomerId: "cus_keep",
+      },
+    });
+
+    const status = await billingService.startTrial(userId.toString());
+
+    expect(status.subscriptionStatus).toBe("trialing");
+    expect(status.isReadOnly).toBe(false);
+
+    const stored = await mongoService.user.findOne({ _id: userId });
+    expect(stored?.billing?.stripeCustomerId).toBe("cus_keep");
+    expect(stored?.billing?.subscriptionStatus).toBe("trialing");
+  });
+
+  it("is idempotent: a second startTrial does not extend the window", async () => {
+    const userId = mongoService.objectId();
+    await mongoService.user.insertOne({
+      _id: userId,
+      email: "once@example.com",
+      name: "Once",
+      firstName: "Once",
+      lastName: "User",
+      locale: "en",
+    });
+
+    const first = await billingService.startTrial(userId.toString());
+    const stored = await mongoService.user.findOne({ _id: userId });
+    const second = await billingService.startTrial(userId.toString());
+
+    expect(second.trialEndsAt).toBe(first.trialEndsAt);
+    expect(stored?.billing?.trialStartedAt?.toISOString()).toBe(
+      (
+        await mongoService.user.findOne({ _id: userId })
+      )?.billing?.trialStartedAt?.toISOString(),
+    );
+  });
+
+  it("throws when the user does not exist", async () => {
+    await expect(
+      billingService.getStatus(mongoService.objectId().toString()),
+    ).rejects.toThrow("User not found");
+  });
+});

--- a/packages/backend/src/billing/services/billing.service.test.ts
+++ b/packages/backend/src/billing/services/billing.service.test.ts
@@ -1,3 +1,5 @@
+import { type BillingSubscriptionStatus } from "@core/types/user.types";
+import { WRITE_ACCESS_BY_STATUS } from "@backend/billing/billing.constants";
 import { deriveBillingStatus } from "./billing.service";
 import { describe, expect, it } from "bun:test";
 
@@ -30,7 +32,7 @@ describe("deriveBillingStatus", () => {
     });
   });
 
-  it("flips to expired and read-only once the trial end date has passed", () => {
+  it("self-expires a legacy trialing record with no Stripe subscription id", () => {
     const trialEndsAt = new Date("2026-08-01T00:00:00.000Z");
     const status = deriveBillingStatus(
       {
@@ -48,7 +50,22 @@ describe("deriveBillingStatus", () => {
     });
   });
 
-  it("treats exactly-at-boundary as expired", () => {
+  it("does not self-expire a Stripe-backed trialing record past trialEndsAt", () => {
+    const trialEndsAt = new Date("2026-08-01T00:00:00.000Z");
+    const status = deriveBillingStatus(
+      {
+        subscriptionStatus: "trialing",
+        trialEndsAt,
+        stripeSubscriptionId: "sub_123",
+      },
+      now,
+    );
+
+    expect(status.subscriptionStatus).toBe("trialing");
+    expect(status.isReadOnly).toBe(false);
+  });
+
+  it("treats exactly-at-boundary as expired for legacy trials", () => {
     const trialEndsAt = now;
     const status = deriveBillingStatus(
       { subscriptionStatus: "trialing", trialEndsAt },
@@ -58,4 +75,34 @@ describe("deriveBillingStatus", () => {
     expect(status.subscriptionStatus).toBe("expired");
     expect(status.isReadOnly).toBe(true);
   });
+
+  const cases: Array<{
+    status: BillingSubscriptionStatus;
+    isReadOnly: boolean;
+  }> = (
+    Object.entries(WRITE_ACCESS_BY_STATUS) as Array<
+      [BillingSubscriptionStatus, boolean]
+    >
+  ).map(([status, writable]) => ({
+    status,
+    isReadOnly: !writable,
+  }));
+
+  for (const { status, isReadOnly } of cases) {
+    it(`maps ${status} writability from WRITE_ACCESS_BY_STATUS`, () => {
+      const derived = deriveBillingStatus(
+        {
+          subscriptionStatus: status,
+          trialEndsAt: new Date("2026-09-01T00:00:00.000Z"),
+          ...(status === "trialing"
+            ? { stripeSubscriptionId: "sub_keep_open" }
+            : {}),
+        },
+        now,
+      );
+
+      expect(derived.subscriptionStatus).toBe(status);
+      expect(derived.isReadOnly).toBe(isReadOnly);
+    });
+  }
 });

--- a/packages/backend/src/billing/services/billing.service.ts
+++ b/packages/backend/src/billing/services/billing.service.ts
@@ -49,12 +49,8 @@ export const deriveBillingStatus = (
 
 class BillingService {
   /**
-   * Starts a trial once per user; a second call is a no-op that just
-   * returns the existing state, so retried/duplicate CTA clicks can never
-   * push the trial window out further. Uses a conditional update so two
-   * concurrent POSTs cannot both write a new trialStartedAt.
-   *
    * Field-level `$set` so existing Stripe ids are never clobbered.
+   * Not exposed over HTTP — a trial starts only via Stripe Checkout.
    */
   startTrial = async (userId: string): Promise<BillingStatusResponse> => {
     const _id = mongoService.objectId(userId);

--- a/packages/backend/src/billing/services/billing.service.ts
+++ b/packages/backend/src/billing/services/billing.service.ts
@@ -1,37 +1,49 @@
 import { type BillingStatusResponse } from "@core/types/billing.types";
 import { type Schema_UserBilling } from "@core/types/user.types";
-import { BILLING_DEFAULTS } from "@backend/billing/billing.constants";
+import {
+  BILLING_PLAN,
+  WRITE_ACCESS_BY_STATUS,
+} from "@backend/billing/billing.constants";
 import mongoService from "@backend/common/services/mongo.service";
 
 /**
- * Pure status derivation: a trial past its end date reads as expired even
- * before anything writes that back to the document. Keeps `getStatus` a
- * simple read with no write-on-read race to reason about.
+ * Pure status derivation. Writability is a total map over the status union
+ * so adding a state without deciding it is a compile error.
+ *
+ * Date override (asymmetric on purpose):
+ * - `trialing` with no `stripeSubscriptionId` (legacy / backfill) self-expires
+ *   when `trialEndsAt <= now`.
+ * - `trialing` with a `stripeSubscriptionId` never self-expires locally —
+ *   Stripe's webhook is authoritative, so a late `active` event cannot lock
+ *   out a customer whose card just succeeded.
  */
 export const deriveBillingStatus = (
   billing: Schema_UserBilling | undefined,
   now: Date,
 ): BillingStatusResponse => {
   if (!billing || billing.subscriptionStatus === "none") {
-    return { subscriptionStatus: "none", trialEndsAt: null, isReadOnly: false };
-  }
-
-  const trialEndsAt = billing.trialEndsAt ?? null;
-  const trialExpired =
-    trialEndsAt !== null && trialEndsAt.getTime() <= now.getTime();
-
-  if (billing.subscriptionStatus === "trialing" && !trialExpired) {
     return {
-      subscriptionStatus: "trialing",
-      trialEndsAt: trialEndsAt?.toISOString() ?? null,
-      isReadOnly: false,
+      subscriptionStatus: "none",
+      trialEndsAt: null,
+      isReadOnly: !WRITE_ACCESS_BY_STATUS.none,
     };
   }
 
+  const trialEndsAt = billing.trialEndsAt ?? null;
+  let subscriptionStatus = billing.subscriptionStatus;
+
+  if (subscriptionStatus === "trialing" && !billing.stripeSubscriptionId) {
+    const trialExpired =
+      trialEndsAt !== null && trialEndsAt.getTime() <= now.getTime();
+    if (trialExpired) {
+      subscriptionStatus = "expired";
+    }
+  }
+
   return {
-    subscriptionStatus: "expired",
+    subscriptionStatus,
     trialEndsAt: trialEndsAt?.toISOString() ?? null,
-    isReadOnly: true,
+    isReadOnly: !WRITE_ACCESS_BY_STATUS[subscriptionStatus],
   };
 };
 
@@ -41,21 +53,15 @@ class BillingService {
    * returns the existing state, so retried/duplicate CTA clicks can never
    * push the trial window out further. Uses a conditional update so two
    * concurrent POSTs cannot both write a new trialStartedAt.
+   *
+   * Field-level `$set` so existing Stripe ids are never clobbered.
    */
   startTrial = async (userId: string): Promise<BillingStatusResponse> => {
     const _id = mongoService.objectId(userId);
     const now = new Date();
 
     const trialEndsAt = new Date(now);
-    trialEndsAt.setDate(
-      trialEndsAt.getDate() + BILLING_DEFAULTS.TRIAL_LENGTH_DAYS,
-    );
-
-    const billing: Schema_UserBilling = {
-      subscriptionStatus: "trialing",
-      trialStartedAt: now,
-      trialEndsAt,
-    };
+    trialEndsAt.setDate(trialEndsAt.getDate() + BILLING_PLAN.TRIAL_LENGTH_DAYS);
 
     const result = await mongoService.user.findOneAndUpdate(
       {
@@ -65,7 +71,13 @@ class BillingService {
           { "billing.trialStartedAt": null },
         ],
       },
-      { $set: { billing } },
+      {
+        $set: {
+          "billing.subscriptionStatus": "trialing",
+          "billing.trialStartedAt": now,
+          "billing.trialEndsAt": trialEndsAt,
+        },
+      },
       { returnDocument: "after" },
     );
 

--- a/packages/backend/src/billing/services/billing.webhook.service.db.test.ts
+++ b/packages/backend/src/billing/services/billing.webhook.service.db.test.ts
@@ -1,0 +1,232 @@
+import { type Request, type Response } from "express";
+import type Stripe from "stripe";
+import { Status } from "@core/errors/status.codes";
+import {
+  cleanupCollections,
+  cleanupTestDb,
+  setupTestDb,
+} from "@backend/__tests__/helpers/mock.db.setup";
+import { mockEnv } from "@backend/__tests__/helpers/mock.setup";
+import billingWebhookController from "@backend/billing/controllers/billing.webhook.controller";
+import { processStripeEvent } from "@backend/billing/services/billing.webhook.service";
+import { setStripeClientForTests } from "@backend/billing/services/stripe.client";
+import mongoService from "@backend/common/services/mongo.service";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  mock,
+} from "bun:test";
+
+const stripeConfigured = {
+  STRIPE_SECRET_KEY: "rk_test_123",
+  STRIPE_WEBHOOK_SECRET: "whsec_test",
+  STRIPE_PRICE_ID: "price_test",
+};
+
+const jsonRes = () => {
+  const json = mock();
+  const res = {
+    status: mock().mockReturnThis(),
+    json,
+  } as unknown as Response;
+  return { res, json };
+};
+
+const subscription = (overrides: Partial<Stripe.Subscription> = {}) =>
+  ({
+    id: "sub_1",
+    status: "trialing",
+    customer: "cus_1",
+    cancel_at_period_end: false,
+    trial_start: 1_775_000_000,
+    trial_end: 1_775_604_800,
+    metadata: { compassUserId: "" },
+    items: {
+      data: [
+        {
+          price: { id: "price_test" },
+          current_period_end: 1_778_196_800,
+        },
+      ],
+    },
+    ...overrides,
+  }) as unknown as Stripe.Subscription;
+
+describe("Stripe webhook", () => {
+  beforeAll(async () => {
+    await setupTestDb(import.meta.url);
+  });
+  beforeEach(cleanupCollections);
+  afterEach(() => {
+    setStripeClientForTests(undefined);
+  });
+  afterAll(cleanupTestDb);
+
+  it("rejects a non-Buffer body so a parsed JSON payload cannot pass", async () => {
+    using _env = mockEnv(stripeConfigured);
+    const { res, json } = jsonRes();
+    await billingWebhookController.handleStripe(
+      { body: { id: "evt_1" }, headers: {} } as unknown as Request,
+      res,
+    );
+
+    expect((res.status as ReturnType<typeof mock>).mock.calls[0]?.[0]).toBe(
+      Status.BAD_REQUEST,
+    );
+    expect(json).toHaveBeenCalledWith({ error: "Invalid webhook payload" });
+  });
+
+  it("returns 400 for a bad signature", async () => {
+    using _env = mockEnv(stripeConfigured);
+    setStripeClientForTests({
+      webhooks: {
+        constructEvent: () => {
+          throw new Error(
+            "No signatures found matching the expected signature",
+          );
+        },
+      },
+    } as unknown as Stripe);
+
+    const { res, json } = jsonRes();
+    await billingWebhookController.handleStripe(
+      {
+        body: Buffer.from("{}"),
+        headers: { "stripe-signature": "bad" },
+      } as unknown as Request,
+      res,
+    );
+
+    expect((res.status as ReturnType<typeof mock>).mock.calls[0]?.[0]).toBe(
+      Status.BAD_REQUEST,
+    );
+    expect(json.mock.calls[0]?.[0]).toEqual({
+      error: "No signatures found matching the expected signature",
+    });
+  });
+
+  it("links customer and subscription ids from checkout.session.completed", async () => {
+    using _env = mockEnv(stripeConfigured);
+    const userId = mongoService.objectId();
+    await mongoService.user.insertOne({
+      _id: userId,
+      email: "new@example.com",
+      name: "New",
+      firstName: "New",
+      lastName: "User",
+      locale: "en",
+      billing: { subscriptionStatus: "awaiting_checkout" },
+    });
+
+    setStripeClientForTests({
+      subscriptions: {
+        retrieve: mock(() =>
+          Promise.resolve(
+            subscription({
+              metadata: { compassUserId: userId.toString() },
+            }),
+          ),
+        ),
+      },
+    } as unknown as Stripe);
+
+    await processStripeEvent({
+      id: "evt_checkout_1",
+      type: "checkout.session.completed",
+      created: 1_775_000_100,
+      data: {
+        object: {
+          id: "cs_1",
+          client_reference_id: userId.toString(),
+          customer: "cus_1",
+          subscription: "sub_1",
+        },
+      },
+    } as unknown as Stripe.Event);
+
+    const stored = await mongoService.user.findOne({ _id: userId });
+    expect(stored?.billing?.subscriptionStatus).toBe("trialing");
+    expect(stored?.billing?.stripeCustomerId).toBe("cus_1");
+    expect(stored?.billing?.stripeSubscriptionId).toBe("sub_1");
+  });
+
+  it("acks a duplicate delivery without a second write", async () => {
+    using _env = mockEnv(stripeConfigured);
+    const userId = mongoService.objectId();
+    await mongoService.user.insertOne({
+      _id: userId,
+      email: "dup@example.com",
+      name: "Dup",
+      firstName: "Dup",
+      lastName: "User",
+      locale: "en",
+      billing: { subscriptionStatus: "awaiting_checkout" },
+    });
+
+    const retrieve = mock(() => Promise.resolve(subscription()));
+    setStripeClientForTests({
+      subscriptions: { retrieve },
+    } as unknown as Stripe);
+
+    const event = {
+      id: "evt_dup_1",
+      type: "customer.subscription.updated",
+      created: 1_775_000_100,
+      data: { object: { id: "sub_1", customer: "cus_1" } },
+    } as unknown as Stripe.Event;
+
+    await mongoService.user.updateOne(
+      { _id: userId },
+      { $set: { "billing.stripeSubscriptionId": "sub_1" } },
+    );
+
+    await processStripeEvent(event);
+    await processStripeEvent(event);
+
+    expect(retrieve).toHaveBeenCalledTimes(1);
+    expect(await mongoService.billingEvent.countDocuments()).toBe(1);
+  });
+
+  it("ignores a stale event whose created time is older than lastStripeEventAt", async () => {
+    using _env = mockEnv(stripeConfigured);
+    const userId = mongoService.objectId();
+    const newer = new Date("2026-08-12T00:00:00.000Z");
+    await mongoService.user.insertOne({
+      _id: userId,
+      email: "stale@example.com",
+      name: "Stale",
+      firstName: "Stale",
+      lastName: "User",
+      locale: "en",
+      billing: {
+        subscriptionStatus: "active",
+        stripeSubscriptionId: "sub_1",
+        stripeCustomerId: "cus_1",
+        lastStripeEventAt: newer,
+      },
+    });
+
+    setStripeClientForTests({
+      subscriptions: {
+        retrieve: mock(() =>
+          Promise.resolve(subscription({ status: "canceled" })),
+        ),
+      },
+    } as unknown as Stripe);
+
+    await processStripeEvent({
+      id: "evt_stale_1",
+      type: "customer.subscription.updated",
+      created: Math.floor(newer.getTime() / 1000) - 90,
+      data: { object: { id: "sub_1" } },
+    } as unknown as Stripe.Event);
+
+    const stored = await mongoService.user.findOne({ _id: userId });
+    expect(stored?.billing?.subscriptionStatus).toBe("active");
+  });
+});

--- a/packages/backend/src/billing/services/billing.webhook.service.db.test.ts
+++ b/packages/backend/src/billing/services/billing.webhook.service.db.test.ts
@@ -229,4 +229,42 @@ describe("Stripe webhook", () => {
     const stored = await mongoService.user.findOne({ _id: userId });
     expect(stored?.billing?.subscriptionStatus).toBe("active");
   });
+
+  it("applies a same-second event so retrieve() can take a later subscription state", async () => {
+    using _env = mockEnv(stripeConfigured);
+    const userId = mongoService.objectId();
+    const created = new Date("2026-08-12T00:00:00.000Z");
+    await mongoService.user.insertOne({
+      _id: userId,
+      email: "same@example.com",
+      name: "Same",
+      firstName: "Same",
+      lastName: "User",
+      locale: "en",
+      billing: {
+        subscriptionStatus: "active",
+        stripeSubscriptionId: "sub_1",
+        stripeCustomerId: "cus_1",
+        lastStripeEventAt: created,
+      },
+    });
+
+    setStripeClientForTests({
+      subscriptions: {
+        retrieve: mock(() =>
+          Promise.resolve(subscription({ status: "canceled" })),
+        ),
+      },
+    } as unknown as Stripe);
+
+    await processStripeEvent({
+      id: "evt_same_second_1",
+      type: "customer.subscription.deleted",
+      created: Math.floor(created.getTime() / 1000),
+      data: { object: { id: "sub_1" } },
+    } as unknown as Stripe.Event);
+
+    const stored = await mongoService.user.findOne({ _id: userId });
+    expect(stored?.billing?.subscriptionStatus).toBe("canceled");
+  });
 });

--- a/packages/backend/src/billing/services/billing.webhook.service.ts
+++ b/packages/backend/src/billing/services/billing.webhook.service.ts
@@ -77,7 +77,7 @@ async function applySubscription(
     {
       _id: mongoService.objectId(userId),
       $or: [
-        { "billing.lastStripeEventAt": { $lt: eventCreatedAt } },
+        { "billing.lastStripeEventAt": { $lte: eventCreatedAt } },
         { "billing.lastStripeEventAt": { $exists: false } },
       ],
     },

--- a/packages/backend/src/billing/services/billing.webhook.service.ts
+++ b/packages/backend/src/billing/services/billing.webhook.service.ts
@@ -1,0 +1,192 @@
+import type Stripe from "stripe";
+import { Logger } from "@core/logger/winston.logger";
+import {
+  STRIPE_TO_COMPASS_STATUS,
+  type StripeSubscriptionStatus,
+} from "@backend/billing/billing.constants";
+import { getStripeClient } from "@backend/billing/services/stripe.client";
+import mongoService from "@backend/common/services/mongo.service";
+
+const logger = Logger("app:billing.webhook");
+
+const HANDLED_TYPES = new Set<Stripe.Event.Type>([
+  "checkout.session.completed",
+  "customer.subscription.created",
+  "customer.subscription.updated",
+  "customer.subscription.deleted",
+]);
+
+const isDuplicateKeyError = (error: unknown): boolean =>
+  typeof error === "object" &&
+  error !== null &&
+  "code" in error &&
+  (error as { code: unknown }).code === 11000;
+
+const toDate = (unixSeconds: number | null | undefined): Date | undefined =>
+  typeof unixSeconds === "number" ? new Date(unixSeconds * 1000) : undefined;
+
+const subscriptionIdOf = (value: unknown): string | undefined => {
+  if (typeof value === "string" && value.length > 0) return value;
+  if (
+    typeof value === "object" &&
+    value !== null &&
+    "id" in value &&
+    typeof (value as { id: unknown }).id === "string"
+  ) {
+    return (value as { id: string }).id;
+  }
+  return undefined;
+};
+
+const customerIdOf = (value: unknown): string | undefined => {
+  if (typeof value === "string" && value.length > 0) return value;
+  if (
+    typeof value === "object" &&
+    value !== null &&
+    "id" in value &&
+    typeof (value as { id: unknown }).id === "string"
+  ) {
+    return (value as { id: string }).id;
+  }
+  return undefined;
+};
+
+async function applySubscription(
+  userId: string,
+  subscription: Stripe.Subscription,
+  eventCreatedAt: Date,
+): Promise<void> {
+  const status =
+    STRIPE_TO_COMPASS_STATUS[subscription.status as StripeSubscriptionStatus];
+  if (!status) {
+    logger.warn(
+      `Ignoring unmapped Stripe subscription status ${subscription.status}`,
+    );
+    return;
+  }
+
+  const priceId = subscription.items.data[0]?.price?.id;
+  const currentPeriodEnd = toDate(
+    subscription.items.data[0]?.current_period_end ??
+      (subscription as { current_period_end?: number }).current_period_end,
+  );
+  const trialEnd = toDate(subscription.trial_end ?? undefined);
+  const trialStart = toDate(subscription.trial_start ?? undefined);
+
+  await mongoService.user.updateOne(
+    {
+      _id: mongoService.objectId(userId),
+      $or: [
+        { "billing.lastStripeEventAt": { $lt: eventCreatedAt } },
+        { "billing.lastStripeEventAt": { $exists: false } },
+      ],
+    },
+    {
+      $set: {
+        "billing.subscriptionStatus": status,
+        "billing.stripeCustomerId": customerIdOf(subscription.customer),
+        "billing.stripeSubscriptionId": subscription.id,
+        ...(priceId ? { "billing.stripePriceId": priceId } : {}),
+        ...(currentPeriodEnd
+          ? { "billing.currentPeriodEnd": currentPeriodEnd }
+          : {}),
+        "billing.cancelAtPeriodEnd": subscription.cancel_at_period_end,
+        "billing.lastStripeEventAt": eventCreatedAt,
+        ...(trialStart ? { "billing.trialStartedAt": trialStart } : {}),
+        ...(trialEnd ? { "billing.trialEndsAt": trialEnd } : {}),
+      },
+    },
+  );
+}
+
+async function findUserIdForSubscription(
+  subscription: Stripe.Subscription,
+  clientReferenceId?: string | null,
+): Promise<string | null> {
+  if (clientReferenceId) {
+    return clientReferenceId;
+  }
+
+  const metadataUserId = subscription.metadata?.["compassUserId"];
+  if (metadataUserId) return metadataUserId;
+
+  const customerId = customerIdOf(subscription.customer);
+  const bySubscription = await mongoService.user.findOne({
+    "billing.stripeSubscriptionId": subscription.id,
+  });
+  if (bySubscription) return bySubscription._id.toString();
+
+  if (customerId) {
+    const byCustomer = await mongoService.user.findOne({
+      "billing.stripeCustomerId": customerId,
+    });
+    if (byCustomer) return byCustomer._id.toString();
+  }
+
+  return null;
+}
+
+async function handleEvent(event: Stripe.Event): Promise<void> {
+  if (!HANDLED_TYPES.has(event.type)) return;
+
+  const stripe = getStripeClient();
+  const eventCreatedAt = toDate(event.created) ?? new Date();
+
+  if (event.type === "checkout.session.completed") {
+    const session = event.data.object as Stripe.Checkout.Session;
+    const subscriptionId = subscriptionIdOf(session.subscription);
+    if (!subscriptionId) {
+      logger.warn("checkout.session.completed had no subscription id");
+      return;
+    }
+    const subscription = await stripe.subscriptions.retrieve(subscriptionId);
+    const userId = await findUserIdForSubscription(
+      subscription,
+      session.client_reference_id,
+    );
+    if (!userId) {
+      logger.warn(
+        `No Compass user for checkout session ${session.id} (client_reference_id=${session.client_reference_id})`,
+      );
+      return;
+    }
+    await applySubscription(userId, subscription, eventCreatedAt);
+    return;
+  }
+
+  const subscriptionId = subscriptionIdOf(event.data.object);
+  if (!subscriptionId) {
+    logger.warn(`${event.type} had no subscription id`);
+    return;
+  }
+  const subscription = await stripe.subscriptions.retrieve(subscriptionId);
+  const userId = await findUserIdForSubscription(subscription);
+  if (!userId) {
+    logger.warn(
+      `No Compass user for Stripe subscription ${subscriptionId} (${event.type})`,
+    );
+    return;
+  }
+  await applySubscription(userId, subscription, eventCreatedAt);
+}
+
+export async function processStripeEvent(event: Stripe.Event): Promise<void> {
+  try {
+    await mongoService.billingEvent.insertOne({
+      _id: event.id,
+      receivedAt: new Date(),
+    });
+  } catch (error) {
+    if (isDuplicateKeyError(error)) {
+      return;
+    }
+    throw error;
+  }
+
+  try {
+    await handleEvent(event);
+  } catch (error) {
+    await mongoService.billingEvent.deleteOne({ _id: event.id });
+    throw error;
+  }
+}

--- a/packages/backend/src/billing/services/stripe.client.ts
+++ b/packages/backend/src/billing/services/stripe.client.ts
@@ -1,0 +1,42 @@
+import Stripe from "stripe";
+import { type StripeSubscriptionStatus } from "@backend/billing/billing.constants";
+import { CONFIG } from "@backend/common/constants/config.constants";
+import { isStripeConfigured } from "@backend/common/constants/config.util";
+
+/**
+ * Pinned Stripe API version. `Stripe.Subscription.Status` must stay equal to
+ * `StripeSubscriptionStatus` or the exhaustiveness assignment below fails.
+ */
+export const STRIPE_API_VERSION = "2025-08-27.basil" as const;
+
+type AssertEqual<A, B> = [A] extends [B]
+  ? [B] extends [A]
+    ? true
+    : never
+  : never;
+const _stripeStatusIsTotal: AssertEqual<
+  Stripe.Subscription.Status,
+  StripeSubscriptionStatus
+> = true;
+void _stripeStatusIsTotal;
+
+let client: Stripe | undefined;
+let clientOverride: Stripe | undefined;
+
+export function getStripeClient(): Stripe {
+  if (clientOverride) return clientOverride;
+  if (!isStripeConfigured(CONFIG) || !CONFIG.STRIPE_SECRET_KEY) {
+    throw new Error("Stripe is not configured");
+  }
+  if (!client) {
+    client = new Stripe(CONFIG.STRIPE_SECRET_KEY, {
+      apiVersion: STRIPE_API_VERSION,
+    });
+  }
+  return client;
+}
+
+export function setStripeClientForTests(next: Stripe | undefined): void {
+  clientOverride = next;
+  client = undefined;
+}

--- a/packages/backend/src/billing/services/stripe.service.db.test.ts
+++ b/packages/backend/src/billing/services/stripe.service.db.test.ts
@@ -1,0 +1,147 @@
+import type Stripe from "stripe";
+import {
+  cleanupCollections,
+  cleanupTestDb,
+  setupTestDb,
+} from "@backend/__tests__/helpers/mock.db.setup";
+import { mockEnv } from "@backend/__tests__/helpers/mock.setup";
+import { setStripeClientForTests } from "@backend/billing/services/stripe.client";
+import stripeService from "@backend/billing/services/stripe.service";
+import mongoService from "@backend/common/services/mongo.service";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  mock,
+} from "bun:test";
+
+const stripeConfigured = {
+  STRIPE_SECRET_KEY: "rk_test_123",
+  STRIPE_WEBHOOK_SECRET: "whsec_test",
+  STRIPE_PRICE_ID: "price_test",
+  FRONTEND_URL: "http://localhost:9080",
+} as const;
+
+describe("StripeService", () => {
+  beforeAll(async () => {
+    await setupTestDb(import.meta.url);
+  });
+  beforeEach(cleanupCollections);
+  afterEach(() => {
+    setStripeClientForTests(undefined);
+  });
+  afterAll(cleanupTestDb);
+
+  it("creates a Checkout session in subscription mode with a trial", async () => {
+    using _env = mockEnv(stripeConfigured);
+    const userId = mongoService.objectId();
+    await mongoService.user.insertOne({
+      _id: userId,
+      email: "pay@example.com",
+      name: "Pay User",
+      firstName: "Pay",
+      lastName: "User",
+      locale: "en",
+    });
+
+    const customersCreate = mock(() => Promise.resolve({ id: "cus_1" }));
+    const sessionsCreate = mock(() =>
+      Promise.resolve({ url: "https://checkout.stripe.com/c/session_1" }),
+    );
+
+    setStripeClientForTests({
+      customers: { create: customersCreate },
+      checkout: { sessions: { create: sessionsCreate } },
+    } as unknown as Stripe);
+
+    const result = await stripeService.createCheckoutSession(userId.toString());
+
+    expect(result.url).toBe("https://checkout.stripe.com/c/session_1");
+    expect(customersCreate).toHaveBeenCalled();
+    const sessionArgs = sessionsCreate.mock.calls[0]?.[0] as {
+      mode: string;
+      client_reference_id: string;
+      subscription_data: { trial_period_days: number };
+      line_items: Array<{ price: string; quantity: number }>;
+    };
+    expect(sessionArgs.mode).toBe("subscription");
+    expect(sessionArgs.client_reference_id).toBe(userId.toString());
+    expect(sessionArgs.subscription_data.trial_period_days).toBe(7);
+    expect(sessionArgs.line_items[0]?.price).toBe("price_test");
+    expect(
+      (sessionArgs as { payment_method_types?: unknown }).payment_method_types,
+    ).toBeUndefined();
+
+    const stored = await mongoService.user.findOne({ _id: userId });
+    expect(stored?.billing?.stripeCustomerId).toBe("cus_1");
+  });
+
+  it("reuses an existing Stripe customer id", async () => {
+    using _env = mockEnv(stripeConfigured);
+    const userId = mongoService.objectId();
+    await mongoService.user.insertOne({
+      _id: userId,
+      email: "pay@example.com",
+      name: "Pay User",
+      firstName: "Pay",
+      lastName: "User",
+      locale: "en",
+      billing: {
+        subscriptionStatus: "awaiting_checkout",
+        stripeCustomerId: "cus_existing",
+      },
+    });
+
+    const customersCreate = mock(() => Promise.resolve({ id: "cus_new" }));
+    const sessionsCreate = mock(() =>
+      Promise.resolve({ url: "https://checkout.stripe.com/c/session_2" }),
+    );
+    setStripeClientForTests({
+      customers: { create: customersCreate },
+      checkout: { sessions: { create: sessionsCreate } },
+    } as unknown as Stripe);
+
+    await stripeService.createCheckoutSession(userId.toString());
+
+    expect(customersCreate).not.toHaveBeenCalled();
+    const sessionArgs = sessionsCreate.mock.calls[0]?.[0] as {
+      customer: string;
+    };
+    expect(sessionArgs.customer).toBe("cus_existing");
+  });
+
+  it("creates a billing portal session for an existing customer", async () => {
+    using _env = mockEnv(stripeConfigured);
+    const userId = mongoService.objectId();
+    await mongoService.user.insertOne({
+      _id: userId,
+      email: "pay@example.com",
+      name: "Pay User",
+      firstName: "Pay",
+      lastName: "User",
+      locale: "en",
+      billing: {
+        subscriptionStatus: "trialing",
+        stripeCustomerId: "cus_portal",
+      },
+    });
+
+    const portalCreate = mock(() =>
+      Promise.resolve({ url: "https://billing.stripe.com/p/session_1" }),
+    );
+    setStripeClientForTests({
+      billingPortal: { sessions: { create: portalCreate } },
+    } as unknown as Stripe);
+
+    const result = await stripeService.createPortalSession(userId.toString());
+    expect(result.url).toBe("https://billing.stripe.com/p/session_1");
+    expect(portalCreate.mock.calls[0]?.[0]).toEqual({
+      customer: "cus_portal",
+      return_url: "http://localhost:9080",
+    });
+  });
+});

--- a/packages/backend/src/billing/services/stripe.service.db.test.ts
+++ b/packages/backend/src/billing/services/stripe.service.db.test.ts
@@ -114,6 +114,42 @@ describe("StripeService", () => {
     expect(sessionArgs.customer).toBe("cus_existing");
   });
 
+  it("sends an incomplete Checkout (awaiting_checkout with a subscription id) to the portal", async () => {
+    using _env = mockEnv(stripeConfigured);
+    const userId = mongoService.objectId();
+    await mongoService.user.insertOne({
+      _id: userId,
+      email: "incomplete@example.com",
+      name: "Incomplete User",
+      firstName: "Incomplete",
+      lastName: "User",
+      locale: "en",
+      billing: {
+        subscriptionStatus: "awaiting_checkout",
+        stripeCustomerId: "cus_incomplete",
+        stripeSubscriptionId: "sub_incomplete",
+      },
+    });
+
+    const sessionsCreate = mock(() =>
+      Promise.resolve({ url: "https://checkout.stripe.com/c/session_5" }),
+    );
+    const portalCreate = mock(() =>
+      Promise.resolve({
+        url: "https://billing.stripe.com/p/session_incomplete",
+      }),
+    );
+    setStripeClientForTests({
+      checkout: { sessions: { create: sessionsCreate } },
+      billingPortal: { sessions: { create: portalCreate } },
+    } as unknown as Stripe);
+
+    const result = await stripeService.createCheckoutSession(userId.toString());
+
+    expect(result.url).toBe("https://billing.stripe.com/p/session_incomplete");
+    expect(sessionsCreate).not.toHaveBeenCalled();
+  });
+
   it("omits trial_period_days when the user already had a Stripe subscription", async () => {
     using _env = mockEnv(stripeConfigured);
     const userId = mongoService.objectId();

--- a/packages/backend/src/billing/services/stripe.service.db.test.ts
+++ b/packages/backend/src/billing/services/stripe.service.db.test.ts
@@ -114,6 +114,74 @@ describe("StripeService", () => {
     expect(sessionArgs.customer).toBe("cus_existing");
   });
 
+  it("omits trial_period_days when the user already had a Stripe subscription", async () => {
+    using _env = mockEnv(stripeConfigured);
+    const userId = mongoService.objectId();
+    await mongoService.user.insertOne({
+      _id: userId,
+      email: "expired@example.com",
+      name: "Expired User",
+      firstName: "Expired",
+      lastName: "User",
+      locale: "en",
+      billing: {
+        subscriptionStatus: "expired",
+        stripeCustomerId: "cus_expired",
+        stripeSubscriptionId: "sub_old",
+      },
+    });
+
+    const sessionsCreate = mock(() =>
+      Promise.resolve({ url: "https://checkout.stripe.com/c/session_3" }),
+    );
+    setStripeClientForTests({
+      customers: { create: mock() },
+      checkout: { sessions: { create: sessionsCreate } },
+    } as unknown as Stripe);
+
+    await stripeService.createCheckoutSession(userId.toString());
+
+    const sessionArgs = sessionsCreate.mock.calls[0]?.[0] as {
+      subscription_data: { trial_period_days?: number };
+    };
+    expect(sessionArgs.subscription_data.trial_period_days).toBeUndefined();
+  });
+
+  it("sends a live subscriber to the Billing Portal instead of a second Checkout", async () => {
+    using _env = mockEnv(stripeConfigured);
+    const userId = mongoService.objectId();
+    await mongoService.user.insertOne({
+      _id: userId,
+      email: "live@example.com",
+      name: "Live User",
+      firstName: "Live",
+      lastName: "User",
+      locale: "en",
+      billing: {
+        subscriptionStatus: "active",
+        stripeCustomerId: "cus_live",
+        stripeSubscriptionId: "sub_live",
+      },
+    });
+
+    const sessionsCreate = mock(() =>
+      Promise.resolve({ url: "https://checkout.stripe.com/c/session_4" }),
+    );
+    const portalCreate = mock(() =>
+      Promise.resolve({ url: "https://billing.stripe.com/p/session_live" }),
+    );
+    setStripeClientForTests({
+      checkout: { sessions: { create: sessionsCreate } },
+      billingPortal: { sessions: { create: portalCreate } },
+    } as unknown as Stripe);
+
+    const result = await stripeService.createCheckoutSession(userId.toString());
+
+    expect(result.url).toBe("https://billing.stripe.com/p/session_live");
+    expect(sessionsCreate).not.toHaveBeenCalled();
+    expect(portalCreate).toHaveBeenCalled();
+  });
+
   it("creates a billing portal session for an existing customer", async () => {
     using _env = mockEnv(stripeConfigured);
     const userId = mongoService.objectId();

--- a/packages/backend/src/billing/services/stripe.service.ts
+++ b/packages/backend/src/billing/services/stripe.service.ts
@@ -1,0 +1,97 @@
+import { type BillingCheckoutResponse } from "@core/types/billing.types";
+import {
+  BILLING_PLAN,
+  getStripePriceId,
+} from "@backend/billing/billing.constants";
+import { getStripeClient } from "@backend/billing/services/stripe.client";
+import { CONFIG } from "@backend/common/constants/config.constants";
+import { isStripeConfigured } from "@backend/common/constants/config.util";
+import mongoService from "@backend/common/services/mongo.service";
+
+const checkoutReturnUrl = (outcome: "success" | "cancel"): string => {
+  const url = new URL(CONFIG.FRONTEND_URL);
+  url.searchParams.set("checkout", outcome);
+  return url.toString();
+};
+
+class StripeService {
+  createCheckoutSession = async (
+    userId: string,
+  ): Promise<BillingCheckoutResponse> => {
+    if (!isStripeConfigured(CONFIG)) {
+      throw new Error("Stripe is not configured");
+    }
+
+    const _id = mongoService.objectId(userId);
+    const user = await mongoService.user.findOne({ _id });
+    if (!user) {
+      throw new Error("User not found");
+    }
+
+    const stripe = getStripeClient();
+    let customerId = user.billing?.stripeCustomerId;
+
+    if (!customerId) {
+      const customer = await stripe.customers.create(
+        {
+          email: user.email,
+          metadata: { compassUserId: userId },
+        },
+        { idempotencyKey: `compass-customer-${userId}` },
+      );
+      customerId = customer.id;
+      await mongoService.user.updateOne(
+        { _id },
+        { $set: { "billing.stripeCustomerId": customerId } },
+      );
+    }
+
+    const session = await stripe.checkout.sessions.create({
+      mode: "subscription",
+      customer: customerId,
+      client_reference_id: userId,
+      line_items: [{ price: getStripePriceId(), quantity: 1 }],
+      subscription_data: {
+        trial_period_days: BILLING_PLAN.TRIAL_LENGTH_DAYS,
+        metadata: { compassUserId: userId },
+      },
+      success_url: checkoutReturnUrl("success"),
+      cancel_url: checkoutReturnUrl("cancel"),
+    });
+
+    if (!session.url) {
+      throw new Error("Stripe Checkout did not return a URL");
+    }
+
+    return { url: session.url };
+  };
+
+  createPortalSession = async (
+    userId: string,
+  ): Promise<BillingCheckoutResponse> => {
+    if (!isStripeConfigured(CONFIG)) {
+      throw new Error("Stripe is not configured");
+    }
+
+    const _id = mongoService.objectId(userId);
+    const user = await mongoService.user.findOne({ _id });
+    if (!user) {
+      throw new Error("User not found");
+    }
+
+    const customerId = user.billing?.stripeCustomerId;
+    if (!customerId) {
+      throw new Error("User not found");
+    }
+
+    const stripe = getStripeClient();
+    const session = await stripe.billingPortal.sessions.create({
+      customer: customerId,
+      return_url: CONFIG.FRONTEND_URL,
+    });
+
+    return { url: session.url };
+  };
+}
+
+export default new StripeService();

--- a/packages/backend/src/billing/services/stripe.service.ts
+++ b/packages/backend/src/billing/services/stripe.service.ts
@@ -29,12 +29,14 @@ class StripeService {
     }
 
     const liveStatus = user.billing?.subscriptionStatus;
-    const hasLiveSubscription =
+    const hasOpenStripeSubscription =
       Boolean(user.billing?.stripeSubscriptionId) &&
+      Boolean(user.billing?.stripeCustomerId) &&
       (liveStatus === "trialing" ||
         liveStatus === "active" ||
-        liveStatus === "past_due");
-    if (hasLiveSubscription) {
+        liveStatus === "past_due" ||
+        liveStatus === "awaiting_checkout");
+    if (hasOpenStripeSubscription) {
       return this.createPortalSession(userId);
     }
 
@@ -57,20 +59,23 @@ class StripeService {
       );
     }
 
-    const session = await stripe.checkout.sessions.create({
-      mode: "subscription",
-      customer: customerId,
-      client_reference_id: userId,
-      line_items: [{ price: getStripePriceId(), quantity: 1 }],
-      subscription_data: {
-        ...(grantTrial
-          ? { trial_period_days: BILLING_PLAN.TRIAL_LENGTH_DAYS }
-          : {}),
-        metadata: { compassUserId: userId },
+    const session = await stripe.checkout.sessions.create(
+      {
+        mode: "subscription",
+        customer: customerId,
+        client_reference_id: userId,
+        line_items: [{ price: getStripePriceId(), quantity: 1 }],
+        subscription_data: {
+          ...(grantTrial
+            ? { trial_period_days: BILLING_PLAN.TRIAL_LENGTH_DAYS }
+            : {}),
+          metadata: { compassUserId: userId },
+        },
+        success_url: checkoutReturnUrl("success"),
+        cancel_url: checkoutReturnUrl("cancel"),
       },
-      success_url: checkoutReturnUrl("success"),
-      cancel_url: checkoutReturnUrl("cancel"),
-    });
+      grantTrial ? { idempotencyKey: `compass-checkout-${userId}` } : undefined,
+    );
 
     if (!session.url) {
       throw new Error("Stripe Checkout did not return a URL");

--- a/packages/backend/src/billing/services/stripe.service.ts
+++ b/packages/backend/src/billing/services/stripe.service.ts
@@ -28,8 +28,19 @@ class StripeService {
       throw new Error("User not found");
     }
 
+    const liveStatus = user.billing?.subscriptionStatus;
+    const hasLiveSubscription =
+      Boolean(user.billing?.stripeSubscriptionId) &&
+      (liveStatus === "trialing" ||
+        liveStatus === "active" ||
+        liveStatus === "past_due");
+    if (hasLiveSubscription) {
+      return this.createPortalSession(userId);
+    }
+
     const stripe = getStripeClient();
     let customerId = user.billing?.stripeCustomerId;
+    const grantTrial = !user.billing?.stripeSubscriptionId;
 
     if (!customerId) {
       const customer = await stripe.customers.create(
@@ -52,7 +63,9 @@ class StripeService {
       client_reference_id: userId,
       line_items: [{ price: getStripePriceId(), quantity: 1 }],
       subscription_data: {
-        trial_period_days: BILLING_PLAN.TRIAL_LENGTH_DAYS,
+        ...(grantTrial
+          ? { trial_period_days: BILLING_PLAN.TRIAL_LENGTH_DAYS }
+          : {}),
         metadata: { compassUserId: userId },
       },
       success_url: checkoutReturnUrl("success"),

--- a/packages/backend/src/common/constants/collections.ts
+++ b/packages/backend/src/common/constants/collections.ts
@@ -1,6 +1,7 @@
 import { IS_DEV } from "@backend/common/constants/config.constants";
 
 export const Collections = {
+  BILLING_EVENT: IS_DEV ? "_dev.billingEvent" : "billingEvent",
   CALENDAR: IS_DEV ? "_dev.calendar" : "calendar",
   EVENT: IS_DEV ? "_dev.event" : "event",
   OAUTH: IS_DEV ? "_dev.oauth" : "oauth",

--- a/packages/backend/src/common/constants/config.constants.test.ts
+++ b/packages/backend/src/common/constants/config.constants.test.ts
@@ -3,7 +3,10 @@ import {
   parseConfigFromEnv,
   parseRawConfig,
 } from "@backend/common/constants/config.constants";
-import { isGoogleConfigured } from "@backend/common/constants/config.util";
+import {
+  isGoogleConfigured,
+  isStripeConfigured,
+} from "@backend/common/constants/config.util";
 import { describe, expect, it } from "bun:test";
 
 // A minimal valid compass config file, mirroring the required fields
@@ -48,6 +51,35 @@ describe("config.constants", () => {
     expect(env.GOOGLE_CLIENT_ID).toBeUndefined();
     expect(env.GOOGLE_CLIENT_SECRET).toBeUndefined();
     expect(isGoogleConfigured(env)).toBe(false);
+  });
+
+  it("parses backend env without Stripe configuration", () => {
+    const env = parseConfigFromEnv(validEnv);
+
+    expect(env.STRIPE_SECRET_KEY).toBeUndefined();
+    expect(isStripeConfigured(env)).toBe(false);
+  });
+
+  it("rejects a partial Stripe configuration", () => {
+    expect(() =>
+      parseConfigFromEnv({
+        ...validEnv,
+        STRIPE_SECRET_KEY: "rk_test_123",
+      }),
+    ).toThrow(
+      "Stripe configuration requires secretKey, webhookSecret, and priceId together",
+    );
+  });
+
+  it("reports Stripe as configured only when all three values are present", () => {
+    const env = parseConfigFromEnv({
+      ...validEnv,
+      STRIPE_SECRET_KEY: "rk_test_123",
+      STRIPE_WEBHOOK_SECRET: "whsec_test",
+      STRIPE_PRICE_ID: "price_test",
+    });
+
+    expect(isStripeConfigured(env)).toBe(true);
   });
 
   it("rejects partially configured Google credentials", () => {

--- a/packages/backend/src/common/constants/config.constants.ts
+++ b/packages/backend/src/common/constants/config.constants.ts
@@ -46,6 +46,9 @@ const ConfigSchema = z
     SYNC_EXECUTION: z.enum(["passive", "active"]).default("passive"),
     POSTHOG_KEY: z.string().nonempty().optional(),
     POSTHOG_HOST: z.string().url().optional(),
+    STRIPE_SECRET_KEY: z.string().nonempty().optional(),
+    STRIPE_WEBHOOK_SECRET: z.string().nonempty().optional(),
+    STRIPE_PRICE_ID: z.string().nonempty().optional(),
   })
   .strict()
   .superRefine((env, context) => {
@@ -62,6 +65,22 @@ const ConfigSchema = z
         path: hasGoogleClientId
           ? ["GOOGLE_CLIENT_SECRET"]
           : ["GOOGLE_CLIENT_ID"],
+      });
+    }
+
+    const stripeKeys = [
+      env.STRIPE_SECRET_KEY,
+      env.STRIPE_WEBHOOK_SECRET,
+      env.STRIPE_PRICE_ID,
+    ];
+    const present = stripeKeys.filter(Boolean).length;
+    if (present > 0 && present < 3) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        fatal: true,
+        message:
+          "Stripe configuration requires secretKey, webhookSecret, and priceId together",
+        path: ["STRIPE_SECRET_KEY"],
       });
     }
   });
@@ -98,6 +117,9 @@ export function parseRawConfig(config: CompassConfig): Config {
     SYNC_EXECUTION: config.sync?.execution,
     POSTHOG_KEY: nonEmpty(config.posthog?.key),
     POSTHOG_HOST: nonEmpty(config.posthog?.host) || DEFAULT_POSTHOG_HOST,
+    STRIPE_SECRET_KEY: nonEmpty(config.stripe?.secretKey),
+    STRIPE_WEBHOOK_SECRET: nonEmpty(config.stripe?.webhookSecret),
+    STRIPE_PRICE_ID: nonEmpty(config.stripe?.priceId),
   });
 }
 
@@ -129,6 +151,9 @@ export function parseConfigFromEnv(
     SYNC_EXECUTION: nonEmpty(rawEnv["SYNC_EXECUTION"]),
     POSTHOG_KEY: rawEnv["POSTHOG_KEY"],
     POSTHOG_HOST: rawEnv["POSTHOG_HOST"] || DEFAULT_POSTHOG_HOST,
+    STRIPE_SECRET_KEY: rawEnv["STRIPE_SECRET_KEY"],
+    STRIPE_WEBHOOK_SECRET: rawEnv["STRIPE_WEBHOOK_SECRET"],
+    STRIPE_PRICE_ID: rawEnv["STRIPE_PRICE_ID"],
   });
 }
 

--- a/packages/backend/src/common/constants/config.util.ts
+++ b/packages/backend/src/common/constants/config.util.ts
@@ -11,3 +11,16 @@ export const isGoogleConfigured = (
 ): boolean =>
   isGoogleClientIdValid(env.GOOGLE_CLIENT_ID) &&
   isGoogleClientSecretValid(env.GOOGLE_CLIENT_SECRET);
+
+const isStripeValueValid = (value?: string): boolean =>
+  Boolean(value && value !== "undefined");
+
+export const isStripeConfigured = (
+  env: Pick<
+    Config,
+    "STRIPE_SECRET_KEY" | "STRIPE_WEBHOOK_SECRET" | "STRIPE_PRICE_ID"
+  >,
+): boolean =>
+  isStripeValueValid(env.STRIPE_SECRET_KEY) &&
+  isStripeValueValid(env.STRIPE_WEBHOOK_SECRET) &&
+  isStripeValueValid(env.STRIPE_PRICE_ID);

--- a/packages/backend/src/common/services/mongo.service.ts
+++ b/packages/backend/src/common/services/mongo.service.ts
@@ -12,6 +12,7 @@ import { NodeEnv } from "@core/constants/core.constants";
 import { Logger } from "@core/logger/winston.logger";
 import { type Schema_User } from "@core/types/user.types";
 import { isTransientMongoNetworkError } from "@core/util/mongo-network-error.util";
+import { type BillingEventRecord } from "@backend/billing/billing-event.record";
 import { type CalendarRecord } from "@backend/calendar/calendar.record";
 import { Collections } from "@backend/common/constants/collections";
 import { CONFIG } from "@backend/common/constants/config.constants";
@@ -22,6 +23,7 @@ const logger = Logger("app:mongo.service");
 interface InternalClient {
   db: Db;
   client: MongoClient;
+  billingEvent: Collection<BillingEventRecord>;
   calendar: Collection<CalendarRecord>;
   event: Collection<EventRecord>;
   user: Collection<Schema_User>;
@@ -41,6 +43,14 @@ class MongoService {
    */
   get calendar(): InternalClient["calendar"] {
     return this.#accessInternalCollectionProps("calendar");
+  }
+
+  /**
+   * Stripe webhook dedupe. `_id` is the Stripe event id so no secondary
+   * index is required.
+   */
+  get billingEvent(): InternalClient["billingEvent"] {
+    return this.#accessInternalCollectionProps("billingEvent");
   }
 
   /**
@@ -93,6 +103,9 @@ class MongoService {
     return {
       db,
       client,
+      billingEvent: db.collection<BillingEventRecord>(
+        Collections.BILLING_EVENT,
+      ),
       calendar: db.collection<CalendarRecord>(Collections.CALENDAR),
       event: db.collection<EventRecord>(Collections.EVENT),
       user: db.collection<Schema_User>(Collections.USER),

--- a/packages/backend/src/config/config.route.test.ts
+++ b/packages/backend/src/config/config.route.test.ts
@@ -26,6 +26,11 @@ describe("GET /api/config", () => {
           cloudMutationMode: "enabled",
           execution: "passive",
         },
+        billing: {
+          isConfigured: false,
+          priceDisplay: "$8/month",
+          trialLengthDays: 7,
+        },
       });
     } finally {
       CONFIG.GOOGLE_CLIENT_ID = originalClientId;
@@ -52,6 +57,11 @@ describe("GET /api/config", () => {
         sync: {
           cloudMutationMode: "enabled",
           execution: "passive",
+        },
+        billing: {
+          isConfigured: false,
+          priceDisplay: "$8/month",
+          trialLengthDays: 7,
         },
       });
     } finally {

--- a/packages/backend/src/config/controllers/config.controller.test.ts
+++ b/packages/backend/src/config/controllers/config.controller.test.ts
@@ -37,9 +37,15 @@ describe("ConfigController.get sync cutover posture", () => {
     CONFIG.SYNC_CLOUD_MUTATION_MODE = "maintenance";
     CONFIG.SYNC_EXECUTION = "passive";
 
-    expect(invokeGet().sync).toEqual({
+    const config = invokeGet();
+    expect(config.sync).toEqual({
       cloudMutationMode: "maintenance",
       execution: "passive",
+    });
+    expect(config.billing).toEqual({
+      isConfigured: false,
+      priceDisplay: "$8/month",
+      trialLengthDays: 7,
     });
   });
 });

--- a/packages/backend/src/config/controllers/config.controller.ts
+++ b/packages/backend/src/config/controllers/config.controller.ts
@@ -1,7 +1,11 @@
 import { type Request, type Response } from "express";
+import { BILLING_PLAN } from "@core/constants/billing.constants";
 import { type AppConfig, AppConfigSchema } from "@core/types/config.types";
 import { CONFIG } from "@backend/common/constants/config.constants";
-import { isGoogleConfigured } from "@backend/common/constants/config.util";
+import {
+  isGoogleConfigured,
+  isStripeConfigured,
+} from "@backend/common/constants/config.util";
 import { getCloudMutationMode } from "@backend/common/services/sync-service/cloud-mutation-mode";
 
 class ConfigController {
@@ -14,6 +18,11 @@ class ConfigController {
         sync: {
           cloudMutationMode: getCloudMutationMode(),
           execution: CONFIG.SYNC_EXECUTION,
+        },
+        billing: {
+          isConfigured: isStripeConfigured(CONFIG),
+          priceDisplay: BILLING_PLAN.PRICE_DISPLAY,
+          trialLengthDays: BILLING_PLAN.TRIAL_LENGTH_DAYS,
         },
       }),
     );

--- a/packages/backend/src/event/controllers/event.controller.ts
+++ b/packages/backend/src/event/controllers/event.controller.ts
@@ -20,6 +20,7 @@ import {
   type SyncEventCalendarId,
   SyncEventCalendarIdSchema,
 } from "@core/types/sync/event.contracts";
+import { assertBillingAllowsWrites } from "@backend/billing/billing.guard";
 import calendarService from "@backend/calendar/services/calendar.service";
 import { assertCloudMutationsAllowed } from "@backend/common/services/sync-service/cloud-mutation-mode";
 import {
@@ -281,6 +282,7 @@ class EventController {
     try {
       assertCloudMutationsAllowed();
       const userId = req.session?.getUserId() as string;
+      await assertBillingAllowsWrites(userId);
       const input = CreateEventInputSchema.parse(req.body);
       const event = await createFromSync(userId, input);
 
@@ -294,6 +296,7 @@ class EventController {
     try {
       assertCloudMutationsAllowed();
       const userId = req.session?.getUserId() as string;
+      await assertBillingAllowsWrites(userId);
       const eventId = req.params["id"] as string;
       const input = ReplaceEventInputSchema.parse(req.body);
       const event = await replaceFromSync(userId, eventId, input);
@@ -308,6 +311,7 @@ class EventController {
     try {
       assertCloudMutationsAllowed();
       const userId = req.session?.getUserId() as string;
+      await assertBillingAllowsWrites(userId);
       const eventId = req.params["id"] as string;
       const scopeParam = req.query["scope"];
       const input = DeleteEventInputSchema.parse({

--- a/packages/backend/src/event/event.error.ts
+++ b/packages/backend/src/event/event.error.ts
@@ -26,6 +26,7 @@ const STATUS_BY_CODE: Record<EventMutationErrorCode, Status> = {
   MAINTENANCE: Status.SERVICE_UNAVAILABLE,
   MOVE_UNSUPPORTED: Status.BAD_REQUEST,
   INVALID_INPUT: Status.BAD_REQUEST,
+  BILLING_REQUIRED: Status.FORBIDDEN,
 };
 
 const RETRYABLE_BY_CODE: Record<EventMutationErrorCode, boolean> = {
@@ -41,6 +42,7 @@ const RETRYABLE_BY_CODE: Record<EventMutationErrorCode, boolean> = {
   MAINTENANCE: true,
   MOVE_UNSUPPORTED: false,
   INVALID_INPUT: false,
+  BILLING_REQUIRED: false,
 };
 
 export class EventMutationException extends BaseError {

--- a/packages/backend/src/servers/express/express.server.ts
+++ b/packages/backend/src/servers/express/express.server.ts
@@ -5,6 +5,7 @@ import {
   middleware as supertokensMiddleware,
 } from "supertokens-node/framework/express";
 import { AuthRoutes } from "@backend/auth/auth.routes.config";
+import { STRIPE_WEBHOOK_PATH } from "@backend/billing/billing.constants";
 import { BillingRoutes } from "@backend/billing/billing.routes.config";
 import { CalendarRoutes } from "@backend/calendar/calendar.routes.config";
 import { type CommonRoutesConfig } from "@backend/common/common.routes.config";
@@ -35,6 +36,10 @@ export const initExpressServer = () => {
   app.use(corsWhitelist);
   app.use(helmet());
   app.use(httpLoggingMiddleware);
+  // Stripe signs the raw bytes. express.json() would parse application/json
+  // first and every signature check would 400. Path-scoped raw parser must
+  // run before the global JSON parser.
+  app.use(STRIPE_WEBHOOK_PATH, express.raw({ type: "application/json" }));
   app.use(express.json());
 
   const routes: Array<CommonRoutesConfig> = [];

--- a/packages/backend/src/user/services/user.service.db.test.ts
+++ b/packages/backend/src/user/services/user.service.db.test.ts
@@ -182,6 +182,49 @@ describe("UserService", () => {
       expect(storedUser?.google).toBeUndefined();
     });
 
+    it("starts a fresh signup in awaiting_checkout", async () => {
+      const userId = mongoService.objectId().toString();
+
+      await userService.upsertUserFromAuth({
+        userId,
+        email: "new-billing@example.com",
+        name: "New Billing",
+      });
+
+      const storedUser = await mongoService.user.findOne({
+        _id: mongoService.objectId(userId),
+      });
+      expect(storedUser?.billing?.subscriptionStatus).toBe("awaiting_checkout");
+    });
+
+    it("does not overwrite billing on a returning user", async () => {
+      const userId = mongoService.objectId();
+      await mongoService.user.insertOne({
+        _id: userId,
+        email: "returning@example.com",
+        name: "Returning",
+        firstName: "Returning",
+        lastName: "User",
+        locale: "en",
+        billing: {
+          subscriptionStatus: "active",
+          stripeCustomerId: "cus_keep",
+        },
+      });
+
+      await userService.upsertUserFromAuth({
+        userId: userId.toString(),
+        email: "returning@example.com",
+        name: "Returning",
+      });
+
+      const storedUser = await mongoService.user.findOne({ _id: userId });
+      expect(storedUser?.billing).toEqual({
+        subscriptionStatus: "active",
+        stripeCustomerId: "cus_keep",
+      });
+    });
+
     // Only Google discovery creates calendars, so without this a
     // password-only account owns none and every write fails
     // CALENDAR_NOT_FOUND.

--- a/packages/backend/src/user/services/user.service.ts
+++ b/packages/backend/src/user/services/user.service.ts
@@ -141,7 +141,10 @@ class UserService {
       { _id: userId },
       {
         $set: updatableUser,
-        $setOnInsert: { signedUpAt: nextSignedUpAt },
+        $setOnInsert: {
+          signedUpAt: nextSignedUpAt,
+          "billing.subscriptionStatus": "awaiting_checkout",
+        },
       },
       { upsert: true, session },
     );

--- a/packages/core/src/config/compass.config.ts
+++ b/packages/core/src/config/compass.config.ts
@@ -56,6 +56,16 @@ const CompassConfigSchema = z
         host: optionalString,
       })
       .nullish(),
+    // Hosted Stripe billing. All-three-or-none is enforced when this is
+    // mapped into backend CONFIG (see config.constants superRefine). Omit
+    // the whole block for self-host — billing enforcement then stays off.
+    stripe: z
+      .object({
+        secretKey: optionalString,
+        webhookSecret: optionalString,
+        priceId: optionalString,
+      })
+      .nullish(),
     // Compass Sync service configuration. Every deployment runs Sync (self-host
     // included) and delegates provider-connection and event routes to it — there
     // is no more legacy-vs-sync choice to make. The block itself stays optional

--- a/packages/core/src/constants/billing.constants.ts
+++ b/packages/core/src/constants/billing.constants.ts
@@ -3,10 +3,10 @@
  * share one source. The Stripe price id is a deployment secret and lives
  * in config, not here.
  *
- * BACKFILL_CUTOFF is the single dated switch for "not grandfathered":
- * existing accounts signed up on or before this instant are placed on a
- * trial. Reverting to grandfathering is a one-line change to this value
- * (or dropping the cutoff predicate in the backfill command).
+ * BACKFILL_CUTOFF is the single dated switch for grandfathering: only
+ * accounts with `signedUpAt <= cutoff` (or missing `signedUpAt`) are
+ * placed on a trial. A far-future default means nobody is grandfathered.
+ * Reverting to grandfathering is a one-line change to this value.
  */
 export const BILLING_PLAN = {
   TRIAL_LENGTH_DAYS: 7,
@@ -14,5 +14,5 @@ export const BILLING_PLAN = {
   PRICE_AMOUNT_CENTS: 800,
   PRICE_CURRENCY: "usd",
   PRICE_DISPLAY: "$8/month",
-  BACKFILL_CUTOFF: "2026-08-13T00:00:00.000Z",
+  BACKFILL_CUTOFF: "2099-12-31T23:59:59.000Z",
 } as const;

--- a/packages/core/src/constants/billing.constants.ts
+++ b/packages/core/src/constants/billing.constants.ts
@@ -1,0 +1,18 @@
+/**
+ * Trial and pricing terms. Kept in core so web copy and backend Checkout
+ * share one source. The Stripe price id is a deployment secret and lives
+ * in config, not here.
+ *
+ * BACKFILL_CUTOFF is the single dated switch for "not grandfathered":
+ * existing accounts signed up on or before this instant are placed on a
+ * trial. Reverting to grandfathering is a one-line change to this value
+ * (or dropping the cutoff predicate in the backfill command).
+ */
+export const BILLING_PLAN = {
+  TRIAL_LENGTH_DAYS: 7,
+  PLAN_NAME: "Compass",
+  PRICE_AMOUNT_CENTS: 800,
+  PRICE_CURRENCY: "usd",
+  PRICE_DISPLAY: "$8/month",
+  BACKFILL_CUTOFF: "2026-08-13T00:00:00.000Z",
+} as const;

--- a/packages/core/src/types/billing.types.ts
+++ b/packages/core/src/types/billing.types.ts
@@ -1,9 +1,35 @@
+import { z } from "zod/v4";
 import { type BillingSubscriptionStatus } from "./user.types";
 
+export const BillingSubscriptionStatusSchema = z.enum([
+  "none",
+  "awaiting_checkout",
+  "trialing",
+  "active",
+  "past_due",
+  "canceled",
+  "expired",
+]);
+
 /** Wire shape: dates are ISO strings, matching every other JSON API response. */
-export interface BillingStatusResponse {
-  subscriptionStatus: BillingSubscriptionStatus;
-  trialEndsAt: string | null;
-  /** True once the trial has ended with no active subscription. */
-  isReadOnly: boolean;
-}
+export const BillingStatusResponseSchema = z.object({
+  subscriptionStatus: BillingSubscriptionStatusSchema,
+  trialEndsAt: z.string().nullable(),
+  /** True when the account must not mutate events. */
+  isReadOnly: z.boolean(),
+});
+export type BillingStatusResponse = z.infer<typeof BillingStatusResponseSchema>;
+
+export const BillingCheckoutResponseSchema = z.object({
+  url: z.string().url(),
+});
+export type BillingCheckoutResponse = z.infer<
+  typeof BillingCheckoutResponseSchema
+>;
+
+export const BillingPortalResponseSchema = z.object({
+  url: z.string().url(),
+});
+export type BillingPortalResponse = z.infer<typeof BillingPortalResponseSchema>;
+
+export type { BillingSubscriptionStatus };

--- a/packages/core/src/types/config.types.ts
+++ b/packages/core/src/types/config.types.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { BILLING_PLAN } from "@core/constants/billing.constants";
 
 export const AppConfigSchema = z.object({
   google: z.object({
@@ -16,6 +17,22 @@ export const AppConfigSchema = z.object({
     .default({
       cloudMutationMode: "enabled",
       execution: "passive",
+    }),
+  /**
+   * Hosted billing. `isConfigured: false` is the self-host escape hatch:
+   * the web must not render a paid gate, and the backend must not enforce
+   * read-only. Defaults keep old `/api/config` payloads parseable.
+   */
+  billing: z
+    .object({
+      isConfigured: z.boolean(),
+      priceDisplay: z.string(),
+      trialLengthDays: z.number(),
+    })
+    .default({
+      isConfigured: false,
+      priceDisplay: BILLING_PLAN.PRICE_DISPLAY,
+      trialLengthDays: BILLING_PLAN.TRIAL_LENGTH_DAYS,
     }),
 });
 

--- a/packages/core/src/types/event-command.contracts.ts
+++ b/packages/core/src/types/event-command.contracts.ts
@@ -156,6 +156,10 @@ export const EventMutationErrorCodeSchema = z.enum([
   // The request body failed contract validation (e.g. an unrecognized key on
   // a strict schema). Always a client-side mistake, never retryable.
   "INVALID_INPUT",
+  // Cloud event writes require a trial or paid subscription. 403, not 401
+  // (SuperTokens retries 401 after refresh) and not 402 (Status has no
+  // PAYMENT_REQUIRED). Never retryable.
+  "BILLING_REQUIRED",
 ]);
 
 export const EventMutationErrorSchema = z.strictObject({

--- a/packages/core/src/types/user.types.ts
+++ b/packages/core/src/types/user.types.ts
@@ -26,17 +26,32 @@ export interface Schema_User {
    * Trial/subscription state. Optional and absent for every user who
    * existed before this field shipped -- treat absence as "none" (never
    * started a trial), matching the established incremental-field pattern
-   * for this schema. No backfill: a required field here would need every
-   * existing document migrated at deploy time.
-   *
-   * NOTE: this only records that a trial started, when it ends, and (once
-   * wired) live Stripe subscription state. It does not yet reflect actual
-   * payment collection -- see keyboard-education/03-monetization-trial-checkout.md.
+   * for this schema.
    */
   billing?: Schema_UserBilling;
 }
 
-export type BillingSubscriptionStatus = "none" | "trialing" | "expired";
+/**
+ * Total subscription union. Adding a member without updating
+ * `WRITE_ACCESS_BY_STATUS` is a compile error.
+ *
+ * - `none` — legacy row, pre-backfill. writable.
+ * - `awaiting_checkout` — account exists, no Stripe subscription. read-only.
+ * - `trialing` — in trial. writable. Legacy rows without a Stripe
+ *   subscription id self-expire locally; Stripe-backed trials do not.
+ * - `active` — paid. writable.
+ * - `past_due` — dunning window. writable + banner.
+ * - `canceled` — subscription canceled. read-only.
+ * - `expired` — trial or unpaid ended. read-only.
+ */
+export type BillingSubscriptionStatus =
+  | "none"
+  | "awaiting_checkout"
+  | "trialing"
+  | "active"
+  | "past_due"
+  | "canceled"
+  | "expired";
 
 export interface Schema_UserBilling {
   subscriptionStatus: BillingSubscriptionStatus;
@@ -44,6 +59,11 @@ export interface Schema_UserBilling {
   trialEndsAt?: Date;
   stripeCustomerId?: string;
   stripeSubscriptionId?: string;
+  stripePriceId?: string;
+  currentPeriodEnd?: Date;
+  cancelAtPeriodEnd?: boolean;
+  lastStripeEventAt?: Date;
+  backfilledAt?: Date;
 }
 
 /**

--- a/packages/scripts/src/cli.test.ts
+++ b/packages/scripts/src/cli.test.ts
@@ -17,6 +17,13 @@ mock.module("@scripts/commands/purge-user", () => ({
   runPurgeUser: mock(() => mockRunPurgeUser()),
 }));
 
+const mockRunBackfillBilling = mock((): Promise<void> => Promise.resolve());
+
+mock.module("@scripts/commands/backfill-billing", () => ({
+  __esModule: true,
+  runBackfillBilling: mock(() => mockRunBackfillBilling()),
+}));
+
 const { default: CompassCLI } = requireActual(
   "@scripts/cli",
 ) as typeof import("@scripts/cli");
@@ -32,6 +39,14 @@ describe("CompassCLI", () => {
     await cli.run();
 
     expect(mockRunPurgeUser).toHaveBeenCalled();
+  });
+
+  it("runs backfill-billing command", async () => {
+    const cli = new CompassCLI(["node", "cli", "backfill-billing"]);
+
+    await cli.run();
+
+    expect(mockRunBackfillBilling).toHaveBeenCalled();
   });
 
   it("calls exitHelpfully for unsupported command", async () => {

--- a/packages/scripts/src/cli.ts
+++ b/packages/scripts/src/cli.ts
@@ -1,5 +1,6 @@
 import { CliValidator } from "@scripts/cli.validator";
 import { runAuditConnectionIdentity } from "@scripts/commands/audit-connection-identity";
+import { runBackfillBilling } from "@scripts/commands/backfill-billing";
 import { runManageFailedJobs } from "@scripts/commands/manage-failed-jobs";
 import { runPurgeUser } from "@scripts/commands/purge-user";
 import { Command } from "commander";
@@ -24,6 +25,9 @@ export default class CompassCLI {
       case cmd === "purge-user":
         await runPurgeUser();
         break;
+      case cmd === "backfill-billing":
+        await runBackfillBilling();
+        break;
       case cmd === "audit-connection-identity":
         await runAuditConnectionIdentity();
         break;
@@ -43,6 +47,14 @@ export default class CompassCLI {
       .allowUnknownOption(true)
       .description(
         "delete every Compass row for one email, across the API db, Sync db, and SuperTokens (--apply to write)",
+      );
+
+    program
+      .command("backfill-billing")
+      .helpOption(false)
+      .allowUnknownOption(true)
+      .description(
+        "place existing accounts without billing status onto a 7-day trial (--apply to write)",
       );
 
     program

--- a/packages/scripts/src/commands/backfill-billing.db.test.ts
+++ b/packages/scripts/src/commands/backfill-billing.db.test.ts
@@ -1,4 +1,5 @@
 import { backfillBilling } from "@scripts/commands/backfill-billing/backfill";
+import { BILLING_PLAN } from "@core/constants/billing.constants";
 import {
   cleanupCollections,
   cleanupTestDb,
@@ -90,5 +91,25 @@ describe("backfill-billing (db)", () => {
       sleep: async () => undefined,
     });
     expect(second.modified).toBe(0);
+  });
+
+  it("includes accounts signed up after an old cutoff when using the default far-future cutoff", async () => {
+    await mongoService.user.insertOne({
+      email: "today@example.com",
+      name: "Today",
+      firstName: "Today",
+      lastName: "User",
+      locale: "en",
+      signedUpAt: NOW,
+    });
+
+    const report = await backfillBilling(mongoService.user, {
+      dryRun: true,
+      cutoff: new Date(BILLING_PLAN.BACKFILL_CUTOFF),
+      batchSize: 500,
+      now: NOW,
+    });
+
+    expect(report.matched).toBe(1);
   });
 });

--- a/packages/scripts/src/commands/backfill-billing.db.test.ts
+++ b/packages/scripts/src/commands/backfill-billing.db.test.ts
@@ -1,0 +1,94 @@
+import { backfillBilling } from "@scripts/commands/backfill-billing/backfill";
+import {
+  cleanupCollections,
+  cleanupTestDb,
+  setupTestDb,
+} from "@backend/__tests__/helpers/mock.db.setup";
+import mongoService from "@backend/common/services/mongo.service";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "bun:test";
+
+const CUTOFF = new Date("2026-08-13T00:00:00.000Z");
+const NOW = new Date("2026-08-13T12:00:00.000Z");
+
+describe("backfill-billing (db)", () => {
+  beforeAll(() => setupTestDb(import.meta.url));
+  beforeEach(cleanupCollections);
+  afterAll(cleanupTestDb);
+
+  it("dry-run reports matches without writing", async () => {
+    await mongoService.user.insertOne({
+      email: "old@example.com",
+      name: "Old",
+      firstName: "Old",
+      lastName: "User",
+      locale: "en",
+      signedUpAt: new Date("2026-08-01T00:00:00.000Z"),
+    });
+
+    const report = await backfillBilling(mongoService.user, {
+      dryRun: true,
+      cutoff: CUTOFF,
+      batchSize: 500,
+      now: NOW,
+    });
+
+    expect(report.matched).toBe(1);
+    expect(report.modified).toBe(0);
+    const stored = await mongoService.user.findOne({
+      email: "old@example.com",
+    });
+    expect(stored?.billing).toBeUndefined();
+  });
+
+  it("applies a trialing window and is idempotent", async () => {
+    await mongoService.user.insertOne({
+      email: "old@example.com",
+      name: "Old",
+      firstName: "Old",
+      lastName: "User",
+      locale: "en",
+      signedUpAt: new Date("2026-08-01T00:00:00.000Z"),
+    });
+    await mongoService.user.insertOne({
+      email: "paid@example.com",
+      name: "Paid",
+      firstName: "Paid",
+      lastName: "User",
+      locale: "en",
+      signedUpAt: new Date("2026-08-01T00:00:00.000Z"),
+      billing: { subscriptionStatus: "active" },
+    });
+
+    const first = await backfillBilling(mongoService.user, {
+      dryRun: false,
+      cutoff: CUTOFF,
+      batchSize: 500,
+      now: NOW,
+      sleep: async () => undefined,
+    });
+    expect(first.modified).toBe(1);
+
+    const stored = await mongoService.user.findOne({
+      email: "old@example.com",
+    });
+    expect(stored?.billing?.subscriptionStatus).toBe("trialing");
+    expect(stored?.billing?.backfilledAt).toEqual(NOW);
+    expect(stored?.billing?.stripeSubscriptionId).toBeUndefined();
+
+    const second = await backfillBilling(mongoService.user, {
+      dryRun: false,
+      cutoff: CUTOFF,
+      batchSize: 500,
+      now: NOW,
+      sleep: async () => undefined,
+    });
+    expect(second.modified).toBe(0);
+  });
+});

--- a/packages/scripts/src/commands/backfill-billing.ts
+++ b/packages/scripts/src/commands/backfill-billing.ts
@@ -1,0 +1,67 @@
+import { backfillBilling } from "@scripts/commands/backfill-billing/backfill";
+import { BILLING_PLAN } from "@core/constants/billing.constants";
+import { Logger } from "@core/logger/winston.logger";
+import mongoService from "@backend/common/services/mongo.service";
+
+const logger = Logger("scripts.commands.backfill-billing");
+
+function parseArgs(argv: string[]): {
+  dryRun: boolean;
+  batchSize: number;
+  cutoff: Date;
+} {
+  const cutoffFlag = argv.indexOf("--cutoff");
+  const cutoffRaw =
+    cutoffFlag >= 0
+      ? argv[cutoffFlag + 1]?.trim()
+      : BILLING_PLAN.BACKFILL_CUTOFF;
+  const cutoff = cutoffRaw
+    ? new Date(cutoffRaw)
+    : new Date(BILLING_PLAN.BACKFILL_CUTOFF);
+  if (Number.isNaN(cutoff.getTime())) {
+    throw new Error("backfill-billing --cutoff must be an ISO date");
+  }
+
+  const batchFlag = argv.indexOf("--batch-size");
+  const batchSize = batchFlag >= 0 ? Number(argv[batchFlag + 1]) : 500;
+  if (!Number.isFinite(batchSize) || batchSize < 1) {
+    throw new Error("backfill-billing --batch-size must be a positive number");
+  }
+
+  return { dryRun: !argv.includes("--apply"), batchSize, cutoff };
+}
+
+/**
+ * Places existing accounts (no billing.subscriptionStatus) onto a 7-day
+ * trial. Dry-run by default; pass `--apply` to write.
+ *
+ * Usage:
+ *   bun run cli backfill-billing [--apply] [--batch-size 500] [--cutoff ISO]
+ */
+export async function runBackfillBilling(): Promise<void> {
+  try {
+    const { dryRun, batchSize, cutoff } = parseArgs(process.argv.slice(3));
+    await mongoService.start();
+
+    logger.info(
+      `backfill-billing dryRun=${dryRun} batchSize=${batchSize} cutoff=${cutoff.toISOString()}`,
+    );
+
+    const report = await backfillBilling(mongoService.user, {
+      dryRun,
+      batchSize,
+      cutoff,
+    });
+
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    logger.info(
+      `backfill-billing dryRun=${report.dryRun} matched=${report.matched} modified=${report.modified}`,
+    );
+
+    await mongoService.stop();
+    process.exit(0);
+  } catch (error) {
+    logger.error(error);
+    process.exit(1);
+  }
+}

--- a/packages/scripts/src/commands/backfill-billing/backfill.ts
+++ b/packages/scripts/src/commands/backfill-billing/backfill.ts
@@ -1,0 +1,81 @@
+import { type Collection, type ObjectId } from "mongodb";
+import { BILLING_PLAN } from "@core/constants/billing.constants";
+import { type Schema_User } from "@core/types/user.types";
+
+export type BackfillBillingReport = {
+  dryRun: boolean;
+  cutoff: string;
+  matched: number;
+  modified: number;
+};
+
+export async function backfillBilling(
+  users: Collection<Schema_User>,
+  options: {
+    dryRun: boolean;
+    cutoff: Date;
+    batchSize: number;
+    now?: Date;
+    sleep?: (ms: number) => Promise<void>;
+  },
+): Promise<BackfillBillingReport> {
+  const now = options.now ?? new Date();
+  const trialEndsAt = new Date(now);
+  trialEndsAt.setDate(trialEndsAt.getDate() + BILLING_PLAN.TRIAL_LENGTH_DAYS);
+
+  const filter = {
+    "billing.subscriptionStatus": { $exists: false },
+    $or: [
+      { signedUpAt: { $lte: options.cutoff } },
+      { signedUpAt: { $exists: false } },
+    ],
+  };
+
+  const matched = await users.countDocuments(filter);
+  if (options.dryRun || matched === 0) {
+    return {
+      dryRun: options.dryRun,
+      cutoff: options.cutoff.toISOString(),
+      matched,
+      modified: 0,
+    };
+  }
+
+  let modified = 0;
+  let lastId: ObjectId | undefined;
+
+  for (;;) {
+    const batchFilter = lastId ? { ...filter, _id: { $gt: lastId } } : filter;
+    const batch = await users
+      .find(batchFilter)
+      .sort({ _id: 1 })
+      .limit(options.batchSize)
+      .project({ _id: 1 })
+      .toArray();
+
+    if (batch.length === 0) break;
+
+    const ids = batch.map((row) => row["_id"]);
+    const result = await users.updateMany(
+      { _id: { $in: ids }, "billing.subscriptionStatus": { $exists: false } },
+      {
+        $set: {
+          "billing.subscriptionStatus": "trialing",
+          "billing.trialStartedAt": now,
+          "billing.trialEndsAt": trialEndsAt,
+          "billing.backfilledAt": now,
+        },
+      },
+    );
+    modified += result.modifiedCount;
+    lastId = ids[ids.length - 1];
+    if (options.sleep) await options.sleep(50);
+  }
+
+  return {
+    dryRun: false,
+    cutoff: options.cutoff.toISOString(),
+    matched,
+    modified,
+  };
+}

--- a/packages/web/src/__tests__/__mocks__/server/mock.handlers.ts
+++ b/packages/web/src/__tests__/__mocks__/server/mock.handlers.ts
@@ -68,6 +68,29 @@ export const globalHandlers = [
   rest.get(`${ENV_WEB.API_BASEURL}/user/metadata`, (_req, res, ctx) => {
     return res(ctx.status(Status.OK), ctx.json({}));
   }),
+  rest.get(`${ENV_WEB.API_BASEURL}/billing/status`, (_req, res, ctx) => {
+    return res(
+      ctx.status(Status.OK),
+      ctx.json({
+        subscriptionStatus: "active",
+        trialEndsAt: null,
+        isReadOnly: false,
+      }),
+    );
+  }),
+  rest.get(`${ENV_WEB.API_BASEURL}/config`, (_req, res, ctx) => {
+    return res(
+      ctx.status(Status.OK),
+      ctx.json({
+        google: { isConfigured: false },
+        billing: {
+          isConfigured: false,
+          priceDisplay: "$8/month",
+          trialLengthDays: 7,
+        },
+      }),
+    );
+  }),
   rest.post(`${ENV_WEB.API_BASEURL}/user/metadata`, (req, res, ctx) => {
     return res(ctx.status(Status.OK), ctx.json(req.json()));
   }),

--- a/packages/web/src/api/billing.api.ts
+++ b/packages/web/src/api/billing.api.ts
@@ -1,0 +1,33 @@
+import {
+  type BillingCheckoutResponse,
+  BillingCheckoutResponseSchema,
+  type BillingPortalResponse,
+  BillingPortalResponseSchema,
+  type BillingStatusResponse,
+  BillingStatusResponseSchema,
+} from "@core/types/billing.types";
+import { BaseApi } from "@web/api/base/base.api";
+
+const BillingApi = {
+  async getStatus(): Promise<BillingStatusResponse> {
+    const response =
+      await BaseApi.get<BillingStatusResponse>(`/billing/status`);
+    return BillingStatusResponseSchema.parse(response.data);
+  },
+
+  async createCheckoutSession(): Promise<BillingCheckoutResponse> {
+    const response = await BaseApi.post<BillingCheckoutResponse>(
+      `/billing/checkout/session`,
+    );
+    return BillingCheckoutResponseSchema.parse(response.data);
+  },
+
+  async createPortalSession(): Promise<BillingPortalResponse> {
+    const response = await BaseApi.post<BillingPortalResponse>(
+      `/billing/portal/session`,
+    );
+    return BillingPortalResponseSchema.parse(response.data);
+  },
+};
+
+export { BillingApi };

--- a/packages/web/src/auth/posthog/track.ts
+++ b/packages/web/src/auth/posthog/track.ts
@@ -23,6 +23,8 @@ export type ProductEvent =
   | "trial_expired"
   | "trial_gate_shown"
   | "trial_gate_cta_clicked"
+  | "billing_gate_shown"
+  | "billing_gate_cta_clicked"
   | "shortcut_tip_shown"
   | "shortcut_tip_acted_on";
 

--- a/packages/web/src/billing/BillingGateModal.tsx
+++ b/packages/web/src/billing/BillingGateModal.tsx
@@ -89,14 +89,16 @@ export const BillingGateModal: FC<BillingGateModalProps> = ({ status }) => {
           >
             {isAwaitingCheckout ? "Start trial" : "Subscribe"}
           </button>
-          <button
-            className="c-button c-button-secondary rounded-full px-6 py-2"
-            disabled={isRedirecting}
-            onClick={() => void redirectTo("portal")}
-            type="button"
-          >
-            Manage billing
-          </button>
+          {isAwaitingCheckout ? null : (
+            <button
+              className="c-button c-button-secondary rounded-full px-6 py-2"
+              disabled={isRedirecting}
+              onClick={() => void redirectTo("portal")}
+              type="button"
+            >
+              Manage billing
+            </button>
+          )}
         </div>
         <button
           className="c-focus-ring text-text-muted text-xs underline-offset-4 hover:text-text hover:underline"

--- a/packages/web/src/billing/BillingGateModal.tsx
+++ b/packages/web/src/billing/BillingGateModal.tsx
@@ -1,0 +1,122 @@
+import { type FC, useEffect, useRef, useState } from "react";
+import { BILLING_PLAN } from "@core/constants/billing.constants";
+import { BillingApi } from "@web/api/billing.api";
+import { useLogout } from "@web/auth/compass/hooks/useLogout";
+import { track } from "@web/auth/posthog/track";
+import { Z_INDEX_MODAL } from "@web/common/constants/web.constants";
+import { runExportMyData } from "@web/common/storage/offline-data/export-user-data.util";
+import { PixelPirateScouting } from "@web/components/WelcomeModal/PixelPirateScouting";
+import { useAppLockReason } from "@web/shortcuts/app-lock";
+
+type BillingGateModalProps = {
+  status: string;
+};
+
+/**
+ * Full app-lock overlay for signed-in users who cannot write (awaiting
+ * checkout, expired, canceled). Intentionally not dismissible.
+ */
+export const BillingGateModal: FC<BillingGateModalProps> = ({ status }) => {
+  useAppLockReason("billingGate", true);
+  const logout = useLogout();
+  const panelRef = useRef<HTMLDivElement>(null);
+  const [isExporting, setIsExporting] = useState(false);
+  const [isRedirecting, setIsRedirecting] = useState(false);
+  const shownRef = useRef(false);
+
+  const isAwaitingCheckout = status === "awaiting_checkout";
+  const title = isAwaitingCheckout
+    ? "Start your 7-day trial"
+    : "Subscribe to keep using Compass";
+  const body = isAwaitingCheckout
+    ? `Compass is ${BILLING_PLAN.PRICE_DISPLAY} after a ${BILLING_PLAN.TRIAL_LENGTH_DAYS}-day trial. A card is required to start.`
+    : `Your trial has ended. Compass is ${BILLING_PLAN.PRICE_DISPLAY}.`;
+
+  useEffect(() => {
+    panelRef.current?.focus();
+    if (!shownRef.current) {
+      shownRef.current = true;
+      track("billing_gate_shown", { status });
+    }
+  }, [status]);
+
+  const redirectTo = async (kind: "checkout" | "portal") => {
+    setIsRedirecting(true);
+    track("billing_gate_cta_clicked", { cta: kind });
+    try {
+      const { url } =
+        kind === "checkout"
+          ? await BillingApi.createCheckoutSession()
+          : await BillingApi.createPortalSession();
+      window.location.assign(url);
+    } finally {
+      setIsRedirecting(false);
+    }
+  };
+
+  const handleExport = async () => {
+    setIsExporting(true);
+    track("billing_gate_cta_clicked", { cta: "export" });
+    try {
+      await runExportMyData();
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 flex items-center justify-center bg-background/80 p-4 backdrop-blur-sm"
+      style={{ zIndex: Z_INDEX_MODAL }}
+    >
+      <div
+        ref={panelRef}
+        aria-label={title}
+        aria-modal="true"
+        className="flex w-120 max-w-full flex-col items-center gap-4 rounded-xl border border-border bg-surface p-8 text-center text-text shadow-xl"
+        role="dialog"
+        tabIndex={-1}
+      >
+        <PixelPirateScouting className="h-14 w-14" />
+        <h1 className="font-medium text-xl">{title}</h1>
+        <p className="text-sm text-text-muted">{body}</p>
+        <div className="mt-2 flex w-full flex-col gap-2">
+          <button
+            className="c-button c-button-primary c-button-elevated rounded-full px-6 py-2"
+            disabled={isRedirecting}
+            onClick={() => void redirectTo("checkout")}
+            type="button"
+          >
+            {isAwaitingCheckout ? "Start trial" : "Subscribe"}
+          </button>
+          <button
+            className="c-button c-button-secondary rounded-full px-6 py-2"
+            disabled={isRedirecting}
+            onClick={() => void redirectTo("portal")}
+            type="button"
+          >
+            Manage billing
+          </button>
+        </div>
+        <button
+          className="c-focus-ring text-text-muted text-xs underline-offset-4 hover:text-text hover:underline"
+          disabled={isExporting}
+          onClick={() => void handleExport()}
+          type="button"
+        >
+          {isExporting ? "Exporting…" : "Export my data"}
+        </button>
+        <button
+          className="c-focus-ring text-text-muted text-xs underline-offset-4 hover:text-text hover:underline"
+          onClick={() => {
+            track("billing_gate_cta_clicked", { cta: "logout" });
+            void logout();
+          }}
+          type="button"
+        >
+          Log out
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/packages/web/src/billing/BillingPastDueBanner.tsx
+++ b/packages/web/src/billing/BillingPastDueBanner.tsx
@@ -1,0 +1,28 @@
+import { type FC } from "react";
+import { BillingApi } from "@web/api/billing.api";
+
+/**
+ * Non-blocking banner during Stripe's dunning window. The account stays
+ * writable; this is the only past_due UI.
+ */
+export const BillingPastDueBanner: FC = () => {
+  return (
+    <div
+      className="flex items-center justify-center gap-3 border-warning/40 border-b bg-warning/10 px-4 py-2 text-sm text-text"
+      role="status"
+    >
+      <p>Payment failed. Update your card to keep Compass after this period.</p>
+      <button
+        className="c-focus-ring font-medium text-warning underline-offset-4 hover:underline"
+        onClick={() => {
+          void BillingApi.createPortalSession().then(({ url }) => {
+            window.location.assign(url);
+          });
+        }}
+        type="button"
+      >
+        Manage billing
+      </button>
+    </div>
+  );
+};

--- a/packages/web/src/billing/TrialCountdownChip.tsx
+++ b/packages/web/src/billing/TrialCountdownChip.tsx
@@ -1,30 +1,52 @@
 import { type FC } from "react";
 import { track } from "@web/auth/posthog/track";
-import { useTrialStatus } from "@web/billing/useTrialStatus";
+import { useAppAccess } from "@web/billing/useAppAccess";
 import { useAuthModal } from "@web/components/AuthModal/hooks/useAuthModal";
 
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+function daysUntil(iso: string | null): number | null {
+  if (!iso) return null;
+  const remaining = Math.ceil((Date.parse(iso) - Date.now()) / MS_PER_DAY);
+  return Number.isNaN(remaining) ? null : Math.max(0, remaining);
+}
+
 /**
- * Sidebar status bar slot: quiet countdown for the anonymous browser trial.
- * Never shown for authenticated users (server billing status governs them).
+ * Sidebar status bar slot: quiet countdown for the anonymous browser trial
+ * and for authenticated users still in a server-side trial.
  */
 export const TrialCountdownChip: FC = () => {
-  const { isExpired, daysLeft, isAnonymousTrial } = useTrialStatus();
+  const access = useAppAccess();
   const { openModal } = useAuthModal();
 
-  if (!isAnonymousTrial || isExpired) return null;
+  if (access.kind === "anonymous-trial" && !access.isExpired) {
+    const isUrgent = access.daysLeft <= 2;
+    return (
+      <button
+        className={`c-focus-ring truncate text-xs ${isUrgent ? "font-semibold text-warning" : "text-text-muted"}`}
+        onClick={() => {
+          track("signup_started", { source: "trial_chip" });
+          openModal("signUp");
+        }}
+        type="button"
+      >
+        Trial: {access.daysLeft} {access.daysLeft === 1 ? "day" : "days"} left
+      </button>
+    );
+  }
 
-  const isUrgent = daysLeft <= 2;
+  if (access.kind === "server" && access.status === "trialing") {
+    const daysLeft = daysUntil(access.trialEndsAt);
+    if (daysLeft === null || daysLeft <= 0) return null;
+    const isUrgent = daysLeft <= 2;
+    return (
+      <p
+        className={`truncate text-xs ${isUrgent ? "font-semibold text-warning" : "text-text-muted"}`}
+      >
+        Trial: {daysLeft} {daysLeft === 1 ? "day" : "days"} left
+      </p>
+    );
+  }
 
-  return (
-    <button
-      className={`c-focus-ring truncate text-xs ${isUrgent ? "font-semibold text-warning" : "text-text-muted"}`}
-      onClick={() => {
-        track("signup_started", { source: "trial_chip" });
-        openModal("signUp");
-      }}
-      type="button"
-    >
-      Trial: {daysLeft} {daysLeft === 1 ? "day" : "days"} left
-    </button>
-  );
+  return null;
 };

--- a/packages/web/src/billing/TrialCountdownChip.tsx
+++ b/packages/web/src/billing/TrialCountdownChip.tsx
@@ -1,6 +1,7 @@
 import { type FC } from "react";
 import { track } from "@web/auth/posthog/track";
 import { useAppAccess } from "@web/billing/useAppAccess";
+import { useTrialStatus } from "@web/billing/useTrialStatus";
 import { useAuthModal } from "@web/components/AuthModal/hooks/useAuthModal";
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
@@ -13,14 +14,18 @@ function daysUntil(iso: string | null): number | null {
 
 /**
  * Sidebar status bar slot: quiet countdown for the anonymous browser trial
- * and for authenticated users still in a server-side trial.
+ * (same clock as TrialGateModal) and for authenticated users still trialing.
+ *
+ * Anonymous rendering goes through `useTrialStatus`, not `useAppAccess`, so a
+ * process-wide test mock of the server hook cannot hide the visitor chip.
  */
 export const TrialCountdownChip: FC = () => {
+  const { isExpired, daysLeft, isAnonymousTrial } = useTrialStatus();
   const access = useAppAccess();
   const { openModal } = useAuthModal();
 
-  if (access.kind === "anonymous-trial" && !access.isExpired) {
-    const isUrgent = access.daysLeft <= 2;
+  if (isAnonymousTrial && !isExpired) {
+    const isUrgent = daysLeft <= 2;
     return (
       <button
         className={`c-focus-ring truncate text-xs ${isUrgent ? "font-semibold text-warning" : "text-text-muted"}`}
@@ -30,20 +35,20 @@ export const TrialCountdownChip: FC = () => {
         }}
         type="button"
       >
-        Trial: {access.daysLeft} {access.daysLeft === 1 ? "day" : "days"} left
+        Trial: {daysLeft} {daysLeft === 1 ? "day" : "days"} left
       </button>
     );
   }
 
   if (access.kind === "server" && access.status === "trialing") {
-    const daysLeft = daysUntil(access.trialEndsAt);
-    if (daysLeft === null || daysLeft <= 0) return null;
-    const isUrgent = daysLeft <= 2;
+    const serverDaysLeft = daysUntil(access.trialEndsAt);
+    if (serverDaysLeft === null || serverDaysLeft <= 0) return null;
+    const isUrgent = serverDaysLeft <= 2;
     return (
       <p
         className={`truncate text-xs ${isUrgent ? "font-semibold text-warning" : "text-text-muted"}`}
       >
-        Trial: {daysLeft} {daysLeft === 1 ? "day" : "days"} left
+        Trial: {serverDaysLeft} {serverDaysLeft === 1 ? "day" : "days"} left
       </p>
     );
   }

--- a/packages/web/src/billing/billing.query.ts
+++ b/packages/web/src/billing/billing.query.ts
@@ -1,0 +1,73 @@
+import { queryOptions, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useNavigate, useSearch } from "@tanstack/react-router";
+import { useEffect } from "react";
+import { type BillingStatusResponse } from "@core/types/billing.types";
+import { AppConfigApi } from "@web/api/app-config.api";
+import { BillingApi } from "@web/api/billing.api";
+import { track } from "@web/auth/posthog/track";
+
+export const billingQueryKeys = {
+  status: ["billing", "status"] as const,
+  config: ["app-config"] as const,
+};
+
+export function billingStatusQueryOptions() {
+  return queryOptions({
+    queryKey: billingQueryKeys.status,
+    queryFn: (): Promise<BillingStatusResponse> => BillingApi.getStatus(),
+    staleTime: 30_000,
+  });
+}
+
+export function appConfigQueryOptions() {
+  return queryOptions({
+    queryKey: billingQueryKeys.config,
+    queryFn: () => AppConfigApi.get(),
+    staleTime: 60_000,
+  });
+}
+
+export function useBillingStatusQuery(enabled: boolean) {
+  return useQuery({
+    ...billingStatusQueryOptions(),
+    enabled,
+  });
+}
+
+export function useAppConfigQuery() {
+  return useQuery(appConfigQueryOptions());
+}
+
+/**
+ * After Stripe Checkout returns `?checkout=success`, keep refetching billing
+ * status for a short window so a late webhook does not leave the gate up.
+ */
+export function useCheckoutReturn() {
+  const queryClient = useQueryClient();
+  const navigate = useNavigate();
+  const { checkout } = useSearch({ from: "__root__" });
+
+  useEffect(() => {
+    if (checkout !== "success") return;
+
+    const invalidate = () => {
+      void queryClient.invalidateQueries({ queryKey: billingQueryKeys.status });
+    };
+    invalidate();
+    track("trial_converted");
+    const interval = window.setInterval(invalidate, 1500);
+    const timeout = window.setTimeout(() => {
+      window.clearInterval(interval);
+      void navigate({
+        to: ".",
+        search: (prev) => ({ ...prev, checkout: undefined }),
+        replace: true,
+      });
+    }, 15_000);
+
+    return () => {
+      window.clearInterval(interval);
+      window.clearTimeout(timeout);
+    };
+  }, [checkout, navigate, queryClient]);
+}

--- a/packages/web/src/billing/useAppAccess.test.tsx
+++ b/packages/web/src/billing/useAppAccess.test.tsx
@@ -1,0 +1,203 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { rest } from "msw";
+import { type PropsWithChildren } from "react";
+import { server } from "@web/__tests__/__mocks__/server/mock.server";
+import * as authStateUtil from "@web/auth/compass/state/auth.state.util";
+import { useAppAccess } from "@web/billing/useAppAccess";
+import { ENV_WEB } from "@web/common/constants/env.constants";
+import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
+import { persistentBrowserStore } from "@web/common/storage/browser-key-value.store";
+import { beforeEach, describe, expect, it, spyOn } from "bun:test";
+
+const daysAgo = (days: number) =>
+  new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+
+const createWrapper = () => {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: PropsWithChildren) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+};
+
+const stubConfig = (isConfigured: boolean) => {
+  server.use(
+    rest.get(`${ENV_WEB.API_BASEURL}/config`, (_req, res, ctx) =>
+      res(
+        ctx.json({
+          google: { isConfigured: false },
+          billing: {
+            isConfigured,
+            priceDisplay: "$8/month",
+            trialLengthDays: 7,
+          },
+        }),
+      ),
+    ),
+  );
+};
+
+const stubBilling = (body: {
+  subscriptionStatus: string;
+  trialEndsAt: string | null;
+  isReadOnly: boolean;
+}) => {
+  server.use(
+    rest.get(`${ENV_WEB.API_BASEURL}/billing/status`, (_req, res, ctx) =>
+      res(ctx.json(body)),
+    ),
+  );
+};
+
+describe("useAppAccess", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("uses the anonymous trial for a fresh visitor", async () => {
+    stubConfig(true);
+    const { result } = renderHook(() => useAppAccess(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.kind).toBe("anonymous-trial");
+    });
+    if (result.current.kind !== "anonymous-trial") {
+      throw new Error("unreachable");
+    }
+    expect(result.current.isExpired).toBe(false);
+    expect(result.current.daysLeft).toBe(7);
+  });
+
+  it("expires the anonymous trial after the window", async () => {
+    persistentBrowserStore.set(STORAGE_KEYS.TRIAL_STARTED_AT, daysAgo(8));
+    stubConfig(true);
+    const { result } = renderHook(() => useAppAccess(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current).toMatchObject({
+        kind: "anonymous-trial",
+        isExpired: true,
+      });
+    });
+  });
+
+  it("fails open while authenticated billing status is loading", () => {
+    const hasUserEverAuthenticatedSpy = spyOn(
+      authStateUtil,
+      "hasUserEverAuthenticated",
+    ).mockReturnValue(true);
+    stubConfig(true);
+    server.use(
+      rest.get(`${ENV_WEB.API_BASEURL}/billing/status`, (_req, res, ctx) =>
+        res(
+          ctx.delay(500),
+          ctx.json({
+            subscriptionStatus: "active",
+            trialEndsAt: null,
+            isReadOnly: false,
+          }),
+        ),
+      ),
+    );
+
+    const { result } = renderHook(() => useAppAccess(), {
+      wrapper: createWrapper(),
+    });
+    expect(result.current).toEqual({ kind: "open" });
+    hasUserEverAuthenticatedSpy.mockRestore();
+  });
+
+  it("fails open when billing status fetch fails", async () => {
+    const hasUserEverAuthenticatedSpy = spyOn(
+      authStateUtil,
+      "hasUserEverAuthenticated",
+    ).mockReturnValue(true);
+    stubConfig(true);
+    server.use(
+      rest.get(`${ENV_WEB.API_BASEURL}/billing/status`, (_req, res, ctx) =>
+        res(ctx.status(500)),
+      ),
+    );
+
+    const { result } = renderHook(() => useAppAccess(), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => {
+      expect(result.current).toEqual({ kind: "open" });
+    });
+    hasUserEverAuthenticatedSpy.mockRestore();
+  });
+
+  it("fails open when Stripe is unconfigured", async () => {
+    const hasUserEverAuthenticatedSpy = spyOn(
+      authStateUtil,
+      "hasUserEverAuthenticated",
+    ).mockReturnValue(true);
+    stubConfig(false);
+
+    const { result } = renderHook(() => useAppAccess(), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => {
+      expect(result.current).toEqual({ kind: "open" });
+    });
+    hasUserEverAuthenticatedSpy.mockRestore();
+  });
+
+  it("returns server active status", async () => {
+    const hasUserEverAuthenticatedSpy = spyOn(
+      authStateUtil,
+      "hasUserEverAuthenticated",
+    ).mockReturnValue(true);
+    stubConfig(true);
+    stubBilling({
+      subscriptionStatus: "active",
+      trialEndsAt: null,
+      isReadOnly: false,
+    });
+
+    const { result } = renderHook(() => useAppAccess(), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => {
+      expect(result.current).toEqual({
+        kind: "server",
+        status: "active",
+        isReadOnly: false,
+        trialEndsAt: null,
+      });
+    });
+    hasUserEverAuthenticatedSpy.mockRestore();
+  });
+
+  it("returns server awaiting_checkout as read-only", async () => {
+    const hasUserEverAuthenticatedSpy = spyOn(
+      authStateUtil,
+      "hasUserEverAuthenticated",
+    ).mockReturnValue(true);
+    stubConfig(true);
+    stubBilling({
+      subscriptionStatus: "awaiting_checkout",
+      trialEndsAt: null,
+      isReadOnly: true,
+    });
+
+    const { result } = renderHook(() => useAppAccess(), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => {
+      expect(result.current).toMatchObject({
+        kind: "server",
+        status: "awaiting_checkout",
+        isReadOnly: true,
+      });
+    });
+    hasUserEverAuthenticatedSpy.mockRestore();
+  });
+});

--- a/packages/web/src/billing/useAppAccess.test.tsx
+++ b/packages/web/src/billing/useAppAccess.test.tsx
@@ -3,22 +3,26 @@ import { renderHook, waitFor } from "@testing-library/react";
 import { rest } from "msw";
 import { type PropsWithChildren } from "react";
 import { server } from "@web/__tests__/__mocks__/server/mock.server";
-import * as authStateUtil from "@web/auth/compass/state/auth.state.util";
+import { SessionContext } from "@web/auth/compass/session/session.context";
 import { useAppAccess } from "@web/billing/useAppAccess";
 import { ENV_WEB } from "@web/common/constants/env.constants";
 import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
 import { persistentBrowserStore } from "@web/common/storage/browser-key-value.store";
-import { beforeEach, describe, expect, it, spyOn } from "bun:test";
+import { beforeEach, describe, expect, it } from "bun:test";
 
 const daysAgo = (days: number) =>
   new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
 
-const createWrapper = () => {
+const createWrapper = (authenticated = false) => {
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
   return ({ children }: PropsWithChildren) => (
-    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    <SessionContext.Provider
+      value={{ authenticated, setAuthenticated: () => {} }}
+    >
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    </SessionContext.Provider>
   );
 };
 
@@ -88,10 +92,6 @@ describe("useAppAccess", () => {
   });
 
   it("fails open while authenticated billing status is loading", () => {
-    const hasUserEverAuthenticatedSpy = spyOn(
-      authStateUtil,
-      "hasUserEverAuthenticated",
-    ).mockReturnValue(true);
     stubConfig(true);
     server.use(
       rest.get(`${ENV_WEB.API_BASEURL}/billing/status`, (_req, res, ctx) =>
@@ -107,17 +107,12 @@ describe("useAppAccess", () => {
     );
 
     const { result } = renderHook(() => useAppAccess(), {
-      wrapper: createWrapper(),
+      wrapper: createWrapper(true),
     });
     expect(result.current).toEqual({ kind: "open" });
-    hasUserEverAuthenticatedSpy.mockRestore();
   });
 
   it("fails open when billing status fetch fails", async () => {
-    const hasUserEverAuthenticatedSpy = spyOn(
-      authStateUtil,
-      "hasUserEverAuthenticated",
-    ).mockReturnValue(true);
     stubConfig(true);
     server.use(
       rest.get(`${ENV_WEB.API_BASEURL}/billing/status`, (_req, res, ctx) =>
@@ -126,35 +121,25 @@ describe("useAppAccess", () => {
     );
 
     const { result } = renderHook(() => useAppAccess(), {
-      wrapper: createWrapper(),
+      wrapper: createWrapper(true),
     });
     await waitFor(() => {
       expect(result.current).toEqual({ kind: "open" });
     });
-    hasUserEverAuthenticatedSpy.mockRestore();
   });
 
   it("fails open when Stripe is unconfigured", async () => {
-    const hasUserEverAuthenticatedSpy = spyOn(
-      authStateUtil,
-      "hasUserEverAuthenticated",
-    ).mockReturnValue(true);
     stubConfig(false);
 
     const { result } = renderHook(() => useAppAccess(), {
-      wrapper: createWrapper(),
+      wrapper: createWrapper(true),
     });
     await waitFor(() => {
       expect(result.current).toEqual({ kind: "open" });
     });
-    hasUserEverAuthenticatedSpy.mockRestore();
   });
 
   it("returns server active status", async () => {
-    const hasUserEverAuthenticatedSpy = spyOn(
-      authStateUtil,
-      "hasUserEverAuthenticated",
-    ).mockReturnValue(true);
     stubConfig(true);
     stubBilling({
       subscriptionStatus: "active",
@@ -163,7 +148,7 @@ describe("useAppAccess", () => {
     });
 
     const { result } = renderHook(() => useAppAccess(), {
-      wrapper: createWrapper(),
+      wrapper: createWrapper(true),
     });
     await waitFor(() => {
       expect(result.current).toEqual({
@@ -173,14 +158,9 @@ describe("useAppAccess", () => {
         trialEndsAt: null,
       });
     });
-    hasUserEverAuthenticatedSpy.mockRestore();
   });
 
   it("returns server awaiting_checkout as read-only", async () => {
-    const hasUserEverAuthenticatedSpy = spyOn(
-      authStateUtil,
-      "hasUserEverAuthenticated",
-    ).mockReturnValue(true);
     stubConfig(true);
     stubBilling({
       subscriptionStatus: "awaiting_checkout",
@@ -189,7 +169,7 @@ describe("useAppAccess", () => {
     });
 
     const { result } = renderHook(() => useAppAccess(), {
-      wrapper: createWrapper(),
+      wrapper: createWrapper(true),
     });
     await waitFor(() => {
       expect(result.current).toMatchObject({
@@ -198,6 +178,5 @@ describe("useAppAccess", () => {
         isReadOnly: true,
       });
     });
-    hasUserEverAuthenticatedSpy.mockRestore();
   });
 });

--- a/packages/web/src/billing/useAppAccess.ts
+++ b/packages/web/src/billing/useAppAccess.ts
@@ -1,0 +1,87 @@
+import { useContext, useEffect, useState } from "react";
+import { type BillingSubscriptionStatus } from "@core/types/user.types";
+import { SessionContext } from "@web/auth/compass/session/session.context";
+import { hasUserEverAuthenticated } from "@web/auth/compass/state/auth.state.util";
+import { track } from "@web/auth/posthog/track";
+import {
+  useAppConfigQuery,
+  useBillingStatusQuery,
+} from "@web/billing/billing.query";
+import {
+  ensureTrialStarted,
+  getTrialDaysLeft,
+} from "@web/billing/trial.storage";
+
+export type AppAccess =
+  | {
+      kind: "anonymous-trial";
+      isExpired: boolean;
+      daysLeft: number;
+    }
+  | {
+      kind: "server";
+      status: BillingSubscriptionStatus;
+      isReadOnly: boolean;
+      trialEndsAt: string | null;
+    }
+  | { kind: "open" };
+
+/**
+ * Reconciles the anonymous localStorage trial with server billing.
+ *
+ * Never-signed-up visitors keep today's anonymous trial (and TrialGateModal).
+ * Signed-in users read `/api/billing/status`. Fail open: a loading, error, or
+ * unconfigured-Stripe state never locks a paying user out of their calendar.
+ */
+export function useAppAccess(): AppAccess {
+  const { authenticated } = useContext(SessionContext);
+  const isGateExempt = authenticated || hasUserEverAuthenticated();
+  const [daysLeft, setDaysLeft] = useState(() => getTrialDaysLeft());
+  const configQuery = useAppConfigQuery();
+  const billingEnabled =
+    isGateExempt && configQuery.data?.billing.isConfigured === true;
+  const billingQuery = useBillingStatusQuery(billingEnabled);
+
+  useEffect(() => {
+    if (ensureTrialStarted()) {
+      track("trial_started");
+    }
+    if (isGateExempt) return;
+
+    const recompute = () => setDaysLeft(getTrialDaysLeft());
+    recompute();
+    document.addEventListener("visibilitychange", recompute);
+    window.addEventListener("focus", recompute);
+    return () => {
+      document.removeEventListener("visibilitychange", recompute);
+      window.removeEventListener("focus", recompute);
+    };
+  }, [isGateExempt]);
+
+  if (!isGateExempt) {
+    return {
+      kind: "anonymous-trial",
+      isExpired: daysLeft <= 0,
+      daysLeft,
+    };
+  }
+
+  if (
+    configQuery.isError ||
+    configQuery.isPending ||
+    configQuery.data?.billing.isConfigured !== true
+  ) {
+    return { kind: "open" };
+  }
+
+  if (billingQuery.isError || billingQuery.isPending || !billingQuery.data) {
+    return { kind: "open" };
+  }
+
+  return {
+    kind: "server",
+    status: billingQuery.data.subscriptionStatus,
+    isReadOnly: billingQuery.data.isReadOnly,
+    trialEndsAt: billingQuery.data.trialEndsAt,
+  };
+}

--- a/packages/web/src/billing/useAppAccess.ts
+++ b/packages/web/src/billing/useAppAccess.ts
@@ -1,16 +1,9 @@
-import { useContext, useEffect, useState } from "react";
 import { type BillingSubscriptionStatus } from "@core/types/user.types";
-import { SessionContext } from "@web/auth/compass/session/session.context";
-import { hasUserEverAuthenticated } from "@web/auth/compass/state/auth.state.util";
-import { track } from "@web/auth/posthog/track";
 import {
   useAppConfigQuery,
   useBillingStatusQuery,
 } from "@web/billing/billing.query";
-import {
-  ensureTrialStarted,
-  getTrialDaysLeft,
-} from "@web/billing/trial.storage";
+import { useTrialStatus } from "@web/billing/useTrialStatus";
 
 export type AppAccess =
   | {
@@ -34,35 +27,17 @@ export type AppAccess =
  * unconfigured-Stripe state never locks a paying user out of their calendar.
  */
 export function useAppAccess(): AppAccess {
-  const { authenticated } = useContext(SessionContext);
-  const isGateExempt = authenticated || hasUserEverAuthenticated();
-  const [daysLeft, setDaysLeft] = useState(() => getTrialDaysLeft());
+  const trial = useTrialStatus();
   const configQuery = useAppConfigQuery();
   const billingEnabled =
-    isGateExempt && configQuery.data?.billing.isConfigured === true;
+    !trial.isAnonymousTrial && configQuery.data?.billing.isConfigured === true;
   const billingQuery = useBillingStatusQuery(billingEnabled);
 
-  useEffect(() => {
-    if (ensureTrialStarted()) {
-      track("trial_started");
-    }
-    if (isGateExempt) return;
-
-    const recompute = () => setDaysLeft(getTrialDaysLeft());
-    recompute();
-    document.addEventListener("visibilitychange", recompute);
-    window.addEventListener("focus", recompute);
-    return () => {
-      document.removeEventListener("visibilitychange", recompute);
-      window.removeEventListener("focus", recompute);
-    };
-  }, [isGateExempt]);
-
-  if (!isGateExempt) {
+  if (trial.isAnonymousTrial) {
     return {
       kind: "anonymous-trial",
-      isExpired: daysLeft <= 0,
-      daysLeft,
+      isExpired: trial.isExpired,
+      daysLeft: trial.daysLeft,
     };
   }
 

--- a/packages/web/src/billing/useTrialStatus.ts
+++ b/packages/web/src/billing/useTrialStatus.ts
@@ -9,8 +9,8 @@ import {
 } from "@web/billing/trial.storage";
 
 export type TrialStatus = {
-  /** Always false for authenticated users in v1 — no payment product exists
-   * yet to gate them against; server billing status governs once Stripe lands. */
+  /** Always false for authenticated / previously-authenticated users —
+   *  server billing status governs them via `useAppAccess`. */
   isExpired: boolean;
   daysLeft: number;
   /** True only while the browser-local clock governs, i.e. a visitor who has
@@ -21,7 +21,9 @@ export type TrialStatus = {
 
 /**
  * Anonymous users run on the browser-local trial clock; signed-in users are
- * never gated in v1 (see 06-trial-spec.md in compass-calendar-internal).
+ * never gated here. `useAppAccess` is the production entry for combining this
+ * clock with server billing. This hook stays for the anonymous clock and its
+ * existing tests.
  *
  * `authenticated` starts false and only flips true once the async SuperTokens
  * check resolves, so it cannot be the sole guard: the common path is to try

--- a/packages/web/src/components/AuthModal/hooks/useAuthModal.ts
+++ b/packages/web/src/components/AuthModal/hooks/useAuthModal.ts
@@ -30,6 +30,7 @@ const PARAM_TO_VIEW = Object.fromEntries(
 export interface AuthSearch {
   auth?: string;
   token?: string;
+  checkout?: string;
 }
 
 export function validateAuthSearch(
@@ -38,6 +39,7 @@ export function validateAuthSearch(
   return {
     auth: typeof search.auth === "string" ? search.auth : undefined,
     token: typeof search.token === "string" ? search.token : undefined,
+    checkout: typeof search.checkout === "string" ? search.checkout : undefined,
   };
 }
 

--- a/packages/web/src/components/RootShell/RootShell.test.tsx
+++ b/packages/web/src/components/RootShell/RootShell.test.tsx
@@ -3,17 +3,25 @@ import { render, screen } from "@web/__tests__/__mocks__/mock.render";
 import { createTestRouter } from "@web/__tests__/utils/providers/createTestRouter";
 import { type AppAccess } from "@web/billing/useAppAccess";
 import { RootShell } from "@web/components/RootShell/RootShell";
-import { afterEach, describe, expect, it, mock } from "bun:test";
+import { afterAll, afterEach, describe, expect, it, mock } from "bun:test";
 
+const actualUseAppAccess = (await import("@web/billing/useAppAccess"))
+  .useAppAccess;
+let isAppAccessMocked = true;
 let access: AppAccess = { kind: "open" };
 
 mock.module("@web/billing/useAppAccess", () => ({
-  useAppAccess: () => access,
+  useAppAccess: (...args: Parameters<typeof actualUseAppAccess>) =>
+    isAppAccessMocked ? access : actualUseAppAccess(...args),
 }));
 
 describe("RootShell billing gates", () => {
   afterEach(() => {
     access = { kind: "open" };
+  });
+
+  afterAll(() => {
+    isAppAccessMocked = false;
   });
 
   const renderShell = async () => {

--- a/packages/web/src/components/RootShell/RootShell.test.tsx
+++ b/packages/web/src/components/RootShell/RootShell.test.tsx
@@ -1,0 +1,53 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@web/__tests__/__mocks__/mock.render";
+import { createTestRouter } from "@web/__tests__/utils/providers/createTestRouter";
+import { type AppAccess } from "@web/billing/useAppAccess";
+import { RootShell } from "@web/components/RootShell/RootShell";
+import { afterEach, describe, expect, it, mock } from "bun:test";
+
+let access: AppAccess = { kind: "open" };
+
+mock.module("@web/billing/useAppAccess", () => ({
+  useAppAccess: () => access,
+}));
+
+describe("RootShell billing gates", () => {
+  afterEach(() => {
+    access = { kind: "open" };
+  });
+
+  const renderShell = async () => {
+    const router = createTestRouter(<RootShell />);
+    render(<div />, { router });
+    await router.load();
+  };
+
+  it("shows the anonymous trial gate without the billing gate", async () => {
+    access = { kind: "anonymous-trial", isExpired: true, daysLeft: 0 };
+    await renderShell();
+
+    expect(
+      screen.getByRole("dialog", { name: "Your free trial has ended" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Manage billing" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows the billing gate without the anonymous trial gate", async () => {
+    access = {
+      kind: "server",
+      status: "awaiting_checkout",
+      isReadOnly: true,
+      trialEndsAt: null,
+    };
+    await renderShell();
+
+    expect(
+      screen.getByRole("dialog", { name: "Start your 7-day trial" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("dialog", { name: "Your free trial has ended" }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/packages/web/src/components/RootShell/RootShell.test.tsx
+++ b/packages/web/src/components/RootShell/RootShell.test.tsx
@@ -55,6 +55,9 @@ describe("RootShell billing gates", () => {
       screen.getByRole("dialog", { name: "Start your 7-day trial" }),
     ).toBeInTheDocument();
     expect(
+      screen.queryByRole("button", { name: "Manage billing" }),
+    ).not.toBeInTheDocument();
+    expect(
       screen.queryByRole("dialog", { name: "Your free trial has ended" }),
     ).not.toBeInTheDocument();
   });

--- a/packages/web/src/components/RootShell/RootShell.tsx
+++ b/packages/web/src/components/RootShell/RootShell.tsx
@@ -1,6 +1,9 @@
 import { Outlet } from "@tanstack/react-router";
+import { BillingGateModal } from "@web/billing/BillingGateModal";
+import { BillingPastDueBanner } from "@web/billing/BillingPastDueBanner";
+import { useCheckoutReturn } from "@web/billing/billing.query";
 import { TrialGateModal } from "@web/billing/TrialGateModal";
-import { useTrialStatus } from "@web/billing/useTrialStatus";
+import { useAppAccess } from "@web/billing/useAppAccess";
 import { AuthModal } from "@web/components/AuthModal/AuthModal";
 import { AuthModalProvider } from "@web/components/AuthModal/AuthModalProvider";
 import { OnboardingChecklist } from "@web/components/OnboardingChecklist/OnboardingChecklist";
@@ -25,16 +28,21 @@ import {
  */
 export function RootShell() {
   const isWelcomeGuideOpen = useWelcomeGuideStore(selectWelcomeGuideOpen);
-  const { isExpired: isTrialExpired } = useTrialStatus();
+  const access = useAppAccess();
+  useCheckoutReturn();
   useNavigationShortcuts();
   useCalendarShellShortcuts();
   useKeyboardOnlyMode();
+
+  const showTrialGate = access.kind === "anonymous-trial" && access.isExpired;
+  const showBillingGate = access.kind === "server" && access.isReadOnly;
+  const showPastDue = access.kind === "server" && access.status === "past_due";
 
   // An expired trial owns the whole screen. The onboarding cards sit at
   // Z_INDEX_TOOLTIP (above Z_INDEX_MODAL), so leaving them mounted would let
   // a gated user click straight through the gate and keep touring. AuthModal
   // stays because the gate's only ways forward are sign up and log in.
-  if (isTrialExpired) {
+  if (showTrialGate) {
     return (
       <AuthModalProvider>
         <Outlet />
@@ -44,8 +52,19 @@ export function RootShell() {
     );
   }
 
+  if (showBillingGate) {
+    return (
+      <AuthModalProvider>
+        <Outlet />
+        <BillingGateModal status={access.status} />
+        <AuthModal />
+      </AuthModalProvider>
+    );
+  }
+
   return (
     <AuthModalProvider>
+      {showPastDue && <BillingPastDueBanner />}
       <Outlet />
       <AuthModal />
       <WelcomeModal />

--- a/packages/web/src/components/Sidebar/SidebarStatusBar.tsx
+++ b/packages/web/src/components/Sidebar/SidebarStatusBar.tsx
@@ -7,6 +7,7 @@ import {
 } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle.util";
 import { useGoogleSyncRefreshSnapshot } from "@web/auth/google/state/google.sync.refresh";
 import { TrialCountdownChip } from "@web/billing/TrialCountdownChip";
+import { useAppAccess } from "@web/billing/useAppAccess";
 import { SYNC_STATUS_VARIANT_CLASSNAME } from "@web/calendars/sync-status.types";
 import { useHasPendingEventMutations } from "@web/events/mutations/useEventPending";
 import { EdgeFocusIndicator } from "@web/grid/shortcuts/EdgeFocusIndicator";
@@ -48,6 +49,7 @@ import { useSseDegraded } from "@web/sse/hooks/useSseDegraded";
  */
 export const SidebarStatusBar: FC = () => {
   const { authenticated } = useContext(SessionContext);
+  const access = useAppAccess();
   useShortcutTipTrigger();
   const activeTipId = useShortcutTipsStore(selectActiveShortcutTipId);
   const isKeyboardOnly = useKeyboardOnlyStore(selectKeyboardOnlyActive);
@@ -101,7 +103,9 @@ export const SidebarStatusBar: FC = () => {
         <div className="flex h-full min-w-0 flex-1 items-center">
           <ShortcutTipIndicator />
         </div>
-      ) : !status && !authenticated ? (
+      ) : !status &&
+        (!authenticated ||
+          (access.kind === "server" && access.status === "trialing")) ? (
         <div className="flex h-full min-w-0 flex-1 items-center">
           <TrialCountdownChip />
         </div>

--- a/packages/web/src/events/mutations/useEventMutations.ts
+++ b/packages/web/src/events/mutations/useEventMutations.ts
@@ -22,12 +22,14 @@ import {
 } from "@core/types/event-command.contracts";
 import { shiftSeriesScheduleByOccurrenceEdit } from "@core/util/event/shift-series-schedule-by-occurrence-edit";
 import { decodeOccurrenceId } from "@core/util/occurrence-id";
+import { getApiErrorCode, isApiError } from "@web/api/util/api.util";
 import { isCalendarReconnectRequired } from "@web/auth/google/state/google.reconnect.calendar";
 import { track } from "@web/auth/posthog/track";
 import {
   selectGoogleSyncConnections,
   useUserMetadataStore,
 } from "@web/auth/state/user-metadata.store";
+import { billingQueryKeys } from "@web/billing/billing.query";
 import { calendarQueryKeys } from "@web/calendars/calendar.query";
 import {
   buildCalendarLookup,
@@ -455,6 +457,11 @@ export function useEventMutations(
       variables: Variables,
       context: EventMutationContext | undefined,
     ) => {
+      if (isApiError(error) && getApiErrorCode(error) === "BILLING_REQUIRED") {
+        void queryClient.invalidateQueries({
+          queryKey: billingQueryKeys.status,
+        });
+      }
       reportError(error);
       const opportunityId = (variables as { opportunityId?: number })
         .opportunityId;

--- a/self-host/README.md
+++ b/self-host/README.md
@@ -19,6 +19,10 @@ The compose stack binds the web and backend containers to `127.0.0.1`; the serve
 - Google setup or no-Google mode: [Google Calendar](../docs/self-hosting/google-calendar.md)
 - Config key reference: [Configuration](../docs/Config/README.md)
 
+Self-host does not use Stripe. Leave the `stripe:` block out of `compass.yaml`
+so the app stays fully writable with no paid gate. See
+[Billing And Trial](../docs/features/billing.md).
+
 ## Files in this folder
 
 - `install.sh` — the installer. Sets up `~/compass`, writes `~/compass/compass.yaml`, and copies the helper scripts.

--- a/self-host/compass.example.yaml
+++ b/self-host/compass.example.yaml
@@ -42,6 +42,12 @@ supertokens:
 #   webhookUrl: REPLACE_WITH_GOOGLE_WEBHOOK_URL # e.g. https://cal.yourdomain.com/api
 #   notificationToken: REPLACE_WITH_NOTIFICATION_TOKEN
 
+# stripe:
+#   secretKey: REPLACE_WITH_STRIPE_SECRET_KEY
+#   webhookSecret: REPLACE_WITH_STRIPE_WEBHOOK_SECRET
+#   priceId: REPLACE_WITH_STRIPE_PRICE_ID
+# Omit this block on self-host. Compass stays fully writable without Stripe.
+
 # Compass Sync service — self-host runs the same architecture as Compass
 # Cloud: this is required, not optional. It uses the SAME bundled mongo as
 # `mongo:` above, isolated to its own `compass_sync` database — no separate


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Hosted Compass no longer grants signed-up users full access forever. At signup the account lands in `awaiting_checkout`, Stripe Checkout collects a card with a **7-day trial** at **$8/month**, and trial expiry without payment is read-only.

The anonymous 7-day `localStorage` trial is unchanged. Self-host omits the `stripe:` config block, `/api/config` reports `billing.isConfigured: false`, and writes stay open.

## What changed

- Total billing status union with exhaustive writability.
- Stripe config (all-three-or-none), Checkout + Billing Portal, webhook with raw-body signature check, `_id` dedupe, retrieve-then-guarded write (`$lte` so same-second events apply).
- Web `useAppAccess` fail-open, `BillingGateModal`, past-due banner, checkout-success polling. Anonymous countdown still uses `useTrialStatus`.
- New accounts `$setOnInsert` `awaiting_checkout`; `bun run cli backfill-billing` for existing rows. Default `BACKFILL_CUTOFF` is far-future (not grandfathered).
- Event write guard `BILLING_REQUIRED` (403) in controllers, skipped when Stripe is unconfigured.
- No `POST /api/billing/trial/start`. First Checkout is the only way to start a paid trial; live/incomplete subscribers are sent to the Billing Portal.

## Simplicity

One plan file (`packages/core/src/constants/billing.constants.ts`) plus one yaml price id. No Stripe.js. `useAppAccess` reuses `useTrialStatus` for the visitor clock instead of duplicating it.

## Automated validation

- `bun run type-check` — pass
- `bun run test:backend:fast` / `test:backend:db` — pass
- `bun run test:web` — pass
- `bun run test:scripts:db` — pass
- `bun run lint` — pass (pre-existing warnings only)
- `bun run knip` — pass

## Independent review

First pass found a cardless `POST /api/billing/trial/start`, repeat `trial_period_days`, same-second webhook drops, a too-early backfill cutoff, and a second Checkout for live/incomplete subs. Those are fixed. Remaining residual: fail-open UI while status loads (writes still 403), Stripe-backed trials do not self-expire locally, calendar APIs other than event writes are ungated.

## Test plan

Staging still needs Stripe **test** keys on `staging-cloud` (`STRIPE_SECRET_KEY` restricted `rk_test_...`, `STRIPE_WEBHOOK_SECRET`, `STRIPE_PRICE_ID`) and `./compass restart`. Production keys are a separate, explicitly approved step. `staging-selfhosted` must not receive Stripe secrets.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-181f7d45-2f36-4ef0-ae31-e1c93fcdfaf6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-181f7d45-2f36-4ef0-ae31-e1c93fcdfaf6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

