### PR TITLE
fix(sync): confirm Google “delete this occurrence” instead of 502

### DIFF
--- a/packages/sync/src/domain/provider-command.service.db.test.ts
+++ b/packages/sync/src/domain/provider-command.service.db.test.ts
@@ -2587,6 +2587,58 @@ describe("provider-linked recurring scopes (this / thisAndFollowing)", () => {
 
       expect(result.outcome.state).toBe("pending");
     });
+
+    it("still deletes when the resolved instance is identity-only (unreadable content)", async () => {
+      const { tenantId, principalId, calendar, master } = await seedMaster();
+      const command = await thisScopeCommand(master, "delete");
+      const writer = new FakeRecurringWriter();
+      writer.fetchInstanceResult = {
+        ...providerInstance("g-inst-unreadable", "", "etag-1"),
+        content: content(""),
+      };
+
+      const result = await executeProviderOccurrenceDelete(
+        deleteDeps(writer),
+        command,
+        master,
+        calendar,
+        now,
+      );
+
+      expect(result.outcome.state).toBe("confirmed");
+      expect(writer.deleteCalls[0]?.providerEventId).toBe("g-inst-unreadable");
+      const exceptions = await events.findSeriesExceptions(
+        tenantId,
+        principalId,
+        master._id,
+      );
+      expect(exceptions[0]?.providerEventId).toBe("g-inst-unreadable");
+    });
+
+    it("does not delete the series master when lookup returns the master's id", async () => {
+      const { tenantId, principalId, calendar, master } = await seedMaster();
+      const command = await thisScopeCommand(master, "delete");
+      const writer = new FakeRecurringWriter();
+      writer.fetchInstanceResult = providerSeries("Old", "etag-1", weekly3);
+
+      const result = await executeProviderOccurrenceDelete(
+        deleteDeps(writer),
+        command,
+        master,
+        calendar,
+        now,
+      );
+
+      expect(result.outcome.state).toBe("confirmed");
+      expect(writer.deleteCalls).toHaveLength(0);
+      const exceptions = await events.findSeriesExceptions(
+        tenantId,
+        principalId,
+        master._id,
+      );
+      expect(exceptions).toHaveLength(1);
+      expect(exceptions[0]?.providerEventId).toBeNull();
+    });
   });
 
   describe("executeProviderSeriesFollowingDelete", () => {

--- a/packages/sync/src/domain/provider-command.service.ts
+++ b/packages/sync/src/domain/provider-command.service.ts
@@ -954,7 +954,8 @@ export async function executeProviderOccurrenceDelete(
     );
   }
   const instance =
-    fetchInstanceResult.value?.kind === "event"
+    fetchInstanceResult.value?.kind === "event" &&
+    fetchInstanceResult.value.providerEventId !== seriesProviderEventId
       ? fetchInstanceResult.value
       : null;
 

--- a/packages/sync/src/providers/google/google-event-writer.adapter.test.ts
+++ b/packages/sync/src/providers/google/google-event-writer.adapter.test.ts
@@ -5,6 +5,7 @@ import {
   deriveGoogleEventId,
   type GoogleEventsApi,
   GoogleEventWriter,
+  googleInstanceEventId,
 } from "@sync/providers/google/google-event-writer.adapter";
 import { ProviderWriteError } from "@sync/providers/provider-event-writer.port";
 
@@ -50,6 +51,7 @@ const scriptedInstance = (
 });
 
 type Behavior = gSchema$Event | Error | undefined;
+type InstancesBehavior = gSchema$Events | Error;
 
 // A scriptable fake for the four Google event calls. Each method records its
 // params and either returns its scripted result or throws its scripted error.
@@ -62,13 +64,15 @@ class FakeEventsApi implements GoogleEventsApi {
     instances: [] as Parameters<GoogleEventsApi["instances"]>[0][],
   };
 
+  #instancesIndex = 0;
+
   constructor(
     private readonly behavior: {
       insert?: Behavior;
       patch?: Behavior;
       delete?: Behavior;
       get?: Behavior;
-      instances?: gSchema$Events | Error;
+      instances?: InstancesBehavior | InstancesBehavior[];
     } = {},
   ) {}
 
