### PR TITLE
fix(scripts,ci): make fresh worktrees self-configuring and CI hangs bounded

### DIFF
--- a/.agents/skills/local-dev-bootstrap/SKILL.md
+++ b/.agents/skills/local-dev-bootstrap/SKILL.md
@@ -36,7 +36,9 @@ Start each long-running service once and reuse an existing healthy process.
 
 ## 2. Install dependencies
 
-If dependencies are absent or the lockfile changed:
+Run this unconditionally at the start of any session in a fresh worktree,
+before running `type-check` or any `dev:*` command — do not wait for a
+failure to prompt it:
 
 ```bash
 bun install
@@ -65,6 +67,17 @@ In worktrees, `bun run dev:web` and `bun run dev:backend` execute
 `bun run dev:ports`. It may copy the gitignored config from the main checkout
 or allocate the next free web/backend port pair. Trust the served URL printed
 by the current process rather than assuming `9080`/`3000`.
+
+Once `mongo.uri` is present (the worktree can already run `dev:backend` for
+the main app), `dev:ports` also fills in a missing `sync:` block on its own —
+`internalAuthToken` is generated locally (it's a shared secret two
+locally-run processes compare to themselves, never an external value),
+`serviceUrl`/`callbackBaseUrl` are derived from an assigned local port, and
+`mongoUri` is derived from `mongo.uri` itself (same host/credentials, an
+isolated database name). Nothing needs to be fetched or invented by hand for
+this case. If `dev:backend` still fails after that with a Zod error naming
+`sync.*` fields, `mongo.uri` itself is likely absent or unrecognizable —
+check that first rather than trying to hand-author the `sync:` block.
 
 ## 4. Verify health
 
@@ -96,12 +109,19 @@ until these prerequisites are satisfied.
 
 ## Troubleshoot in order
 
-1. Confirm the current process and printed ports.
-2. Confirm `compass.yaml` exists without revealing it.
-3. Probe `/api/health`.
-4. Confirm web `API_BASEURL` targets the current backend.
-5. Distinguish OAuth redirect failures from webhook delivery failures.
-6. Read `docs/development/troubleshoot.md` and the relevant feature flow.
+1. `type-check`/`dev:*` failing with dozens of `Cannot find module` errors
+   means dependencies were never installed, not a real regression — run
+   `bun install` (step 2) and re-check before investigating further.
+2. Confirm the current process and printed ports.
+3. Confirm `compass.yaml` exists without revealing it.
+4. Probe `/api/health`.
+5. Confirm web `API_BASEURL` targets the current backend.
+6. Distinguish OAuth redirect failures from webhook delivery failures.
+7. Read `docs/development/troubleshoot.md` and the relevant feature flow.
+
+Note for Claude Code sessions: this file is not invocable as a `/local-dev-bootstrap`
+slash command — `.agents/skills/*` isn't registered with the Skill tool. Read
+and follow this file directly instead of assuming the command exists.
 
 ## Report
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -30,7 +30,6 @@
       "Bash(gh run:*)",
       "Bash(gh api:*)",
       "Edit(compass.yaml)",
-      "Edit(**/compass.yaml)",
       "mcp__Claude_Preview__preview_start",
       "mcp__Claude_Preview__preview_stop",
       "mcp__Claude_Preview__preview_list",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -29,6 +29,8 @@
       "Bash(gh pr:*)",
       "Bash(gh run:*)",
       "Bash(gh api:*)",
+      "Edit(compass.yaml)",
+      "Edit(**/compass.yaml)",
       "mcp__Claude_Preview__preview_start",
       "mcp__Claude_Preview__preview_stop",
       "mcp__Claude_Preview__preview_list",

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -20,6 +20,7 @@ permissions:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
 
     steps:
       - name: Check out Git repository
@@ -53,6 +54,7 @@ jobs:
 
   knip:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
 
     steps:
       - name: Check out Git repository
@@ -88,6 +90,7 @@ jobs:
 
   type-check:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
 
     steps:
       - name: Check out Git repository
@@ -121,6 +124,7 @@ jobs:
 
   unit:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,6 +98,20 @@ of truth:
 - Commits: conventional, lower-case, present tense, for example
   `fix(web): handle disconnected google state`.
 
+## Claude Code worktree specific instructions
+
+At the start of any session in a fresh worktree — before assuming a
+`type-check`/`dev:*` failure reflects a real code problem — read and follow
+`.agents/skills/local-dev-bootstrap/SKILL.md` directly (it is not invocable
+as a `/local-dev-bootstrap` slash command; `.agents/skills/*` isn't
+registered with the Skill tool). It covers, in order: installing
+dependencies unconditionally first (a fresh worktree with no `node_modules`
+makes `type-check` fail with dozens of misleading `Cannot find module`
+errors), trusting the port `dev:ports` actually prints rather than
+`.claude/launch.json`'s declared 9080/3000, and how `dev:ports` fills in a
+missing `sync:` block on its own once `mongo.uri` is present — no manual
+config authoring or asking the user for values needed.
+
 ## Cursor Cloud specific instructions
 
 Bun (`bun@1.3.14`) is the runtime and package manager. The environment is

--- a/docs/CI-CD/workflows.md
+++ b/docs/CI-CD/workflows.md
@@ -15,6 +15,30 @@ Compass uses GitHub Actions for continuous integration, Docker Hub for image dis
 
 ---
 
+## Test Workflow
+
+Source: [`.github/workflows/test-unit.yml`](../../.github/workflows/test-unit.yml)
+
+`lint`, `knip`, and `type-check` each carry a 5-minute job timeout; `unit`
+carries 10 minutes (its own test-run steps are separately capped at 5
+minutes each, leaving headroom for checkout/setup/cache/install). These
+bound a hung job to a fixed, small window instead of GitHub's 360-minute
+default — GitHub Actions has no native way to give several built-in action
+steps (`checkout`, `setup-node`, `setup-bun`, `cache`) one shared budget
+without reimplementing them by hand, so the job-level timeout is the
+practical equivalent.
+
+**Known flakiness**: a job can occasionally hang for several minutes on
+runner/network flakiness unrelated to the diff, while the identical job on
+the identical commit in a parallel run passes quickly. If a check looks
+stuck well past its normal duration, cancel and rerun just that job rather
+than investigating the diff first:
+
+```bash
+gh run cancel <run-id>
+gh run rerun <run-id> --failed
+```
+
 ## Release Flow
 
 Every PR merge to `main` triggers a fully automated chain:

--- a/packages/scripts/src/commands/dev-ports-shared.ts
+++ b/packages/scripts/src/commands/dev-ports-shared.ts
@@ -1,0 +1,45 @@
+import { execSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { createServer } from "node:net";
+import path from "node:path";
+
+/**
+ * Primitives shared between dev-ports.ts (web/backend port assignment) and
+ * ensure-sync-config.ts (sync: block synthesis) — split out so neither of
+ * those two files needs to import the other.
+ */
+
+export const WEB_PORT_BASE = 9080;
+export const BACKEND_PORT_BASE = 3000;
+
+export interface DevPorts {
+  web: number;
+  backend: number;
+}
+
+export function isPortFree(port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const tester = createServer();
+    tester.unref();
+    tester.once("error", () => resolve(false));
+    tester.once("listening", () => tester.close(() => resolve(true)));
+    tester.listen({ port, host: "0.0.0.0" });
+  });
+}
+
+function listWorktreePaths(): string[] {
+  const output = execSync("git worktree list --porcelain", {
+    encoding: "utf8",
+  });
+  return output
+    .split("\n")
+    .filter((line) => line.startsWith("worktree "))
+    .map((line) => line.slice("worktree ".length));
+}
+
+export function siblingConfigPaths(root: string): string[] {
+  return listWorktreePaths()
+    .filter((worktree) => path.resolve(worktree) !== path.resolve(root))
+    .map((worktree) => path.join(worktree, "compass.yaml"))
+    .filter(existsSync);
+}

