### PR TITLE
fix(web): commit focused time option on tab

### DIFF
--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/TimePicker.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/TimePicker.test.tsx
@@ -42,4 +42,41 @@ describe("TimePicker", () => {
 
     expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
   });
+
+  it("commits the focused filtered option when the user presses Tab", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+
+    const combobox = screen.getByRole("combobox");
+    await user.click(combobox);
+    await user.type(combobox, "1:30");
+    await user.tab();
+
+    expect(combobox).toHaveTextContent("1:30 PM");
+    expect(screen.getByRole("button", { name: "Description" })).toHaveFocus();
+  });
+
+  it("keeps the original value when Tabbing without choosing a new option", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+
+    const combobox = screen.getByRole("combobox");
+    await user.click(combobox);
+    await user.tab();
+
+    expect(combobox).toHaveTextContent("1 PM");
+    expect(screen.getByRole("button", { name: "Description" })).toHaveFocus();
+  });
+
+  it("discards typed filter on Escape instead of committing", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+
+    const combobox = screen.getByRole("combobox");
+    await user.click(combobox);
+    await user.type(combobox, "1:30");
+    await user.keyboard("{Escape}");
+
+    expect(combobox).toHaveTextContent("1 PM");
+  });
 });

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/TimePicker.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/TimePicker.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useState } from "react";
 import { type SelectOption } from "@web/common/types/component.types";
@@ -82,5 +82,31 @@ describe("TimePicker", () => {
 
     expect(screen.getByText("1 PM")).toBeInTheDocument();
     expect(screen.queryByText("1:30 PM")).not.toBeInTheDocument();
+  });
+
+  it("does not commit while IME composition is active", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+
+    const combobox = screen.getByRole("combobox", { name: "Start time" });
+    await user.click(combobox);
+    await user.type(combobox, "1:30");
+    fireEvent.keyDown(combobox, { key: "Tab", isComposing: true });
+
+    expect(screen.getByRole("listbox")).toBeInTheDocument();
+    await user.keyboard("{Escape}");
+    expect(screen.getByText("1 PM")).toBeInTheDocument();
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+  });
+
+  it("announces that Tab selects the focused option", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+
+    await user.click(screen.getByRole("combobox", { name: "Start time" }));
+
+    expect(
+      screen.getByText(/press Tab to select the option and exit the menu/i),
+    ).toBeInTheDocument();
   });
 });

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/TimePicker.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/TimePicker.test.tsx
@@ -18,6 +18,7 @@ function Harness() {
   return (
     <div>
       <TimePicker
+        aria-label="Start time"
         inputId="startTimePicker"
         isMenuOpen={isMenuOpen}
         onChange={setValue}
@@ -35,7 +36,7 @@ describe("TimePicker", () => {
     const user = userEvent.setup();
     render(<Harness />);
 
-    await user.click(screen.getByRole("combobox"));
+    await user.click(screen.getByRole("combobox", { name: "Start time" }));
     expect(screen.getByRole("listbox")).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: "Description" }));
@@ -47,12 +48,13 @@ describe("TimePicker", () => {
     const user = userEvent.setup();
     render(<Harness />);
 
-    const combobox = screen.getByRole("combobox");
+    const combobox = screen.getByRole("combobox", { name: "Start time" });
     await user.click(combobox);
     await user.type(combobox, "1:30");
     await user.tab();
 
-    expect(combobox).toHaveTextContent("1:30 PM");
+    expect(screen.getByText("1:30 PM")).toBeInTheDocument();
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Description" })).toHaveFocus();
   });
 
@@ -60,11 +62,12 @@ describe("TimePicker", () => {
     const user = userEvent.setup();
     render(<Harness />);
 
-    const combobox = screen.getByRole("combobox");
+    const combobox = screen.getByRole("combobox", { name: "Start time" });
     await user.click(combobox);
     await user.tab();
 
-    expect(combobox).toHaveTextContent("1 PM");
+    expect(screen.getByText("1 PM")).toBeInTheDocument();
+    expect(screen.queryByText("1:30 PM")).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Description" })).toHaveFocus();
   });
 
@@ -72,11 +75,12 @@ describe("TimePicker", () => {
     const user = userEvent.setup();
     render(<Harness />);
 
-    const combobox = screen.getByRole("combobox");
+    const combobox = screen.getByRole("combobox", { name: "Start time" });
     await user.click(combobox);
     await user.type(combobox, "1:30");
     await user.keyboard("{Escape}");
 
-    expect(combobox).toHaveTextContent("1 PM");
+    expect(screen.getByText("1 PM")).toBeInTheDocument();
+    expect(screen.queryByText("1:30 PM")).not.toBeInTheDocument();
   });
 });

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/TimePicker.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/TimePicker.tsx
@@ -121,7 +121,8 @@ export const TimePicker = ({
         }}
         openMenuOnFocus={true}
         options={options}
