### PR TITLE
fix(sync): remint access token in-process on events.list 401

### DIFF
--- a/packages/sync/src/domain/calendar-import.service.ts
+++ b/packages/sync/src/domain/calendar-import.service.ts
@@ -1,5 +1,6 @@
 import { toColorLabelMap } from "@sync/domain/color-label-map";
 import { syncHorizon } from "@sync/domain/horizon";
+import { listEventPageWithAuthRetry } from "@sync/domain/list-event-page-with-auth-retry";
 import { ProviderPageApplier } from "@sync/domain/provider-page-applier";
 import { type AccessTokenSource } from "@sync/domain/provider-write-ladder";
 import {
@@ -105,19 +106,18 @@ export async function importCalendarEvents(
     calendar.connectionId,
   );
 
-  const run = new ImportRun(deps, calendar, resource, now);
+  const run = new ImportRun(deps, calendar, resource, now, accessToken);
 
   // The windowed fast pass only runs on a fresh start — a resume mid-full-pass
   // already imported the window, and redoing it would only repeat work.
   if (resource.pageCursor === null) {
-    await run.readPass({ accessToken, window: horizonWindow(now()) });
+    await run.readPass({ window: horizonWindow(now()) });
     if (options?.onWindowedPassComplete) {
       await options.onWindowedPassComplete();
     }
   }
 
   const syncCursor = await run.readPass({
-    accessToken,
     checkpointed: true,
     resumeFrom: resource.pageCursor,
   });
@@ -163,12 +163,16 @@ class ImportRun {
   #readerSkipped = 0;
   #orphans = 0;
 
+  #accessToken: string;
+
   constructor(
     private readonly deps: CalendarImportDeps,
     private readonly calendar: ProviderCalendarRecord,
     private readonly resource: SyncResourceRecord,
     now: () => Date,
+    accessToken: string,
   ) {
+    this.#accessToken = accessToken;
     // Import writes the active (live) generation — the one reads serve. Only a
     // repair stages a separate importGeneration; the first import runs with
     // active and import both at 0, so it populates the generation reads serve.
@@ -191,7 +195,6 @@ class ImportRun {
   // Drive the reader through one pass. Returns the provider's sync cursor when
   // the pass produced one (only an unwindowed pass can).
   async readPass(options: {
-    accessToken: string;
     window?: EventWindow;
     checkpointed?: boolean;
     resumeFrom?: string | null;
@@ -200,13 +203,19 @@ class ImportRun {
     let syncCursor: string | null = null;
 
     do {
-      const page = await this.deps.reader.listEventPage({
-        accessToken: options.accessToken,
-        calendarId: this.calendar.providerCalendarId,
-        window: options.window ?? null,
-        pageToken,
-        colorLabels: toColorLabelMap(this.calendar.eventLabels),
-      });
+      const read = await listEventPageWithAuthRetry(
+        this.deps,
+        this.calendar.connectionId,
+        {
+          accessToken: this.#accessToken,
+          calendarId: this.calendar.providerCalendarId,
+          window: options.window ?? null,
+          pageToken,
+          colorLabels: toColorLabelMap(this.calendar.eventLabels),
+        },
+      );
+      this.#accessToken = read.accessToken;
+      const page = read.page;
       if (options.checkpointed) this.#readerSkipped += page.skipped;
       // A first import has no local events to delete, so standalone
       // cancellations the applier returns are discarded.

--- a/packages/sync/src/domain/calendar-pull.service.db.test.ts
+++ b/packages/sync/src/domain/calendar-pull.service.db.test.ts
@@ -35,7 +35,11 @@ class FakeReader implements ProviderEventReader {
   #pages: ProviderEventPage[];
   #error?: unknown;
 
-  constructor(pages: ProviderEventPage[], error?: unknown) {
+  constructor(
+    pages: ProviderEventPage[],
+    error?: unknown,
+    private readonly errorOnce = false,
+  ) {
     this.#pages = [...pages];
     this.#error = error;
   }
@@ -44,7 +48,11 @@ class FakeReader implements ProviderEventReader {
     input: ProviderEventReadInput,
   ): Promise<ProviderEventPage> {
     this.calls.push(input);
-    if (this.#error) throw this.#error;
+    if (this.#error) {
+      const error = this.#error;
+      if (this.errorOnce) this.#error = undefined;
+      throw error;
+    }
     const page = this.#pages.shift();
     if (!page) throw new Error("FakeReader: no page scripted");
     return page;
@@ -445,6 +453,44 @@ describe("pullCalendarChanges", () => {
     if (result.status !== "applied") throw new Error("expected applied");
     expect(result.deleted).toBe(0);
     expect(result.resource.syncCursor).toBe("cursor-1");
+  });
+
+  it("retries the page with a reminted token after a one-off 401", async () => {
+    const calendar = await seedCalendar();
+    await seedImported(calendar);
+    const reader = new FakeReader(
+      [page([single("a")], { nextSyncToken: "cursor-1" })],
+      new ProviderEventReadError("authExpired", "401"),
+      true,
+    );
+    const invalidated: string[] = [];
+    const tokens: string[] = [];
+    const custody = {
+      getValidAccessToken: async () => {
+        const token = tokens.length === 0 ? "stale-token" : "fresh-token";
+        tokens.push(token);
+        return token;
+      },
+      discardRevoked: async () => {},
+      invalidateAccessToken: async (connectionId: string) => {
+        invalidated.push(connectionId);
+      },
+    };
+
+    const result = await pullCalendarChanges(
+      { ...deps(reader), custody },
+      calendar,
+      now,
+    );
+
+    if (result.status !== "applied") throw new Error("expected applied");
+    expect(result.changed).toBe(1);
+    expect(result.resource.syncCursor).toBe("cursor-1");
+    expect(invalidated).toEqual([calendar.connectionId]);
+    expect(reader.calls.map((call) => call.accessToken)).toEqual([
+      "stale-token",
+      "fresh-token",
+    ]);
   });
 
   it("hands off to repair on an expired cursor without touching it", async () => {

--- a/packages/sync/src/domain/calendar-pull.service.ts
+++ b/packages/sync/src/domain/calendar-pull.service.ts
@@ -89,7 +89,7 @@ export async function pullCalendarChanges(
     return { status: "notImported", resource };
   }
 
-  const accessToken = await deps.custody.getValidAccessToken(
+  let accessToken = await deps.custody.getValidAccessToken(
     calendar.connectionId,
   );
 

--- a/packages/sync/src/domain/calendar-pull.service.ts
+++ b/packages/sync/src/domain/calendar-pull.service.ts
@@ -1,4 +1,5 @@
 import { toColorLabelMap } from "@sync/domain/color-label-map";
+import { listEventPageWithAuthRetry } from "@sync/domain/list-event-page-with-auth-retry";
 import { ProviderPageApplier } from "@sync/domain/provider-page-applier";
 import { type AccessTokenSource } from "@sync/domain/provider-write-ladder";
 import { type ProviderEventCancellation } from "@sync/providers/provider-event.port";
@@ -114,15 +115,21 @@ export async function pullCalendarChanges(
   do {
     let page: Awaited<ReturnType<ProviderEventReader["listEventPage"]>>;
     try {
-      page = await deps.reader.listEventPage({
-        accessToken,
-        calendarId: calendar.providerCalendarId,
-        // The cursor applies only to the first request of a batch; paging then
-        // continues by pageToken alone.
-        cursor: pageToken === null ? cursor : null,
-        pageToken,
-        colorLabels,
-      });
+      const read = await listEventPageWithAuthRetry(
+        deps,
+        calendar.connectionId,
+        {
+          accessToken,
+          calendarId: calendar.providerCalendarId,
+          // The cursor applies only to the first request of a batch; paging then
+          // continues by pageToken alone.
+          cursor: pageToken === null ? cursor : null,
+          pageToken,
+          colorLabels,
+        },
+      );
+      page = read.page;
+      accessToken = read.accessToken;
     } catch (error) {
       // An expired cursor cannot be resumed; hand off to repair without
       // touching the stored cursor.

--- a/packages/sync/src/domain/calendar-repair.service.ts
+++ b/packages/sync/src/domain/calendar-repair.service.ts
@@ -1,4 +1,5 @@
 import { toColorLabelMap } from "@sync/domain/color-label-map";
+import { listEventPageWithAuthRetry } from "@sync/domain/list-event-page-with-auth-retry";
 import { ProviderPageApplier } from "@sync/domain/provider-page-applier";
 import { type AccessTokenSource } from "@sync/domain/provider-write-ladder";
 import { type ProviderEventReader } from "@sync/providers/provider-event-reader.port";
@@ -86,7 +87,7 @@ export async function repairCalendar(
           resource._id,
         );
 
-  const accessToken = await deps.custody.getValidAccessToken(
+  let accessToken = await deps.custody.getValidAccessToken(
     calendar.connectionId,
   );
 
@@ -106,12 +107,14 @@ export async function repairCalendar(
   let pageToken: string | null = null;
   let cursor: string | null = null;
   do {
-    const page = await deps.reader.listEventPage({
+    const read = await listEventPageWithAuthRetry(deps, calendar.connectionId, {
       accessToken,
       calendarId: calendar.providerCalendarId,
       pageToken,
       colorLabels,
     });
+    const page = read.page;
+    accessToken = read.accessToken;
     await applier.applyPage(page.events);
     pageToken = page.nextPageToken;
     cursor = page.nextSyncToken ?? cursor;

--- a/packages/sync/src/domain/list-event-page-with-auth-retry.test.ts
+++ b/packages/sync/src/domain/list-event-page-with-auth-retry.test.ts
@@ -1,0 +1,156 @@
+import { type ConnectionId } from "@core/types/sync/identity.contracts";
+import { listEventPageWithAuthRetry } from "@sync/domain/list-event-page-with-auth-retry";
+import { type AccessTokenSource } from "@sync/domain/provider-write-ladder";
+import { ProviderAuthError } from "@sync/providers/provider-auth.port";
+import {
+  type ProviderEventPage,
+  ProviderEventReadError,
+  type ProviderEventReader,
+  type ProviderEventReadInput,
+} from "@sync/providers/provider-event-reader.port";
+import { describe, expect, it } from "bun:test";
+
+const connectionId = "507f1f77bcf86cd799439011" as ConnectionId;
+
+const emptyPage = (): ProviderEventPage => ({
+  events: [],
+  skipped: 0,
+  nextPageToken: null,
+  nextSyncToken: "cursor-1",
+});
+
+const input = (accessToken: string): ProviderEventReadInput => ({
+  accessToken,
+  calendarId: "primary",
+});
+
+class ScriptedReader implements ProviderEventReader {
+  readonly provider = "google" as const;
+  tokens: string[] = [];
+  constructor(private readonly outcomes: Array<ProviderEventPage | Error>) {}
+  async listEventPage(
+    readInput: ProviderEventReadInput,
+  ): Promise<ProviderEventPage> {
+    this.tokens.push(readInput.accessToken);
+    const next = this.outcomes.shift();
+    if (!next) throw new Error("ScriptedReader: no outcome left");
+    if (next instanceof Error) throw next;
+    return next;
+  }
+}
+
+const custody = (opts: {
+  tokens?: string[];
+  refreshError?: Error;
+}): AccessTokenSource & { invalidated: string[] } => {
+  const tokens = [...(opts.tokens ?? ["fresh-token"])];
+  const invalidated: string[] = [];
+  return {
+    invalidated,
+    getValidAccessToken: async () => {
+      if (opts.refreshError) throw opts.refreshError;
+      const token = tokens.shift();
+      if (!token) throw new Error("custody: no token scripted");
+      return token;
+    },
+    discardRevoked: async () => {},
+    invalidateAccessToken: async (id) => {
+      invalidated.push(id);
+    },
+  };
+};
+
+describe("listEventPageWithAuthRetry", () => {
+  it("returns the page unchanged when the read succeeds", async () => {
+    const page = emptyPage();
+    const reader = new ScriptedReader([page]);
+    const source = custody({ tokens: ["unused"] });
+
+    const result = await listEventPageWithAuthRetry(
+      { reader, custody: source },
+      connectionId,
+      input("cached-token"),
+    );
+
+    expect(result).toEqual({ page, accessToken: "cached-token" });
+    expect(source.invalidated).toEqual([]);
+    expect(reader.tokens).toEqual(["cached-token"]);
+  });
+
+  it("rethrows non-auth read errors without touching the cache", async () => {
+    const reader = new ScriptedReader([
+      new ProviderEventReadError("transient", "429"),
+    ]);
+    const source = custody({});
+
+    await expect(
+      listEventPageWithAuthRetry(
+        { reader, custody: source },
+        connectionId,
+        input("cached-token"),
+      ),
+    ).rejects.toMatchObject({ reason: "transient" });
+    expect(source.invalidated).toEqual([]);
+  });
+
+  it("invalidates the cached token and retries the page with a fresh one", async () => {
+    const page = emptyPage();
+    const reader = new ScriptedReader([
+      new ProviderEventReadError("authExpired", "401"),
+      page,
+    ]);
+    const source = custody({ tokens: ["fresh-token"] });
+
+    const result = await listEventPageWithAuthRetry(
+      { reader, custody: source },
+      connectionId,
+      input("stale-token"),
+    );
+
+    expect(result).toEqual({ page, accessToken: "fresh-token" });
+    expect(source.invalidated).toEqual([connectionId]);
+    expect(reader.tokens).toEqual(["stale-token", "fresh-token"]);
+  });
+
+  it("surfaces a revoked grant when refresh fails after the 401", async () => {
+    const reader = new ScriptedReader([
+      new ProviderEventReadError("authExpired", "401"),
+    ]);
+    const source = custody({
+      refreshError: new ProviderAuthError(
+        "authorizationRevoked",
+        "invalid_grant",
+      ),
+    });
+
+    await expect(
+      listEventPageWithAuthRetry(
+        { reader, custody: source },
+        connectionId,
+        input("stale-token"),
+      ),
+    ).rejects.toMatchObject({ reason: "authorizationRevoked" });
+    expect(source.invalidated).toEqual([connectionId]);
+  });
+
+  it("treats a 401 on the freshly minted token as a dead grant", async () => {
+    const reader = new ScriptedReader([
+      new ProviderEventReadError("authExpired", "401"),
+      new ProviderEventReadError("authExpired", "401"),
+    ]);
+    const source = custody({ tokens: ["fresh-token"] });
+
+    await expect(
+      listEventPageWithAuthRetry(
+        { reader, custody: source },
+        connectionId,
+        input("stale-token"),
+      ),
+    ).rejects.toMatchObject({
+      name: "ProviderAuthError",
+      reason: "authorizationRevoked",
+    });
+    expect(source.invalidated).toEqual([connectionId]);
+    expect(reader.tokens).toEqual(["stale-token", "fresh-token"]);
+  });
+});

--- a/packages/sync/src/domain/list-event-page-with-auth-retry.ts
+++ b/packages/sync/src/domain/list-event-page-with-auth-retry.ts
@@ -1,0 +1,67 @@
+import { type ConnectionId } from "@core/types/sync/identity.contracts";
+import { type AccessTokenSource } from "@sync/domain/provider-write-ladder";
+import { ProviderAuthError } from "@sync/providers/provider-auth.port";
+import {
+  type ProviderEventPage,
+  ProviderEventReadError,
+  type ProviderEventReader,
+  type ProviderEventReadInput,
+} from "@sync/providers/provider-event-reader.port";
+
+export interface EventPageAuthRetryDeps {
+  reader: ProviderEventReader;
+  custody: AccessTokenSource;
+}
+
+// Read one event page, reminting the access token in-process if Google rejects
+// the cached one (401 / authExpired).
+//
+// Incremental pulls fetch a token once, then call events.list. A stale cached
+// token (clock skew, Google expiry before our stored expiresAt) used to throw
+// out to the job worker: each attempt logged "Sync job engine failed", retried
+// with backoff, and — until the cache was invalidated — replayed the same
+// rejected token. A dead grant (invalid_grant on refresh) still burned the
+// ladder as ProviderEventReadError(transient) before #2754, then as one error
+// plus a delayed retry after it.
+//
+// Force-refresh here so a stale token recovers without a job attempt or a
+// PostHog error, and a revoked grant surfaces as ProviderAuthError on this
+// attempt so dispatch drops the job and the connection asks for reconnect.
+export async function listEventPageWithAuthRetry(
+  deps: EventPageAuthRetryDeps,
+  connectionId: ConnectionId,
+  input: ProviderEventReadInput,
+): Promise<{ page: ProviderEventPage; accessToken: string }> {
+  try {
+    return {
+      page: await deps.reader.listEventPage(input),
+      accessToken: input.accessToken,
+    };
+  } catch (error) {
+    if (!isAuthExpired(error)) throw error;
+  }
+
+  await deps.custody.invalidateAccessToken(connectionId);
+  const accessToken = await deps.custody.getValidAccessToken(connectionId);
+  try {
+    return {
+      page: await deps.reader.listEventPage({ ...input, accessToken }),
+      accessToken,
+    };
+  } catch (error) {
+    if (!isAuthExpired(error)) throw error;
+    // A token minted just now was still rejected: this is not a stale cache.
+    // Treat it as a dead grant so dispatch drops instead of retrying 20 times.
+    throw new ProviderAuthError(
+      "authorizationRevoked",
+      "Google rejected a freshly minted access token",
+      { cause: error },
+    );
+  }
+}
+
+function isAuthExpired(error: unknown): error is ProviderEventReadError {
+  return (
+    error instanceof ProviderEventReadError && error.reason === "authExpired"
+  );
+}

--- a/packages/sync/src/domain/sync-job-dispatch.service.db.test.ts
+++ b/packages/sync/src/domain/sync-job-dispatch.service.db.test.ts
@@ -78,18 +78,25 @@ class FakeReader implements ProviderEventReader {
   readonly provider = "google" as const;
   #pages: ProviderEventPage[];
   #error: ProviderEventReadError | null;
+  #errorOnce: boolean;
 
   constructor(
     pages: ProviderEventPage[],
     error: ProviderEventReadError | null = null,
+    errorOnce = false,
   ) {
     this.#pages = [...pages];
     this.#error = error;
+    this.#errorOnce = errorOnce;
   }
   async listEventPage(
     _input: ProviderEventReadInput,
   ): Promise<ProviderEventPage> {
-    if (this.#error) throw this.#error;
+    if (this.#error) {
+      const error = this.#error;
+      if (this.#errorOnce) this.#error = null;
+      throw error;
+    }
     const next = this.#pages.shift();
     if (!next) throw new Error("FakeReader: no page scripted");
     return next;
@@ -507,29 +514,69 @@ describe("dispatchSyncJob", () => {
     expect(discarded).toEqual([]);
   });
 
-  it("invalidates the cached access token and rethrows on a rejected 401 read", async () => {
+  it("remints the access token in-process and completes a pull after a one-off 401", async () => {
+    const calendar = await seedCalendar();
+    const resource = await seedResource(calendar, "cursor-0");
+    const reader = new FakeReader(
+      [page([], "cursor-1")],
+      new ProviderEventReadError("authExpired", "Google rejected the token"),
+      true,
+    );
+    const invalidated: string[] = [];
+    let minted = 0;
+    const authExpiredCustody: SyncJobDispatchDeps["custody"] = {
+      getValidAccessToken: async () => {
+        minted += 1;
+        return minted === 1 ? "stale-token" : "fresh-token";
+      },
+      discardRevoked: async () => {},
+      invalidateAccessToken: async (connectionId) => {
+        invalidated.push(connectionId);
+      },
+    };
+
+    const outcome = await dispatchSyncJob(
+      deps(reader, authExpiredCustody),
+      jobFor(resource, "incrementalPull"),
+      now,
+    );
+
+    expect(outcome).toEqual({ result: "done" });
+    expect(invalidated).toEqual([calendar.connectionId]);
+    expect(minted).toBe(2);
+  });
+
+  it("drops a pull when a freshly minted token is still rejected with 401", async () => {
     const calendar = await seedCalendar();
     const resource = await seedResource(calendar, "cursor-0");
     const reader = new FakeReader(
       [],
       new ProviderEventReadError("authExpired", "Google rejected the token"),
     );
+    const discarded: string[] = [];
     const invalidated: string[] = [];
     const authExpiredCustody: SyncJobDispatchDeps["custody"] = {
       ...tokenSource,
+      discardRevoked: async (connectionId) => {
+        discarded.push(connectionId);
+      },
       invalidateAccessToken: async (connectionId) => {
         invalidated.push(connectionId);
       },
     };
 
-    await expect(
-      dispatchSyncJob(
-        deps(reader, authExpiredCustody),
-        jobFor(resource, "incrementalPull"),
-        now,
-      ),
-    ).rejects.toThrow(ProviderEventReadError);
+    const outcome = await dispatchSyncJob(
+      deps(reader, authExpiredCustody),
+      jobFor(resource, "incrementalPull"),
+      now,
+    );
+
+    expect(outcome.result).toBe("drop");
+    if (outcome.result === "drop") {
+      expect(outcome.reason).toContain("authorizationRevoked");
+    }
     expect(invalidated).toEqual([calendar.connectionId]);
+    expect(discarded).toEqual([calendar.connectionId]);
   });
 
   it("drops a job whose resource no longer exists", async () => {

--- a/packages/sync/src/domain/sync-job-dispatch.service.db.test.ts
+++ b/packages/sync/src/domain/sync-job-dispatch.service.db.test.ts
@@ -541,7 +541,7 @@ describe("dispatchSyncJob", () => {
       now,
     );
 
-    expect(outcome).toEqual({ result: "done" });
+    expect(outcome.result).toBe("done");
     expect(invalidated).toEqual([calendar.connectionId]);
     expect(minted).toBe(2);
   });

--- a/packages/sync/src/domain/sync-job-dispatch.service.ts
+++ b/packages/sync/src/domain/sync-job-dispatch.service.ts
@@ -113,13 +113,12 @@ export async function dispatchSyncJob(
       };
     }
 
-    // The provider rejected the cached access token (401). Invalidate it so
-    // the retry that the worker's generic catch schedules mints a fresh token
-    // instead of replaying the same rejected one — otherwise every attempt in
-    // the retry ladder fails the same way and the job dead-letters even though
-    // a fresh token would have worked. If the refresh itself then fails with
-    // authorizationRevoked, that surfaces as ProviderAuthError on the next
-    // attempt and is handled by the branch above.
+    // The provider rejected the cached access token (401). Event reads
+    // (pull/import/repair) remint in-process via listEventPageWithAuthRetry;
+    // this fallback covers any path that still throws authExpired. Invalidate
+    // so the worker retry mints a fresh token instead of replaying the same
+    // rejected one. If the refresh then fails with authorizationRevoked, that
+    // surfaces as ProviderAuthError on the next attempt and is handled above.
     if (
       error instanceof ProviderEventReadError &&
       error.reason === "authExpired"

--- a/packages/sync/src/domain/sync-job-worker.service.db.test.ts
+++ b/packages/sync/src/domain/sync-job-worker.service.db.test.ts
@@ -665,6 +665,44 @@ describe("SyncJobWorker", () => {
     expect(requeued.state).toBe("pending");
   });
 
+  it("drops a persistent events.list 401 instead of burning the retry ladder", async () => {
+    const calendar = await seedCalendar();
+    const resource = await seedResource(calendar, "cursor-0");
+    const job = await enqueue(resource, "incrementalPull");
+    const drops: string[] = [];
+    const errors: Error[] = [];
+    const w = new SyncJobWorker(
+      deps(
+        new FakeReader(
+          [],
+          new ProviderEventReadError(
+            "authExpired",
+            "Google rejected the token",
+          ),
+        ),
+      ),
+      OWNER,
+      {
+        now,
+        onDrop: (_job, reason) => drops.push(reason),
+        onError: (error) => {
+          if (error instanceof Error) errors.push(error);
+        },
+      },
+    );
+
+    await w.runOnce();
+
+    expect(
+      await jobs.findById(resource.tenantId, resource.principalId, job._id),
+    ).toBeNull();
+    expect(drops).toHaveLength(1);
+    expect(drops[0]).toContain("authorizationRevoked");
+    // Must not log "Sync job engine failed" — that fingerprint reopened the
+    // PostHog incident when 401s were retried as transient.
+    expect(errors).toEqual([]);
+  });
+
   it("settles a durably-rejected read instead of burning the retry ladder", async () => {
     const calendar = await seedCalendar();
     const resource = await seedResource(calendar, "cursor-0");

--- a/packages/sync/src/providers/google/google-event-reader.adapter.ts
+++ b/packages/sync/src/providers/google/google-event-reader.adapter.ts
@@ -161,10 +161,11 @@ const TRANSIENT_REASONS = [
 // (410 Gone) forces a full re-import. A 401 means the access token was rejected
 // - it may have expired mid-job on a long-running import or repair, or the
 // cached token may simply be stale - so the caller must invalidate the cached
-// token before retrying; otherwise every retry replays the same rejected
-// token, burns the retry ladder, and dead-letters the job. Also retryable: a
-// rate limit or server/network error, or a quota-shaped 403. Anything else is
-// an unrecoverable read failure.
+// token and retry the same page with a fresh one in-process; otherwise every
+// job retry replays the same rejected token, burns the retry ladder, and
+// dead-letters the job (and logs a PostHog "Sync job engine failed" on each
+// attempt). Also retryable: a rate limit or server/network error, or a
+// quota-shaped 403. Anything else is an unrecoverable read failure.
 function classifyReadError(
   error: unknown,
 ): "cursorExpired" | "authExpired" | "transient" | "readFailed" {

--- a/packages/sync/src/providers/provider-event-reader.port.ts
+++ b/packages/sync/src/providers/provider-event-reader.port.ts
@@ -52,11 +52,12 @@ export interface ProviderEventReader {
 
 // Why a page read could not complete. `cursorExpired` (the stored sync token is
 // too old) is not retryable with the same token — the caller must re-import in
-// full. `authExpired` is a rejected access token — retryable, but only after
-// the caller invalidates the cached token so the next attempt mints a fresh
-// one. `transient` is a retryable network/provider failure; `readFailed` is an
-// unrecoverable rejection. Distinct from ProviderEventError, which is a
-// per-event normalization failure the reader absorbs into `skipped`.
+// full. `authExpired` is a rejected access token — retryable in-process after
+// the caller invalidates the cached token and mints a fresh one. A second
+// `authExpired` on that fresh token is treated as a dead grant. `transient` is
+// a retryable network/provider failure; `readFailed` is an unrecoverable
+// rejection. Distinct from ProviderEventError, which is a per-event
+// normalization failure the reader absorbs into `skipped`.
 export type ProviderEventReadErrorReason =
   | "cursorExpired"
   | "authExpired"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Staging `incrementalPull` jobs on connection `6a7250be…` were failing Google `events.list` with HTTP 401 `authError`. PostHog reused the old “Sync job engine failed” fingerprint (calendarListSync/subscriptionMaintain ladders already cleared after #2635/#2696/#2712). #2729 classified those 401s as `ProviderEventReadError(transient)`, so the worker retried the **same cached access token** up to 20 times and logged an error every attempt. #2754 later classified 401 as `authExpired` and invalidated the cache, but recovery still waited for the next job attempt — so a stale token still hit PostHog, and a dead/invalid grant still burned a retry before dropping.

This remints the access token **in-process** on the same `events.list` page (pull, import, and repair):

- Stale cached token → invalidate, refresh, retry the page. Job succeeds. No engine-failure log.
- Refresh `invalid_grant` / `authorizationRevoked` → dispatch drops the job and discards the credential so the connection asks for reconnect.
- Fresh token still 401 → treat as a dead grant (same drop), not 20 retries.

Ops for the current staging connection still applies: reconnect Google (or `manage-failed-jobs` if a row already exhausted). Deploying this stops the retry storm and the fingerprint reopen; it does not revive an already-revoked grant. #2748 (provider event identity collisions) is unrelated.

## Simplicity

One helper (`listEventPageWithAuthRetry`) used by the three event-read engines. Reuses existing custody `invalidateAccessToken` + `getValidAccessToken` and the existing `ProviderAuthError` drop path. No new job states or health classes. No further simplification after the base-to-head pass — extracting the helper is the DRY boundary; inlining would triplicate the remint/drop contract.

## Automated validation

- `bun test:sync:fast -- packages/sync/src/domain/list-event-page-with-auth-retry.test.ts` — 5 pass
- `bun test:sync --` pull, dispatch, worker db tests — 62 pass
- import/repair db suites — green
- `bun run lint` — no new issues in touched files
- GitHub Test + CodeQL on the branch — success

## Independent review

Fresh read-only review of `main...HEAD`: no confirmed findings.

## Test plan

- [x] Helper: success, transient rethrow, 401 then remint, refresh revoked, second 401 → dead grant
- [x] Pull remints and applies after a one-off 401
- [x] Dispatch completes after one-off 401; drops persistent 401 without engine-error logging
- [x] Worker drops persistent 401 and does not call `onError`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-30f2bf26-6340-4650-b98a-a1b2a033feaf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-30f2bf26-6340-4650-b98a-a1b2a033feaf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

