### PR TITLE
fix(web): filter benign ResizeObserver loop warning from PostHog

### DIFF
--- a/packages/web/src/auth/posthog/posthog-exception-filter.util.test.ts
+++ b/packages/web/src/auth/posthog/posthog-exception-filter.util.test.ts
@@ -70,6 +70,30 @@ describe("filterPosthogBeforeSend", () => {
     ).toBeNull();
   });
 
+  it("drops the ResizeObserver loop completed browser warning", () => {
+    expect(
+      filterPosthogBeforeSend(
+        exceptionEvent([
+          {
+            type: "Error",
+            value:
+              "ResizeObserver loop completed with undelivered notifications.",
+          },
+        ]),
+      ),
+    ).toBeNull();
+  });
+
+  it("drops the Firefox ResizeObserver loop limit exceeded variant", () => {
+    expect(
+      filterPosthogBeforeSend(
+        exceptionEvent([
+          { type: "Error", value: "ResizeObserver loop limit exceeded" },
+        ]),
+      ),
+    ).toBeNull();
+  });
+
   it("keeps Script error. when stack frames are present", () => {
     const event = exceptionEvent([
       {

--- a/packages/web/src/auth/posthog/posthog-exception-filter.util.ts
+++ b/packages/web/src/auth/posthog/posthog-exception-filter.util.ts
@@ -16,6 +16,17 @@ const CEFSHARP_SCANNER_MESSAGE =
  */
 const SCRIPT_ERROR_MESSAGE = "Script error.";
 
+/**
+ * Benign browser warning fired via `window.onerror` when a ResizeObserver
+ * callback can't finish notifying within one frame (e.g. it triggers layout
+ * that would require another cycle). Chrome/Firefox surface it as a script
+ * error even though nothing threw; it's not actionable on its own.
+ */
+const RESIZE_OBSERVER_LOOP_MESSAGES = new Set([
+  "ResizeObserver loop completed with undelivered notifications.",
+  "ResizeObserver loop limit exceeded",
+]);
+
 type ExceptionEntry = {
   type?: unknown;
   value?: unknown;
@@ -60,6 +71,8 @@ const isDroppableException = (entry: ExceptionEntry): boolean => {
   if (typeof entry.value !== "string") return false;
 
   if (entry.value === CEFSHARP_SCANNER_MESSAGE) return true;
+
+  if (RESIZE_OBSERVER_LOOP_MESSAGES.has(entry.value)) return true;
 
   // Opaque cross-origin errors. Keep the rare case where frames somehow
   // survived sanitization so a real stack is never discarded.


### PR DESCRIPTION
## Summary

- Reported via PostHog/Discord: `ResizeObserver loop completed with undelivered notifications.` was showing up as a tracked error.
- This is a well-known, non-actionable browser warning — Chrome/Firefox fire it via `window.onerror` when a `ResizeObserver` callback can't finish its notification cycle within one frame. Nothing actually threw. Since PostHog's `capture_unhandled_errors` listens on `window.onerror`, it was picked up and reported as a real exception.
- Added this signature (plus the older Firefox variant `ResizeObserver loop limit exceeded`) to the existing droppable-exception filter, alongside the other known-benign browser signatures already filtered there (CefSharp scanner noise, opaque cross-origin `Script error.`, SuperTokens network blips).

Investigation also found several likely *sources* of the observer activity (grid measurement hooks with a measure→setState→resize cycle, floating-ui `autoUpdate` on tooltips/menus) — these are expected in an app with dynamic, size-driven layout and not something to remove; only the reporting-side false positive is fixed here.

## Simplicity

Minimal fix: two string constants + one conditional check, following the exact existing pattern in `posthog-exception-filter.util.ts` (no new abstractions, no changes to the layout/observer code).

## Automated validation

N/A — this is error-filtering config, not a UI change; no browser-observable behavior to verify.

## Independent review

Not run for this change.

## Test plan

- `TZ=UTC NODE_ENV=test bun test ./src/auth/posthog/posthog-exception-filter.util.test.ts` (from `packages/web`) — 12 pass, 0 fail (2 new tests added)
- `bun run type-check` — clean