### PR TITLE
fix(backend): gate hosted users without a stripe subscription

### DIFF
--- a/docs/development/cli.md
+++ b/docs/development/cli.md
@@ -15,7 +15,7 @@ Primary file:
 | Command | Implementation | Notes |
 | --- | --- | --- |
 | `bun run cli purge-user --email <address> [--apply] [--out report.json]` | `packages/scripts/src/commands/purge-user.ts` | Deletes one user's API, Sync, and SuperTokens data. Defaults to dry-run. |
-| `bun run cli backfill-billing [--apply] [--batch-size 500] [--cutoff ISO]` | `packages/scripts/src/commands/backfill-billing.ts` | Places existing accounts without billing status onto a 7-day trial. Defaults to dry-run. |
+| `bun run cli backfill-billing [--apply] [--batch-size 500] [--cutoff ISO]` | `packages/scripts/src/commands/backfill-billing.ts` | Places existing accounts without billing status into awaiting_checkout. Defaults to dry-run. |
 | `bun run cli purge-corrupt-sync-events [--apply]` | `packages/scripts/src/commands/purge-corrupt-sync-events.ts` | Deletes invalid Sync event documents. Defaults to dry-run. |
 | `bun run cli refresh-connection-states [--apply]` | `packages/scripts/src/commands/refresh-connection-states.ts` | Re-derives Sync connection state. Defaults to dry-run. |
 | `bun run cli manage-failed-jobs <list\|clear\|requeue> …` | `packages/scripts/src/commands/manage-failed-jobs.ts` | Operator tooling for Sync jobs that exhausted the self-heal requeue budget. Defaults to dry-run; pass `--apply` to persist. |

--- a/docs/features/billing.md
+++ b/docs/features/billing.md
@@ -21,11 +21,13 @@ writes stay open.
 There is no `POST /api/billing/trial/start`. A trial only begins through
 Stripe Checkout (`trial_period_days` on the first subscription).
 
-Existing accounts are not grandfathered. `bun run cli backfill-billing` places
-rows without `billing.subscriptionStatus` onto a 7-day trial. The default
-`BACKFILL_CUTOFF` is far in the future so every such row is included; set it
-to a past instant to grandfather newer signups. Those rows have no Stripe
-subscription id, so they self-expire locally when `trialEndsAt` passes.
+Existing accounts are not grandfathered. Hosted users without a Stripe
+subscription id (including missing billing, `none`, and local/backfill
+`trialing` rows) derive as `awaiting_checkout` and see the Start-trial gate.
+`bun run cli backfill-billing` stamps `awaiting_checkout` on rows that still
+lack `billing.subscriptionStatus`. The default `BACKFILL_CUTOFF` is far in
+the future so every such row is included; set it to a past instant to skip
+newer signups. A trial only begins through Stripe Checkout.
 
 ## Staging
 

--- a/packages/backend/src/billing/billing.constants.ts
+++ b/packages/backend/src/billing/billing.constants.ts
@@ -39,7 +39,7 @@ export const WRITE_ACCESS_BY_STATUS: Record<
   BillingSubscriptionStatus,
   boolean
 > = {
-  none: true,
+  none: false,
   awaiting_checkout: false,
   trialing: true,
   active: true,

--- a/packages/backend/src/billing/billing.guard.db.test.ts
+++ b/packages/backend/src/billing/billing.guard.db.test.ts
@@ -79,4 +79,20 @@ describe("assertBillingAllowsWrites", () => {
       mutationCode: "BILLING_REQUIRED",
     });
   });
+
+  it("rejects missing billing and local trialing without a Stripe subscription", async () => {
+    using _env = mockEnv(stripeConfigured);
+    const missing = await insertUser();
+    const localTrial = await insertUser({
+      subscriptionStatus: "trialing",
+      trialEndsAt: new Date("2099-01-01T00:00:00.000Z"),
+    });
+
+    await expect(assertBillingAllowsWrites(missing)).rejects.toMatchObject({
+      mutationCode: "BILLING_REQUIRED",
+    });
+    await expect(assertBillingAllowsWrites(localTrial)).rejects.toMatchObject({
+      mutationCode: "BILLING_REQUIRED",
+    });
+  });
 });

