### PR TITLE
fix(web): ignore keyboard events with a missing key

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -185,6 +185,7 @@
   },
   "patchedDependencies": {
     "@tanstack/react-router@1.170.17": "patches/@tanstack%2Freact-router@1.170.17.patch",
+    "@tanstack/hotkeys@0.3.3": "patches/@tanstack%2Fhotkeys@0.3.3.patch",
   },
   "overrides": {
     "gaxios": "^7.1.3",

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
   ],
   "packageManager": "bun@1.3.14",
   "patchedDependencies": {
-    "@tanstack/react-router@1.170.17": "patches/@tanstack%2Freact-router@1.170.17.patch"
+    "@tanstack/react-router@1.170.17": "patches/@tanstack%2Freact-router@1.170.17.patch",
+    "@tanstack/hotkeys@0.3.3": "patches/@tanstack%2Fhotkeys@0.3.3.patch"
   }
 }

--- a/packages/web/src/__tests__/utils/keyboard.test.util.ts
+++ b/packages/web/src/__tests__/utils/keyboard.test.util.ts
@@ -26,3 +26,18 @@ export function pressKey(
     }),
   );
 }
+
+/** Some browsers fire KeyboardEvents with `key` unset. */
+export function dispatchMissingKey(
+  type: "keydown" | "keyup",
+  target: Element | Node | Window | Document = document,
+) {
+  const event = new KeyboardEvent(type, {
+    bubbles: true,
+    cancelable: true,
+    composed: true,
+  });
+  Object.defineProperty(event, "key", { get: () => undefined });
+  target.dispatchEvent(event);
+  return event;
+}

--- a/packages/web/src/components/OnboardingChecklist/useChecklistDetection.test.tsx
+++ b/packages/web/src/components/OnboardingChecklist/useChecklistDetection.test.tsx
@@ -1,5 +1,6 @@
 import { act, renderHook } from "@testing-library/react";
 import { type ReactNode } from "react";
+import { dispatchMissingKey } from "@web/__tests__/utils/keyboard.test.util";
 import { SessionContext } from "@web/auth/compass/session/session.context";
 import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
 import { persistentBrowserStore } from "@web/common/storage/browser-key-value.store";
@@ -103,5 +104,19 @@ describe("useChecklistDetection", () => {
     act(() => eventJumpActions.setActive(true));
     pressKey("z", { metaKey: true });
     expect(completed()).toEqual({});
+  });
+
+  it("ignores KeyboardEvents with no key instead of throwing", () => {
+    renderHook(() => useChecklistDetection(true), {
+      wrapper: wrapperFor(false),
+    });
+
+    expect(() => {
+      act(() => {
+        dispatchMissingKey("keydown");
+      });
+    }).not.toThrow();
+
+    expect(completed().undo).toBeUndefined();
   });
 });

--- a/packages/web/src/components/OnboardingChecklist/useChecklistDetection.ts
+++ b/packages/web/src/components/OnboardingChecklist/useChecklistDetection.ts
@@ -5,6 +5,7 @@ import { isEditableKeyboardTarget } from "@web/common/utils/form/form.util";
 import { checklistActions } from "@web/components/OnboardingChecklist/checklist.store";
 import { useDraftStore } from "@web/events/stores/draft.store";
 import { useEdgeFocusStore } from "@web/grid/shortcuts/edge-focus.store";
+import { keyboardKey } from "@web/shortcuts/is-bare-letter-key";
 import { useEventJumpStore } from "@web/shortcuts/shift-hint/event-jump.store";
 
 const ARROW_KEYS = new Set(["ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight"]);
