### PR TITLE
feat(web): show Product Hunt badge on welcome

### DIFF
--- a/packages/web/src/components/WelcomeModal/ProductHuntBadge.tsx
+++ b/packages/web/src/components/WelcomeModal/ProductHuntBadge.tsx
@@ -9,7 +9,7 @@ export function ProductHuntBadge() {
       href={PRODUCT_HUNT_URL}
       target="_blank"
       rel="noopener noreferrer"
-      className="c-focus-ring inline-flex rounded-sm"
+      className="c-focus-ring mx-auto flex w-fit rounded-sm"
     >
       <img
         alt="Compass Calendar - The keyboard-first calendar. Get organized quickly. | Product Hunt"

--- a/packages/web/src/components/WelcomeModal/ProductHuntBadge.tsx
+++ b/packages/web/src/components/WelcomeModal/ProductHuntBadge.tsx
@@ -9,7 +9,7 @@ export function ProductHuntBadge() {
       href={PRODUCT_HUNT_URL}
       target="_blank"
       rel="noopener noreferrer"
-      className="c-focus-ring mx-auto flex w-fit rounded-sm"
+      className="c-focus-ring inline-flex rounded-sm"
     >
       <img
         alt="Compass Calendar - The keyboard-first calendar. Get organized quickly. | Product Hunt"

--- a/packages/web/src/components/WelcomeModal/ProductHuntBadge.tsx
+++ b/packages/web/src/components/WelcomeModal/ProductHuntBadge.tsx
@@ -1,0 +1,22 @@
+const PRODUCT_HUNT_URL =
+  "https://www.producthunt.com/products/compass-calendar?embed=true&utm_source=badge-featured&utm_medium=badge&utm_campaign=badge-compass-calendar-2";
+const PRODUCT_HUNT_BADGE_SRC =
+  "https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1222394&theme=dark&t=1786683338797";
+
+export function ProductHuntBadge() {
+  return (
+    <a
+      href={PRODUCT_HUNT_URL}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="c-focus-ring inline-flex rounded-sm"
+    >
+      <img
+        alt="Compass Calendar - The keyboard-first calendar. Get organized quickly. | Product Hunt"
+        width={250}
+        height={54}
+        src={PRODUCT_HUNT_BADGE_SRC}
+      />
+    </a>
+  );
+}

--- a/packages/web/src/components/WelcomeModal/WelcomeGuideBody.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeGuideBody.tsx
@@ -24,7 +24,7 @@ export function WelcomeGuideBody() {
 
   return (
     <>
-      <div className="flex flex-col gap-2">
+      <div className="flex w-full flex-col gap-2">
         <h2 className="font-bold text-2xl text-text leading-snug">
           The keyboard-first calendar
         </h2>
@@ -32,12 +32,13 @@ export function WelcomeGuideBody() {
           Rediscover the joy of shortcuts as you build your perfect schedule. No
           mouse required.
         </p>
-        <div className="flex justify-center pt-1">
-          <ProductHuntBadge />
-        </div>
       </div>
 
-      <div className="flex flex-col divide-y divide-border">
+      <div className="flex w-full justify-center">
+        <ProductHuntBadge />
+      </div>
+
+      <div className="flex w-full flex-col divide-y divide-border">
         {FAQ_ITEMS.map((item, index) => {
           const isExpanded = expandedFaqs.has(item.question);
           const answerId = `${disclosureIdPrefix}-faq-answer-${index}`;

--- a/packages/web/src/components/WelcomeModal/WelcomeGuideBody.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeGuideBody.tsx
@@ -1,5 +1,6 @@
 import { useId, useState } from "react";
 import { FAQ_ITEMS } from "./faq";
+import { ProductHuntBadge } from "./ProductHuntBadge";
 
 export function WelcomeGuideBody() {
   const disclosureIdPrefix = useId();
@@ -31,6 +32,9 @@ export function WelcomeGuideBody() {
           Rediscover the joy of shortcuts as you build your perfect schedule. No
           mouse required.
         </p>
+        <div className="flex justify-center pt-1">
+          <ProductHuntBadge />
+        </div>
       </div>
 
       <div className="flex flex-col divide-y divide-border">

--- a/packages/web/src/components/WelcomeModal/WelcomeModal.test.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeModal.test.tsx
@@ -72,6 +72,14 @@ describe("WelcomeModal", () => {
     expect(screen.getByText(/Rediscover the joy of shortcuts/)).toBeTruthy();
     expect(screen.getByRole("img", { name: /pixel pirate/i })).toBeTruthy();
     expect(screen.getByText("No signup required")).toBeTruthy();
+    expect(
+      screen.getByRole("link", {
+        name: "Compass Calendar - The keyboard-first calendar. Get organized quickly. | Product Hunt",
+      }),
+    ).toHaveAttribute(
+      "href",
+      "https://www.producthunt.com/products/compass-calendar?embed=true&utm_source=badge-featured&utm_medium=badge&utm_campaign=badge-compass-calendar-2",
+    );
   });
 
   it("opens the auth modal from the Log in pill", async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds the Product Hunt featured badge to the welcome guide so new users see it on first visit (and anyone who reopens the welcome guide).

The official embed is a native link + image with a visible focus ring. It sits in a full-width row under the intro copy so it centers in the modal (the welcome panel uses `items-start`, which left-aligned a nested badge).

## Simplicity

One `ProductHuntBadge` component and a centered row in the existing welcome body. Dropped redundant `mx-auto` / `w-fit` on the link after the parent row already centers it. No extra state, effects, or refs.

## Automated validation

- Welcome modal tests: 11 pass, including a role/name assertion for the Product Hunt link and href.
- `bun run lint`: no new findings (10 pre-existing warnings elsewhere).
- Manual: anonymous IndexedDB mode at `http://localhost:9080` — badge loads and is horizontally centered with Start Now.

## Independent review

Fresh read-only review of `origin/main...HEAD`: no confirmed findings. Native link, accessible name from alt, focus ring, `noopener noreferrer`, no storage/event-data changes.

## Test plan

- `bun test:web packages/web/src/components/WelcomeModal/WelcomeModal.test.tsx` — 11 pass
- `bun run lint`
- Welcome modal visual check that the badge is centered

![Welcome modal with centered Product Hunt badge](https://cursor.com/artifacts/c/art-19be8e6e-abc2-43dd-8c7f-81918b8b2a4a)
<a href="https://cursor.com/agents/bc-9431e607-16c7-44b0-853c-f013814e4860/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fwelcome_modal_badge_centered.mp4"><img src="https://cursor.com/artifacts/c/art-8ca35a7e-5186-4a8c-97af-c4387efde773" alt="welcome_modal_badge_centered.mp4" /></a>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9431e607-16c7-44b0-853c-f013814e4860?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9431e607-16c7-44b0-853c-f013814e4860&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

