### PR TITLE
fix(web): show calendar age on life view before birthday

### DIFF
--- a/packages/web/src/views/Life/LifeView.test.tsx
+++ b/packages/web/src/views/Life/LifeView.test.tsx
@@ -218,6 +218,23 @@ describe("LifeView", () => {
     ).toBeInTheDocument();
   });
 
+  it("shows calendar age before the birthday rather than weeks divided by 52", async () => {
+    renderWithStore(<LifeView today={new Date(2026, 7, 12)} />);
+    await waitFor(() => {
+      expect(
+        screen.getByRole("complementary", { name: "Sidebar" }),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByRole("textbox", { name: "Date of birth" }), {
+      target: { value: "1993-09-14" },
+    });
+
+    expect(
+      screen.getByText("1,717 weeks lived - 32 years - 43%"),
+    ).toBeInTheDocument();
+  });
+
   it("updates the grid size when the lifespan changes", async () => {
     await renderLifeViewWithSidebar();
 

--- a/packages/web/src/views/Life/LifeView.tsx
+++ b/packages/web/src/views/Life/LifeView.tsx
@@ -18,6 +18,7 @@ import { useAppShortcutUp } from "@web/shortcuts/useAppShortcut";
 import { LifeGrid } from "./LifeGrid";
 import { LifeSidebarContent } from "./LifeSidebarContent";
 import {
+  getAgeInYears,
   getCurrentWeekLabel,
   getRandomLifespan,
   getTotalLifeDots,
@@ -61,8 +62,11 @@ export function LifeView({ today }: LifeViewProps) {
     [preferences.birthDate, totalDots, currentDate],
   );
   const hasBirthDate = parseLifeDate(preferences.birthDate) !== null;
+  const yearsLived = hasBirthDate
+    ? getAgeInYears(preferences.birthDate, currentDate)
+    : null;
   const summary = hasBirthDate
-    ? `${formatWeeks(weeksLived)} weeks lived - ${Math.floor(weeksLived / 52)} years - ${Math.round((weeksLived / totalDots) * 100)}%`
+    ? `${formatWeeks(weeksLived)} weeks lived - ${yearsLived} years - ${Math.round((weeksLived / totalDots) * 100)}%`
     : "Birth date not set";
   const currentWeekLabel = hasBirthDate
     ? getCurrentWeekLabel(currentDate, weeksLived, totalDots)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The Life view summary derived years from `weeksLived / 52`, which can show the next birthday early (e.g. Sep 14, 1993 on Aug 12, 2026 displayed 33 years instead of 32). The summary now uses `getAgeInYears`, which only increments after the birthday.

Weeks lived and percent of lifespan are unchanged.

## Simplicity

Reuses the existing calendar-age helper already used for random lifespan. No new date math.

## Automated validation

- `bun run test:web -- packages/web/src/views/Life/LifeView.test.tsx packages/web/src/views/Life/life.utils.test.ts` — 25 pass, 0 fail (includes new pre-birthday case: Aug 12, 2026 + Sep 14, 1993 → 32 years).
- Browser: `/life` with birth date Sep 14, 1993 shows `1,717 weeks lived - 32 years - 43%`.

## Independent review

Not run in this change; the diff is a one-line display formula plus a regression test.

## Test plan

- `bun run test:web -- packages/web/src/views/Life/LifeView.test.tsx packages/web/src/views/Life/life.utils.test.ts`
- `bun run lint` (exit 0; existing warnings only)
- Manual: `http://localhost:9080/life` with Date of birth Sep 14, 1993
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d13768ee-2053-416e-8c9f-e310b66df541?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d13768ee-2053-416e-8c9f-e310b66df541&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