@@ -42,7 +43,7 @@ export function useChecklistDetection(enabled: boolean) {
       if (
         (event.metaKey || event.ctrlKey) &&
         !event.shiftKey &&
-        event.key.toLowerCase() === "z"
+        keyboardKey(event).toLowerCase() === "z"
       ) {
         checklistActions.completeItem("undo");
         return;

--- a/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.test.tsx
+++ b/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.test.tsx
@@ -1,5 +1,6 @@
 import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { dispatchMissingKey } from "@web/__tests__/utils/keyboard.test.util";
 import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
 import { persistentBrowserStore } from "@web/common/storage/browser-key-value.store";
 import { ShortcutShowcase } from "@web/components/ShortcutShowcase/ShortcutShowcase";
@@ -62,6 +63,19 @@ describe("ShortcutShowcase", () => {
     act(() => shortcutShowcaseActions.skip());
     expect(screen.queryByLabelText("Shortcut practice")).toBeNull();
     expect(isAppLocked()).toBe(false);
+  });
+
+  it("ignores KeyboardEvents with no key instead of throwing", () => {
+    render(<ShortcutShowcase />);
+    act(() => shortcutShowcaseActions.start());
+
+    expect(() => {
+      act(() => {
+        dispatchMissingKey("keydown");
+      });
+    }).not.toThrow();
+
+    expect(screen.getByLabelText("Shortcut practice")).toBeTruthy();
   });
 
   it("advances through every lesson by doing, and graduates on Enter", async () => {

--- a/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.tsx
+++ b/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.tsx
@@ -48,7 +48,10 @@ import {
 } from "@web/components/ShortcutShowcase/showcase.store";
 import { ShortcutKeys } from "@web/components/Shortcuts/ShortcutKeys";
 import { useAppLockReason } from "@web/shortcuts/app-lock";
-import { isBareLetterKey } from "@web/shortcuts/is-bare-letter-key";
+import {
+  isBareLetterKey,
+  keyboardKey,
+} from "@web/shortcuts/is-bare-letter-key";
 import { KEYMAP } from "@web/shortcuts/keymap";
 import { ShortcutTipParts } from "@web/shortcuts/tips/ShortcutTipParts";
 import { ARM_WINDOW_MS } from "@web/shortcuts/useEditSequenceShortcut";
@@ -272,7 +275,7 @@ const ShowcaseTakeover: FC = () => {
       ) {
         event.preventDefault();
         const hints = Object.values(practiceRef.current.jumpChips);
-        const typed = jumpBufferRef.current + event.key.toLowerCase();
+        const typed = jumpBufferRef.current + keyboardKey(event).toLowerCase();
         if (hints.includes(typed)) {
           jumpBufferRef.current = "";
           apply((state) => jumpToChipHint(state, typed));
@@ -306,7 +309,10 @@ const ShowcaseTakeover: FC = () => {
         return;
       }
 
-      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "z") {
+      if (
+        (event.metaKey || event.ctrlKey) &&
+        keyboardKey(event).toLowerCase() === "z"
+      ) {
         event.preventDefault();
         const before = practiceRef.current;
         if (event.shiftKey) {

--- a/packages/web/src/components/WelcomeModal/WelcomeModal.test.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeModal.test.tsx
@@ -1,6 +1,7 @@
-import { render, screen, within } from "@testing-library/react";
+import { act, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createContext } from "react";
+import { dispatchMissingKey } from "@web/__tests__/utils/keyboard.test.util";
 import { type CompassSession } from "@web/auth/compass/session/session.types";
 import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
 
@@ -224,6 +225,22 @@ describe("WelcomeModal", () => {
     await user.keyboard("s");
 
     expect(localStorage.getItem(STORAGE_KEYS.HAS_SEEN_WELCOME)).toBe("true");
+  });
+
+  it("ignores KeyboardEvents with no key instead of throwing", () => {
+    render(<WelcomeModal />);
+    // Dispatch from inside the modal's onKeyDown scope (not the dialog root
+    // itself) so the event bubbles through the handler like a real keypress.
+    const signUp = screen.getByRole("button", { name: "Sign up" });
+
+    expect(() => {
+      act(() => {
+        dispatchMissingKey("keydown", signUp);
+      });
+    }).not.toThrow();
+
+    expect(mockOpenModal).not.toHaveBeenCalled();
+    expect(localStorage.getItem(STORAGE_KEYS.HAS_SEEN_WELCOME)).toBeNull();
   });
 
   it("ignores the shortcut keys when a modifier is held", async () => {

--- a/packages/web/src/components/WelcomeModal/WelcomeModal.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeModal.tsx
@@ -13,6 +13,7 @@ import { useAuthModal } from "@web/components/AuthModal/hooks/useAuthModal";
 import { OverlayPanel } from "@web/components/OverlayPanel/OverlayPanel";
 import { shortcutShowcaseActions } from "@web/components/ShortcutShowcase/showcase.store";
 import { ShortcutHint } from "@web/components/Shortcuts/ShortcutHint";
+import { keyboardKey } from "@web/shortcuts/is-bare-letter-key";
 import { PixelPirate } from "./PixelPirate";
 import { WelcomeGuideBody } from "./WelcomeGuideBody";
 import { hasSeenWelcome, markWelcomeSeen } from "./welcome.modal.util";
@@ -66,7 +67,7 @@ export function WelcomeModal() {
 
   const handleShortcutKey = (e: React.KeyboardEvent) => {
     if (e.metaKey || e.ctrlKey || e.altKey) return;
-    const key = e.key.toLowerCase();
+    const key = keyboardKey(e).toLowerCase();
     if (key === "u") {
       e.preventDefault();
       handOffToAuth("sign_up");

--- a/packages/web/src/shortcuts/is-bare-letter-key.test.ts
+++ b/packages/web/src/shortcuts/is-bare-letter-key.test.ts
@@ -1,0 +1,51 @@
+import {
+  isBareLetterKey,
+  keyboardKey,
+  normalizedKeyboardKey,
+} from "@web/shortcuts/is-bare-letter-key";
+import { describe, expect, it } from "bun:test";
+
+const eventWithKey = (key: unknown): KeyboardEvent => {
+  const event = new KeyboardEvent("keydown", {
+    bubbles: true,
+    cancelable: true,
+  });
+  Object.defineProperty(event, "key", { get: () => key });
+  return event;
+};
+
+describe("keyboardKey", () => {
+  it("returns the key when it is a string", () => {
+    expect(keyboardKey(eventWithKey("e"))).toBe("e");
+  });
+
+  it("returns empty string when key is missing", () => {
+    expect(keyboardKey(eventWithKey(undefined))).toBe("");
+    expect(keyboardKey(eventWithKey(null))).toBe("");
+  });
+});
+
+describe("normalizedKeyboardKey", () => {
+  it("lowercases single-character keys", () => {
+    expect(normalizedKeyboardKey(eventWithKey("E"))).toBe("e");
+  });
+
+  it("leaves named keys unchanged", () => {
+    expect(normalizedKeyboardKey(eventWithKey("Escape"))).toBe("Escape");
+  });
+
+  it("does not throw when key is missing", () => {
+    expect(normalizedKeyboardKey(eventWithKey(undefined))).toBe("");
+  });
+});
+
+describe("isBareLetterKey", () => {
+  it("matches an unmodified letter", () => {
+    expect(isBareLetterKey(eventWithKey("s"), "s")).toBe(true);
+    expect(isBareLetterKey(eventWithKey("S"), "s")).toBe(true);
+  });
+
+  it("returns false instead of throwing when key is missing", () => {
+    expect(isBareLetterKey(eventWithKey(undefined), "s")).toBe(false);
+  });
+});

--- a/packages/web/src/shortcuts/is-bare-letter-key.ts
+++ b/packages/web/src/shortcuts/is-bare-letter-key.ts
@@ -1,8 +1,29 @@
+/**
+ * Some browsers, extensions, and IME/autofill paths fire KeyboardEvents with
+ * `key` unset. Calling `.length` / `.toLowerCase()` on that value is a
+ * TypeError and is what production error tracking reports as
+ * "Cannot read properties of undefined (reading 'length'|'toLowerCase')".
+ */
+export const keyboardKey = (event: Pick<KeyboardEvent, "key">): string =>
+  typeof event.key === "string" ? event.key : "";
+
+/** Lowercase a single-character key; leave named keys (Escape, ArrowUp) as-is. */
+export const normalizedKeyboardKey = (
+  event: Pick<KeyboardEvent, "key">,
+): string => {
+  const key = keyboardKey(event);
+  return key.length === 1 ? key.toLowerCase() : key;
+};
+
 /** True for an unmodified single-letter key matching `letter` (case-insensitive). */
-export const isBareLetterKey = (event: KeyboardEvent, letter: string) =>
-  event.key.length === 1 &&
-  event.key.toLowerCase() === letter &&
-  !event.metaKey &&
-  !event.ctrlKey &&
-  !event.altKey &&
-  !event.shiftKey;
+export const isBareLetterKey = (event: KeyboardEvent, letter: string) => {
+  const key = keyboardKey(event);
+  return (
+    key.length === 1 &&
+    key.toLowerCase() === letter &&
+    !event.metaKey &&
+    !event.ctrlKey &&
+    !event.altKey &&
+    !event.shiftKey
+  );
+};

--- a/packages/web/src/shortcuts/keyboard-only/useKeyboardOnlyMode.test.tsx
+++ b/packages/web/src/shortcuts/keyboard-only/useKeyboardOnlyMode.test.tsx
@@ -1,4 +1,5 @@
 import { act, renderHook } from "@testing-library/react";
+import { dispatchMissingKey } from "@web/__tests__/utils/keyboard.test.util";
 import { clearAppLockReasons, setAppLockReason } from "@web/shortcuts/app-lock";
 import {
   initialKeyboardOnlyState,
@@ -197,5 +198,16 @@ describe("useKeyboardOnlyMode", () => {
 
     expect(useKeyboardOnlyStore.getState().isActive).toBe(true);
     expect(useEventJumpStore.getState().isActive).toBe(false);
+  });
+
+  it("ignores KeyboardEvents with no key instead of throwing", () => {
+    renderHook(() => useKeyboardOnlyMode());
+
+    expect(() => {
+      dispatchMissingKey("keydown");
+      dispatchMissingKey("keyup");
+    }).not.toThrow();
+
+    expect(useKeyboardOnlyStore.getState().isActive).toBe(false);
   });
 });

--- a/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.test.tsx
+++ b/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.test.tsx
@@ -1,5 +1,6 @@
 import { act, cleanup, renderHook } from "@testing-library/react";
 import { EventIdSchema } from "@core/types/domain-primitives";
+import { dispatchMissingKey } from "@web/__tests__/utils/keyboard.test.util";
 import { type GridEvent } from "@web/common/types/web.event.types";
 import { clearAppLockReasons, setAppLockReason } from "@web/shortcuts/app-lock";
 import {
@@ -259,6 +260,18 @@ describe("useShiftHoldEventHints", () => {
     });
 
     expect(onSequence).toHaveBeenCalledWith("start");
+    expect(useEventJumpStore.getState().isActive).toBe(false);
+    expect(result.current.hints).toEqual([]);
+  });
+
+  it("ignores KeyboardEvents with no key instead of throwing", () => {
+    const { result } = mountHints();
+
+    expect(() => {
+      dispatchMissingKey("keydown");
+      dispatchMissingKey("keyup");
+    }).not.toThrow();
+
     expect(useEventJumpStore.getState().isActive).toBe(false);
     expect(result.current.hints).toEqual([]);
   });

--- a/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.ts
+++ b/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.ts
@@ -5,7 +5,11 @@ import { type GridEvent } from "@web/common/types/web.event.types";
 import { isEditableKeyboardTarget } from "@web/common/utils/form/form.util";
 import { isAppLocked } from "@web/shortcuts/app-lock";
 import { isHigherEscapeOwner } from "@web/shortcuts/escape-ownership";
-import { isBareLetterKey } from "@web/shortcuts/is-bare-letter-key";
+import {
+  isBareLetterKey,
+  keyboardKey,
+  normalizedKeyboardKey,
+} from "@web/shortcuts/is-bare-letter-key";
 import { KEYMAP } from "@web/shortcuts/keymap";
 import {
   assignDayJumpKeys,
@@ -280,7 +284,7 @@ export function useShiftHoldEventHints({
       }
 
       // Arrows keep mode on so letter-then-arrows can move focus.
-      if (event.key.startsWith("Arrow")) {
+      if (keyboardKey(event).startsWith("Arrow")) {
         clearAmbiguousCommitTimer();
         stripDigitBuffer();
         return;
@@ -290,7 +294,7 @@ export function useShiftHoldEventHints({
         return;
       }
 
-      const key = event.key.length === 1 ? event.key.toLowerCase() : event.key;
+      const key = normalizedKeyboardKey(event);
       if (key.length !== 1) return;
 
       // Swallow j/k and other unmatched printable shortcuts while jump is on.
@@ -359,7 +363,7 @@ export function useShiftHoldEventHints({
     };
 
     const onKeyUp = (event: KeyboardEvent) => {
-      const key = event.key.length === 1 ? event.key.toLowerCase() : event.key;
+      const key = normalizedKeyboardKey(event);
       if (!suppressKeyUpRef.current.has(key)) return;
       suppressKeyUpRef.current.delete(key);
       event.preventDefault();

--- a/packages/web/src/shortcuts/tips/useShortcutTipTrigger.test.tsx
+++ b/packages/web/src/shortcuts/tips/useShortcutTipTrigger.test.tsx
@@ -1,0 +1,73 @@
+import { act, renderHook } from "@testing-library/react";
+import { dispatchMissingKey } from "@web/__tests__/utils/keyboard.test.util";
+import {
+  CALENDAR_VIEW_INTERACTION_ID_ATTRIBUTES,
+  calendarEventIdElementSelector,
+} from "@web/grid/interaction/view-event-registry";
+import { useShortcutTipsStore } from "@web/shortcuts/tips/shortcut-tips.store";
+import { useShortcutTipTrigger } from "@web/shortcuts/tips/useShortcutTipTrigger";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+
+const resetStore = () => {
+  useShortcutTipsStore.setState({
+    muted: false,
+    mouseStreak: 0,
+    activeTipId: null,
+    lastShownTipId: null,
+    lastRotatedAt: null,
+  });
+};
+
+/** Focuses a stand-in for a calendar event card so `eventFocused` is true. */
+const focusCalendarEvent = () => {
+  const card = document.createElement("div");
+  card.setAttribute(CALENDAR_VIEW_INTERACTION_ID_ATTRIBUTES[0], "evt-1");
+  card.tabIndex = -1;
+  document.body.appendChild(card);
+  card.focus();
+  return card;
+};
+
+describe("useShortcutTipTrigger", () => {
+  beforeEach(() => {
+    resetStore();
+  });
+
+  afterEach(() => {
+    resetStore();
+    document.body.innerHTML = "";
+  });
+
+  it("credits the edit-sequence tip on a bare e", () => {
+    const card = focusCalendarEvent();
+    expect(
+      document.activeElement?.closest(calendarEventIdElementSelector()),
+    ).toBe(card);
+
+    renderHook(() => useShortcutTipTrigger());
+    act(() => useShortcutTipsStore.setState({ activeTipId: "edit-sequence" }));
+
+    act(() => {
+      document.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "e", bubbles: true }),
+      );
+    });
+
+    expect(useShortcutTipsStore.getState().activeTipId).toBeNull();
+  });
+
+  it("ignores KeyboardEvents with no key instead of throwing", () => {
+    focusCalendarEvent();
+    renderHook(() => useShortcutTipTrigger());
+    act(() => useShortcutTipsStore.setState({ activeTipId: "edit-sequence" }));
+
+    expect(() => {
+      act(() => {
+        dispatchMissingKey("keydown");
+      });
+    }).not.toThrow();
+
+    // A missing key normalizes to "", not "e", so the tip stays active.
+    expect(useShortcutTipsStore.getState().activeTipId).toBe("edit-sequence");
+  });
+});

--- a/packages/web/src/shortcuts/tips/useShortcutTipTrigger.ts
+++ b/packages/web/src/shortcuts/tips/useShortcutTipTrigger.ts
@@ -4,6 +4,7 @@ import {
   selectIsEventFormOpen,
   useDraftStore,
 } from "@web/events/stores/draft.store";
+import { keyboardKey } from "@web/shortcuts/is-bare-letter-key";
 import {
   selectActiveShortcutTipId,
   shortcutTipsActions,
@@ -45,13 +46,13 @@ export function useShortcutTipTrigger() {
         activeTipId === "edit-sequence" &&
         !event.shiftKey &&
         !event.altKey &&
-        event.key.toLowerCase() === "e"
+        keyboardKey(event).toLowerCase() === "e"
       ) {
         shortcutTipsActions.actedOn("edit-sequence");
       } else if (
         activeTipId === "nudge" &&
         event.shiftKey &&
-        event.key.startsWith("Arrow")
+        keyboardKey(event).startsWith("Arrow")
       ) {
         shortcutTipsActions.actedOn("nudge");
       } else if (activeTipId === "target-event" && event.key === "Shift") {

--- a/packages/web/src/shortcuts/useEditSequenceShortcut.test.tsx
+++ b/packages/web/src/shortcuts/useEditSequenceShortcut.test.tsx
@@ -1,6 +1,9 @@
 import { resolveModifier } from "@tanstack/react-hotkeys";
 import { renderHook } from "@web/__tests__/__mocks__/mock.render";
-import { pressKey } from "@web/__tests__/utils/keyboard.test.util";
+import {
+  dispatchMissingKey,
+  pressKey,
+} from "@web/__tests__/utils/keyboard.test.util";
 import { clearAppLockReasons, setAppLockReason } from "@web/shortcuts/app-lock";
 import {
   selectEditSequenceMenuVisible,
@@ -274,5 +277,18 @@ describe("useEditSequenceShortcut", () => {
 
       document.removeEventListener("keydown", seen, true);
     });
+  });
+
+  it("ignores KeyboardEvents with no key instead of throwing", () => {
+    const onSequence = mock(() => {});
+    renderHook(() => useEditSequenceShortcut({ onSequence }));
+
+    expect(() => {
+      dispatchMissingKey("keydown");
+      dispatchMissingKey("keyup");
+    }).not.toThrow();
+
+    expect(isEditSequenceArmed()).toBe(false);
+    expect(onSequence).not.toHaveBeenCalled();
   });
 });

--- a/packages/web/src/shortcuts/useEditSequenceShortcut.ts
+++ b/packages/web/src/shortcuts/useEditSequenceShortcut.ts
@@ -13,7 +13,11 @@ import {
   editSequenceActions,
   useEditSequenceStore,
 } from "@web/shortcuts/edit-sequence/edit-sequence.store";
-import { isBareLetterKey } from "@web/shortcuts/is-bare-letter-key";
+import {
+  isBareLetterKey,
+  keyboardKey,
+  normalizedKeyboardKey,
+} from "@web/shortcuts/is-bare-letter-key";
 import { KEYMAP } from "@web/shortcuts/keymap";
 import { isEventJumpActive } from "@web/shortcuts/shift-hint/event-jump.store";
 
@@ -39,9 +43,6 @@ export const resetEditSequenceArm = () => {
 /** Any modifier at all, used to reject chords as the *second* key. */
 const hasModifier = (event: KeyboardEvent) =>
   event.metaKey || event.ctrlKey || event.altKey || event.shiftKey;
-
-const normalizeKey = (event: KeyboardEvent) =>
-  event.key.length === 1 ? event.key.toLowerCase() : event.key;
 
 /**
  * The single owner of both edit leaders.
@@ -100,7 +101,7 @@ export function useEditSequenceShortcut({
     };
 
     const isModLeader = (event: KeyboardEvent) => {
-      if (event.key.toLowerCase() !== LEADER_KEY) return false;
+      if (keyboardKey(event).toLowerCase() !== LEADER_KEY) return false;
       if (event.shiftKey || event.altKey) return false;
       return isMac
         ? event.metaKey && !event.ctrlKey
@@ -128,7 +129,7 @@ export function useEditSequenceShortcut({
           return;
         }
 
-        const key = normalizeKey(event);
+        const key = normalizedKeyboardKey(event);
         const field =
           key in EDIT_SEQUENCE_FIELD_BY_KEY
             ? EDIT_SEQUENCE_FIELD_BY_KEY[key as EditSequenceSecondKey]
@@ -171,7 +172,7 @@ export function useEditSequenceShortcut({
     };
 
     const onKeyUp = (event: KeyboardEvent) => {
-      const key = normalizeKey(event);
+      const key = normalizedKeyboardKey(event);
       if (!suppressKeyUp.has(key)) return;
 
       suppressKeyUp.delete(key);

--- a/packages/web/src/views/Forms/EventForm/EventForm.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.tsx
@@ -47,6 +47,7 @@ import {
 } from "@web/events/grid-event-draft.adapter";
 import { BUSY_EVENT_TITLE } from "@web/events/queries/event.view-model";
 import { useEventById } from "@web/events/queries/useEventById";
+import { keyboardKey } from "@web/shortcuts/is-bare-letter-key";
 import { KEYMAP } from "@web/shortcuts/keymap";
 import { useAppShortcut } from "@web/shortcuts/useAppShortcut";
 import { CalendarSelect } from "@web/views/Forms/EventForm/CalendarSelect/CalendarSelect";
@@ -431,11 +432,11 @@ export const EventForm: React.FC<GridEventFormProps> = memo(
         e.stopPropagation();
       }
 
-      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "<") {
+      if ((e.metaKey || e.ctrlKey) && keyboardKey(e).toLowerCase() === "<") {
         e.preventDefault();
       }
 
-      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "d") {
+      if ((e.metaKey || e.ctrlKey) && keyboardKey(e).toLowerCase() === "d") {
         e.preventDefault();
       }
 

--- a/patches/@tanstack%2Fhotkeys@0.3.3.patch
+++ b/patches/@tanstack%2Fhotkeys@0.3.3.patch
@@ -1,0 +1,24 @@
+diff --git a/dist/constants.cjs b/dist/constants.cjs
+index 186045d8d2085df4db0afca8cb74bea01c427edc..70eb00e6ff6feebb5bb39d796f4f2691006a02f9 100644
+--- a/dist/constants.cjs
++++ b/dist/constants.cjs
+@@ -351,6 +351,7 @@ function isSingleLetterKey(key) {
+ 	return /^\p{Letter}$/u.test(key);
+ }
+ function normalizeKeyName(key) {
++	if (typeof key !== "string") return "";
+ 	if (key in KEY_ALIASES) return KEY_ALIASES[key];
+ 	if (isSingleLetterKey(key)) return key.toUpperCase();
+ 	const upperKey = key.toUpperCase();
+diff --git a/dist/constants.js b/dist/constants.js
+index 1bde9bd6b8208c05c741d7173cee075fb8d7b1b0..1cc1fd11eaa4ab8c98c0a492223ed20244a5c486 100644
+--- a/dist/constants.js
++++ b/dist/constants.js
+@@ -350,6 +350,7 @@ function isSingleLetterKey(key) {
+ 	return /^\p{Letter}$/u.test(key);
+ }
+ function normalizeKeyName(key) {
++	if (typeof key !== "string") return "";
+ 	if (key in KEY_ALIASES) return KEY_ALIASES[key];
+ 	if (isSingleLetterKey(key)) return key.toUpperCase();
+ 	const upperKey = key.toUpperCase();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Discord/PostHog reported production TypeErrors:

- `Cannot read properties of undefined (reading 'length')` (4)
- `Cannot read properties of undefined (reading 'toLowerCase')` (1)

Those match the document-level shortcut listeners added with event jump, Hardcore mode, edit sequences, and the Shortcut Showcase. They call `event.key.length` / `event.key.toLowerCase()` on every keydown/keyup. Some browsers, extensions, IME, and autofill paths fire `KeyboardEvent`s with `key` unset; Chrome then throws exactly those messages. One such event hits several capture listeners, which matches a burst of the same TypeError.

**Fix:** treat a non-string `event.key` as `""` in a shared helper, and use it from `isBareLetterKey` plus the other shortcut/onboarding listeners so they no-op instead of throwing.

The same events also crash `@tanstack/hotkeys` (`normalizeKeyName` → `key.toUpperCase()`), which backs `useAppShortcut`. That library is patched to return `""` when `key` is not a string.

PostHog MCP was unavailable during this run, so this is from the Discord signatures plus the call sites that produce them. After deploy, confirm the issues stop receiving events and resolve them.

## Simplicity

One helper (`keyboardKey` / `normalizedKeyboardKey`) and a one-line guard in the existing TanStack hotkeys patch pattern. No new shortcut behavior.

## Automated validation

Focused web tests for the helper and the document-level listeners that previously threw. Dispatching a keyless `KeyboardEvent` no longer throws from Compass listeners or TanStack hotkeys.

## Independent review

Not run for this change.

## Test plan

```bash
cd packages/web && TZ=UTC NODE_ENV=test bun test ./src/shortcuts/is-bare-letter-key.test.ts ./src/shortcuts/useEditSequenceShortcut.test.tsx ./src/shortcuts/shift-hint/useShiftHoldEventHints.test.tsx ./src/shortcuts/keyboard-only/useKeyboardOnlyMode.test.tsx
bun lint
```

41 pass, 0 fail. `bun lint` reports only pre-existing warnings.

### Error signatures addressed

- `TypeError: Cannot read properties of undefined (reading 'length')`
- `TypeError: Cannot read properties of undefined (reading 'toLowerCase')`
- Related: `@tanstack/hotkeys` `key.toUpperCase()` on the same events

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-83db691d-1951-4926-a24b-f1401980a133?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-83db691d-1951-4926-a24b-f1401980a133&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