--- a/packages/backend/src/billing/services/billing.service.db.test.ts
+++ b/packages/backend/src/billing/services/billing.service.db.test.ts
@@ -38,8 +38,8 @@ describe("BillingService (db)", () => {
 
     const status = await billingService.startTrial(userId.toString());
 
-    expect(status.subscriptionStatus).toBe("trialing");
-    expect(status.isReadOnly).toBe(false);
+    expect(status.subscriptionStatus).toBe("awaiting_checkout");
+    expect(status.isReadOnly).toBe(true);
 
     const stored = await mongoService.user.findOne({ _id: userId });
     expect(stored?.billing?.stripeCustomerId).toBe("cus_keep");

--- a/packages/backend/src/billing/services/billing.service.test.ts
+++ b/packages/backend/src/billing/services/billing.service.test.ts
@@ -6,15 +6,23 @@ import { describe, expect, it } from "bun:test";
 describe("deriveBillingStatus", () => {
   const now = new Date("2026-08-10T00:00:00.000Z");
 
-  it("returns none when no billing record exists", () => {
+  it("treats a missing billing record as awaiting_checkout", () => {
     expect(deriveBillingStatus(undefined, now)).toEqual({
-      subscriptionStatus: "none",
+      subscriptionStatus: "awaiting_checkout",
       trialEndsAt: null,
-      isReadOnly: false,
+      isReadOnly: true,
     });
   });
 
-  it("returns trialing and writable while the trial window is open", () => {
+  it("treats none as awaiting_checkout", () => {
+    expect(deriveBillingStatus({ subscriptionStatus: "none" }, now)).toEqual({
+      subscriptionStatus: "awaiting_checkout",
+      trialEndsAt: null,
+      isReadOnly: true,
+    });
+  });
+
+  it("treats a local trialing record with no Stripe subscription as awaiting_checkout", () => {
     const trialEndsAt = new Date("2026-08-20T00:00:00.000Z");
     const status = deriveBillingStatus(
       {
@@ -26,13 +34,13 @@ describe("deriveBillingStatus", () => {
     );
 
     expect(status).toEqual({
-      subscriptionStatus: "trialing",
+      subscriptionStatus: "awaiting_checkout",
       trialEndsAt: trialEndsAt.toISOString(),
-      isReadOnly: false,
+      isReadOnly: true,
     });
   });
 
-  it("self-expires a legacy trialing record with no Stripe subscription id", () => {
+  it("treats an expired local trialing record as awaiting_checkout, not expired", () => {
     const trialEndsAt = new Date("2026-08-01T00:00:00.000Z");
     const status = deriveBillingStatus(
       {
@@ -44,7 +52,7 @@ describe("deriveBillingStatus", () => {
     );
 
     expect(status).toEqual({
-      subscriptionStatus: "expired",
+      subscriptionStatus: "awaiting_checkout",
       trialEndsAt: trialEndsAt.toISOString(),
       isReadOnly: true,
     });
@@ -65,17 +73,6 @@ describe("deriveBillingStatus", () => {
     expect(status.isReadOnly).toBe(false);
   });
 
-  it("treats exactly-at-boundary as expired for legacy trials", () => {
-    const trialEndsAt = now;
-    const status = deriveBillingStatus(
-      { subscriptionStatus: "trialing", trialEndsAt },
-      now,
-    );
-
-    expect(status.subscriptionStatus).toBe("expired");
-    expect(status.isReadOnly).toBe(true);
-  });
-
   const cases: Array<{
     status: BillingSubscriptionStatus;
     isReadOnly: boolean;
@@ -83,10 +80,12 @@ describe("deriveBillingStatus", () => {
     Object.entries(WRITE_ACCESS_BY_STATUS) as Array<
       [BillingSubscriptionStatus, boolean]
     >
-  ).map(([status, writable]) => ({
-    status,
-    isReadOnly: !writable,
-  }));
+  )
+    .filter(([status]) => status !== "none")
+    .map(([status, writable]) => ({
+      status,
+      isReadOnly: !writable,
+    }));
 
   for (const { status, isReadOnly } of cases) {
     it(`maps ${status} writability from WRITE_ACCESS_BY_STATUS`, () => {

--- a/packages/backend/src/billing/services/billing.service.test.ts
+++ b/packages/backend/src/billing/services/billing.service.test.ts
@@ -1,4 +1,7 @@
-import { type BillingSubscriptionStatus } from "@core/types/user.types";
+import {
+  type BillingSubscriptionStatus,
+  type Schema_UserBilling,
+} from "@core/types/user.types";
 import { WRITE_ACCESS_BY_STATUS } from "@backend/billing/billing.constants";
 import { deriveBillingStatus } from "./billing.service";
 import { describe, expect, it } from "bun:test";
@@ -16,6 +19,19 @@ describe("deriveBillingStatus", () => {
 
   it("treats none as awaiting_checkout", () => {
     expect(deriveBillingStatus({ subscriptionStatus: "none" }, now)).toEqual({
+      subscriptionStatus: "awaiting_checkout",
+      trialEndsAt: null,
+      isReadOnly: true,
+    });
+  });
+
+  it("treats a billing object with a customer id but no status as awaiting_checkout", () => {
+    expect(
+      deriveBillingStatus(
+        { stripeCustomerId: "cus_partial" } as Schema_UserBilling,
+        now,
+      ),
+    ).toEqual({
       subscriptionStatus: "awaiting_checkout",
       trialEndsAt: null,
       isReadOnly: true,

--- a/packages/backend/src/billing/services/billing.service.ts
+++ b/packages/backend/src/billing/services/billing.service.ts
@@ -10,40 +10,41 @@ import mongoService from "@backend/common/services/mongo.service";
  * Pure status derivation. Writability is a total map over the status union
  * so adding a state without deciding it is a compile error.
  *
- * Date override (asymmetric on purpose):
- * - `trialing` with no `stripeSubscriptionId` (legacy / backfill) self-expires
- *   when `trialEndsAt <= now`.
- * - `trialing` with a `stripeSubscriptionId` never self-expires locally —
- *   Stripe's webhook is authoritative, so a late `active` event cannot lock
- *   out a customer whose card just succeeded.
+ * A hosted trial starts only via Stripe Checkout. Missing billing, `none`,
+ * and `trialing` with no `stripeSubscriptionId` (legacy / backfill local
+ * trials) all surface as `awaiting_checkout` so the Start-trial gate shows.
+ *
+ * `trialing` with a `stripeSubscriptionId` never self-expires locally —
+ * Stripe's webhook is authoritative, so a late `active` event cannot lock
+ * out a customer whose card just succeeded.
  */
 export const deriveBillingStatus = (
   billing: Schema_UserBilling | undefined,
-  now: Date,
+  _now: Date,
 ): BillingStatusResponse => {
   if (!billing || billing.subscriptionStatus === "none") {
     return {
-      subscriptionStatus: "none",
+      subscriptionStatus: "awaiting_checkout",
       trialEndsAt: null,
-      isReadOnly: !WRITE_ACCESS_BY_STATUS.none,
+      isReadOnly: true,
     };
   }
 
-  const trialEndsAt = billing.trialEndsAt ?? null;
-  let subscriptionStatus = billing.subscriptionStatus;
-
-  if (subscriptionStatus === "trialing" && !billing.stripeSubscriptionId) {
-    const trialExpired =
-      trialEndsAt !== null && trialEndsAt.getTime() <= now.getTime();
-    if (trialExpired) {
-      subscriptionStatus = "expired";
-    }
+  if (
+    billing.subscriptionStatus === "trialing" &&
+    !billing.stripeSubscriptionId
+  ) {
+    return {
+      subscriptionStatus: "awaiting_checkout",
+      trialEndsAt: billing.trialEndsAt?.toISOString() ?? null,
+      isReadOnly: true,
+    };
   }
 
   return {
-    subscriptionStatus,
-    trialEndsAt: trialEndsAt?.toISOString() ?? null,
-    isReadOnly: !WRITE_ACCESS_BY_STATUS[subscriptionStatus],
+    subscriptionStatus: billing.subscriptionStatus,
+    trialEndsAt: billing.trialEndsAt?.toISOString() ?? null,
+    isReadOnly: !WRITE_ACCESS_BY_STATUS[billing.subscriptionStatus],
   };
 };
 

--- a/packages/backend/src/billing/services/billing.service.ts
+++ b/packages/backend/src/billing/services/billing.service.ts
@@ -10,9 +10,10 @@ import mongoService from "@backend/common/services/mongo.service";
  * Pure status derivation. Writability is a total map over the status union
  * so adding a state without deciding it is a compile error.
  *
- * A hosted trial starts only via Stripe Checkout. Missing billing, `none`,
- * and `trialing` with no `stripeSubscriptionId` (legacy / backfill local
- * trials) all surface as `awaiting_checkout` so the Start-trial gate shows.
+ * A hosted trial starts only via Stripe Checkout. Missing billing, a billing
+ * object with no `subscriptionStatus`, `none`, and `trialing` with no
+ * `stripeSubscriptionId` (legacy / backfill local trials) all surface as
+ * `awaiting_checkout` so the Start-trial gate shows.
  *
  * `trialing` with a `stripeSubscriptionId` never self-expires locally —
  * Stripe's webhook is authoritative, so a late `active` event cannot lock
@@ -22,10 +23,11 @@ export const deriveBillingStatus = (
   billing: Schema_UserBilling | undefined,
   _now: Date,
 ): BillingStatusResponse => {
-  if (!billing || billing.subscriptionStatus === "none") {
+  const storedStatus = billing?.subscriptionStatus;
+  if (!billing || !storedStatus || storedStatus === "none") {
     return {
       subscriptionStatus: "awaiting_checkout",
-      trialEndsAt: null,
+      trialEndsAt: billing?.trialEndsAt?.toISOString() ?? null,
       isReadOnly: true,
     };
   }

--- a/packages/backend/src/billing/services/stripe.service.db.test.ts
+++ b/packages/backend/src/billing/services/stripe.service.db.test.ts
@@ -85,6 +85,7 @@ describe("StripeService", () => {
 
     const stored = await mongoService.user.findOne({ _id: userId });
     expect(stored?.billing?.stripeCustomerId).toBe("cus_1");
+    expect(stored?.billing?.subscriptionStatus).toBe("awaiting_checkout");
   });
 
   it("reuses an existing Stripe customer id", async () => {

--- a/packages/backend/src/billing/services/stripe.service.ts
+++ b/packages/backend/src/billing/services/stripe.service.ts
@@ -61,7 +61,15 @@ class StripeService {
       customerId = customer.id;
       await mongoService.user.updateOne(
         { _id },
-        { $set: { "billing.stripeCustomerId": customerId } },
+        {
+          $set: {
+            "billing.stripeCustomerId": customerId,
+            ...(!user.billing?.subscriptionStatus ||
+            user.billing.subscriptionStatus === "none"
+              ? { "billing.subscriptionStatus": "awaiting_checkout" }
+              : {}),
+          },
+        },
       );
     }
 

--- a/packages/core/src/types/user.types.ts
+++ b/packages/core/src/types/user.types.ts
@@ -35,10 +35,12 @@ export interface Schema_User {
  * Total subscription union. Adding a member without updating
  * `WRITE_ACCESS_BY_STATUS` is a compile error.
  *
- * - `none` — legacy row, pre-backfill. writable.
+ * - `none` — legacy row, pre-backfill. Hosted derivation maps this to
+ *   `awaiting_checkout` (read-only). Self-host never consults this map.
  * - `awaiting_checkout` — account exists, no Stripe subscription. read-only.
- * - `trialing` — in trial. writable. Legacy rows without a Stripe
- *   subscription id self-expire locally; Stripe-backed trials do not.
+ * - `trialing` — Stripe Checkout trial in progress. writable. Local
+ *   `trialing` rows without a Stripe subscription id also derive as
+ *   `awaiting_checkout`.
  * - `active` — paid. writable.
  * - `past_due` — dunning window. writable + banner.
  * - `canceled` — subscription canceled. read-only.

--- a/packages/scripts/src/commands/backfill-billing.db.test.ts
+++ b/packages/scripts/src/commands/backfill-billing.db.test.ts
@@ -48,7 +48,7 @@ describe("backfill-billing (db)", () => {
     expect(stored?.billing).toBeUndefined();
   });
 
-  it("applies a trialing window and is idempotent", async () => {
+  it("stamps awaiting_checkout and is idempotent", async () => {
     await mongoService.user.insertOne({
       email: "old@example.com",
       name: "Old",
@@ -79,9 +79,10 @@ describe("backfill-billing (db)", () => {
     const stored = await mongoService.user.findOne({
       email: "old@example.com",
     });
-    expect(stored?.billing?.subscriptionStatus).toBe("trialing");
+    expect(stored?.billing?.subscriptionStatus).toBe("awaiting_checkout");
     expect(stored?.billing?.backfilledAt).toEqual(NOW);
     expect(stored?.billing?.stripeSubscriptionId).toBeUndefined();
+    expect(stored?.billing?.trialEndsAt).toBeUndefined();
 
     const second = await backfillBilling(mongoService.user, {
       dryRun: false,

--- a/packages/scripts/src/commands/backfill-billing.ts
+++ b/packages/scripts/src/commands/backfill-billing.ts
@@ -32,8 +32,8 @@ function parseArgs(argv: string[]): {
 }
 
 /**
- * Places existing accounts (no billing.subscriptionStatus) onto a 7-day
- * trial. Dry-run by default; pass `--apply` to write.
+ * Places existing accounts (no billing.subscriptionStatus) into
+ * awaiting_checkout. Dry-run by default; pass `--apply` to write.
  *
  * Usage:
  *   bun run cli backfill-billing [--apply] [--batch-size 500] [--cutoff ISO]

--- a/packages/scripts/src/commands/backfill-billing/backfill.ts
+++ b/packages/scripts/src/commands/backfill-billing/backfill.ts
@@ -1,5 +1,4 @@
 import { type Collection, type ObjectId } from "mongodb";
-import { BILLING_PLAN } from "@core/constants/billing.constants";
 import { type Schema_User } from "@core/types/user.types";
 
 export type BackfillBillingReport = {
@@ -20,8 +19,6 @@ export async function backfillBilling(
   },
 ): Promise<BackfillBillingReport> {
   const now = options.now ?? new Date();
-  const trialEndsAt = new Date(now);
-  trialEndsAt.setDate(trialEndsAt.getDate() + BILLING_PLAN.TRIAL_LENGTH_DAYS);
 
   const filter = {
     "billing.subscriptionStatus": { $exists: false },
@@ -60,9 +57,7 @@ export async function backfillBilling(
       { _id: { $in: ids }, "billing.subscriptionStatus": { $exists: false } },
       {
         $set: {
-          "billing.subscriptionStatus": "trialing",
-          "billing.trialStartedAt": now,
-          "billing.trialEndsAt": trialEndsAt,
+          "billing.subscriptionStatus": "awaiting_checkout",
           "billing.backfilledAt": now,
         },
       },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Google OAuth for an email that already has a Compass user is a SIGNIN (session remapped; existing calendars stay). The Start-trial gate never appeared because missing billing, `none`, and local/backfill `trialing` rows were writable.

Hosted users without a Stripe subscription id now derive as `awaiting_checkout` (read-only). A trial starts only via Stripe Checkout. Self-host is unchanged (`billing.isConfigured: false` keeps the app open).

`backfill-billing` stamps `awaiting_checkout` instead of a local 7-day trial.

Follow-up: creating a Stripe customer no longer leaves a billing document without `subscriptionStatus` (that used to fail Zod parse and fail-open the client gate).

## Simplicity

Derivation-only for existing unpaid rows; no Mongo migration. Customer create stamps `awaiting_checkout` only when status is missing or `none`.

## Automated validation

- `bun test:backend`: 345 pass, 1 skip (first commit)
- Focused billing tests after the P1 fix: 26 pass
- `bun test:scripts`: 33 pass
- `bun type-check`: pass
- `bun lint`: pass (pre-existing warnings only)

Staging Google OAuth cannot be finished from this agent. After deploy, the same sign-in should keep calendars and show **Start your 7-day trial**.

## Independent review

Approve after fixing P1: a customer-only billing document must not drop the client gate. No remaining P0/P1.

## Test plan

- `bun test:backend`
- `bun test:scripts`
- `bun type-check`
- `bun lint`
- `bun packages/scripts/src/testing/test-mongo-env.ts backend --` on the four billing files after the P1 fix

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-840f8baf-d672-4278-ad05-7264cfd551f1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-840f8baf-d672-4278-ad05-7264cfd551f1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