@@ -106,9 +110,12 @@ class FakeEventsApi implements GoogleEventsApi {
     params: Parameters<GoogleEventsApi["instances"]>[0],
   ): Promise<gSchema$Events> {
     this.calls.instances.push(params);
-    if (this.behavior.instances instanceof Error) throw this.behavior.instances;
+    const scripted = Array.isArray(this.behavior.instances)
+      ? this.behavior.instances[this.#instancesIndex++]
+      : this.behavior.instances;
+    if (scripted instanceof Error) throw scripted;
     return (
-      this.behavior.instances ?? {
+      scripted ?? {
         kind: "calendar#events",
         items: [
           scriptedInstance(`${params.eventId}_instance`, params.originalStart),
@@ -586,6 +593,7 @@ describe("GoogleEventWriter", () => {
   it("returns null when no instance exists at that instant", async () => {
     const api = new FakeEventsApi({
       instances: { kind: "calendar#events", items: [] },
+      get: gError(404),
     });
     const { writer } = writerWith(api);
 
@@ -598,6 +606,168 @@ describe("GoogleEventWriter", () => {
     });
 
     expect(read).toBeNull();
+    expect(api.calls.get[0]?.eventId).toBe(
+      googleInstanceEventId("series-1", "2025-01-15T09:00:00-05:00", "timed"),
+    );
+  });
+
+  it("retries an all-day originalStart as RFC3339 UTC midnight after Google 400s the date-only filter", async () => {
+    const api = new FakeEventsApi({
+      instances: [
+        gError(400),
+        {
+          kind: "calendar#events",
+          items: [
+            {
+              kind: "calendar#event",
+              id: "series-1_20260820",
+              etag: '"v1"',
+              status: "confirmed",
+              summary: "T",
+              recurringEventId: "series-1",
+              originalStartTime: { date: "2026-08-20" },
+              start: { date: "2026-08-20" },
+              end: { date: "2026-08-21" },
+            },
+          ],
+        },
+      ],
+    });
+    const { writer } = writerWith(api);
+
+    const read = await writer.fetchInstanceAt({
+      accessToken: "at",
+      calendarId: "cal",
+      seriesProviderEventId: "series-1",
+      originalStartAt: "2026-08-20T00:00:00.000Z",
+      scheduleKind: "allDay",
+    });
+
+    expect(api.calls.instances.map((call) => call.originalStart)).toEqual([
+      "2026-08-20",
+      "2026-08-20T00:00:00Z",
+    ]);
+    expect(read?.kind).toBe("event");
+    expect(read?.providerEventId).toBe("series-1_20260820");
+    expect(api.calls.get).toHaveLength(0);
+  });
+
+  it("still returns the instance id when Google content fails the neutral contract", async () => {
+    const api = new FakeEventsApi({
+      instances: {
+        kind: "calendar#events",
+        items: [
+          {
+            kind: "calendar#event",
+            id: "series-1_20260820",
+            etag: '"v1"',
+            status: "confirmed",
+            summary: "T",
+            recurringEventId: "series-1",
+            originalStartTime: { date: "2026-08-20" },
+            start: { date: "2026-08-20" },
+            end: { date: "2026-08-21" },
+            attendees: [
+              { email: "guest@example.com", displayName: "x".repeat(300) },
+            ],
+          },
+        ],
+      },
+    });
+    const { writer } = writerWith(api);
+
+    const read = await writer.fetchInstanceAt({
+      accessToken: "at",
+      calendarId: "cal",
+      seriesProviderEventId: "series-1",
+      originalStartAt: "2026-08-20T00:00:00.000Z",
+      scheduleKind: "allDay",
+    });
+
+    expect(read?.kind).toBe("event");
+    expect(read?.providerEventId).toBe("series-1_20260820");
+  });
+
+  it("GETs the constructed Google instance id when the originalStart filter matches nothing", async () => {
+    const constructedId = googleInstanceEventId(
+      "series-1",
+      "2026-08-20T00:00:00.000Z",
+      "allDay",
+    );
+    const api = new FakeEventsApi({
+      instances: { kind: "calendar#events", items: [] },
+      get: {
+        kind: "calendar#event",
+        id: constructedId,
+        etag: '"v1"',
+        status: "confirmed",
+        summary: "T",
+        recurringEventId: "series-1",
+        originalStartTime: { date: "2026-08-20" },
+        start: { date: "2026-08-20" },
+        end: { date: "2026-08-21" },
+      },
+    });
+    const { writer } = writerWith(api);
+
+    const read = await writer.fetchInstanceAt({
+      accessToken: "at",
+      calendarId: "cal",
+      seriesProviderEventId: "series-1",
+      originalStartAt: "2026-08-20T00:00:00.000Z",
+      scheduleKind: "allDay",
+    });
+
+    expect(constructedId).toBe("series-1_20260820");
+    expect(api.calls.get[0]?.eventId).toBe(constructedId);
+    expect(read?.providerEventId).toBe(constructedId);
+  });
+
+  it("does not treat the series master as the occurrence; GETs the constructed instance id instead", async () => {
+    const constructedId = googleInstanceEventId(
+      "series-1",
+      "2026-08-20T00:00:00.000Z",
+      "allDay",
+    );
+    const api = new FakeEventsApi({
+      instances: {
+        kind: "calendar#events",
+        items: [
+          {
+            kind: "calendar#event",
+            id: "series-1",
+            etag: '"master"',
+            status: "confirmed",
+            summary: "Series",
+            recurrence: ["RRULE:FREQ=DAILY"],
+            start: { date: "2026-08-01" },
+            end: { date: "2026-08-02" },
+          },
+        ],
+      },
+      get: {
+        kind: "calendar#event",
+        id: constructedId,
+        etag: '"v1"',
+        status: "confirmed",
+        summary: "T",
+        recurringEventId: "series-1",
+        originalStartTime: { date: "2026-08-20" },
+        start: { date: "2026-08-20" },
+        end: { date: "2026-08-21" },
+      },
+    });
+    const { writer } = writerWith(api);
+
+    const read = await writer.fetchInstanceAt({
+      accessToken: "at",
+      calendarId: "cal",
+      seriesProviderEventId: "series-1",
+      originalStartAt: "2026-08-20T00:00:00.000Z",
+      scheduleKind: "allDay",
+    });
+
+    expect(read?.providerEventId).toBe(constructedId);
   });
 
   it("returns null (not an error) when the series itself is gone", async () => {

--- a/packages/sync/src/providers/google/google-event-writer.adapter.ts
+++ b/packages/sync/src/providers/google/google-event-writer.adapter.ts
@@ -415,15 +415,9 @@ async function resolveInstanceItem(
       break;
     } catch (error) {
       if (isNotFound(error)) return null;
-      if (googleStatus(error) === 400 && index < filters.length - 1) {
-        sawBadRequest = true;
-        continue;
-      }
-      if (googleStatus(error) === 400) {
-        sawBadRequest = true;
-        break;
-      }
-      throw error;
+      if (googleStatus(error) !== 400) throw error;
+      sawBadRequest = true;
+      if (index >= filters.length - 1) break;
     }
   }
 

--- a/packages/sync/src/providers/google/google-event-writer.adapter.ts
+++ b/packages/sync/src/providers/google/google-event-writer.adapter.ts
@@ -11,7 +11,11 @@ import dayjs from "@core/util/date/dayjs";
 import { googleColorIdFields } from "@sync/providers/google/google-color.map";
 import { normalizeGoogleEvent } from "@sync/providers/google/google-event.normalizer";
 import { GOOGLE_REQUEST_TIMEOUT_MS } from "@sync/providers/google/google-http.constants";
-import { type ProviderEventRead } from "@sync/providers/provider-event.port";
+import {
+  type ProviderEvent,
+  ProviderEventError,
+  type ProviderEventRead,
+} from "@sync/providers/provider-event.port";
 import {
   type InvitationIntent,
   type ProviderCreateInput,
@@ -250,20 +254,9 @@ export class GoogleEventWriter implements ProviderEventWriter {
   ): Promise<ProviderEventRead | null> {
     const api = this.#makeApi(input.accessToken);
     try {
-      const page = await api.instances({
-        calendarId: input.calendarId,
-        eventId: input.seriesProviderEventId,
-        originalStart: toOriginalStartFilter(
-          input.originalStartAt,
-          input.scheduleKind,
-        ),
-      });
-      const item = page.items?.[0];
-      // No instance at that instant: never materialized (a rule that never
-      // actually produced an occurrence there), or the series itself is gone
-      // — either way, nothing for the caller to patch/delete.
+      const item = await resolveInstanceItem(api, input);
       if (!item) return null;
-      return normalizeGoogleEvent(item);
+      return readResolvedInstance(item, input);
     } catch (error) {
       // A 404 on the SERIES itself (not just the instance) surfaces here too
       // — both mean "nothing to resolve", so both return null rather than
@@ -365,6 +358,151 @@ function toOriginalStartFilter(
     .format(dayjs.DateFormat.YEAR_MONTH_DAY_FORMAT);
 }
 
+function toRfc3339UtcMidnight(originalStartAt: string): string {
+  return dayjs.utc(originalStartAt).format(dayjs.DateFormat.RFC3339);
+}
+
+// Google instance ids are `{seriesId}_{originalStart}`: all-day YYYYMMDD,
+// timed YYYYMMDDTHHMMSSZ (always UTC). Used when events.instances with
+// originalStart returns nothing or 400s — GET of this id still addresses
+// the occurrence, including after it was moved (the suffix is the ORIGINAL
+// start, not the current one).
+export function googleInstanceEventId(
+  seriesProviderEventId: string,
+  originalStartAt: string,
+  scheduleKind: "timed" | "allDay",
+): string {
+  const instant = dayjs.utc(originalStartAt);
+  const suffix =
+    scheduleKind === "allDay"
+      ? instant.format(dayjs.DateFormat.YEAR_MONTH_DAY_COMPACT_FORMAT)
+      : instant.format(dayjs.DateFormat.RFC5545);
+  return `${seriesProviderEventId}_${suffix}`;
+}
+
+function isOccurrenceItem(
+  item: gSchema$Event | undefined,
+  seriesProviderEventId: string,
+): item is gSchema$Event {
+  return Boolean(item?.id && item.id !== seriesProviderEventId);
+}
+
+async function resolveInstanceItem(
+  api: GoogleEventsApi,
+  input: ProviderInstanceFetchInput,
+): Promise<gSchema$Event | null> {
+  const filters =
+    input.scheduleKind === "allDay"
+      ? [
+          toOriginalStartFilter(input.originalStartAt, "allDay"),
+          toRfc3339UtcMidnight(input.originalStartAt),
+        ]
+      : [input.originalStartAt];
+
+  let sawBadRequest = false;
+  for (let index = 0; index < filters.length; index += 1) {
+    const originalStart = filters[index] as string;
+    try {
+      const page = await api.instances({
+        calendarId: input.calendarId,
+        eventId: input.seriesProviderEventId,
+        originalStart,
+      });
+      const item = page.items?.[0];
+      if (isOccurrenceItem(item, input.seriesProviderEventId)) return item;
+      // Empty page or the series master itself: do not retry RFC3339 unless
+      // Google rejected the previous filter. Fall through to constructed GET.
+      break;
+    } catch (error) {
+      if (isNotFound(error)) return null;
+      if (googleStatus(error) === 400 && index < filters.length - 1) {
+        sawBadRequest = true;
+        continue;
+      }
+      if (googleStatus(error) === 400) {
+        sawBadRequest = true;
+        break;
+      }
+      throw error;
+    }
+  }
+
+  try {
+    const event = await api.get({
+      calendarId: input.calendarId,
+      eventId: googleInstanceEventId(
+        input.seriesProviderEventId,
+        input.originalStartAt,
+        input.scheduleKind,
+      ),
+    });
+    if (isOccurrenceItem(event, input.seriesProviderEventId)) return event;
+    return null;
+  } catch (error) {
+    if (isNotFound(error)) return null;
+    if (sawBadRequest && googleStatus(error) === 400) return null;
+    throw error;
+  }
+}
+
+function readResolvedInstance(
+  item: gSchema$Event,
+  input: ProviderInstanceFetchInput,
+): ProviderEventRead | null {
+  if (!isOccurrenceItem(item, input.seriesProviderEventId)) return null;
+  try {
+    return normalizeGoogleEvent(item);
+  } catch (error) {
+    if (!(error instanceof ProviderEventError)) throw error;
+    return identityOnlyInstance(item, input);
+  }
+}
+
+// Delete (and a subsequent patch) only need the instance's provider id. A
+// content/schedule the contract rejects must not strand the command pending.
+function identityOnlyInstance(
+  item: gSchema$Event,
+  input: ProviderInstanceFetchInput,
+): ProviderEvent {
+  const start = dayjs.utc(input.originalStartAt);
+  const schedule =
+    input.scheduleKind === "allDay"
+      ? {
+          kind: "allDay" as const,
+          start: start.format(dayjs.DateFormat.YEAR_MONTH_DAY_FORMAT),
+          end: start
+            .add(1, "day")
+            .format(dayjs.DateFormat.YEAR_MONTH_DAY_FORMAT),
+        }
+      : {
+          kind: "timed" as const,
+          start: input.originalStartAt,
+          end: input.originalStartAt,
+          timeZone: "UTC",
+        };
+  return {
+    kind: "event",
+    providerEventId: item.id as string,
+    providerVersion: item.etag?.trim() || "missing",
+    providerUpdatedAt: item.updated ?? null,
+    content: {
+      title: "",
+      description: "",
+      location: "",
+      organizer: null,
+      attendees: [],
+      conference: null,
+    },
+    schedule: schedule as EventSchedule,
+    busy: true,
+    recurrence: {
+      kind: "instance",
+      seriesProviderId: input.seriesProviderEventId,
+      recurrenceId: new Date(input.originalStartAt).toISOString(),
+    },
+  };
+}
+
 // Google's sendUpdates values are exactly the neutral invitation intents.
 function toSendUpdates(invitation: InvitationIntent): string {
   return invitation;
@@ -382,6 +520,15 @@ function classifyWriteError(error: unknown): ProviderWriteError {
   // An already-classified error (e.g. a missing-identity result) must not be
   // re-wrapped as transient just because it carries no HTTP status.
   if (error instanceof ProviderWriteError) return error;
+  // A per-event normalize failure has no HTTP status. Mapping it to
+  // `transient` left occurrence deletes pending forever (HTTP 502 on every
+  // retry). The lookup path now recovers identity without a full read; any
+  // leftover throw is a permanent rejection, not a blip.
+  if (error instanceof ProviderEventError) {
+    return new ProviderWriteError("permanentProviderError", error.message, {
+      cause: redactedCause(error),
+    });
+  }
 
   const status = googleStatus(error);
   const cause = redactedCause(error);

--- a/packages/web/src/events/event.api.ts
+++ b/packages/web/src/events/event.api.ts
@@ -39,12 +39,17 @@ const EventApi = {
   },
 
   replace: async (id: EventId, input: ReplaceEventInput): Promise<Event> => {
-    const response = await BaseApi.put<unknown>(`/event/${id}`, input);
+    const response = await BaseApi.put<unknown>(
+      `/event/${encodeURIComponent(id)}`,
+      input,
+    );
     return EventResponseSchema.parse(response.data).event;
   },
 
   delete: (id: EventId, scope: "this" | "thisAndFollowing" | "all") => {
-    return BaseApi.delete<void>(`/event/${id}?scope=${scope}`);
+    return BaseApi.delete<void>(
+      `/event/${encodeURIComponent(id)}?scope=${scope}`,
+    );
   },
 };
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Deleting one Google-linked recurring instance (`DELETE /api/event/{id}::{recurrenceId}?scope=this`) could return HTTP 502 `PROVIDER_FAILURE` forever. Compass maps a Sync command that never reaches `confirmed` to 502. For all-day occurrences this happened when:

- `fetchInstanceAt` required a full `normalizeGoogleEvent` before delete, and a `ProviderEventError` (no HTTP status) was classified as **transient**, leaving the command **pending**
- Google `events.instances` `originalStart` as a date-only string returned **400**, classified as **permanentProviderError**
- `items[0]` could be the series master, and upserting that id as an exception collided with `provider_event_identity`

This change resolves the instance by id without a full content read, retries all-day `originalStart` as RFC3339 UTC midnight after a 400, GETs Google’s constructed instance id (`{seriesId}_{YYYYMMDD}` / `{seriesId}_{YYYYMMDDTHHMMSSZ}`) when the filter misses, and refuses to delete the series master id. The web client also `encodeURIComponent`s occurrence ids on PUT/DELETE.

## Simplicity

Lookup, format retry, and constructed-id GET live in the Google writer. The command executor only adds a master-id guard. A follow-up commit flattens the 400-handling branches in `resolveInstanceItem`. No new error codes or 502 mapping changes.

## Automated validation

- Adapter: all-day date-only 400 then RFC3339 success; unmappable attendee content still returns instance id; empty filter GETs `series-1_20260820`; series-master `items[0]` falls through to constructed id; missing instance + GET 404 returns null. Re-run after the flatten: 35 pass.
- Domain: identity-only fetch still confirms delete; lookup returning the master id tombstones locally without calling `deleteEvent` (53 pass).

## Independent review

Bugbot on the branch diff: no bugs.

## Test plan

- `bun test packages/sync/src/providers/google/google-event-writer.adapter.test.ts` — 35 pass
- `bun packages/scripts/src/testing/test-mongo-env.ts sync -- packages/sync/src/domain/provider-command.service.db.test.ts` — 53 pass
- `bunx biome check` on the five changed files — clean

After deploy, retry delete of the 2026-08-20 instance of series `6a7df365127b1f4a000b57fb`. Expected: 204 and the occurrence gone from Compass and Google.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-728be165-3e4e-47b0-a6b1-a662c1276765?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-728be165-3e4e-47b0-a6b1-a662c1276765&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