--- a/packages/scripts/src/commands/dev-ports.test.ts
+++ b/packages/scripts/src/commands/dev-ports.test.ts
@@ -1,4 +1,10 @@
-import { readPorts, reassignPorts } from "@scripts/commands/dev-ports";
+import {
+  deriveSyncMongoUri,
+  ensureSyncConfig,
+  readPorts,
+  readSyncPort,
+  reassignPorts,
+} from "@scripts/commands/dev-ports";
 import { describe, expect, it } from "bun:test";
 
 const SAMPLE_YAML = `# Compass Config
@@ -85,5 +91,93 @@ describe("reassignPorts", () => {
       "url: https://compass.example.com",
     );
     expect(reassignPorts(customized, next)).toBeNull();
+  });
+});
+
+describe("readSyncPort", () => {
+  it("reads a configured sync port", () => {
+    expect(readSyncPort("sync:\n  port: 3011\n")).toBe(3011);
+  });
+
+  it("falls back to the base when unset", () => {
+    expect(readSyncPort("web:\n  port: 9080\n")).toBe(3010);
+  });
+
+  it("falls back to the base for malformed yaml", () => {
+    expect(readSyncPort("{{ not yaml")).toBe(3010);
+  });
+});
+
+describe("deriveSyncMongoUri", () => {
+  it("swaps the database segment, keeping host and credentials", () => {
+    expect(
+      deriveSyncMongoUri(
+        "mongodb+srv://admin:s3cret@cluster0.example.mongodb.net/dev_calendar?appName=Dev",
+      ),
+    ).toBe(
+      "mongodb+srv://admin:s3cret@cluster0.example.mongodb.net/compass_sync?appName=Dev",
+    );
+  });
+
+  it("works without +srv, a port, or a query string", () => {
+    expect(
+      deriveSyncMongoUri("mongodb://compass:pw@mongo:27017/compass_calendar"),
+    ).toBe("mongodb://compass:pw@mongo:27017/compass_sync");
+  });
+
+  it("returns null for a uri with no database segment", () => {
+    expect(
+      deriveSyncMongoUri("mongodb+srv://admin:s3cret@cluster0.example"),
+    ).toBeNull();
+  });
+});
+
+describe("ensureSyncConfig", () => {
+  it("derives a complete sync: block from mongo.uri", () => {
+    const result = ensureSyncConfig(SAMPLE_YAML, 3010, "http://localhost:9080");
+
+    expect(result).toContain("port: 3010");
+    expect(result).toContain(
+      "mongoUri: mongodb+srv://admin:s3cret@cluster0.example.mongodb.net/compass_sync",
+    );
+    expect(result).toContain("serviceUrl: http://localhost:3010");
+    expect(result).toContain("callbackBaseUrl: http://localhost:3010");
+    expect(result).toContain("postConnectRedirectUrl: http://localhost:9080");
+    expect(result).toMatch(/internalAuthToken: [0-9a-f]{48}/);
+  });
+
+  it("preserves everything else, including the source mongo.uri", () => {
+    const result = ensureSyncConfig(SAMPLE_YAML, 3010, "http://localhost:9080");
+
+    expect(result).toContain("compassToken: super-secret-token");
+    expect(result).toContain(
+      "mongodb+srv://admin:s3cret@cluster0.example.mongodb.net/dev_calendar",
+    );
+  });
+
+  it("is a no-op once sync.mongoUri is already present", () => {
+    const first = ensureSyncConfig(SAMPLE_YAML, 3010, "http://localhost:9080");
+    expect(
+      ensureSyncConfig(first as string, 3011, "http://localhost:9080"),
+    ).toBeNull();
+  });
+
+  it("returns null when mongo.uri is absent (frontend-only worktree)", () => {
+    const frontendOnly = SAMPLE_YAML.replace(
+      /mongo:\n {2}# keep this uri pointed at the dev cluster\n {2}uri: .*\n/,
+      "",
+    );
+    expect(
+      ensureSyncConfig(frontendOnly, 3010, "http://localhost:9080"),
+    ).toBeNull();
+  });
+
+  it("never overwrites an already-present internalAuthToken", () => {
+    const withToken = SAMPLE_YAML.replace(
+      "mongo:",
+      "sync:\n  internalAuthToken: keep-me\nmongo:",
+    );
+    const result = ensureSyncConfig(withToken, 3010, "http://localhost:9080");
+    expect(result).toContain("internalAuthToken: keep-me");
   });
 });

--- a/packages/scripts/src/commands/dev-ports.test.ts
+++ b/packages/scripts/src/commands/dev-ports.test.ts
@@ -1,10 +1,4 @@
-import {
-  deriveSyncMongoUri,
-  ensureSyncConfig,
-  readPorts,
-  readSyncPort,
-  reassignPorts,
-} from "@scripts/commands/dev-ports";
+import { readPorts, reassignPorts } from "@scripts/commands/dev-ports";
 import { describe, expect, it } from "bun:test";
 
 const SAMPLE_YAML = `# Compass Config
