### PR TITLE
fix(web): hide signed-out toast for first-time visitors

### DIFF
--- a/packages/web/src/api/util/api.util.test.ts
+++ b/packages/web/src/api/util/api.util.test.ts
@@ -4,6 +4,8 @@ import {
   GoogleConnectErrorResponseSchema,
 } from "@core/types/auth.types";
 import { session } from "@web/auth/compass/session/Session";
+import { markUserAsAuthenticated } from "@web/auth/compass/state/auth.state.util";
+import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
 import {
   type ApiError,
   type ApiRequestConfig,
@@ -328,10 +330,28 @@ describe("handleErrorResponse", () => {
     signOutSpy.mockRestore();
   });
 
+  it("does not treat a 401 as sign-out for a first-time visitor", async () => {
+    window.history.pushState({}, "", "/week");
+    window.localStorage.removeItem(STORAGE_KEYS.AUTH);
+    const signOutSpy = spyOn(session, "signOut").mockResolvedValue(undefined);
+    const error = createApiError(
+      { status: Status.UNAUTHORIZED },
+      { url: "/event" },
+    );
+
+    await expect(
+      handleErrorResponse(error, { onGoogleRevoked: undefined }),
+    ).rejects.toBe(error);
+
+    expect(signOutSpy).not.toHaveBeenCalled();
+    signOutSpy.mockRestore();
+  });
+
   it("still signs the user out on an unauthorized data-endpoint response", async () => {
     // Already on the calendar route, so signOut skips the (jsdom-unsupported)
     // navigation and we can assert purely on the sign-out call.
     window.history.pushState({}, "", "/week");
+    markUserAsAuthenticated("person@example.com");
     const signOutSpy = spyOn(session, "signOut").mockResolvedValue(undefined);
     const error = createApiError(
       { status: Status.UNAUTHORIZED },
@@ -351,6 +371,7 @@ describe("handleErrorResponse", () => {
     // every route that actually needed it the "you've been signed out" message
     // was destroyed before it could be read. Routing in-app keeps it alive.
     window.history.pushState({}, "", "/day/2026-07-31");
+    markUserAsAuthenticated("person@example.com");
     const navigate = mock((_options: { to: string }) => Promise.resolve());
     mock.module("@web/routers", () => ({ router: { navigate } }));
     const signOutSpy = spyOn(session, "signOut").mockResolvedValue(undefined);

--- a/packages/web/src/api/util/api.util.ts
+++ b/packages/web/src/api/util/api.util.ts
@@ -5,6 +5,7 @@ import {
   GoogleConnectErrorResponseSchema,
 } from "@core/types/auth.types";
 import { session } from "@web/auth/compass/session/Session";
+import { hasUserEverAuthenticated } from "@web/auth/compass/state/auth.state.util";
 import { ENV_WEB } from "@web/common/constants/env.constants";
 import { DEFAULT_CALENDAR_ROUTE } from "@web/common/constants/routes";
 import {
@@ -205,17 +206,26 @@ export const handleErrorResponse = async (
     throw error;
   }
 
-  const isAuthEndpoint = requestUrl?.includes("/signinup");
+  const isAuthEndpoint =
+    requestUrl?.includes("/signinup") ||
+    requestUrl?.includes("/session/refresh") ||
+    requestUrl?.includes("/signout");
 
   // A 404 on a data endpoint means a resource is missing (e.g. syncing a
   // just-created event onto a calendar the server hasn't provisioned yet),
   // not that the session is invalid - so it must never force a sign-out.
-  // Only genuine session-level failures (GONE/UNAUTHORIZED) do.
+  // Only genuine session-level failures (GONE/UNAUTHORIZED) do, and only
+  // for browsers that have actually signed in before. A first-time visitor
+  // can still receive 401s (SuperTokens refresh on the first API call,
+  // a protected route hit without a session) — that is "not signed in",
+  // not "you have been signed out".
   if (
     !isAuthEndpoint &&
     (status === Status.GONE || status === Status.UNAUTHORIZED)
   ) {
-    await signOut(status);
+    if (hasUserEverAuthenticated()) {
+      await signOut(status);
+    }
   } else if (!isAuthEndpoint) {
     console.error(error);
   }

--- a/packages/web/src/auth/compass/session/SessionProvider.tsx
+++ b/packages/web/src/auth/compass/session/SessionProvider.tsx
@@ -23,7 +23,7 @@ import { SessionContext } from "./session.context";
 SuperTokens.init({
   appInfo: {
     appName: APP_NAME,
-    apiDomain: ENV_WEB.API_BASEURL,
+    apiDomain: ENV_WEB.BACKEND_BASEURL,
     apiBasePath: ROOT_ROUTES.API,
   },
   recipeList: [
@@ -31,9 +31,9 @@ SuperTokens.init({
     EmailPassword.init(),
     EmailVerification.init(),
     Session.init({
-      postAPIHook: async (context) => {
-        session.emit(context);
-      },
+      // Session lifecycle only. postAPIHook shares action names
+      // (REFRESH_SESSION) with onHandleEvent but is an HTTP-hook payload,
+      // not a successful session refresh.
       onHandleEvent: (event) => {
         session.emit(event);
       },

--- a/packages/web/src/auth/compass/user/hooks/useLoadProfile.test.ts
+++ b/packages/web/src/auth/compass/user/hooks/useLoadProfile.test.ts
@@ -1,6 +1,8 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
+import { Status } from "@core/errors/status.codes";
 import { type UserProfile } from "@core/types/user.types";
 import { type UseLoadProfileResult } from "@web/auth/compass/user/hooks/useLoadProfile";
+import * as errorToast from "@web/common/utils/toast/error-toast.util";
 import {
   afterAll,
   afterEach,
@@ -14,6 +16,7 @@ import {
 
 const getLastKnownEmail = mock(() => "person@example.com");
 const markUserAsAuthenticated = mock();
+const hasUserEverAuthenticated = mock(() => true);
 const getProfile = mock();
 
 const mockProfile: UserProfile = {
@@ -30,6 +33,7 @@ const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 0));
 
 mock.module("@web/auth/compass/state/auth.state.util", () => ({
   getLastKnownEmail,
+  hasUserEverAuthenticated,
   markUserAsAuthenticated,
 }));
 
@@ -78,6 +82,7 @@ describe("useLoadProfile", () => {
   beforeEach(() => {
     getLastKnownEmail.mockClear().mockReturnValue("person@example.com");
     markUserAsAuthenticated.mockClear();
+    hasUserEverAuthenticated.mockClear().mockReturnValue(true);
     getProfile.mockClear();
     consoleErrorSpy = spyOn(console, "error").mockImplementation(() => {});
   });
@@ -142,5 +147,45 @@ describe("useLoadProfile", () => {
     expect(result.current.email).toBeNull();
     expect(result.current.profile).toBeNull();
     expect(markUserAsAuthenticated).not.toHaveBeenCalled();
+  });
+
+  it("does not show a signed-out toast when a first-time visitor's profile request is unauthorized", async () => {
+    hasUserEverAuthenticated.mockReturnValue(false);
+    const error = Object.assign(new Error("Request failed with status 401"), {
+      response: { status: Status.UNAUTHORIZED },
+    });
+    getProfile.mockRejectedValue(error);
+    const showSessionExpiredToast = spyOn(
+      errorToast,
+      "showSessionExpiredToast",
+    ).mockReturnValue("toast-id");
+    const { useLoadProfile } = await importHook();
+
+    renderHook(() => useLoadProfile(true));
+
+    await waitFor(() => {
+      expect(getProfile).toHaveBeenCalledTimes(1);
+    });
+    expect(showSessionExpiredToast).not.toHaveBeenCalled();
+    showSessionExpiredToast.mockRestore();
+  });
+
+  it("shows a signed-out toast when a returning visitor's profile request is unauthorized", async () => {
+    const error = Object.assign(new Error("Request failed with status 401"), {
+      response: { status: Status.UNAUTHORIZED },
+    });
+    getProfile.mockRejectedValue(error);
+    const showSessionExpiredToast = spyOn(
+      errorToast,
+      "showSessionExpiredToast",
+    ).mockReturnValue("toast-id");
+    const { useLoadProfile } = await importHook();
+
+    renderHook(() => useLoadProfile(true));
+
+    await waitFor(() => {
+      expect(showSessionExpiredToast).toHaveBeenCalledTimes(1);
+    });
+    showSessionExpiredToast.mockRestore();
   });
 });

--- a/packages/web/src/auth/compass/user/hooks/useLoadProfile.test.ts
+++ b/packages/web/src/auth/compass/user/hooks/useLoadProfile.test.ts
@@ -16,7 +16,7 @@ import {
 
 const getLastKnownEmail = mock(() => "person@example.com");
 const markUserAsAuthenticated = mock();
-const hasUserEverAuthenticated = mock(() => true);
+const hasUserEverAuthenticated = mock(() => false);
 const getProfile = mock();
 
 const mockProfile: UserProfile = {
@@ -82,13 +82,14 @@ describe("useLoadProfile", () => {
   beforeEach(() => {
     getLastKnownEmail.mockClear().mockReturnValue("person@example.com");
     markUserAsAuthenticated.mockClear();
-    hasUserEverAuthenticated.mockClear().mockReturnValue(true);
+    hasUserEverAuthenticated.mockClear().mockReturnValue(false);
     getProfile.mockClear();
     consoleErrorSpy = spyOn(console, "error").mockImplementation(() => {});
   });
 
   afterEach(() => {
     consoleErrorSpy.mockRestore();
+    hasUserEverAuthenticated.mockReturnValue(false);
   });
 
   it("does not log backend-unavailable profile failures in frontend-only mode", async () => {
@@ -171,6 +172,7 @@ describe("useLoadProfile", () => {
   });
 
   it("shows a signed-out toast when a returning visitor's profile request is unauthorized", async () => {
+    hasUserEverAuthenticated.mockReturnValue(true);
     const error = Object.assign(new Error("Request failed with status 401"), {
       response: { status: Status.UNAUTHORIZED },
     });

--- a/packages/web/src/auth/compass/user/hooks/useLoadProfile.ts
+++ b/packages/web/src/auth/compass/user/hooks/useLoadProfile.ts
@@ -5,6 +5,7 @@ import { UserApi } from "@web/api/user.api";
 import { isBackendUnavailableError } from "@web/api/util/backend-unavailable-error.util";
 import {
   getLastKnownEmail,
+  hasUserEverAuthenticated,
   markUserAsAuthenticated,
 } from "@web/auth/compass/state/auth.state.util";
 import { showSessionExpiredToast } from "@web/common/utils/toast/error-toast.util";
@@ -55,7 +56,9 @@ export function useLoadProfile(
           status === Status.UNAUTHORIZED || status === Status.FORBIDDEN;
 
         if (isUnauthorized) {
-          showSessionExpiredToast();
+          if (hasUserEverAuthenticated()) {
+            showSessionExpiredToast();
+          }
           return;
         }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

First-time visitors (incognito / new users) were immediately seeing **You've been signed out. Please sign in again.** on staging, next to the Welcome modal.

The API error interceptor treated every `401`/`410` as session expiry. A brand-new browser can still get those statuses (SuperTokens session refresh on the first API call, or a protected route with no session). That is “not signed in,” not “you were signed out.”

The toast now only appears when this browser has authenticated before (`hasUserEverAuthenticated`). SuperTokens session wiring listens only to lifecycle `onHandleEvent`s, not `postAPIHook` payloads that reuse the `REFRESH_SESSION` name.

## Simplicity

Gate stays as two one-line checks at the interceptor and profile catch. No new helpers or modules. SuperTokens `apiDomain` now uses the origin (`BACKEND_BASEURL`), matching the backend.

## Automated validation

- Unit: first-time visitor `401` does not call `session.signOut` or show the toast; returning visitor still does.
- Profile load: first-time `401` stays quiet; returning visitor still toasts.
- `bun run test:web` — pass
- `bun run lint` — pass (existing repo warnings only)
- GitHub CI: lint, type-check, knip, unit (core/web/backend/sync/scripts), e2e, CodeQL — pass

## Independent review

Fresh read-only review of the full `origin/main` diff: no confirmed findings. Logout still clears local auth state; interceptor `signOut` keeps the flag so a returning expired session still gets the toast.

## Test plan

- `bun packages/scripts/src/testing/test-parallel.ts web -- packages/web/src/api/util/api.util.test.ts packages/web/src/auth/compass/user/hooks/useLoadProfile.test.ts`
- `bun packages/scripts/src/testing/test-parallel.ts web -- packages/web/src/auth/compass/session/SessionProvider.test.tsx`
- `bun run test:web`
- `bun run lint`
- GitHub Actions Test + CodeQL on the PR

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0605f31a-5390-41ec-8d59-b75c37a341a9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0605f31a-5390-41ec-8d59-b75c37a341a9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

