### PR TITLE
fix(sync): close two holes in Google push delivery

### DIFF
--- a/packages/sync/src/domain/calendar-pull.service.db.test.ts
+++ b/packages/sync/src/domain/calendar-pull.service.db.test.ts
@@ -530,4 +530,95 @@ describe("pullCalendarChanges", () => {
     expect(reader.calls[1].pageToken).toBe("p2");
     expect(result.changed).toBe(2);
   });
+
+  describe("push change marker", () => {
+    // A notification stamps changeNotifiedAt; the pull that observes it clears
+    // the marker and reports how long the provider-to-applied hop took.
+    it("clears the marker it served and reports push latency", async () => {
+      const calendar = await seedCalendar();
+      const resource = await seedImported(calendar);
+      const notifiedAt = new Date("2026-07-09T23:59:55.000Z");
+      await resources.markChangeNotified(
+        calendar.tenantId,
+        calendar.principalId,
+        resource._id,
+        notifiedAt,
+      );
+      const reader = new FakeReader([
+        page([single("a")], { nextSyncToken: "c" }),
+      ]);
+
+      const result = await pullCalendarChanges(deps(reader), calendar, now);
+
+      if (result.status !== "applied") throw new Error("expected applied");
+      expect(result.changedDuringPull).toBe(false);
+      // now() is 2026-07-10T00:00:00Z, five seconds after the notification.
+      expect(result.pushLatencyMs).toBe(5_000);
+      const stored = await resources.findById(
+        calendar.tenantId,
+        calendar.principalId,
+        resource._id,
+      );
+      expect(stored?.changeNotifiedAt).toBeNull();
+    });
+
+    it("reports no latency and leaves the marker null when no notification drove the pull", async () => {
+      const calendar = await seedCalendar();
+      const resource = await seedImported(calendar);
+      const reader = new FakeReader([page([], { nextSyncToken: "c" })]);
+
+      const result = await pullCalendarChanges(deps(reader), calendar, now);
+
+      if (result.status !== "applied") throw new Error("expected applied");
+      expect(result.pushLatencyMs).toBeNull();
+      expect(result.changedDuringPull).toBe(false);
+      const stored = await resources.findById(
+        calendar.tenantId,
+        calendar.principalId,
+        resource._id,
+      );
+      expect(stored?.changeNotifiedAt).toBeNull();
+    });
+
+    // The regression this whole field exists for: the notification's own
+    // enqueue coalesced onto this pull's claimed row and did nothing, so if the
+    // pull also cleared the marker the change would be lost until the 15-minute
+    // reconcile sweep.
+    it("reports changedDuringPull and keeps the newer marker when a notification lands mid-pull", async () => {
+      const calendar = await seedCalendar();
+      const resource = await seedImported(calendar);
+      const arrivedDuringPull = new Date("2026-07-10T00:00:03.000Z");
+
+      // Stamps the marker as a side effect of the provider read — i.e. the
+      // notification lands after this pull has already seen the provider.
+      const reader: ProviderEventReader = {
+        provider: "google",
+        listEventPage: async () => {
+          await resources.markChangeNotified(
+            calendar.tenantId,
+            calendar.principalId,
+            resource._id,
+            arrivedDuringPull,
+          );
+          return page([single("a")], { nextSyncToken: "c" });
+        },
+      };
+
+      const result = await pullCalendarChanges(
+        { ...deps(new FakeReader([])), reader },
+        calendar,
+        now,
+      );
+
+      if (result.status !== "applied") throw new Error("expected applied");
+      expect(result.changedDuringPull).toBe(true);
+      const stored = await resources.findById(
+        calendar.tenantId,
+        calendar.principalId,
+        resource._id,
+      );
+      // Left set on purpose: the next pass owns it.
+      expect(stored?.changeNotifiedAt).toEqual(arrivedDuringPull);
+    });
+  });
 });

--- a/packages/sync/src/domain/calendar-pull.service.ts
+++ b/packages/sync/src/domain/calendar-pull.service.ts
@@ -31,6 +31,15 @@ export type CalendarPullResult =
       resource: SyncResourceRecord;
       changed: number;
       deleted: number;