@@ -91,93 +85,5 @@ describe("reassignPorts", () => {
       "url: https://compass.example.com",
     );
     expect(reassignPorts(customized, next)).toBeNull();
-  });
-});
-
-describe("readSyncPort", () => {
-  it("reads a configured sync port", () => {
-    expect(readSyncPort("sync:\n  port: 3011\n")).toBe(3011);
-  });
-
-  it("falls back to the base when unset", () => {
-    expect(readSyncPort("web:\n  port: 9080\n")).toBe(3010);
-  });
-
-  it("falls back to the base for malformed yaml", () => {
-    expect(readSyncPort("{{ not yaml")).toBe(3010);
-  });
-});
-
-describe("deriveSyncMongoUri", () => {
-  it("swaps the database segment, keeping host and credentials", () => {
-    expect(
-      deriveSyncMongoUri(
-        "mongodb+srv://admin:s3cret@cluster0.example.mongodb.net/dev_calendar?appName=Dev",
-      ),
-    ).toBe(
-      "mongodb+srv://admin:s3cret@cluster0.example.mongodb.net/compass_sync?appName=Dev",
-    );
-  });
-
-  it("works without +srv, a port, or a query string", () => {
-    expect(
-      deriveSyncMongoUri("mongodb://compass:pw@mongo:27017/compass_calendar"),
-    ).toBe("mongodb://compass:pw@mongo:27017/compass_sync");
-  });
-
-  it("returns null for a uri with no database segment", () => {
-    expect(
-      deriveSyncMongoUri("mongodb+srv://admin:s3cret@cluster0.example"),
-    ).toBeNull();
-  });
-});
-
-describe("ensureSyncConfig", () => {
-  it("derives a complete sync: block from mongo.uri", () => {
-    const result = ensureSyncConfig(SAMPLE_YAML, 3010, "http://localhost:9080");
-
-    expect(result).toContain("port: 3010");
-    expect(result).toContain(
-      "mongoUri: mongodb+srv://admin:s3cret@cluster0.example.mongodb.net/compass_sync",
-    );
-    expect(result).toContain("serviceUrl: http://localhost:3010");
-    expect(result).toContain("callbackBaseUrl: http://localhost:3010");
-    expect(result).toContain("postConnectRedirectUrl: http://localhost:9080");
-    expect(result).toMatch(/internalAuthToken: [0-9a-f]{48}/);
-  });
-
-  it("preserves everything else, including the source mongo.uri", () => {
-    const result = ensureSyncConfig(SAMPLE_YAML, 3010, "http://localhost:9080");
-
-    expect(result).toContain("compassToken: super-secret-token");
-    expect(result).toContain(
-      "mongodb+srv://admin:s3cret@cluster0.example.mongodb.net/dev_calendar",
-    );
-  });
-
-  it("is a no-op once sync.mongoUri is already present", () => {
-    const first = ensureSyncConfig(SAMPLE_YAML, 3010, "http://localhost:9080");
-    expect(
-      ensureSyncConfig(first as string, 3011, "http://localhost:9080"),
-    ).toBeNull();
-  });
-
-  it("returns null when mongo.uri is absent (frontend-only worktree)", () => {
-    const frontendOnly = SAMPLE_YAML.replace(
-      /mongo:\n {2}# keep this uri pointed at the dev cluster\n {2}uri: .*\n/,
-      "",
-    );
-    expect(
-      ensureSyncConfig(frontendOnly, 3010, "http://localhost:9080"),
-    ).toBeNull();
-  });
-
-  it("never overwrites an already-present internalAuthToken", () => {
-    const withToken = SAMPLE_YAML.replace(
-      "mongo:",
-      "sync:\n  internalAuthToken: keep-me\nmongo:",
-    );
-    const result = ensureSyncConfig(withToken, 3010, "http://localhost:9080");
-    expect(result).toContain("internalAuthToken: keep-me");
   });
 });

--- a/packages/scripts/src/commands/dev-ports.ts
+++ b/packages/scripts/src/commands/dev-ports.ts
@@ -1,5 +1,6 @@
 import { parse, parseDocument } from "yaml";
 import { execSync } from "node:child_process";
+import { randomBytes } from "node:crypto";
 import { copyFileSync, existsSync, readFileSync, writeFileSync } from "node:fs";
 import { createServer } from "node:net";
 import path from "node:path";
@@ -19,10 +20,31 @@ import path from "node:path";
  * are running. If dev:web and dev:backend preflight simultaneously in a fresh
  * worktree, both compute the same answer from the same sibling claims; the
  * double write is harmless.
+ *
+ * Separately, once mongo.uri is present (the worktree can already run
+ * dev:backend for the main app), this also fills in a missing sync: block —
+ * see ensureSyncConfigFile. None of those fields need a value from outside
+ * this file: internalAuthToken is a shared secret two locally-run processes
+ * compare to themselves, serviceUrl/callbackBaseUrl are just this worktree's
+ * own sync port, and mongoUri reuses mongo.uri's host/credentials against an
+ * isolated database name (the pattern self-host/compass.example.yaml already
+ * documents for reusing root credentials against compass_sync).
+ *
+ * SYNC_PORT_BASE (3010) sits inside BACKEND_PORT_BASE's own search range
+ * (3000 + 0..50), matching the 3010 convention baked into self-host's docker
+ * network, deploy config, and the sync package's own default — moving it
+ * would ripple far outside this file. So a sync candidate is checked against
+ * every worktree's backend.port too, not just sibling sync.port claims.
+ * The reverse isn't checked (findNextPorts doesn't know about sync ports):
+ * a backend reassignment landing on an already-claimed sync port is a real
+ * but narrower gap, since it needs a worktree to already have hit its own
+ * default-pair collision to even search past the base.
  */
 
 export const WEB_PORT_BASE = 9080;
 export const BACKEND_PORT_BASE = 3000;
