### PR TITLE
fix(web): remove shuffle icon from life quotes

### DIFF
--- a/packages/web/src/views/Life/LifeQuote.tsx
+++ b/packages/web/src/views/Life/LifeQuote.tsx
@@ -1,26 +1,11 @@
-import { ShuffleIcon } from "@phosphor-icons/react";
-import { useState } from "react";
-import { TooltipWrapper } from "@web/components/Tooltip/TooltipWrapper";
 import { getRandomLifeQuote } from "./life-quotes";
 
 export function LifeQuote() {
-  const [quote, setQuote] = useState(getRandomLifeQuote);
+  const quote = getRandomLifeQuote();
 
   return (
-    <section className="flex items-start gap-1 text-text-muted">
-      <blockquote aria-live="polite" className="min-w-0 flex-1 italic">
-        {quote}
-      </blockquote>
-      <TooltipWrapper description="Show another quote">
-        <button
-          aria-label="Shuffle life quote"
-          className="flex size-8 items-center justify-center rounded-full text-text-muted transition-colors hover:bg-surface-panel hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
-          onClick={() => setQuote((current) => getRandomLifeQuote(current))}
-          type="button"
-        >
-          <ShuffleIcon aria-hidden="true" size={17} />
-        </button>
-      </TooltipWrapper>
+    <section className="text-text-muted">
+      <blockquote className="italic">{quote}</blockquote>
     </section>
   );
 }

--- a/packages/web/src/views/Life/LifeView.test.tsx
+++ b/packages/web/src/views/Life/LifeView.test.tsx
@@ -169,6 +169,9 @@ describe("LifeView", () => {
       screen.queryByRole("button", { name: /zoom/i }),
     ).not.toBeInTheDocument();
     expect(screen.queryByText(/ctrl\+scroll|pinch/i)).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Shuffle life quote" }),
+    ).not.toBeInTheDocument();
   });
 
   it("opens the birth date picker when Enter is pressed on the focused field", async () => {

--- a/packages/web/src/views/Life/life-quotes.test.ts
+++ b/packages/web/src/views/Life/life-quotes.test.ts
@@ -3,13 +3,6 @@ import { describe, expect, it } from "bun:test";
 
 describe("life quotes", () => {
   it("chooses from the supplied quotes", () => {
-    expect(getRandomLifeQuote(undefined, () => 0)).toBe(LIFE_QUOTES[0]);
-  });
-
-  it("chooses a different quote when shuffled", () => {
-    expect(getRandomLifeQuote(LIFE_QUOTES[0], () => 0)).toBe(LIFE_QUOTES[1]);
-    expect(getRandomLifeQuote(LIFE_QUOTES[0], () => 1)).not.toBe(
-      LIFE_QUOTES[0],
-    );
+    expect(getRandomLifeQuote(() => 0)).toBe(LIFE_QUOTES[0]);
   });
 });

--- a/packages/web/src/views/Life/life-quotes.ts
+++ b/packages/web/src/views/Life/life-quotes.ts
@@ -53,16 +53,10 @@ export const LIFE_QUOTES = [
   "“Life moves pretty fast. If you don’t stop and look around once in a while, you could miss it.” (Ferris Bueller’s Day Off)",
 ] as const;
 
-export function getRandomLifeQuote(
-  currentQuote?: string,
-  random = getSecureRandomNumber,
-) {
-  const quotes = currentQuote
-    ? LIFE_QUOTES.filter((quote) => quote !== currentQuote)
-    : LIFE_QUOTES;
+export function getRandomLifeQuote(random = getSecureRandomNumber) {
   const index = Math.min(
-    quotes.length - 1,
-    Math.floor(random() * quotes.length),
+    LIFE_QUOTES.length - 1,
+    Math.floor(random() * LIFE_QUOTES.length),
   );
-  return quotes[index] ?? LIFE_QUOTES[0];
+  return LIFE_QUOTES[index] ?? LIFE_QUOTES[0];
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes the shuffle button next to quotes on the Life page sidebar. A random quote still appears on load.

## Simplicity

Dropped the quote shuffle control, tooltip, and the helper logic that avoided repeating the current quote on shuffle.

## Automated validation

- Focused web tests for Life quotes and LifeView passed (16 tests).
- Manual check on `/life`: quote still renders; no shuffle control or tooltip.

## Independent review

No extra reviewer pass in this session. Diff is a small UI removal plus test updates.

## Test plan

- `bun run test:web -- packages/web/src/views/Life/life-quotes.test.ts packages/web/src/views/Life/LifeView.test.tsx`
- `bun run lint`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ca9eaa2f-9f37-4a06-a0c7-68faf7149a43?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ca9eaa2f-9f37-4a06-a0c7-68faf7149a43&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

