### PR TITLE
fix(sync): import selected hidden calendars and offset-only events

### DIFF
--- a/packages/sync/src/providers/google/google-calendar.adapter.test.ts
+++ b/packages/sync/src/providers/google/google-calendar.adapter.test.ts
@@ -277,6 +277,39 @@ describe("GoogleCalendarAdapter", () => {
     expect(active).toEqual({ live: true, gone: false, hidden: false });
   });
 
+  it("keeps a hidden calendar active when Google is still showing it", async () => {
+    const api = new FakeCalendarListApi([
+      page({
+        items: [
+          entry({ id: "shown-hidden", hidden: true, selected: true }),
+          entry({ id: "unselected-hidden", hidden: true, selected: false }),
+          entry({ id: "hidden-omitted-selected", hidden: true }),
+          entry({
+            id: "deleted-but-selected",
+            deleted: true,
+            selected: true,
+          }),
+        ],
+        nextSyncToken: "s",
+      }),
+    ]);
+    const { adapter } = adapterWith(api);
+
+    const { calendars } = await adapter.discoverCalendars({
+      accessToken: "at",
+    });
+    const active = Object.fromEntries(
+      calendars.map((c) => [c.providerCalendarId, c.active]),
+    );
+
+    expect(active).toEqual({
+      "shown-hidden": true,
+      "unselected-hidden": false,
+      "hidden-omitted-selected": false,
+      "deleted-but-selected": false,
+    });
+  });
+
   it("falls back through summaryOverride, summary, then id for the display name", async () => {
     const api = new FakeCalendarListApi([
       page({

--- a/packages/sync/src/providers/google/google-calendar.adapter.ts
+++ b/packages/sync/src/providers/google/google-calendar.adapter.ts
@@ -221,9 +221,12 @@ async function mapCalendar(
     color: item.backgroundColor || null,
     eventLabels: await api.getEventLabels(item.id),
     primary: item.primary === true,
-    // deleted appears in incremental results; hidden means the user removed it
-    // from their list. Either makes the calendar inactive, not gone.
-    active: item.deleted !== true && item.hidden !== true,
+    // Deleted calendars are gone. Hidden-from-list is not the same as
+    // "Google is not showing this": the Calendar UI still displays events
+    // when selected is true. Import those so connection health cannot stay
+    // green while a selected calendar is silently skipped.
+    active:
+      item.deleted !== true && (item.hidden !== true || item.selected === true),
     accessRole,
     capabilities: CAPABILITIES_BY_ROLE[accessRole],
   };

--- a/packages/sync/src/providers/google/google-event-reader.adapter.test.ts
+++ b/packages/sync/src/providers/google/google-event-reader.adapter.test.ts
@@ -52,12 +52,15 @@ const page = (
   ...overrides,
 });
 
-function adapterWith(api: GoogleEventListApi) {
+function adapterWith(
+  api: GoogleEventListApi,
+  log?: { warn: (message: string) => void },
+) {
   const tokensSeen: string[] = [];
   const adapter = new GoogleEventReaderAdapter((accessToken) => {
     tokensSeen.push(accessToken);
     return api;
-  });
+  }, log);
   return { adapter, tokensSeen };
 }
 
@@ -159,6 +162,33 @@ describe("GoogleEventReaderAdapter", () => {
 
     expect(result.events.map((e) => e.providerEventId)).toEqual(["ok"]);
     expect(result.skipped).toBe(1);
+  });
+
+  it("logs the skip reason and provider event id, never the title", async () => {
+    const warnings: string[] = [];
+    const api = new FakeEventListApi([
+      page({
+        items: [
+          gEvent({
+            id: "no-etag",
+            etag: undefined,
+            summary: "Secret title must not be logged",
+          }),
+        ],
+      }),
+    ]);
+    const { adapter } = adapterWith(api, {
+      warn: (message) => warnings.push(message),
+    });
+
+    await adapter.listEventPage({
+      accessToken: "tok",
+      calendarId: "primary@google.com",
+    });
+
+    expect(warnings).toEqual([
+      "Skipped unusable Google event no-etag (missingIdentity)",
+    ]);
   });
 
   it("skips a content-oversized event instead of failing the whole page", async () => {

--- a/packages/sync/src/providers/google/google-event-reader.adapter.test.ts
+++ b/packages/sync/src/providers/google/google-event-reader.adapter.test.ts
@@ -54,7 +54,7 @@ const page = (
 
 function adapterWith(
   api: GoogleEventListApi,
-  log?: { warn: (message: string) => void },
+  log: { warn: (message: string) => void } = { warn: () => {} },
 ) {
   const tokensSeen: string[] = [];
   const adapter = new GoogleEventReaderAdapter((accessToken) => {

--- a/packages/sync/src/providers/google/google-event-reader.adapter.ts
+++ b/packages/sync/src/providers/google/google-event-reader.adapter.ts
@@ -1,5 +1,6 @@
 import { calendar } from "@googleapis/calendar";
 import { OAuth2Client } from "google-auth-library";
+import { Logger } from "@core/logger/winston.logger";
 import { type gCalendar, type gSchema$Event } from "@core/types/gcal";
 import { normalizeGoogleEvent } from "@sync/providers/google/google-event.normalizer";
 import { GOOGLE_REQUEST_TIMEOUT_MS } from "@sync/providers/google/google-http.constants";
@@ -39,6 +40,8 @@ export interface GoogleEventListApi {
 export type GoogleEventListApiFactory = (
   accessToken: string,
 ) => GoogleEventListApi;
+
+const logger = Logger("sync:google-event-reader");
 
 const defaultApiFactory: GoogleEventListApiFactory = (accessToken) => {
   const auth = new OAuth2Client();
@@ -84,8 +87,14 @@ export class GoogleEventReaderAdapter implements ProviderEventReader {
 
   #makeApi: GoogleEventListApiFactory;
 
-  constructor(makeApi: GoogleEventListApiFactory = defaultApiFactory) {
+  #log: { warn: (message: string) => void };
+
+  constructor(
+    makeApi: GoogleEventListApiFactory = defaultApiFactory,
+    log?: { warn: (message: string) => void },
+  ) {
     this.#makeApi = makeApi;
+    this.#log = log ?? logger;
   }
 
   async listEventPage(
@@ -109,6 +118,9 @@ export class GoogleEventReaderAdapter implements ProviderEventReader {
         // dropped so one bad row never fails the whole page or the import.
         if (error instanceof ProviderEventError) {
           skipped++;
+          this.#log.warn(
+            `Skipped unusable Google event ${item.id ?? "(no id)"} (${error.reason})`,
+          );
           continue;
         }
         throw error;

--- a/packages/sync/src/providers/google/google-event.normalizer.test.ts
+++ b/packages/sync/src/providers/google/google-event.normalizer.test.ts
@@ -253,22 +253,24 @@ describe("normalizeGoogleEvent", () => {
     );
   });
 
-  it("throws when a timed event carries no time zone", () => {
-    const error = (() => {
-      try {
-        normalizeGoogleEvent(
-          gEvent({
-            start: { dateTime: "2025-01-15T09:00:00-05:00" },
-            end: { dateTime: "2025-01-15T10:00:00-05:00" },
-          }),
-        );
-      } catch (e) {
-        return e;
-      }
-    })() as ProviderEventError;
+  it("keeps an offset-only timed event instead of dropping it", () => {
+    const read = asProviderEvent(
+      normalizeGoogleEvent(
+        gEvent({
+          start: { dateTime: "2025-01-15T09:00:00-05:00" },
+          end: { dateTime: "2025-01-15T10:00:00-05:00" },
+        }),
+      ),
+    );
+    if (read.schedule.kind !== "timed") throw new Error("expected timed");
 
-    expect(error).toBeInstanceOf(ProviderEventError);
-    expect(error.reason).toBe("unmappableSchedule");
+    expect(read.schedule.timeZone).toBe("UTC");
+    expect(Date.parse(read.schedule.start)).toBe(
+      Date.parse("2025-01-15T09:00:00-05:00"),
+    );
+    expect(Date.parse(read.schedule.end)).toBe(
+      Date.parse("2025-01-15T10:00:00-05:00"),
+    );
   });
 
   it("falls back to UTC for a fixed-offset time zone instead of dropping the event", () => {

--- a/packages/sync/src/providers/google/google-event.normalizer.ts
+++ b/packages/sync/src/providers/google/google-event.normalizer.ts
@@ -193,17 +193,13 @@ function mapSchedule(item: gSchema$Event) {
   }
 
   if (start.dateTime && end.dateTime) {
+    // Google requires either an RFC3339 offset on dateTime or a timeZone.
+    // Clients often send only the offset; dropping those events hid them
+    // from Compass while Google still showed them. Missing or non-IANA
+    // zones fall back to UTC — the instant is preserved, wall-clock zone
+    // is not (same as the GMT-07:00 path below).
     const timeZone = start.timeZone ?? end.timeZone;
-    if (!timeZone) {
-      throw new ProviderEventError(
-        "unmappableSchedule",
-        "Timed event carried no time zone",
-      );
-    }
-    // Resolve to a valid IANA zone before re-anchoring: toOffsetIso's .tz()
-    // call needs one, and a fixed-offset string ("GMT-07:00") would otherwise
-    // reach it unvalidated.
-    const ianaTimeZone = toIanaTimeZone(timeZone);
+    const ianaTimeZone = timeZone ? toIanaTimeZone(timeZone) : "UTC";
     return parseSchedule({
       kind: "timed",
       start: toOffsetIso({ ...start, timeZone: ianaTimeZone }),

--- a/packages/sync/src/providers/provider-calendar.port.ts
+++ b/packages/sync/src/providers/provider-calendar.port.ts
@@ -23,8 +23,9 @@ export interface DiscoveredCalendar {
   }[];
   // The provider designates this as the account's default calendar.
   readonly primary: boolean;
-  // The calendar is present and visible in the account's list. A deleted or
-  // hidden calendar is reported inactive so preferences survive its return.
+  // The calendar is present for the account. Deleted calendars are inactive.
+  // Hidden-from-list calendars stay active when the provider is still showing
+  // their events (Google's selected flag).
   readonly active: boolean;
   readonly accessRole: CalendarAccessRole;
   readonly capabilities: SyncCalendarCapabilities;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Compass could report a healthy Google connection while some events never appeared on the grid. Two import bugs caused that:

1. Calendar discovery treated Google `hidden: true` as inactive even when `selected: true`, so those calendars were never imported, never listed in the sidebar, and never counted in `lastSyncedAt`.
2. Timed events with an RFC3339 offset but no IANA `timeZone` were dropped as `unmappableSchedule`. Google allows that shape; the reader then incremented `skipped` with no log.

This keeps selected-but-hidden calendars active, imports offset-only timed events (instant preserved, zone UTC), and logs skip reason plus provider event id (never title).

Existing calendar-list rediscovery enqueues `initialImport` when a calendar becomes active, so already-connected accounts pick this up on the next list pass.

## Simplicity

The discovery rule is a one-line superset of the previous check. Offset-only events reuse the existing GMT-offset UTC fallback instead of adding a new schedule path.

## Automated validation

- Focused Google adapter/normalizer/reader tests: 63 pass
- `bun run test:sync:fast`: 328 pass, 0 fail
- `bun run lint`: exit 0 (pre-existing warnings only; none in these files)

## Independent review

Not run.

## Test plan

- `bun test packages/sync/src/providers/google/google-calendar.adapter.test.ts packages/sync/src/providers/google/google-event.normalizer.test.ts packages/sync/src/providers/google/google-event-reader.adapter.test.ts`
- `bun run test:sync:fast`
- `bun run lint`

After deploy, Refresh or wait for calendar-list rediscovery so selected-but-hidden calendars import. Confirm the missing Walk/Haircut events and that those calendars appear in the Compass sidebar.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e98d49a5-de5e-4bfd-a225-b349aaba3c85?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e98d49a5-de5e-4bfd-a225-b349aaba3c85&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

