### PR TITLE
feat(web): fade showcase overlay into the calendar

### DIFF
--- a/packages/web/src/common/constants/motion.constants.ts
+++ b/packages/web/src/common/constants/motion.constants.ts
@@ -1,3 +1,4 @@
 /** JS unmount delays paired with Tailwind `duration-*` on the same surface. */
 export const MODAL_DISMISS_MS = 400;
 export const BANNER_DISMISS_MS = 300;
+export const SHOWCASE_REVEAL_MS = 500;

--- a/packages/web/src/common/constants/motion.constants.ts
+++ b/packages/web/src/common/constants/motion.constants.ts
@@ -1,4 +1,5 @@
 /** JS unmount delays paired with Tailwind `duration-*` on the same surface. */
 export const MODAL_DISMISS_MS = 400;
 export const BANNER_DISMISS_MS = 300;
-export const SHOWCASE_REVEAL_MS = 500;
+/** Overlay hold + fade; keep in sync with `c-showcase-curtain`. */
+export const SHOWCASE_REVEAL_MS = 900;

--- a/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.test.tsx
+++ b/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
 import { persistentBrowserStore } from "@web/common/storage/browser-key-value.store";
@@ -123,10 +123,68 @@ describe("ShortcutShowcase", () => {
     expect(screen.getByText(/young cap'n/)).toBeTruthy();
 
     pressKey("Enter");
-    expect(useShortcutShowcaseStore.getState().isActive).toBe(false);
+    expect(screen.getByLabelText("Shortcut practice")).toHaveAttribute(
+      "data-closing",
+    );
+    expect(useShortcutShowcaseStore.getState().isActive).toBe(true);
+
+    await waitFor(() => {
+      expect(useShortcutShowcaseStore.getState().isActive).toBe(false);
+    });
+    expect(screen.queryByLabelText("Shortcut practice")).toBeNull();
     expect(
       persistentBrowserStore.get(STORAGE_KEYS.HAS_SEEN_SHORTCUT_SHOWCASE),
     ).toBe("true");
+  });
+
+  it("fades the takeover on Enter Compass, then unmounts", async () => {
+    const user = userEvent.setup();
+    render(<ShortcutShowcase />);
+    showStep("graduation");
+
+    await user.click(screen.getByRole("button", { name: "Enter Compass" }));
+    expect(screen.getByLabelText("Shortcut practice")).toHaveAttribute(
+      "data-closing",
+    );
+    expect(
+      screen.getByRole("button", { name: "Enter Compass" }),
+    ).toBeDisabled();
+    expect(useShortcutShowcaseStore.getState().isActive).toBe(true);
+
+    pressKey("Enter");
+    expect(useShortcutShowcaseStore.getState().isActive).toBe(true);
+
+    await waitFor(() => {
+      expect(screen.queryByLabelText("Shortcut practice")).toBeNull();
+    });
+    expect(useShortcutShowcaseStore.getState().isActive).toBe(false);
+  });
+
+  it("graduates immediately when reduced motion is preferred", async () => {
+    const originalMatchMedia = window.matchMedia;
+    window.matchMedia = (query: string) =>
+      ({
+        matches: query.includes("prefers-reduced-motion"),
+        media: query,
+        onchange: null,
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => false,
+      }) as MediaQueryList;
+
+    try {
+      render(<ShortcutShowcase />);
+      showStep("graduation");
+      pressKey("Enter");
+      await waitFor(() => {
+        expect(useShortcutShowcaseStore.getState().isActive).toBe(false);
+      });
+      expect(screen.queryByLabelText("Shortcut practice")).toBeNull();
+    } finally {
+      window.matchMedia = originalMatchMedia;
+    }
   });
 
   it("offers 'Do it for me' from the first step, and swaps it out at graduation", async () => {

--- a/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.test.tsx
+++ b/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.test.tsx
@@ -128,9 +128,12 @@ describe("ShortcutShowcase", () => {
     );
     expect(useShortcutShowcaseStore.getState().isActive).toBe(true);
 
-    await waitFor(() => {
-      expect(useShortcutShowcaseStore.getState().isActive).toBe(false);
-    });
+    await waitFor(
+      () => {
+        expect(useShortcutShowcaseStore.getState().isActive).toBe(false);
+      },
+      { timeout: 2000 },
+    );
     expect(screen.queryByLabelText("Shortcut practice")).toBeNull();
     expect(
       persistentBrowserStore.get(STORAGE_KEYS.HAS_SEEN_SHORTCUT_SHOWCASE),
@@ -154,9 +157,12 @@ describe("ShortcutShowcase", () => {
     pressKey("Enter");
     expect(useShortcutShowcaseStore.getState().isActive).toBe(true);
 
-    await waitFor(() => {
-      expect(screen.queryByLabelText("Shortcut practice")).toBeNull();
-    });
+    await waitFor(
+      () => {
+        expect(screen.queryByLabelText("Shortcut practice")).toBeNull();
+      },
+      { timeout: 2000 },
+    );
     expect(useShortcutShowcaseStore.getState().isActive).toBe(false);
   });
 

--- a/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.test.tsx
+++ b/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.test.tsx
@@ -127,6 +127,9 @@ describe("ShortcutShowcase", () => {
       "data-closing",
     );
     expect(useShortcutShowcaseStore.getState().isActive).toBe(true);
+    expect(
+      persistentBrowserStore.get(STORAGE_KEYS.HAS_SEEN_SHORTCUT_SHOWCASE),
+    ).toBe("true");
 
     await waitFor(
       () => {

--- a/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.tsx
+++ b/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.tsx
@@ -37,6 +37,7 @@ import {
   SHOWCASE_STEP_IDS,
   STRETCH_KEYCAPS,
 } from "@web/components/ShortcutShowcase/showcase.steps";
+import { markShortcutShowcaseSeen } from "@web/components/ShortcutShowcase/showcase.storage";
 import {
   selectShowcaseActive,
   selectShowcaseConfirmingSkip,
@@ -86,6 +87,9 @@ const ShowcaseTakeover: FC = () => {
   useAppLockReason("shortcutShowcase", true);
 
   const graduate = () => {
+    // Persist before the curtain so a reload during the reveal does not
+    // relaunch the takeover. finish() marks seen again when it unmounts.
+    markShortcutShowcaseSeen();
     beginDismiss(() => shortcutShowcaseActions.finish());
   };
   const graduateRef = useRef(graduate);
@@ -169,7 +173,6 @@ const ShowcaseTakeover: FC = () => {
       const store = useShortcutShowcaseStore.getState();
       if (!store.isActive) return;
       if (closingRef.current) {
-        event.preventDefault();
         event.stopPropagation();
         return;
       }

--- a/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.tsx
+++ b/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.tsx
@@ -7,7 +7,9 @@ import {
   useState,
 } from "react";
 import { track } from "@web/auth/posthog/track";
+import { SHOWCASE_REVEAL_MS } from "@web/common/constants/motion.constants";
 import { Z_INDEX_MODAL } from "@web/common/constants/web.constants";
+import { useDismissTransition } from "@web/common/hooks/useDismissTransition";
 import { PracticeCalendar } from "@web/components/ShortcutShowcase/PracticeCalendar";
 import {
   clearFocus,
@@ -75,10 +77,17 @@ const ShowcaseTakeover: FC = () => {
   );
   const stepId = stepIdAt(stepIndex);
   const step = getShowcaseStep(stepId);
+  const { closing, beginDismiss } = useDismissTransition(SHOWCASE_REVEAL_MS);
+  const closingRef = useRef(false);
+  closingRef.current = closing;
 
   // The takeover owns the keyboard: silence every real app handler
   // (useAppShortcut, the e-sequence, bare-letter s/h) while it is up.
   useAppLockReason("shortcutShowcase", true);
+
+  const graduate = () => {
+    beginDismiss(() => shortcutShowcaseActions.finish());
+  };
 
   const [practice, setPractice] = useState(initialPracticeState);
   const practiceRef = useRef(practice);
@@ -157,6 +166,11 @@ const ShowcaseTakeover: FC = () => {
     const onKeyDown = (event: KeyboardEvent) => {
       const store = useShortcutShowcaseStore.getState();
       if (!store.isActive) return;
+      if (closingRef.current) {
+        event.preventDefault();
+        event.stopPropagation();
+        return;
+      }
       const currentStepId = stepIdAt(store.stepIndex);
 
       if (store.isConfirmingSkip) {
@@ -200,7 +214,7 @@ const ShowcaseTakeover: FC = () => {
 
       if (currentStepId === "graduation" && event.key === "Enter") {
         event.preventDefault();
-        shortcutShowcaseActions.finish();
+        graduate();
         return;
       }
 
@@ -408,11 +422,12 @@ const ShowcaseTakeover: FC = () => {
   return (
     <section
       aria-label="Shortcut practice"
-      className="fixed inset-0 flex items-center justify-center bg-background"
+      className="fixed inset-0 flex items-center justify-center bg-background transition-opacity duration-500 ease-out data-closing:opacity-0 motion-reduce:transition-none"
+      data-closing={closing || undefined}
       data-onboarding-ui=""
       style={{ zIndex: Z_INDEX_MODAL }}
     >
-      <div className="flex h-[80vh] max-h-160 w-full max-w-5xl gap-8 px-8">
+      <div className="flex h-[80vh] max-h-160 w-full max-w-5xl gap-8 px-8 transition-[opacity,transform] duration-500 ease-out data-closing:scale-95 data-closing:opacity-0 motion-reduce:transition-none">
         <aside className="flex w-80 shrink-0 flex-col justify-center gap-4">
           {isConfirmingSkip ? (
             <>
@@ -467,7 +482,8 @@ const ShowcaseTakeover: FC = () => {
                   <button
                     type="button"
                     className={PRIMARY_BUTTON_CLASS}
-                    onClick={shortcutShowcaseActions.finish}
+                    disabled={closing}
+                    onClick={graduate}
                   >
                     Enter Compass
                   </button>

--- a/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.tsx
+++ b/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.tsx
@@ -424,12 +424,14 @@ const ShowcaseTakeover: FC = () => {
   return (
     <section
       aria-label="Shortcut practice"
-      className="fixed inset-0 flex items-center justify-center bg-background transition-opacity duration-500 ease-out data-closing:opacity-0 motion-reduce:transition-none"
+      className={`fixed inset-0 flex items-center justify-center bg-background ${closing ? "c-showcase-curtain" : ""}`}
       data-closing={closing || undefined}
       data-onboarding-ui=""
       style={{ zIndex: Z_INDEX_MODAL }}
     >
-      <div className="flex h-[80vh] max-h-160 w-full max-w-5xl gap-8 px-8 transition-[opacity,transform] duration-500 ease-out data-closing:scale-95 data-closing:opacity-0 motion-reduce:transition-none">
+      <div
+        className={`flex h-[80vh] max-h-160 w-full max-w-5xl gap-8 px-8 ${closing ? "c-showcase-enter-stage" : ""}`}
+      >
         <aside className="flex w-80 shrink-0 flex-col justify-center gap-4">
           {isConfirmingSkip ? (
             <>

--- a/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.tsx
+++ b/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.tsx
@@ -88,6 +88,8 @@ const ShowcaseTakeover: FC = () => {
   const graduate = () => {
     beginDismiss(() => shortcutShowcaseActions.finish());
   };
+  const graduateRef = useRef(graduate);
+  graduateRef.current = graduate;
 
   const [practice, setPractice] = useState(initialPracticeState);
   const practiceRef = useRef(practice);
@@ -214,7 +216,7 @@ const ShowcaseTakeover: FC = () => {
 
       if (currentStepId === "graduation" && event.key === "Enter") {
         event.preventDefault();
-        graduate();
+        graduateRef.current();
         return;
       }
 

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -152,6 +152,9 @@
   --animate-sync-icon-wave: syncIconWave 2.4s linear infinite;
   --animate-loader-spin: loaderSpin 1.1s linear infinite;
   --animate-pirate-scout: pirateScout 2.2s ease-in-out infinite;
+  --animate-showcase-curtain: showcaseCurtain 900ms ease-in-out forwards;
+  --animate-showcase-enter-stage: showcaseEnterStage 550ms
+    cubic-bezier(0.16, 1, 0.3, 1) forwards;
 
   @keyframes loaderSpin {
     from {
@@ -177,6 +180,31 @@
     }
     to {
       mask-position: -50% 0;
+    }
+  }
+
+  /* Graduation: hold, then dissolve the opaque takeover. */
+  @keyframes showcaseCurtain {
+    0%,
+    22% {
+      opacity: 1;
+    }
+    100% {
+      opacity: 0;
+    }
+  }
+
+  /* Practice stage steps forward into the real calendar. */
+  @keyframes showcaseEnterStage {
+    from {
+      opacity: 1;
+      filter: blur(0);
+      transform: scale(1);
+    }
+    to {
+      opacity: 0;
+      filter: blur(8px);
+      transform: scale(1.06);
     }
   }
 
@@ -351,6 +379,24 @@
 
   @media (prefers-reduced-motion: reduce) {
     animation: none;
+  }
+}
+
+@utility c-showcase-curtain {
+  animation: var(--animate-showcase-curtain);
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+    opacity: 0;
+  }
+}
+
+@utility c-showcase-enter-stage {
+  animation: var(--animate-showcase-enter-stage);
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+    opacity: 0;
   }
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Graduation from the Shortcut Showcase (Enter / Enter Compass) curtain-lifts the practice takeover so the already-rendered week view with sample events is revealed underneath.

The reveal is a two-beat enter (~900ms): the practice stage zooms slightly forward and softens, then the opaque curtain holds and dissolves. Skip stays instant. Reduced motion still finishes immediately. “Seen” is persisted when the curtain starts so a reload mid-reveal does not relaunch the takeover.

## Simplicity

Reuses `useDismissTransition`. Motion lives in two small CSS utilities next to the existing pirate-scout animation tokens — no motion library, no calendar-side animation, no store-shape change. The extra refs stay because the document keydown listener must not rebind every render.

## Automated validation

- `bun test:web -- packages/web/src/components/ShortcutShowcase/ShortcutShowcase.test.tsx` — 10 pass
- `bun run lint` — exit 0 (pre-existing warnings only)
- Manual: first-run and palette replay through graduation; practice stage zooms/blurs, then the curtain dissolves into the week view with sample events and the practice checklist

<a href="https://cursor.com/agents/bc-19923272-b573-4bec-9c05-43c8e90d2995/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fshowcase_graduation_two_beat_reveal.mp4"><img src="https://cursor.com/artifacts/c/art-0c914272-cb59-4ed7-b1a2-db49e85a4927" alt="showcase_graduation_two_beat_reveal.mp4" /></a>
![Week view after graduation reveal](https://cursor.com/artifacts/c/art-e853acb8-5941-48d4-8520-84f63168104e)

## Independent review

Fresh read-only review of `main...HEAD` found no blocker/high/medium issues. Two low findings were fixed: persist showcase-seen before the curtain, and stop cancelling browser shortcuts with `preventDefault` while closing.

## Test plan

- `bun test:web -- packages/web/src/components/ShortcutShowcase/ShortcutShowcase.test.tsx`
- `bun run lint`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-19923272-b573-4bec-9c05-43c8e90d2995?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-19923272-b573-4bec-9c05-43c8e90d2995&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

