### PR TITLE
fix(web): skip calendar onboarding overlays on /life

### DIFF
--- a/packages/web/src/components/RootShell/RootShell.test.tsx
+++ b/packages/web/src/components/RootShell/RootShell.test.tsx
@@ -2,6 +2,8 @@ import "@testing-library/jest-dom";
 import { render, screen } from "@web/__tests__/__mocks__/mock.render";
 import { createTestRouter } from "@web/__tests__/utils/providers/createTestRouter";
 import { type AppAccess } from "@web/billing/useAppAccess";
+import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
+import { persistentBrowserStore } from "@web/common/storage/browser-key-value.store";
 import { RootShell } from "@web/components/RootShell/RootShell";
 import { afterAll, afterEach, describe, expect, it, mock } from "bun:test";
 
@@ -15,20 +17,22 @@ mock.module("@web/billing/useAppAccess", () => ({
     isAppAccessMocked ? access : actualUseAppAccess(...args),
 }));
 
+const renderShell = async (initialPath = "/") => {
+  const router = createTestRouter(<RootShell />, {
+    initialEntries: [initialPath],
+  });
+  render(<div />, { router });
+  await router.load();
+};
+
+afterAll(() => {
+  isAppAccessMocked = false;
+});
+
 describe("RootShell billing gates", () => {
   afterEach(() => {
     access = { kind: "open" };
   });
-
-  afterAll(() => {
-    isAppAccessMocked = false;
-  });
-
-  const renderShell = async () => {
-    const router = createTestRouter(<RootShell />);
-    render(<div />, { router });
-    await router.load();
-  };
 
   it("shows the anonymous trial gate without the billing gate", async () => {
     access = { kind: "anonymous-trial", isExpired: true, daysLeft: 0 };
@@ -60,5 +64,67 @@ describe("RootShell billing gates", () => {
     expect(
       screen.queryByRole("dialog", { name: "Your free trial has ended" }),
     ).not.toBeInTheDocument();
+  });
+});
+
+describe("RootShell calendar onboarding on /life", () => {
+  afterEach(() => {
+    access = { kind: "open" };
+  });
+
+  it("does not show welcome or the practice card on /life, and does not burn flags", async () => {
+    await renderShell("/life");
+
+    expect(
+      screen.queryByRole("dialog", { name: "Welcome to Compass Calendar" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("complementary", {
+        name: "Shortcut practice checklist",
+      }),
+    ).not.toBeInTheDocument();
+    expect(persistentBrowserStore.get(STORAGE_KEYS.HAS_SEEN_WELCOME)).toBe(
+      null,
+    );
+    expect(
+      persistentBrowserStore.get(STORAGE_KEYS.HAS_SEEN_SHORTCUT_SHOWCASE),
+    ).toBe(null);
+    expect(persistentBrowserStore.get(STORAGE_KEYS.CHECKLIST_DONE)).toBe(null);
+  });
+
+  it("still shows welcome on /week for a first-time anonymous visitor", async () => {
+    await renderShell("/week");
+
+    expect(
+      screen.getByRole("dialog", { name: "Welcome to Compass Calendar" }),
+    ).toBeInTheDocument();
+  });
+
+  it("hides an in-progress practice card on /life without dismissing it", async () => {
+    persistentBrowserStore.set(STORAGE_KEYS.HAS_SEEN_WELCOME, "true");
+    persistentBrowserStore.set(STORAGE_KEYS.HAS_SEEN_SHORTCUT_SHOWCASE, "true");
+
+    await renderShell("/life");
+
+    expect(
+      screen.queryByRole("complementary", {
+        name: "Shortcut practice checklist",
+      }),
+    ).not.toBeInTheDocument();
+    expect(persistentBrowserStore.get(STORAGE_KEYS.CHECKLIST_DONE)).toBe(null);
+  });
+
+  it("shows the practice card on /week after the showcase has been seen", async () => {
+    persistentBrowserStore.set(STORAGE_KEYS.HAS_SEEN_WELCOME, "true");
+    persistentBrowserStore.set(STORAGE_KEYS.HAS_SEEN_SHORTCUT_SHOWCASE, "true");
+
+    await renderShell("/week");
+
+    expect(
+      screen.getByRole("complementary", {
+        name: "Shortcut practice checklist",
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Practice on sample events")).toBeInTheDocument();
   });
 });

--- a/packages/web/src/components/RootShell/RootShell.test.tsx
+++ b/packages/web/src/components/RootShell/RootShell.test.tsx
@@ -1,11 +1,21 @@
 import "@testing-library/jest-dom";
+import { type ReactElement } from "react";
 import { render, screen } from "@web/__tests__/__mocks__/mock.render";
 import { createTestRouter } from "@web/__tests__/utils/providers/createTestRouter";
+import { SessionContext } from "@web/auth/compass/session/session.context";
 import { type AppAccess } from "@web/billing/useAppAccess";
 import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
 import { persistentBrowserStore } from "@web/common/storage/browser-key-value.store";
 import { RootShell } from "@web/components/RootShell/RootShell";
-import { afterAll, afterEach, describe, expect, it, mock } from "bun:test";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  mock,
+} from "bun:test";
 
 const actualUseAppAccess = (await import("@web/billing/useAppAccess"))
   .useAppAccess;
@@ -17,8 +27,23 @@ mock.module("@web/billing/useAppAccess", () => ({
     isAppAccessMocked ? access : actualUseAppAccess(...args),
 }));
 
-const renderShell = async (initialPath = "/") => {
-  const router = createTestRouter(<RootShell />, {
+const anonymousSession = {
+  authenticated: false,
+  setAuthenticated: () => {},
+};
+
+const renderShell = async (
+  initialPath = "/",
+  { anonymous = false }: { anonymous?: boolean } = {},
+) => {
+  const ui: ReactElement = anonymous ? (
+    <SessionContext.Provider value={anonymousSession}>
+      <RootShell />
+    </SessionContext.Provider>
+  ) : (
+    <RootShell />
+  );
+  const router = createTestRouter(ui, {
     initialEntries: [initialPath],
   });
   render(<div />, { router });
@@ -68,12 +93,12 @@ describe("RootShell billing gates", () => {
 });
 
 describe("RootShell calendar onboarding on /life", () => {
-  afterEach(() => {
+  beforeEach(() => {
     access = { kind: "open" };
   });
 
   it("does not show welcome or the practice card on /life, and does not burn flags", async () => {
-    await renderShell("/life");
+    await renderShell("/life", { anonymous: true });
 
     expect(
       screen.queryByRole("dialog", { name: "Welcome to Compass Calendar" }),
@@ -93,7 +118,7 @@ describe("RootShell calendar onboarding on /life", () => {
   });
 
   it("still shows welcome on /week for a first-time anonymous visitor", async () => {
-    await renderShell("/week");
+    await renderShell("/week", { anonymous: true });
 
     expect(
       screen.getByRole("dialog", { name: "Welcome to Compass Calendar" }),
@@ -104,7 +129,7 @@ describe("RootShell calendar onboarding on /life", () => {
     persistentBrowserStore.set(STORAGE_KEYS.HAS_SEEN_WELCOME, "true");
     persistentBrowserStore.set(STORAGE_KEYS.HAS_SEEN_SHORTCUT_SHOWCASE, "true");
 
-    await renderShell("/life");
+    await renderShell("/life", { anonymous: true });
 
     expect(
       screen.queryByRole("complementary", {
@@ -118,7 +143,7 @@ describe("RootShell calendar onboarding on /life", () => {
     persistentBrowserStore.set(STORAGE_KEYS.HAS_SEEN_WELCOME, "true");
     persistentBrowserStore.set(STORAGE_KEYS.HAS_SEEN_SHORTCUT_SHOWCASE, "true");
 
-    await renderShell("/week");
+    await renderShell("/week", { anonymous: true });
 
     expect(
       screen.getByRole("complementary", {

--- a/packages/web/src/components/RootShell/RootShell.tsx
+++ b/packages/web/src/components/RootShell/RootShell.tsx
@@ -1,4 +1,4 @@
-import { Outlet } from "@tanstack/react-router";
+import { Outlet, useLocation } from "@tanstack/react-router";
 import { BillingGateModal } from "@web/billing/BillingGateModal";
 import { BillingPastDueBanner } from "@web/billing/BillingPastDueBanner";
 import { useCheckoutReturn } from "@web/billing/billing.query";
@@ -19,6 +19,7 @@ import {
   useCalendarShellShortcuts,
   useNavigationShortcuts,
 } from "@web/shortcuts/useGlobalShortcuts";
+import { isLifePathname } from "./isLifePathname";
 
 /**
  * The auth modal is driven by the router's `?auth=` search param, so its
@@ -27,6 +28,8 @@ import {
  * available on every matched route, including 404s.
  */
 export function RootShell() {
+  const { pathname } = useLocation();
+  const deferCalendarOnboarding = isLifePathname(pathname);
   const isWelcomeGuideOpen = useWelcomeGuideStore(selectWelcomeGuideOpen);
   const access = useAppAccess();
   useCheckoutReturn();
@@ -67,9 +70,9 @@ export function RootShell() {
       {showPastDue && <BillingPastDueBanner />}
       <Outlet />
       <AuthModal />
-      <WelcomeModal />
-      <ShortcutShowcase />
-      <OnboardingChecklist />
+      {!deferCalendarOnboarding && <WelcomeModal />}
+      {!deferCalendarOnboarding && <ShortcutShowcase />}
+      {!deferCalendarOnboarding && <OnboardingChecklist />}
       {isWelcomeGuideOpen && <WelcomeGuideModal />}
     </AuthModalProvider>
   );

--- a/packages/web/src/components/RootShell/isLifePathname.test.ts
+++ b/packages/web/src/components/RootShell/isLifePathname.test.ts
@@ -1,0 +1,18 @@
+import { ROOT_ROUTES } from "@web/common/constants/routes";
+import { isLifePathname } from "./isLifePathname";
+import { describe, expect, it } from "bun:test";
+
+describe("isLifePathname", () => {
+  it("matches /life and nested life paths", () => {
+    expect(isLifePathname(ROOT_ROUTES.LIFE)).toBe(true);
+    expect(isLifePathname(`${ROOT_ROUTES.LIFE}/`)).toBe(true);
+    expect(isLifePathname(`${ROOT_ROUTES.LIFE}/share`)).toBe(true);
+  });
+
+  it("does not match calendar routes", () => {
+    expect(isLifePathname(ROOT_ROUTES.ROOT)).toBe(false);
+    expect(isLifePathname(ROOT_ROUTES.WEEK)).toBe(false);
+    expect(isLifePathname(ROOT_ROUTES.DAY)).toBe(false);
+    expect(isLifePathname("/lifetime")).toBe(false);
+  });
+});

--- a/packages/web/src/components/RootShell/isLifePathname.ts
+++ b/packages/web/src/components/RootShell/isLifePathname.ts
@@ -1,0 +1,8 @@
+import { ROOT_ROUTES } from "@web/common/constants/routes";
+
+/** True for `/life` and any nested life path. */
+export function isLifePathname(pathname: string): boolean {
+  return (
+    pathname === ROOT_ROUTES.LIFE || pathname.startsWith(`${ROOT_ROUTES.LIFE}/`)
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`/life` is a public lead magnet. First-time visitors were still getting the calendar Welcome modal, and dismissing it could start the shortcut showcase and then the “Practice on sample events” card — none of which apply to the life grid.

`RootShell` now unmounts `WelcomeModal`, `ShortcutShowcase`, and `OnboardingChecklist` when the path is `/life` (or a nested life path). Onboarding localStorage flags are not written, so a later visit to `/week` or `/day` still gets the normal calendar onboarding.

Auth (`?auth=`), the user-initiated welcome guide, and Life’s own birth-date autofocus are unchanged. Trial and billing gates are unchanged.

## Simplicity

One pathname check in `RootShell` (the existing overlay chokepoint) plus a tiny `isLifePathname` helper. No new storage keys, no Life-specific welcome copy, and no changes to showcase/checklist stores.

## Automated validation

- `bun run test:web packages/web/src/components/RootShell` — 8 pass, 0 fail
- `bun run lint` — clean for this change (existing repo warnings only)
- CI `unit (web)` initially failed because Welcome is suppressed when the shared test session is already authenticated; onboarding tests now pin an anonymous `SessionContext`
- Manual: anonymous `/life` shows the life grid with no welcome or practice card; `/week` still shows Welcome

![Life view with no calendar onboarding overlay](https://cursor.com/artifacts/c/art-72a3b001-7fec-4905-818d-e7497c0c46f2)
![Week view still showing the Welcome modal](https://cursor.com/artifacts/c/art-c4a332ca-71a9-481b-aaa0-af3487d597ca)
<a href="https://cursor.com/agents/bc-8459f9a2-1b5b-4ac8-b67b-b189644afcd8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flife_skips_welcome_week_shows_welcome.mp4"><img src="https://cursor.com/artifacts/c/art-e193b0c0-f81b-43d7-a5e5-12fc193ac096" alt="life_skips_welcome_week_shows_welcome.mp4" /></a>

## Independent review

Not run as a separate reviewer pass; behavior covered by RootShell tests plus the browser walkthrough.

## Test plan

- `bun run test:web packages/web/src/components/RootShell`
- `bun run lint`
- Browser: `http://localhost:9080/life` then `http://localhost:9080/week`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8459f9a2-1b5b-4ac8-b67b-b189644afcd8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8459f9a2-1b5b-4ac8-b67b-b189644afcd8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