-        tabSelectsValue={false}
+        // Tab commits the focused (filtered) option and moves to the next field.
+        tabSelectsValue={true}
         isValidNewOption={(inputValue) => {
           const parsed = parseUserTime(inputValue, value?.value);
           if (!parsed) return false;

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/TimePicker.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/TimePicker.tsx
@@ -108,6 +108,27 @@ export const TimePicker = ({
           }
 
           if (key === "Tab") {
+            // Commit the focused option ourselves. react-select's
+            // tabSelectsValue preventDefaults Tab and, with blurInputOnSelect,
+            // leaves focus on the document instead of the next field.
+            if (!e.shiftKey) {
+              const focusedEl = containerRef.current?.getElementsByClassName(
+                `${TIMEPICKER}__option--is-focused`,
+              )[0];
+              const focusedLabel = focusedEl?.textContent?.trim();
+              if (focusedLabel) {
+                const listed = options?.find(
+                  (o) => (o as TimeOption).label === focusedLabel,
+                ) as TimeOption | undefined;
+                const created = parseUserTime(focusedLabel, value?.value);
+                const option =
+                  listed ??
+                  (created?.label === focusedLabel ? created : undefined);
+                if (option) {
+                  _onChange(option);
+                }
+              }
+            }
             setIsMenuOpen(false);
           }
         }}
@@ -121,8 +142,7 @@ export const TimePicker = ({
         }}
         openMenuOnFocus={true}
         options={options}
-        // Tab commits the focused (filtered) option and moves to the next field.
-        tabSelectsValue={true}
+        tabSelectsValue={false}
         isValidNewOption={(inputValue) => {
           const parsed = parseUserTime(inputValue, value?.value);
           if (!parsed) return false;

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/TimePicker.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/TimePicker.tsx
@@ -33,6 +33,25 @@ const timePickerTextStyles = {
   placeholder: themeColor("var(--text-muted)"),
 };
 
+const TIMEPICKER = "timepicker";
+
+function optionFromFocusedMenu(
+  container: HTMLElement | null,
+  options: TimeOption[] | undefined,
+  currentValue: string | undefined,
+): TimeOption | undefined {
+  const focusedLabel = container
+    ?.getElementsByClassName(`${TIMEPICKER}__option--is-focused`)[0]
+    ?.textContent?.trim();
+  if (!focusedLabel) return undefined;
+
+  const listed = options?.find((option) => option.label === focusedLabel);
+  if (listed) return listed;
+
+  const created = parseUserTime(focusedLabel, currentValue);
+  return created?.label === focusedLabel ? created : undefined;
+}
+
 export const TimePicker = ({
   isMenuOpen,
   onChange: _onChange,
@@ -42,7 +61,6 @@ export const TimePicker = ({
   value,
   ...props
 }: Props) => {
-  const TIMEPICKER = "timepicker";
   const containerRef = useRef<HTMLDivElement>(null);
   const scrollRafRef = useRef<number | null>(null);
   const layerId = useId();
@@ -111,23 +129,14 @@ export const TimePicker = ({
             // Commit the focused option ourselves. react-select's
             // tabSelectsValue preventDefaults Tab and, with blurInputOnSelect,
             // leaves focus on the document instead of the next field.
+            if (e.nativeEvent.isComposing) return;
             if (!e.shiftKey) {
-              const focusedEl = containerRef.current?.getElementsByClassName(
-                `${TIMEPICKER}__option--is-focused`,
-              )[0];
-              const focusedLabel = focusedEl?.textContent?.trim();
-              if (focusedLabel) {
-                const listed = options?.find(
-                  (o) => (o as TimeOption).label === focusedLabel,
-                ) as TimeOption | undefined;
-                const created = parseUserTime(focusedLabel, value?.value);
-                const option =
-                  listed ??
-                  (created?.label === focusedLabel ? created : undefined);
-                if (option) {
-                  _onChange(option);
-                }
-              }
+              const option = optionFromFocusedMenu(
+                containerRef.current,
+                options,
+                value?.value,
+              );
+              if (option) _onChange(option);
             }
             setIsMenuOpen(false);
           }
@@ -143,6 +152,28 @@ export const TimePicker = ({
         openMenuOnFocus={true}
         options={options}
         tabSelectsValue={false}
+        ariaLiveMessages={{
+          guidance: ({
+            context,
+            isSearchable,
+            isMulti,
+            isInitialFocus,
+            "aria-label": ariaLabel,
+          }) => {
+            switch (context) {
+              case "menu":
+                return "Use Up and Down to choose options, press Enter to select the currently focused option, press Escape to exit the menu, press Tab to select the option and exit the menu.";
+              case "input":
+                return isInitialFocus
+                  ? `${ariaLabel || "Select"} is focused ${isSearchable ? ",type to refine list" : ""}, press Down to open the menu, ${isMulti ? " press left to focus selected values" : ""}`
+                  : "";
+              case "value":
+                return "Use left and right to toggle between focused values, press Backspace to remove the currently focused value";
+              default:
+                return "";
+            }
+          },
+        }}
         isValidNewOption={(inputValue) => {
           const parsed = parseUserTime(inputValue, value?.value);
           if (!parsed) return false;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Typing in the event form time combobox filters the list and focuses a matching option (for example `10 AM`). Users then press Tab expecting that option to be selected and focus to move to the next field.

`tabSelectsValue` was `false`, so Tab closed the menu and restored the original time. Enabling react-select’s `tabSelectsValue` commits the option but also `preventDefault`s Tab and, with `blurInputOnSelect`, leaves focus on the document.

The Tab handler now commits the focused listed or creatable option, then lets Tab move to the next field. Composition (IME) Tab is ignored. Screen-reader menu guidance announces that Tab selects. Escape and click-away still discard the typed filter. Shift+Tab still does not commit.

## Simplicity

Extracted `optionFromFocusedMenu` so the Tab path is guard clauses instead of nested DOM/label matching. No new parsing, no blur-to-commit, and no change to `TimePickers` compliment-time logic. Retained existing `useRef`/`useEffect` for menu scroll cleanup (pre-existing). Copied react-select’s non-menu ARIA guidance strings because `defaultAriaLiveMessages` is not a public export.

## Automated validation

- `bun test:web -- packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/TimePicker.test.tsx` — 6 pass (click-away, filter+Tab commit and focus move, Tab without a new choice, Escape discard, IME Tab, Tab announcement)
- `bun run lint` — no new issues in touched files (10 pre-existing repo warnings)

## Browser scenario

Anonymous week view at `http://localhost:9080`. Clicked an 8 PM slot, focused Start time, typed `10 A`, pressed Tab. Start time became `10 AM` and focus moved to End time. Repeated with `11 A` → `11 AM`. Backend connection-refused console errors are expected without `dev:backend`.

## Independent review

Fresh read-only review of `origin/main...HEAD` after the IME/ARIA follow-up: no confirmed actionable findings. Earlier review’s IME Tab commit and missing Tab announcement were fixed.

## Test plan

- `bun test:web -- packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/TimePicker.test.tsx`
- `bun run lint`
- Browser: filter start time and Tab to commit
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-072e4410-c10e-47f5-8853-ff80d115ce99?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-072e4410-c10e-47f5-8853-ff80d115ce99&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