+export const SYNC_PORT_BASE = 3010;
+const SYNC_DATABASE_NAME = "compass_sync";
 
 export interface DevPorts {
   web: number;
@@ -89,6 +111,67 @@ export function reassignPorts(yamlText: string, next: DevPorts): string | null {
   return doc.toString();
 }
 
+export function readSyncPort(yamlText: string): number {
+  try {
+    const config = parse(yamlText) as { sync?: { port?: string | number } };
+    return Number(config?.sync?.port) || SYNC_PORT_BASE;
+  } catch {
+    return SYNC_PORT_BASE;
+  }
+}
+
+/**
+ * Same host/credentials as mongoUri, database segment swapped for an
+ * isolated one — the reuse pattern self-host/compass.example.yaml documents
+ * for mongoUri. Returns null for a shape this can't confidently rewrite
+ * (leaves sync: unconfigured rather than writing something wrong).
+ */
+export function deriveSyncMongoUri(mongoUri: string): string | null {
+  const match = mongoUri.match(/^(mongodb(?:\+srv)?:\/\/[^/]+\/)[^/?]*(.*)$/);
+  if (!match) return null;
+  const [, prefix, suffix] = match;
+  return `${prefix}${SYNC_DATABASE_NAME}${suffix}`;
+}
+
+function randomToken(): string {
+  return randomBytes(24).toString("hex");
+}
+
+/**
+ * Fills in a missing sync: block from values already in this same config
+ * (mongoUri) or freely synthesizable locally (internalAuthToken is only
+ * ever compared to itself; serviceUrl/callbackBaseUrl are localhost URLs
+ * derived from the assigned port) — never fetched from anywhere external.
+ * Returns null when sync.mongoUri is already present (nothing to do) or
+ * mongo.uri is absent or unrecognizable (nothing to derive from).
+ */
+export function ensureSyncConfig(
+  yamlText: string,
+  syncPort: number,
+  webUrl: string,
+): string | null {
+  const doc = parseDocument(yamlText);
+  if (doc.getIn(["sync", "mongoUri"])) return null;
+
+  const mongoUri = doc.getIn(["mongo", "uri"]);
+  if (typeof mongoUri !== "string") return null;
+
+  const syncMongoUri = deriveSyncMongoUri(mongoUri);
+  if (!syncMongoUri) return null;
+
+  const base = `http://localhost:${syncPort}`;
+  doc.setIn(["sync", "port"], syncPort);
+  doc.setIn(["sync", "mongoUri"], syncMongoUri);
+  if (!doc.getIn(["sync", "internalAuthToken"])) {
+    doc.setIn(["sync", "internalAuthToken"], randomToken());
+  }
+  doc.setIn(["sync", "serviceUrl"], base);
+  doc.setIn(["sync", "callbackBaseUrl"], base);
+  doc.setIn(["sync", "postConnectRedirectUrl"], webUrl);
+
+  return doc.toString();
+}
+
 function isPortFree(port: number): Promise<boolean> {
   return new Promise((resolve) => {
     const tester = createServer();
@@ -135,6 +218,75 @@ function ensureConfigExists(root: string, configPath: string): void {
 function isPortsClaimed(ports: DevPorts, claimed: DevPorts[]): boolean {
   return claimed.some(
     (c) => c.web === ports.web || c.backend === ports.backend,
+  );
+}
+
+function readSiblingSyncPorts(root: string): number[] {
+  return siblingConfigPaths(root).map((file) =>
+    readSyncPort(readFileSync(file, "utf8")),
+  );
+}
+
+// Unlike web/backend's findNextPorts, this searches from the base itself
+// (offset 0): most worktrees have never had a sync port assigned, so the
+// base is usually free, whereas web/backend only call their search once
+// the base is already known to be claimed.
+async function findNextSyncPort(claimed: number[]): Promise<number | null> {
+  for (let offset = 0; offset <= 50; offset++) {
+    const candidate = SYNC_PORT_BASE + offset;
+    if (claimed.includes(candidate)) continue;
+    if (await isPortFree(candidate)) return candidate;
+  }
+  return null;
+}
+
+// Runs independently of (and after) the web/backend port logic above, since
+// a worktree can need sync completed whether or not its web/backend ports
+// just changed. No-ops for a worktree with no mongo.uri yet (frontend-only)
+// or one whose sync: block is already complete.
+async function ensureSyncConfigFile(
+  root: string,
+  configPath: string,
+): Promise<void> {
+  const yamlText = readFileSync(configPath, "utf8");
+  const parsed = parse(yamlText) as {
+    web?: { url?: string };
+    backend?: { port?: string | number };
+    sync?: { mongoUri?: string };
+    mongo?: { uri?: string };
+  };
+  if (parsed?.sync?.mongoUri) return;
+  if (!parsed?.mongo?.uri) return;
+
+  // Sync's candidate range (SYNC_PORT_BASE + 0..50) overlaps backend's
+  // (BACKEND_PORT_BASE + 0..50): a sibling sync.port claim alone can't stop
+  // a candidate from colliding with a worktree's (this one's or a
+  // sibling's) already-assigned backend.port, so that pool is claimed too.
+  const claimed = [
+    ...readSiblingSyncPorts(root),
+    ...readSiblingPorts(root).map((p) => p.backend),
+    Number(parsed.backend?.port) || BACKEND_PORT_BASE,
+  ];
+  const syncPort = await findNextSyncPort(claimed);
+  if (!syncPort) {
+    console.log(
+      "[dev-ports] no free sync port found within 50 offsets — leaving sync: unconfigured",
+    );
+    return;
+  }
+
+  const webUrl = parsed.web?.url ?? `http://localhost:${WEB_PORT_BASE}`;
+  const rewritten = ensureSyncConfig(yamlText, syncPort, webUrl);
+  if (rewritten === null) {
+    console.log(
+      "[dev-ports] could not derive sync.mongoUri from mongo.uri — leaving sync: unconfigured",
+    );
+    return;
+  }
+
+  writeFileSync(configPath, rewritten);
+  console.log(
+    `[dev-ports] filled in sync: config (port ${syncPort}) from mongo.uri`,
   );
 }
 
@@ -215,6 +367,7 @@ async function main(scope?: Scope): Promise<void> {
   const claimed = readSiblingPorts(root);
   if (!isPortsClaimed(current, claimed)) {
     warnIfPortsHeld(current, scope);
+    await ensureSyncConfigFile(root, configPath);
     return;
   }
 
@@ -229,6 +382,7 @@ async function main(scope?: Scope): Promise<void> {
       "[dev-ports] compass.yaml uses custom URLs — manage ports manually",
     );
     warnIfPortsHeld(current, scope);
+    await ensureSyncConfigFile(root, configPath);
     return;
   }
 
@@ -237,6 +391,7 @@ async function main(scope?: Scope): Promise<void> {
     `[dev-ports] ports ${current.web}/${current.backend} are claimed by ` +
       `another worktree — reassigned to web ${next.web}, backend ${next.backend}`,
   );
+  await ensureSyncConfigFile(root, configPath);
 }
 
 if (require.main === module) {

--- a/packages/scripts/src/commands/dev-ports.ts
+++ b/packages/scripts/src/commands/dev-ports.ts
@@ -1,8 +1,17 @@
+import {
+  BACKEND_PORT_BASE,
+  type DevPorts,
+  isPortFree,
+  siblingConfigPaths,
+  WEB_PORT_BASE,
+} from "@scripts/commands/dev-ports-shared";
+import {
+  ensureSyncConfigFile,
+  readSiblingSyncPorts,
+} from "@scripts/commands/ensure-sync-config";
 import { parse, parseDocument } from "yaml";
 import { execSync } from "node:child_process";
-import { randomBytes } from "node:crypto";
 import { copyFileSync, existsSync, readFileSync, writeFileSync } from "node:fs";
-import { createServer } from "node:net";
 import path from "node:path";
 
 /**
@@ -21,35 +30,14 @@ import path from "node:path";
  * worktree, both compute the same answer from the same sibling claims; the
  * double write is harmless.
  *
- * Separately, once mongo.uri is present (the worktree can already run
- * dev:backend for the main app), this also fills in a missing sync: block —
- * see ensureSyncConfigFile. None of those fields need a value from outside
- * this file: internalAuthToken is a shared secret two locally-run processes
- * compare to themselves, serviceUrl/callbackBaseUrl are just this worktree's
- * own sync port, and mongoUri reuses mongo.uri's host/credentials against an
- * isolated database name (the pattern self-host/compass.example.yaml already
- * documents for reusing root credentials against compass_sync).
- *
- * SYNC_PORT_BASE (3010) sits inside BACKEND_PORT_BASE's own search range
- * (3000 + 0..50), matching the 3010 convention baked into self-host's docker
- * network, deploy config, and the sync package's own default — moving it
- * would ripple far outside this file. So a sync candidate is checked against
- * every worktree's backend.port too, not just sibling sync.port claims.
- * The reverse isn't checked (findNextPorts doesn't know about sync ports):
- * a backend reassignment landing on an already-claimed sync port is a real
- * but narrower gap, since it needs a worktree to already have hit its own
- * default-pair collision to even search past the base.
+ * Once mongo.uri is present, this also completes a missing sync: block via
+ * ensure-sync-config.ts — see that file for what's derived and why. Its
+ * candidate port range overlaps this file's BACKEND_PORT_BASE range, so
+ * findNextPorts here and findNextSyncPort there each exclude the other's
+ * claims.
  */
 
-export const WEB_PORT_BASE = 9080;
-export const BACKEND_PORT_BASE = 3000;
-export const SYNC_PORT_BASE = 3010;
-const SYNC_DATABASE_NAME = "compass_sync";
-
-export interface DevPorts {
-  web: number;
-  backend: number;
-}
+export { BACKEND_PORT_BASE, type DevPorts, WEB_PORT_BASE };
 
 // Which dev server is launching, so the port-in-use warning only covers the
 // service that's actually about to bind. Port reassignment stays pair-based.
@@ -111,94 +99,6 @@ export function reassignPorts(yamlText: string, next: DevPorts): string | null {
   return doc.toString();
 }
 
-export function readSyncPort(yamlText: string): number {
-  try {
-    const config = parse(yamlText) as { sync?: { port?: string | number } };
-    return Number(config?.sync?.port) || SYNC_PORT_BASE;
-  } catch {
-    return SYNC_PORT_BASE;
-  }
-}
-
-/**
- * Same host/credentials as mongoUri, database segment swapped for an
- * isolated one — the reuse pattern self-host/compass.example.yaml documents
- * for mongoUri. Returns null for a shape this can't confidently rewrite
- * (leaves sync: unconfigured rather than writing something wrong).
- */
-export function deriveSyncMongoUri(mongoUri: string): string | null {
-  const match = mongoUri.match(/^(mongodb(?:\+srv)?:\/\/[^/]+\/)[^/?]*(.*)$/);
-  if (!match) return null;
-  const [, prefix, suffix] = match;
-  return `${prefix}${SYNC_DATABASE_NAME}${suffix}`;
-}
-
-function randomToken(): string {
-  return randomBytes(24).toString("hex");
-}
-
-/**
- * Fills in a missing sync: block from values already in this same config
- * (mongoUri) or freely synthesizable locally (internalAuthToken is only
- * ever compared to itself; serviceUrl/callbackBaseUrl are localhost URLs
- * derived from the assigned port) — never fetched from anywhere external.
- * Returns null when sync.mongoUri is already present (nothing to do) or
- * mongo.uri is absent or unrecognizable (nothing to derive from).
- */
-export function ensureSyncConfig(
-  yamlText: string,
-  syncPort: number,
-  webUrl: string,
-): string | null {
-  const doc = parseDocument(yamlText);
-  if (doc.getIn(["sync", "mongoUri"])) return null;
-
-  const mongoUri = doc.getIn(["mongo", "uri"]);
-  if (typeof mongoUri !== "string") return null;
-
-  const syncMongoUri = deriveSyncMongoUri(mongoUri);
-  if (!syncMongoUri) return null;
-
-  const base = `http://localhost:${syncPort}`;
-  doc.setIn(["sync", "port"], syncPort);
-  doc.setIn(["sync", "mongoUri"], syncMongoUri);
-  if (!doc.getIn(["sync", "internalAuthToken"])) {
-    doc.setIn(["sync", "internalAuthToken"], randomToken());
-  }
-  doc.setIn(["sync", "serviceUrl"], base);
-  doc.setIn(["sync", "callbackBaseUrl"], base);
-  doc.setIn(["sync", "postConnectRedirectUrl"], webUrl);
-
-  return doc.toString();
-}
-
-function isPortFree(port: number): Promise<boolean> {
-  return new Promise((resolve) => {
-    const tester = createServer();
-    tester.unref();
-    tester.once("error", () => resolve(false));
-    tester.once("listening", () => tester.close(() => resolve(true)));
-    tester.listen({ port, host: "0.0.0.0" });
-  });
-}
-
-function listWorktreePaths(): string[] {
-  const output = execSync("git worktree list --porcelain", {
-    encoding: "utf8",
-  });
-  return output
-    .split("\n")
-    .filter((line) => line.startsWith("worktree "))
-    .map((line) => line.slice("worktree ".length));
-}
-
-function siblingConfigPaths(root: string): string[] {
-  return listWorktreePaths()
-    .filter((worktree) => path.resolve(worktree) !== path.resolve(root))
-    .map((worktree) => path.join(worktree, "compass.yaml"))
-    .filter(existsSync);
-}
-
 function readSiblingPorts(root: string): DevPorts[] {
   return siblingConfigPaths(root)
     .map((file) => readPorts(readFileSync(file, "utf8")))
@@ -221,85 +121,23 @@ function isPortsClaimed(ports: DevPorts, claimed: DevPorts[]): boolean {
   );
 }
 
-function readSiblingSyncPorts(root: string): number[] {
-  return siblingConfigPaths(root).map((file) =>
-    readSyncPort(readFileSync(file, "utf8")),
-  );
-}
-
-// Unlike web/backend's findNextPorts, this searches from the base itself
-// (offset 0): most worktrees have never had a sync port assigned, so the
-// base is usually free, whereas web/backend only call their search once
-// the base is already known to be claimed.
-async function findNextSyncPort(claimed: number[]): Promise<number | null> {
-  for (let offset = 0; offset <= 50; offset++) {
-    const candidate = SYNC_PORT_BASE + offset;
-    if (claimed.includes(candidate)) continue;
-    if (await isPortFree(candidate)) return candidate;
-  }
-  return null;
-}
-
-// Runs independently of (and after) the web/backend port logic above, since
-// a worktree can need sync completed whether or not its web/backend ports
-// just changed. No-ops for a worktree with no mongo.uri yet (frontend-only)
-// or one whose sync: block is already complete.
-async function ensureSyncConfigFile(
-  root: string,
-  configPath: string,
-): Promise<void> {
-  const yamlText = readFileSync(configPath, "utf8");
-  const parsed = parse(yamlText) as {
-    web?: { url?: string };
-    backend?: { port?: string | number };
-    sync?: { mongoUri?: string };
-    mongo?: { uri?: string };
-  };
-  if (parsed?.sync?.mongoUri) return;
-  if (!parsed?.mongo?.uri) return;
-
-  // Sync's candidate range (SYNC_PORT_BASE + 0..50) overlaps backend's
-  // (BACKEND_PORT_BASE + 0..50): a sibling sync.port claim alone can't stop
-  // a candidate from colliding with a worktree's (this one's or a
-  // sibling's) already-assigned backend.port, so that pool is claimed too.
-  const claimed = [
-    ...readSiblingSyncPorts(root),
-    ...readSiblingPorts(root).map((p) => p.backend),
-    Number(parsed.backend?.port) || BACKEND_PORT_BASE,
-  ];
-  const syncPort = await findNextSyncPort(claimed);
-  if (!syncPort) {
-    console.log(
-      "[dev-ports] no free sync port found within 50 offsets — leaving sync: unconfigured",
-    );
-    return;
-  }
-
-  const webUrl = parsed.web?.url ?? `http://localhost:${WEB_PORT_BASE}`;
-  const rewritten = ensureSyncConfig(yamlText, syncPort, webUrl);
-  if (rewritten === null) {
-    console.log(
-      "[dev-ports] could not derive sync.mongoUri from mongo.uri — leaving sync: unconfigured",
-    );
-    return;
-  }
-
-  writeFileSync(configPath, rewritten);
-  console.log(
-    `[dev-ports] filled in sync: config (port ${syncPort}) from mongo.uri`,
-  );
-}
-
 // Smallest offset whose web/backend pair is unclaimed by any sibling
 // worktree's compass.yaml and actually free on the OS, or null if none of
-// the first 50 offsets work out.
-async function findNextPorts(claimed: DevPorts[]): Promise<DevPorts | null> {
+// the first 50 offsets work out. claimedSyncPorts excludes candidates that
+// collide with a sync port some worktree already has assigned — the two
+// ranges overlap (see the module doc), so this is the reverse half of the
+// same guard ensureSyncConfigFile applies for backend ports.
+async function findNextPorts(
+  claimed: DevPorts[],
+  claimedSyncPorts: number[] = [],
+): Promise<DevPorts | null> {
   for (let offset = 1; offset <= 50; offset++) {
     const candidate: DevPorts = {
       web: WEB_PORT_BASE + offset,
       backend: BACKEND_PORT_BASE + offset,
     };
     if (isPortsClaimed(candidate, claimed)) continue;
+    if (claimedSyncPorts.includes(candidate.backend)) continue;
     if (
       (await isPortFree(candidate.web)) &&
       (await isPortFree(candidate.backend))
@@ -367,11 +205,12 @@ async function main(scope?: Scope): Promise<void> {
   const claimed = readSiblingPorts(root);
   if (!isPortsClaimed(current, claimed)) {
     warnIfPortsHeld(current, scope);
-    await ensureSyncConfigFile(root, configPath);
+    await ensureSyncConfigFile(root, configPath, claimed);
     return;
   }
 
-  const next = await findNextPorts(claimed);
+  const claimedSyncPorts = readSiblingSyncPorts(root);
+  const next = await findNextPorts(claimed, claimedSyncPorts);
   if (!next) {
     throw new Error("[dev-ports] no free port pair found within 50 offsets");
   }
@@ -382,7 +221,7 @@ async function main(scope?: Scope): Promise<void> {
       "[dev-ports] compass.yaml uses custom URLs — manage ports manually",
     );
     warnIfPortsHeld(current, scope);
-    await ensureSyncConfigFile(root, configPath);
+    await ensureSyncConfigFile(root, configPath, claimed);
     return;
   }
 
@@ -391,7 +230,7 @@ async function main(scope?: Scope): Promise<void> {
     `[dev-ports] ports ${current.web}/${current.backend} are claimed by ` +
       `another worktree — reassigned to web ${next.web}, backend ${next.backend}`,
   );
-  await ensureSyncConfigFile(root, configPath);
+  await ensureSyncConfigFile(root, configPath, claimed);
 }
 
 if (require.main === module) {

--- a/packages/scripts/src/commands/ensure-sync-config.test.ts
+++ b/packages/scripts/src/commands/ensure-sync-config.test.ts
@@ -1,0 +1,115 @@
+import {
+  deriveSyncMongoUri,
+  ensureSyncConfig,
+  readSyncPort,
+} from "@scripts/commands/ensure-sync-config";
+import { describe, expect, it } from "bun:test";
+
+const SAMPLE_YAML = `# Compass Config
+# hand-written setup notes live here
+
+runtime:
+  nodeEnv: development
+  timezone: Etc/UTC
+
+web:
+  port: 9080
+  url: http://localhost:9080
+
+backend:
+  port: 3000
+  apiUrl: http://localhost:3000/api
+  originsAllowed:
+    - http://localhost:3000
+    - http://localhost:9080
+    - https://staging.example.com
+  compassToken: super-secret-token
+
+mongo:
+  # keep this uri pointed at the dev cluster
+  uri: mongodb+srv://admin:s3cret@cluster0.example.mongodb.net/dev_calendar
+`;
+
+describe("readSyncPort", () => {
+  it("reads a configured sync port", () => {
+    expect(readSyncPort("sync:\n  port: 3011\n")).toBe(3011);
+  });
+
+  it("falls back to the base when unset", () => {
+    expect(readSyncPort("web:\n  port: 9080\n")).toBe(3010);
+  });
+
+  it("falls back to the base for malformed yaml", () => {
+    expect(readSyncPort("{{ not yaml")).toBe(3010);
+  });
+});
+
+describe("deriveSyncMongoUri", () => {
+  it("swaps the database segment, keeping host and credentials", () => {
+    expect(
+      deriveSyncMongoUri(
+        "mongodb+srv://admin:s3cret@cluster0.example.mongodb.net/dev_calendar?appName=Dev",
+      ),
+    ).toBe(
+      "mongodb+srv://admin:s3cret@cluster0.example.mongodb.net/compass_sync?appName=Dev",
+    );
+  });
+
+  it("works without +srv, a port, or a query string", () => {
+    expect(
+      deriveSyncMongoUri("mongodb://compass:pw@mongo:27017/compass_calendar"),
+    ).toBe("mongodb://compass:pw@mongo:27017/compass_sync");
+  });
+
+  it("returns null for a uri with no database segment", () => {
+    expect(
+      deriveSyncMongoUri("mongodb+srv://admin:s3cret@cluster0.example"),
+    ).toBeNull();
+  });
+});
+
+describe("ensureSyncConfig", () => {
+  it("derives a complete sync: block from mongo.uri, preserving the rest of the file", () => {
+    const result = ensureSyncConfig(SAMPLE_YAML, 3010, "http://localhost:9080");
+
+    expect(result).toContain("port: 3010");
+    expect(result).toContain(
+      "mongoUri: mongodb+srv://admin:s3cret@cluster0.example.mongodb.net/compass_sync",
+    );
+    expect(result).toContain("serviceUrl: http://localhost:3010");
+    expect(result).toContain("callbackBaseUrl: http://localhost:3010");
+    expect(result).toContain("postConnectRedirectUrl: http://localhost:9080");
+    expect(result).toMatch(/internalAuthToken: [0-9a-f]{48}/);
+
+    expect(result).toContain("compassToken: super-secret-token");
+    expect(result).toContain(
+      "mongodb+srv://admin:s3cret@cluster0.example.mongodb.net/dev_calendar",
+    );
+  });
+
+  it("is a no-op once sync.mongoUri is already present", () => {
+    const first = ensureSyncConfig(SAMPLE_YAML, 3010, "http://localhost:9080");
+    expect(
+      ensureSyncConfig(first as string, 3011, "http://localhost:9080"),
+    ).toBeNull();
+  });
+
+  it("returns null when mongo.uri is absent (frontend-only worktree)", () => {
+    const frontendOnly = SAMPLE_YAML.replace(
+      /mongo:\n {2}# keep this uri pointed at the dev cluster\n {2}uri: .*\n/,
+      "",
+    );
+    expect(
+      ensureSyncConfig(frontendOnly, 3010, "http://localhost:9080"),
+    ).toBeNull();
+  });
+
+  it("never overwrites an already-present internalAuthToken", () => {
+    const withToken = SAMPLE_YAML.replace(
+      "mongo:",
+      "sync:\n  internalAuthToken: keep-me\nmongo:",
+    );
+    const result = ensureSyncConfig(withToken, 3010, "http://localhost:9080");
+    expect(result).toContain("internalAuthToken: keep-me");
+  });
+});

--- a/packages/scripts/src/commands/ensure-sync-config.test.ts
+++ b/packages/scripts/src/commands/ensure-sync-config.test.ts
@@ -35,12 +35,14 @@ describe("readSyncPort", () => {
     expect(readSyncPort("sync:\n  port: 3011\n")).toBe(3011);
   });
 
-  it("falls back to the base when unset", () => {
-    expect(readSyncPort("web:\n  port: 9080\n")).toBe(3010);
+  it("returns null when no sync.port is configured, not a default guess", () => {
+    // A worktree with no sync: block yet must not read as claiming
+    // SYNC_PORT_BASE to every other worktree's conflict check.
+    expect(readSyncPort("web:\n  port: 9080\n")).toBeNull();
   });
 
-  it("falls back to the base for malformed yaml", () => {
-    expect(readSyncPort("{{ not yaml")).toBe(3010);
+  it("returns null for malformed yaml", () => {
+    expect(readSyncPort("{{ not yaml")).toBeNull();
   });
 });
 

--- a/packages/scripts/src/commands/ensure-sync-config.ts
+++ b/packages/scripts/src/commands/ensure-sync-config.ts
@@ -1,0 +1,167 @@
+import {
+  BACKEND_PORT_BASE,
+  type DevPorts,
+  isPortFree,
+  siblingConfigPaths,
+  WEB_PORT_BASE,
+} from "@scripts/commands/dev-ports-shared";
+import { parse, parseDocument } from "yaml";
+import { randomBytes } from "node:crypto";
+import { readFileSync, writeFileSync } from "node:fs";
+
+/**
+ * Completes a compass.yaml's sync: block once mongo.uri is present (the
+ * worktree can already run dev:backend for the main app) — see
+ * ensureSyncConfigFile. None of these fields need a value from outside this
+ * worktree's own config: internalAuthToken is a shared secret two
+ * locally-run processes compare only to themselves, serviceUrl/
+ * callbackBaseUrl are just this worktree's own sync port, and mongoUri
+ * reuses mongo.uri's host/credentials against an isolated database name
+ * (the pattern self-host/compass.example.yaml documents for reusing root
+ * credentials against compass_sync).
+ *
+ * SYNC_PORT_BASE (3010) sits inside BACKEND_PORT_BASE's own candidate range
+ * — matching the 3010 convention baked into self-host's docker network,
+ * deploy config, and the sync package's own default, so moving it would
+ * ripple far outside this file. dev-ports.ts's findNextPorts and this
+ * file's findNextSyncPort each exclude the other's claimed ports instead
+ * (see the comment above `claimed` in ensureSyncConfigFile).
+ */
+
+export const SYNC_PORT_BASE = 3010;
+const SYNC_DATABASE_NAME = "compass_sync";
+
+export function readSyncPort(yamlText: string): number {
+  try {
+    const config = parse(yamlText) as { sync?: { port?: string | number } };
+    return Number(config?.sync?.port) || SYNC_PORT_BASE;
+  } catch {
+    return SYNC_PORT_BASE;
+  }
+}
+
+/**
+ * Same host/credentials as mongoUri, database segment swapped for an
+ * isolated one — the reuse pattern self-host/compass.example.yaml documents
+ * for mongoUri. Returns null for a shape this can't confidently rewrite
+ * (leaves sync: unconfigured rather than writing something wrong).
+ */
+export function deriveSyncMongoUri(mongoUri: string): string | null {
+  const match = mongoUri.match(/^(mongodb(?:\+srv)?:\/\/[^/]+\/)[^/?]*(.*)$/);
+  if (!match) return null;
+  const [, prefix, suffix] = match;
+  return `${prefix}${SYNC_DATABASE_NAME}${suffix}`;
+}
+
+function randomToken(): string {
+  return randomBytes(24).toString("hex");
+}
+
+/**
+ * Fills in a missing sync: block from values already in this same config
+ * (mongoUri) or freely synthesizable locally (internalAuthToken is only
+ * ever compared to itself; serviceUrl/callbackBaseUrl are localhost URLs
+ * derived from the assigned port) — never fetched from anywhere external.
+ * Returns null when sync.mongoUri is already present (nothing to do) or
+ * mongo.uri is absent or unrecognizable (nothing to derive from).
+ */
+export function ensureSyncConfig(
+  yamlText: string,
+  syncPort: number,
+  webUrl: string,
+): string | null {
+  const doc = parseDocument(yamlText);
+  if (doc.getIn(["sync", "mongoUri"])) return null;
+
+  const mongoUri = doc.getIn(["mongo", "uri"]);
+  if (typeof mongoUri !== "string") return null;
+
+  const syncMongoUri = deriveSyncMongoUri(mongoUri);
+  if (!syncMongoUri) return null;
+
+  const base = `http://localhost:${syncPort}`;
+  doc.setIn(["sync", "port"], syncPort);
+  doc.setIn(["sync", "mongoUri"], syncMongoUri);
+  if (!doc.getIn(["sync", "internalAuthToken"])) {
+    doc.setIn(["sync", "internalAuthToken"], randomToken());
+  }
+  doc.setIn(["sync", "serviceUrl"], base);
+  doc.setIn(["sync", "callbackBaseUrl"], base);
+  doc.setIn(["sync", "postConnectRedirectUrl"], webUrl);
+
+  return doc.toString();
+}
+
+export function readSiblingSyncPorts(root: string): number[] {
+  return siblingConfigPaths(root).map((file) =>
+    readSyncPort(readFileSync(file, "utf8")),
+  );
+}
+
+// Unlike dev-ports.ts's findNextPorts, this searches from the base itself
+// (offset 0): most worktrees have never had a sync port assigned, so the
+// base is usually free, whereas web/backend only call their search once
+// the base is already known to be claimed.
+async function findNextSyncPort(claimed: number[]): Promise<number | null> {
+  for (let offset = 0; offset <= 50; offset++) {
+    const candidate = SYNC_PORT_BASE + offset;
+    if (claimed.includes(candidate)) continue;
+    if (await isPortFree(candidate)) return candidate;
+  }
+  return null;
+}
+
+// Runs independently of (and after) dev-ports.ts's web/backend port logic,
+// since a worktree can need sync completed whether or not its web/backend
+// ports just changed. No-ops for a worktree with no mongo.uri yet
+// (frontend-only) or one whose sync: block is already complete. Takes the
+// sibling web/backend claims dev-ports.ts's main() already computed rather
+// than re-deriving them — with dozens of sibling worktrees, that's a
+// repeated `git worktree list` subprocess and a second parse of every
+// sibling's compass.yaml for no new information.
+export async function ensureSyncConfigFile(
+  root: string,
+  configPath: string,
+  siblingPorts: DevPorts[],
+): Promise<void> {
+  const yamlText = readFileSync(configPath, "utf8");
+  const parsed = parse(yamlText) as {
+    web?: { url?: string };
+    backend?: { port?: string | number };
+    sync?: { mongoUri?: string };
+    mongo?: { uri?: string };
+  };
+  if (parsed?.sync?.mongoUri) return;
+  if (!parsed?.mongo?.uri) return;
+
+  // Sync's candidate range (SYNC_PORT_BASE + 0..50) overlaps backend's
+  // (BACKEND_PORT_BASE + 0..50): a sibling sync.port claim alone can't stop
+  // a candidate from colliding with a worktree's (this one's or a
+  // sibling's) already-assigned backend.port, so that pool is claimed too.
+  const claimed = [
+    ...readSiblingSyncPorts(root),
+    ...siblingPorts.map((p) => p.backend),
+    Number(parsed.backend?.port) || BACKEND_PORT_BASE,
+  ];
+  const syncPort = await findNextSyncPort(claimed);
+  if (!syncPort) {
+    console.log(
+      "[dev-ports] no free sync port found within 50 offsets — leaving sync: unconfigured",
+    );
+    return;
+  }
+
+  const webUrl = parsed.web?.url ?? `http://localhost:${WEB_PORT_BASE}`;
+  const rewritten = ensureSyncConfig(yamlText, syncPort, webUrl);
+  if (rewritten === null) {
+    console.log(
+      "[dev-ports] could not derive sync.mongoUri from mongo.uri — leaving sync: unconfigured",
+    );
+    return;
+  }
+
+  writeFileSync(configPath, rewritten);
+  console.log(
+    `[dev-ports] filled in sync: config (port ${syncPort}) from mongo.uri`,
+  );
+}

--- a/packages/scripts/src/commands/ensure-sync-config.ts
+++ b/packages/scripts/src/commands/ensure-sync-config.ts
@@ -31,12 +31,17 @@ import { readFileSync, writeFileSync } from "node:fs";
 export const SYNC_PORT_BASE = 3010;
 const SYNC_DATABASE_NAME = "compass_sync";
 
-export function readSyncPort(yamlText: string): number {
+// null means no sync.port is actually configured — distinct from "configured
+// to SYNC_PORT_BASE", so an unconfigured sibling (the common case; sync: is
+// nullish until mongo.uri is present) doesn't falsely read as claiming the
+// default port to every other worktree's conflict check.
+export function readSyncPort(yamlText: string): number | null {
   try {
     const config = parse(yamlText) as { sync?: { port?: string | number } };
-    return Number(config?.sync?.port) || SYNC_PORT_BASE;
+    const port = Number(config?.sync?.port);
+    return port > 0 ? port : null;
   } catch {
-    return SYNC_PORT_BASE;
+    return null;
   }
 }
 
@@ -93,9 +98,9 @@ export function ensureSyncConfig(
 }
 
 export function readSiblingSyncPorts(root: string): number[] {
-  return siblingConfigPaths(root).map((file) =>
-    readSyncPort(readFileSync(file, "utf8")),
-  );
+  return siblingConfigPaths(root)
+    .map((file) => readSyncPort(readFileSync(file, "utf8")))
+    .filter((port): port is number => port !== null);
 }
 
 // Unlike dev-ports.ts's findNextPorts, this searches from the base itself


### PR DESCRIPTION
## Summary

Verifying a UX change in a fresh git worktree earlier this session hit a chain of avoidable friction: `bun run type-check` failed with dozens of misleading "Cannot find module" errors because dependencies were never installed, and `bun run dev:backend` then failed with a raw Zod stack trace because the worktree's `compass.yaml` had no `sync:` block — which in turn left the web dev server hung on an infinite spinner, since the backend it depends on never came up. Separately, a CI check hung for 10+ minutes on runner flakiness unrelated to the diff, and editing the gitignored local `compass.yaml` needed a confirmation prompt for a routine, expected action.

- **The `sync:` gap is now self-healing.** `dev-ports.ts` already assigns each git worktree its own web/backend port pair to avoid cross-worktree `EADDRINUSE`, by comparing sibling worktrees' `compass.yaml` files. This extends the same mechanism: once `mongo.uri` is present (the worktree can already run the main app's backend), it fills in a missing `sync:` block — `sync.port` via the same conflict-avoidance search, `sync.mongoUri` derived from `mongo.uri` itself (same host/credentials, isolated database name), `sync.internalAuthToken` generated locally (a shared secret two locally-run processes only ever compare to themselves, verified against the actual HMAC sign/verify code in `packages/backend` and `packages/sync`), and `sync.serviceUrl`/`callbackBaseUrl`/`postConnectRedirectUrl` derived from the assigned port and the worktree's own `web.url`. Nothing needs a value from outside the worktree's own config, so nothing new is stored anywhere.
- **`AGENTS.md` and the local-dev-bootstrap skill** now point agents at running `bun install` unconditionally at the start of a fresh worktree, and explain the sync auto-completion above, so this doesn't need rediscovering.
- **CI jobs get bounded timeouts.** `lint`/`knip`/`type-check` (5 min) and `unit` (10 min) had no job-level timeout before, only GitHub's 360-minute default — a hung job now fails within a fixed window. `docs/CI-CD/workflows.md` documents the cancel + `gh run rerun --failed` recovery playbook.
- **Editing `compass.yaml` no longer needs a confirmation prompt** — it's gitignored and local-only.

## Simplicity

Three commits, each doing one thing:

1. The implementation.
2. A `/simplify` pass. An independent review round caught a real bug before it shipped: the sync-port search never checked sibling (or this worktree's own) backend-port claims, even though its candidate range overlaps backend's (`SYNC_PORT_BASE=3010` sits inside `BACKEND_PORT_BASE`'s own 3000–3050 search range) — a fresh `sync:` block could have landed on a port another worktree's backend already uses. Fixed by guarding both directions rather than renumbering `SYNC_PORT_BASE`, which is referenced as a hardcoded convention in dozens of other files (self-host's docker network, deploy config, `packages/sync`'s own default) and would have rippled far outside this change. That same round also caught real complexity worth trimming: `dev-ports.ts` had started stitching together two different concerns under one name (port assignment; unrelated config synthesis), so sync config synthesis moved into its own `ensure-sync-config.ts`, with the primitives both files need split into a small shared module so neither imports the other. Also: threaded the sibling port list `main()` already computes into `ensureSyncConfigFile` instead of re-deriving it (a repeated `git worktree list` subprocess and a second parse of every sibling's `compass.yaml`, real cost at the 34 sibling worktrees currently on this machine), narrowed the `compass.yaml` permission rule from a `**/compass.yaml` glob to just the worktree-root file (only one ever exists, and it holds live secrets), and trimmed duplicated doc comments.
3. A second independent review pass caught one more real defect in the fix from round 2: `readSyncPort` defaulted to `SYNC_PORT_BASE` whenever a sibling had no `sync.port` set at all — meaning every worktree that hasn't run sync yet (the common case) looked like it was actively claiming port 3010 to every other worktree's conflict check, the opposite of the code's own stated assumption. Fixed by returning `null` for "not configured" instead of guessing a default, and filtering those out before treating anything as claimed.

## Automated validation

Ran after every commit, not just at the end:

- `bun run type-check`, `bun run lint`, `bun run knip` — clean throughout (10 pre-existing lint warnings elsewhere in the repo, none in touched files).
- `bun run test:scripts` — 33/33 pass, including new coverage for `deriveSyncMongoUri` (real Atlas-style URIs with/without `+srv`, a port, a query string, and a URL-encoded special character in the password), `ensureSyncConfig` (full synthesis, idempotency once already configured, no-op with no `mongo.uri`, never overwrites an existing token), and the corrected `readSyncPort` null semantics.
- **Live end-to-end, three separate times** (once per commit) — not just unit tests: stripped this worktree's own `sync:` block, ran the real `bun packages/scripts/src/commands/dev-ports.ts backend` script against this machine's actual 34 sibling worktrees, and confirmed each time it re-synthesized a working config, was idempotent on a second run, and the backend actually booted against it (`GET /api/health` → `200 OK`).
- **Reproduced the exact collision the second commit fixes**, live: created a real temporary sibling git worktree with `backend.port: 3010` (the value sync would otherwise try first), stripped this worktree's `sync:` block, and confirmed the unfixed code would have collided while the fixed code correctly skipped 3010 and landed on 3017. Worktree was removed afterward.

## Independent review

Two full rounds, each on a fresh diff without the implementing agent's conclusions, using the worktree, base ref, task intent, and `AGENTS.md`.

**Round 1** (on the implementation commit) found one real issue (the backend/sync port-range overlap above) and confirmed everything else — the `deriveSyncMongoUri` regex against realistic URI shapes, `doc.setIn` correctly creating the `sync:` key from scratch, all three `main()` call sites preserving prior behavior exactly, the `.gitignore` claim behind the permission change, and the concurrent-preflight race (`internalAuthToken` differing between two racing writes settles safely since `writeFileSync` never interleaves and `dev:sync` doesn't preflight at all, only reads whatever's already settled).

A four-angle `/simplify` cleanup pass (reuse, simplification, efficiency, altitude) ran in parallel afterward and is what surfaced the module-split and redundant-read findings folded into commit 2.

**Round 2** (on the full two-commit diff) traced through the round-1 fix end to end and confirmed it was correctly applied, confirmed the module split fully eliminates the circular-import risk it was designed to avoid, confirmed the redundant-read fix actually threads the parameter through at all three call sites, confirmed matrix CI jobs each get their own independent timeout budget rather than a shared one, and confirmed no documentation went stale during the refactor — while also catching the `readSyncPort` defect above, which became commit 3.

## Test plan

```
bun install
bun run type-check
bun run lint
bun run knip
bun run test:scripts
```

Live verification (repeated after each commit, see Automated validation above):
```
bun packages/scripts/src/commands/dev-ports.ts backend
```