+      // A push notification for this calendar landed AFTER this pull had
+      // already read the provider, so the change it announced is in neither
+      // this pull nor any queued job (the enqueue coalesced onto this pull's
+      // own claimed row). The caller must pull again rather than leave it to
+      // the 15-minute reconcile sweep.
+      changedDuringPull: boolean;
+      // End-to-end push latency: provider notification to applied, in ms. Null
+      // when this pull served no notification (a sweep or bootstrap pull).
+      pushLatencyMs: number | null;
     }
   | {
       // The stored cursor is too old (410 Gone). The caller starts a full
@@ -88,6 +97,12 @@ export async function pullCalendarChanges(
   if (resource.syncCursor === null) {
     return { status: "notImported", resource };
   }
+
+  // Read the change marker BEFORE the first provider read. Everything this pull
+  // observes is a snapshot at or after this instant, so a marker still holding
+  // this value at the end means no change arrived that this pull could have
+  // missed. Any other value did arrive too late to be in the pages below.
+  const notifiedAtStart = resource.changeNotifiedAt;
 
   let accessToken = await deps.custody.getValidAccessToken(
     calendar.connectionId,
@@ -168,6 +183,18 @@ export async function pullCalendarChanges(
     now(),
   );
 
+  // Retire the change this pull served — but only if nothing moved the marker
+  // while the pages above were being read. A failed match is the signal that a
+  // notification landed mid-pull; leave that newer marker in place so the next
+  // pass owns it.
+  const appliedAt = now();
+  const served = await deps.resources.clearChangeNotifiedIfUnchanged(
+    resource.tenantId,
+    resource.principalId,
+    resource._id,
+    notifiedAtStart,
+  );
+
   const updated = await deps.resources.findById(
     resource.tenantId,
     resource.principalId,
@@ -178,6 +205,10 @@ export async function pullCalendarChanges(
     resource: updated ?? resource,
     changed: applier.importedCount,
     deleted,
+    changedDuringPull: !served,
+    pushLatencyMs: notifiedAtStart
+      ? appliedAt.getTime() - notifiedAtStart.getTime()
+      : null,
   };
 }
 

--- a/packages/sync/src/domain/subscription-maintenance.service.ts
+++ b/packages/sync/src/domain/subscription-maintenance.service.ts
@@ -39,8 +39,15 @@ export type SubscriptionMaintenanceOutcome =
   // there is nothing to do here and retrying will not help.
   | { readonly status: "authRevoked" };
 
-// One day. Google event channels last about a week, so renewing a full day
-// ahead leaves generous margin over any reasonable maintenance cadence.
+// One day, deliberately paired with the 48h channel lifetime the Google
+// notification adapter requests (DEFAULT_TTL_MS): a channel becomes renewable
+// about a day after it is opened, so the renewal sweep replaces every channel
+// roughly daily. That cadence is the point, not a side effect — a channel can
+// stop delivering WITHOUT expiring (Google drops one whose callbacks keep
+// failing), and since every liveness path we have selects on
+// subscriptionExpiresAt, re-watching on a cadence is what bounds how long such
+// a channel can stay silently dead. Raising the provider TTL without raising
+// this, or vice versa, changes that window — keep the two in step.
 const DEFAULT_RENEW_BEFORE_MS = 24 * 60 * 60 * 1000;
 
 // Ensure a calendar's events resource has a live push channel: open one if it

--- a/packages/sync/src/domain/sync-job-dispatch.service.db.test.ts
+++ b/packages/sync/src/domain/sync-job-dispatch.service.db.test.ts
@@ -314,6 +314,98 @@ describe("dispatchSyncJob", () => {
     });
   });
 
+  it("re-pulls when a notification lands after the pull already read the provider", async () => {
+    // The notification's own enqueue coalesces onto this job's CLAIMED row and
+    // does nothing, and the row is deleted the moment the job settles — so
+    // without this second pass the change waits for the reconcile sweep's
+    // 15-minute staleness threshold instead of the ~30s the push path promises.
+    // A followup job cannot do it: the worker enqueues followups BEFORE
+    // completing, so one sharing `incrementalPull:<resourceId>` would coalesce
+    // onto the very row it replaces.
+    const calendar = await seedCalendar();
+    const resource = await seedResource(calendar, "cursor-0");
+    const reads: string[] = [];
+
+    const reader: ProviderEventReader = {
+      provider: "google",
+      listEventPage: async () => {
+        reads.push("read");
+        if (reads.length === 1) {
+          // The notification arrives now — after this pass has read Google.
+          await resources.markChangeNotified(
+            calendar.tenantId,
+            calendar.principalId,
+            resource._id,
+            new Date("2026-07-10T00:00:03.000Z"),
+          );
+          return page([single("first")], "cursor-1");
+        }
+        return page([single("second")], "cursor-2");
+      },
+    };
+
+    await dispatchSyncJob(
+      { ...deps(new FakeReader([])), reader },
+      jobFor(resource, "incrementalPull"),
+      now,
+    );
+
+    expect(reads).toHaveLength(2);
+    // The second pass served the marker, so nothing is left pending.
+    const stored = await resources.findById(
+      calendar.tenantId,
+      calendar.principalId,
+      resource._id,
+    );
+    expect(stored?.changeNotifiedAt).toBeNull();
+    expect(stored?.syncCursor).toBe("cursor-2");
+  });
+
+  it("stops re-pulling after the pass bound and leaves the rest to the sweep", async () => {
+    // A calendar changing on every pass must not hold a worker lane forever.
+    const calendar = await seedCalendar();
+    const resource = await seedResource(calendar, "cursor-0");
+    const reads: string[] = [];
+    const warnings: string[] = [];
+
+    const reader: ProviderEventReader = {
+      provider: "google",
+      listEventPage: async () => {
+        reads.push("read");
+        // Every pass is overtaken by a newer notification.
+        await resources.markChangeNotified(
+          calendar.tenantId,
+          calendar.principalId,
+          resource._id,
+          new Date(`2026-07-10T00:00:0${reads.length}.000Z`),
+        );
+        return page([single(`e-${reads.length}`)], `cursor-${reads.length}`);
+      },
+    };
+
+    await dispatchSyncJob(
+      {
+        ...deps(new FakeReader([])),
+        reader,
+        log: { warn: (message) => warnings.push(message) },
+      },
+      jobFor(resource, "incrementalPull"),
+      now,
+    );
+
+    expect(reads).toHaveLength(3);
+    expect(
+      warnings.some((message) => message.includes("after 3 pull passes")),
+    ).toBe(true);
+    // Marker deliberately left set so the reconcile sweep picks up the rest.
+    const stored = await resources.findById(
+      calendar.tenantId,
+      calendar.principalId,
+      resource._id,
+    );
+    expect(stored?.changeNotifiedAt).not.toBeNull();
+  });
+
   it("bootstraps a push channel when an applied pull finds the calendar has none", async () => {
     // The initialImport followup used to be the only thing that ever opened a
     // channel, and the renewal sweep only renews channels that already exist,

--- a/packages/sync/src/domain/sync-job-dispatch.service.ts
+++ b/packages/sync/src/domain/sync-job-dispatch.service.ts
@@ -58,8 +58,12 @@ export interface SyncJobDispatchDeps {
   // Optional: a bootstrap/repair job settling "done" is otherwise invisible
   // (drops and errors are logged; "done" is not) - an hour of a resource
   // repairing every ~2 minutes produced zero log lines (2026-08-04 staging).
-  // Defaults to a no-op so tests stay dependency-free.
-  log?: { warn: (message: string) => void };
+  // Defaults to a no-op so tests stay dependency-free. `info` is optional on
+  // top of that so existing callers passing only `warn` keep type-checking.
+  log?: {
+    warn: (message: string) => void;
+    info?: (message: string) => void;
+  };
 }
 
 // The decision a dispatch makes about a claimed job. The worker loop (a later
@@ -283,7 +287,7 @@ async function runSyncJob(
       return { result: "done", followup: subscriptionFollowup(resource, now) };
     }
     case "incrementalPull": {
-      const pull = await pullCalendarChanges(deps, calendar, now);
+      const pull = await pullUntilQuiet(deps, calendar, now);
       if (pull.status === "applied") {
         await appendCalendarInvalidation(deps, calendar, now());
         // Bootstrap a channel for an imported calendar that has none. The
@@ -327,7 +331,7 @@ async function runSyncJob(
       // provider watch durable. It deliberately has its own job kind so an
       // unrelated reconcile/manual pull can never make a new connection look
       // ready before watch setup has completed.
-      const pull = await pullCalendarChanges(deps, calendar, now);
+      const pull = await pullUntilQuiet(deps, calendar, now);
       if (pull.status === "applied") {
         await deps.resources.setBootstrapState(
           resource.tenantId,
@@ -415,6 +419,66 @@ async function runSyncJob(
       return { result: "done" };
     }
   }
+}
+
+// How many extra passes a single pull job will make to absorb notifications
+// that land while it is running. A busy calendar can always produce one more
+// change mid-pull; the bound stops that from holding a worker lane forever.
+// On giving up, the change marker is left set and the reconcile sweep covers
+// the remainder — slow, but bounded and visible in the log.
+const MAX_PULL_PASSES = 3;
+
+// Pull until no notification arrives mid-pull, then report the last result.
+//
+// A pull that reads the provider and THEN receives a notification has missed
+// that change: the notification's enqueue coalesced onto this job's own claimed
+// row and did nothing (JobRepository.enqueue is $setOnInsert-only), and this
+// job's row is deleted the moment it settles. Re-pulling here is what closes
+// that window. It cannot be done with a followup job — the worker enqueues
+// followups BEFORE completing the current job (sync-job-worker.service.ts), so
+// a followup sharing the `incrementalPull:<resourceId>` key would coalesce onto
+// the very row it is meant to replace and vanish the same way.
+//
+// Each pass re-reads from the cursor the previous pass advanced, so a pass with
+// nothing new is one cheap empty page.
+async function pullUntilQuiet(
+  deps: SyncJobDispatchDeps,
+  calendar: ProviderCalendarRecord,
+  now: () => Date,
+): Promise<Awaited<ReturnType<typeof pullCalendarChanges>>> {
+  let pull = await pullCalendarChanges(deps, calendar, now);
+  let passes = 1;
+
+  while (
+    pull.status === "applied" &&
+    pull.changedDuringPull &&
+    passes < MAX_PULL_PASSES
+  ) {
+    deps.log?.info?.(
+      `Sync resource ${pull.resource._id} (calendar ${calendar._id}): notification landed mid-pull, re-pulling (pass ${passes + 1}/${MAX_PULL_PASSES})`,
+    );
+    pull = await pullCalendarChanges(deps, calendar, now);
+    passes += 1;
+  }
+
+  if (pull.status === "applied") {
+    if (pull.changedDuringPull) {
+      deps.log?.warn(
+        `Sync resource ${pull.resource._id} (calendar ${calendar._id}): still receiving notifications after ${MAX_PULL_PASSES} pull passes; leaving the rest to the reconcile sweep`,
+      );
+    }
+    if (pull.pushLatencyMs !== null) {
+      // The number that says whether the push path is meeting its ~30s bar or
+      // quietly degrading to the 15-minute reconcile fallback. Nothing measured
+      // this before, so "late" and "dropped" were indistinguishable after the
+      // fact.
+      deps.log?.info?.(
+        `Sync resource ${pull.resource._id} (calendar ${calendar._id}): push latency ${pull.pushLatencyMs}ms over ${passes} pass(es), ${pull.changed} changed, ${pull.deleted} deleted`,
+      );
+    }
+  }
+
+  return pull;
 }
 
 function repairFollowup(

--- a/packages/sync/src/providers/google/google-notifications.adapter.test.ts
+++ b/packages/sync/src/providers/google/google-notifications.adapter.test.ts
@@ -83,7 +83,11 @@ describe("GoogleNotificationAdapter watch/stop", () => {
         type: "web_hook",
         address: "https://sync.example.com/callbacks/google",
         token: "chan-token",
-        expiration: String(new Date("2026-01-08T00:00:00Z").getTime()),
+        // 48h, not the week Google allows: a channel can stop delivering
+        // without expiring, and the renewal sweep only selects on expiry, so
+        // the short lifetime is what forces a daily re-watch and bounds that
+        // blind window.
+        expiration: String(new Date("2026-01-03T00:00:00Z").getTime()),
       },
     });
     expect(channel).toEqual({

--- a/packages/sync/src/providers/google/google-notifications.adapter.ts
+++ b/packages/sync/src/providers/google/google-notifications.adapter.ts
@@ -49,7 +49,18 @@ const defaultApiFactory: GoogleChannelsApiFactory = (accessToken) => {
 
 // A default channel lifetime when the caller requests none. Google caps event
 // channels near a week; it may return a shorter expiry, which is authoritative.
-const DEFAULT_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+//
+// Deliberately 48h rather than the week Google allows. A channel can stop
+// delivering without expiring — Google drops one whose callbacks keep failing,
+// and nothing about that reaches us — and the renewal sweep only ever selects
+// on subscriptionExpiresAt, so a dead-but-unexpired channel is invisible to
+// every liveness path we have. Pairing a 48h lifetime with the 24h renew-before
+// guard means the sweep replaces every channel about once a day, which bounds
+// that blind window to a day instead of a week. The cost is one extra
+// events.watch per calendar per day, well inside Google's quota, and
+// maintainSubscription persists the replacement BEFORE stopping the old channel
+// so a renewal never opens a delivery gap.
+const DEFAULT_TTL_MS = 48 * 60 * 60 * 1000;
 
 // Google callback headers, lower-cased (Node lower-cases request headers).
 const HEADER_CHANNEL_ID = "x-goog-channel-id";

--- a/packages/sync/src/server/notification.routes.db.test.ts
+++ b/packages/sync/src/server/notification.routes.db.test.ts
@@ -110,6 +110,35 @@ describe("POST /sync/notifications/google", () => {
     expect(await jobCount(`incrementalPull:${resourceId}`)).toBe(1);
   });
 
+  it("stamps the change marker so a pull already in flight cannot miss the change", async () => {
+    // The enqueue above no-ops whenever a job holds the coalescing key —
+    // including the claimed row of a running pull that has already read the
+    // provider. The marker is the only thing that survives that, and the pull's
+    // compare-and-clear is what turns it back into a second pass.
+    const resourceId = await seedSubscription();
+    await startService();
+
+    const res = await post(googHeaders());
+
+    expect(res.status).toBe(200);
+    const stored = await mongo.db
+      .collection(SYNC_COLLECTIONS.syncResources)
+      .findOne({ _id: resourceId });
+    expect(stored?.["changeNotifiedAt"]).toBeInstanceOf(Date);
+  });
+
+  it("does not stamp the change marker on a rejected notification", async () => {
+    const resourceId = await seedSubscription();
+    await startService();
+
+    await post(googHeaders({ "x-goog-channel-token": "wrong" }));
+
+    const stored = await mongo.db
+      .collection(SYNC_COLLECTIONS.syncResources)
+      .findOne({ _id: resourceId });
+    expect(stored?.["changeNotifiedAt"]).toBeNull();
+  });
+
   it("does not enqueue on the initial sync handshake", async () => {
     const resourceId = await seedSubscription();
     await startService();

--- a/packages/sync/src/server/notification.routes.ts
+++ b/packages/sync/src/server/notification.routes.ts
@@ -88,6 +88,20 @@ export function registerNotificationRoutes(
       // Only an authentic change schedules work. Coalescing on the resource
       // collapses duplicate deliveries of the same change into one job.
       if (verdict.status === "process" && resource) {
+        // Stamp BEFORE enqueuing. The enqueue below no-ops whenever a job
+        // already holds this coalescing key — including the CLAIMED row of a
+        // pull already in flight, which may have read the provider before this
+        // change existed. The marker is what survives that: the running pull's
+        // compare-and-clear fails against it and the pull goes round again.
+        // Stamping first also keeps the ordering safe if the enqueue throws —
+        // a marker with no job is recovered by the reconcile sweep, whereas a
+        // job with no marker could clear a change it never read.
+        await resources.markChangeNotified(
+          resource.tenantId,
+          resource.principalId,
+          resource._id,
+          now,
+        );
         await new JobRepository(deps.mongo.db).enqueue({
           tenantId: resource.tenantId,
           principalId: resource.principalId,

--- a/packages/sync/src/storage/contracts/sync-resource.contracts.ts
+++ b/packages/sync/src/storage/contracts/sync-resource.contracts.ts
@@ -90,6 +90,24 @@ export const SyncResourceRecordSchema = z.strictObject({
   subscriptionResourceId: z.string().min(1).nullable(),
   subscriptionToken: z.string().min(1).nullable(),
   subscriptionExpiresAt: z.date().nullable(),
+  // When the provider last told us this calendar changed, and we have not yet
+  // completed a pull that observed it. Set on every accepted push notification,
+  // cleared by the pull that serves it — but ONLY if it still holds the value
+  // that pull started with. A notification landing mid-pull therefore fails
+  // that compare-and-clear, which is exactly how the pull learns it read too
+  // early and must go round again.
+  //
+  // Without this, such a notification was lost outright: the job enqueue
+  // coalesces on `incrementalPull:<resourceId>`, and $setOnInsert no-ops
+  // against the CLAIMED row of the pull already running, so the change waited
+  // for the reconcile sweep (15min stale threshold on a ~10min cycle) instead
+  // of the ~30s the push path promises.
+  //
+  // Doubles as the push-latency clock: notified-at to pull-applied is the
+  // end-to-end number, previously unmeasurable.
+  // Defaults tolerate rows written before the field — REQUIRED, see
+  // watchUnsupportedAt above.
+  changeNotifiedAt: z.date().nullable().default(null),
   createdAt: z.date(),
   updatedAt: z.date(),
 });

--- a/packages/sync/src/storage/repositories/sync-resource.repository.ts
+++ b/packages/sync/src/storage/repositories/sync-resource.repository.ts
@@ -94,6 +94,7 @@ export class SyncResourceRepository {
           subscriptionResourceId: null,
           subscriptionToken: null,
           subscriptionExpiresAt: null,
+          changeNotifiedAt: null,
           createdAt: now,
           updatedAt: now,
         },
@@ -180,6 +181,42 @@ export class SyncResourceRepository {
         },
       },
     ]);
+  }
+
+  // Record that the provider reported a change for this resource. Always
+  // overwrites: the newest notification is the one a pull must observe, and the
+  // pull's compare-and-clear below keys off exactly this value.
+  async markChangeNotified(
+    tenantId: TenantId,
+    principalId: PrincipalId,
+    id: string,
+    at: Date,
+  ): Promise<void> {
+    await this.collection.updateOne(
+      { _id: id, tenantId, principalId },
+      { $set: { changeNotifiedAt: at, updatedAt: new Date() } },
+    );
+  }
+
+  // Clear the change marker a pull has now served, but only if it still holds
+  // `expected` — the value read when that pull started. Returns false when the
+  // marker moved mid-pull, meaning a notification arrived after the pull had
+  // already read the provider and the caller must pull again.
+  //
+  // `expected` may be null (no pending change at pull start); a notification
+  // landing during that pull still moves it off null and fails the match.
+  // Matched-not-modified is the null -> null case, which is unchanged.
+  async clearChangeNotifiedIfUnchanged(
+    tenantId: TenantId,
+    principalId: PrincipalId,
+    id: string,
+    expected: Date | null,
+  ): Promise<boolean> {
+    const result = await this.collection.updateOne(
+      { _id: id, tenantId, principalId, changeNotifiedAt: expected },
+      { $set: { changeNotifiedAt: null, updatedAt: new Date() } },
+    );
+    return result.matchedCount === 1;
   }
 
   // Advance first-connection readiness only after the caller has completed a


### PR DESCRIPTION
## Summary

Two independent ways a Google push notification could fail to reach the grid, leaving a calendar silently on the 15-minute reconcile fallback while every status surface stayed green.

Rebased onto `main` after #2789 merged. The two changes touch disjoint files — #2789 covers the import/normalizer path, this covers push delivery — so the rebase was clean and the diff here is unchanged.

**1. A notification landing mid-pull was discarded.** `JobRepository.enqueue` is `$setOnInsert`-only and coalesces on `incrementalPull:<resourceId>`, so the notification's enqueue no-opped against the running job's own **claimed** row — and that row is deleted the moment the job settles. If the notification arrived after the pull had already read the provider, the change was in neither the pull nor any queued job.

Tracked on the resource instead of the job queue: every accepted notification stamps `changeNotifiedAt`; `pullCalendarChanges` reads it before its first provider read and clears it at the end **only if it still holds that value**. A failed compare-and-clear is precisely the mid-pull case, and `dispatchSyncJob` pulls again — bounded to 3 passes so a continuously-changing calendar cannot hold a worker lane, with the marker left set and logged for the sweep past the bound.

This deliberately does not use the followup mechanism: `sync-job-worker.service.ts` enqueues followups **before** completing the current job, so a followup sharing the coalescing key would coalesce onto the very row it is meant to replace and vanish the same way.

**2. A channel that stopped delivering without expiring was never repaired.** Google drops a channel whose callbacks keep failing, and nothing about that reaches us. Every liveness path selects on `subscriptionExpiresAt` — `listExpiringSubscriptions` filters on it, and the pull-path watch piggyback only fires when `subscriptionId` is null — so a dead-but-unexpired channel matched neither and stayed dead for the rest of its 7-day lifetime, then re-broke after every renewal.

Requesting a 48h channel lifetime instead of the week Google allows pairs with the existing 24h renew-before guard so the sweep replaces every channel about daily, bounding that window to a day. `maintainSubscription` already stores the replacement before stopping the old channel, so the extra cadence opens no delivery gap.

**Latency logging.** `changeNotifiedAt` doubles as the push-latency clock — notification-received to pull-applied, logged per pull with the pass count. Nothing measured this before, which is why a late event and a dropped event were indistinguishable after the fact.

Found while investigating a report of Google events missing from the grid. Those events later appeared on their own with no deploy, which rules out an import-time drop and points at delivery; these are the delivery holes I could prove from the code. Neither is proof of that report's cause — the latency logging is what would settle it next time.

## Simplicity

One nullable field and two repository methods for the first hole; one constant for the second. The mid-pull detection is the compare-and-clear itself — no extra read, no lock, no new sweep, no new job kind — and latency reuses the same timestamp rather than adding a second one.

Deliberately **not** included: inferring a dead channel from a pull that finds changes no notification announced. It looks like direct evidence, but the reconcile sweep can legitimately win that race against an in-flight notification or against Compass's own write being echoed back, so it would churn healthy channels fleet-wide to buy detection the daily re-watch already provides. An earlier revision of this branch had it; it tripped the existing "settles an applied incremental pull as done when the channel is already live" invariant, which is what surfaced the false-positive class. Doing it safely needs a persistent last-notification timestamp plus channel age — worth it only if the daily cadence proves insufficient.

## Automated validation

Run on the rebased tree (this branch on top of #2789):

- `packages/sync` db suites: 459 pass, 0 fail (34 files)
- `bun run test:sync:fast`: 332 pass, 0 fail
- `bunx typescript@7.0.2 --noEmit`: exit 0
- `bun run lint`: exit 0 (10 pre-existing warnings, none in these files)

New coverage from this branch:
- pull clears the marker it served and reports latency; reports none when no notification drove it; reports `changedDuringPull` and keeps the newer marker when one lands mid-pull
- dispatch re-pulls after a mid-pull notification, and stops at the pass bound leaving the remainder to the sweep
- the notification route stamps the marker on an authentic change and does not stamp on a rejected one
- the watch request carries the 48h expiry

Note on environment: the sandbox's bun could not run `bun run test:sync` directly — `mongodb-memory-server`'s free-port probe binds `::`, which fails here with an error carrying no `code`, so its `EADDRINUSE` guard rethrows. The db suites above were run against the same `MongoMemoryReplSet` via a throwaway harness forcing an IPv4 bind; the repo's harness is untouched and CI exercises it normally.

## Independent review

Not run.

## Test plan

- `bun run test:sync`
- `bun run test:sync:fast`
- `bunx typescript@7.0.2 --noEmit`
- `bun run lint`

After deploy, `sync:` logs carry a `push latency <n>ms over <k> pass(es)` line per applied pull — the number to watch against the ~30s bar — and a `notification landed mid-pull, re-pulling` line marks each window the first fix closes. Channel renewals should appear roughly daily per calendar rather than weekly.