### PR TITLE
fix(web): focus current time for picker arrow keys

### DIFF
--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/TimePicker.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/TimePicker.test.tsx
@@ -1,19 +1,28 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useState } from "react";
 import { type SelectOption } from "@web/common/types/component.types";
+import { getTimeOptions } from "@web/common/utils/datetime/web.date.util";
 import { TimePicker } from "./TimePicker";
 import { describe, expect, it } from "bun:test";
 
-const options: SelectOption<string>[] = [
+const intervalOptions: SelectOption<string>[] = [
   { value: "13:00", label: "1 PM" },
   { value: "13:15", label: "1:15 PM" },
   { value: "13:30", label: "1:30 PM" },
 ];
+const dayOptions = getTimeOptions();
+const fiveThirty = { label: "5:30 PM", value: "5:30 PM" };
 
-function Harness() {
+function Harness({
+  initialValue = intervalOptions[0],
+  options = intervalOptions,
+}: {
+  initialValue?: SelectOption<string>;
+  options?: SelectOption<string>[];
+}) {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
-  const [value, setValue] = useState(options[0]);
+  const [value, setValue] = useState(initialValue);
 
   return (
     <div>
@@ -108,5 +117,60 @@ describe("TimePicker", () => {
     expect(
       screen.getByText(/press Tab to select the option and exit the menu/i),
     ).toBeInTheDocument();
+  });
+});
+
+const focusedOptionName = (combobox: HTMLElement) => {
+  const activeId = combobox.getAttribute("aria-activedescendant");
+  expect(activeId).toBeTruthy();
+  const option = document.getElementById(activeId!);
+  expect(option).toBeTruthy();
+  return option!;
+};
+
+describe("TimePicker arrow-key focus", () => {
+  it("focuses the current time on open so arrow keys move one interval", async () => {
+    const user = userEvent.setup();
+    render(<Harness initialValue={{ ...fiveThirty }} options={dayOptions} />);
+
+    const combobox = screen.getByRole("combobox", { name: "Start time" });
+    await user.click(combobox);
+
+    expect(screen.getByRole("listbox")).toBeInTheDocument();
+    expect(focusedOptionName(combobox)).toHaveTextContent("5:30 PM");
+
+    await user.keyboard("{ArrowUp}");
+    expect(focusedOptionName(combobox)).toHaveTextContent("5:15 PM");
+
+    await user.keyboard("{ArrowDown}");
+    expect(focusedOptionName(combobox)).toHaveTextContent("5:30 PM");
+
+    await user.keyboard("{ArrowDown}");
+    expect(focusedOptionName(combobox)).toHaveTextContent("5:45 PM");
+  });
+
+  it("keeps a custom time selectable and arrow-navigable from nearby intervals", async () => {
+    const user = userEvent.setup();
+    render(
+      <Harness
+        initialValue={{ label: "5:33 PM", value: "5:33 PM" }}
+        options={dayOptions}
+      />,
+    );
+
+    const combobox = screen.getByRole("combobox", { name: "Start time" });
+    await user.click(combobox);
+
+    const listbox = screen.getByRole("listbox");
+    expect(
+      within(listbox).getByRole("option", { name: "5:33 PM" }),
+    ).toBeInTheDocument();
+    expect(focusedOptionName(combobox)).toHaveTextContent("5:33 PM");
+
+    await user.keyboard("{ArrowUp}");
+    expect(focusedOptionName(combobox)).toHaveTextContent("5:30 PM");
+
+    await user.keyboard("{ArrowDown}{ArrowDown}");
+    expect(focusedOptionName(combobox)).toHaveTextContent("5:45 PM");
   });
 });

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/TimePicker.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/TimePicker.tsx
@@ -6,6 +6,7 @@ import { type SelectOption } from "@web/common/types/component.types";
 import { type TimeOption } from "@web/common/types/util.types";
 import { parseUserTime } from "@web/common/utils/datetime/web.date.util";
 import { useFloatingLayer } from "@web/shortcuts/floating-layer";
+import { resolveTimePickerSelection } from "./resolveTimePickerSelection";
 
 export interface Props extends Omit<RSProps, "onChange" | "value"> {
   isMenuOpen: boolean;
@@ -66,6 +67,9 @@ export const TimePicker = ({
   const layerId = useId();
   useFloatingLayer(`timePicker:${layerId}`, isMenuOpen);
 
+  const { value: selectValue, options: selectOptions } =
+    resolveTimePickerSelection(value, options);
+
   const cancelScrollToSelected = () => {
     if (scrollRafRef.current !== null) {
       cancelAnimationFrame(scrollRafRef.current);
@@ -103,7 +107,7 @@ export const TimePicker = ({
         className={selectClassName}
         classNamePrefix={TIMEPICKER}
         styles={timePickerTextStyles}
-        value={value}
+        value={selectValue}
         maxMenuHeight={4 * 41}
         blurInputOnSelect
         menuIsOpen={isMenuOpen}
@@ -133,7 +137,7 @@ export const TimePicker = ({
             if (!e.shiftKey) {
               const option = optionFromFocusedMenu(
                 containerRef.current,
-                options,
+                selectOptions,
                 value?.value,
               );
               if (option) _onChange(option);
@@ -150,7 +154,7 @@ export const TimePicker = ({
           setIsMenuOpen(false);
         }}
         openMenuOnFocus={true}
-        options={options}
+        options={selectOptions}
         tabSelectsValue={false}
         ariaLiveMessages={{
           guidance: ({
@@ -178,7 +182,9 @@ export const TimePicker = ({
           const parsed = parseUserTime(inputValue, value?.value);
           if (!parsed) return false;
           // Don't show create row if the parsed time is already in options
-          if (options?.some((o) => (o as TimeOption).value === parsed.value)) {
+          if (
+            selectOptions?.some((o) => (o as TimeOption).value === parsed.value)
+          ) {
             return false;
           }
           return true;

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/resolveTimePickerSelection.test.ts
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/resolveTimePickerSelection.test.ts
@@ -1,0 +1,49 @@
+import { getTimeOptions } from "@web/common/utils/datetime/web.date.util";
+import { resolveTimePickerSelection } from "./resolveTimePickerSelection";
+import { describe, expect, it } from "bun:test";
+
+describe("resolveTimePickerSelection", () => {
+  const options = getTimeOptions();
+
+  it("returns the option object from the list when values match", () => {
+    const constructed = { label: "5:30 PM", value: "5:30 PM" };
+    const { value, options: nextOptions } = resolveTimePickerSelection(
+      constructed,
+      options,
+    );
+    const listed = options.find((option) => option.value === "5:30 PM");
+
+    expect(listed).toBeDefined();
+    expect(value).toBe(listed);
+    expect(value).not.toBe(constructed);
+    expect(nextOptions).toBe(options);
+  });
+
+  it("inserts a custom time so react-select can focus it by reference", () => {
+    const custom = { label: "5:33 PM", value: "5:33 PM" };
+    const { value, options: nextOptions } = resolveTimePickerSelection(
+      custom,
+      options,
+    );
+
+    expect(value).toBe(custom);
+    expect(nextOptions).not.toBe(options);
+    expect(nextOptions?.find((option) => option.value === "5:33 PM")).toBe(
+      custom,
+    );
+
+    const index = nextOptions!.findIndex(
+      (option) => option.value === "5:33 PM",
+    );
+    expect(nextOptions![index - 1]?.value).toBe("5:30 PM");
+    expect(nextOptions![index + 1]?.value).toBe("5:45 PM");
+  });
+
+  it("passes through when options are missing", () => {
+    const value = { label: "5:30 PM", value: "5:30 PM" };
+    expect(resolveTimePickerSelection(value, undefined)).toEqual({
+      value,
+      options: undefined,
+    });
+  });
+});

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/resolveTimePickerSelection.test.ts
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/resolveTimePickerSelection.test.ts
@@ -12,8 +12,10 @@ describe("resolveTimePickerSelection", () => {
       options,
     );
     const listed = options.find((option) => option.value === "5:30 PM");
+    if (!listed) {
+      throw new Error("expected 5:30 PM in getTimeOptions()");
+    }
 
-    expect(listed).toBeDefined();
     expect(value).toBe(listed);
     expect(value).not.toBe(constructed);
     expect(nextOptions).toBe(options);

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/resolveTimePickerSelection.ts
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/resolveTimePickerSelection.ts
@@ -1,0 +1,44 @@
+import { YMDHAM_FORMAT } from "@core/constants/date.constants";
+import dayjs from "@core/util/date/dayjs";
+import { type SelectOption } from "@web/common/types/component.types";
+import { type TimeOption } from "@web/common/types/util.types";
+
+const timeValueToMinutes = (timeValue: string): number => {
+  const parsed = dayjs(`2000-01-01 ${timeValue}`, YMDHAM_FORMAT);
+  return parsed.hour() * 60 + parsed.minute();
+};
+
+/**
+ * react-select's openMenu focuses the selected option via reference equality
+ * (`options.indexOf(value)`). Compass often passes a separately constructed
+ * value object, so resolve to the matching option (or insert a custom time)
+ * before handing props to CreatableSelect.
+ */
+export const resolveTimePickerSelection = (
+  value: SelectOption<string>,
+  options: TimeOption[] | undefined,
+): { value: SelectOption<string>; options: TimeOption[] | undefined } => {
+  if (!options?.length) {
+    return { value, options };
+  }
+
+  const exactMatch = options.find((option) => option.value === value.value);
+  if (exactMatch) {
+    return { value: exactMatch, options };
+  }
+
+  const valueMinutes = timeValueToMinutes(value.value);
+  const insertAt = options.findIndex(
+    (option) => timeValueToMinutes(option.value) > valueMinutes,
+  );
+  const nextOptions =
+    insertAt === -1
+      ? [...options, value as TimeOption]
+      : [
+          ...options.slice(0, insertAt),
+          value as TimeOption,
+          ...options.slice(insertAt),
+        ];
+
+  return { value, options: nextOptions };
+};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Supersedes #2769 (rebased onto current `main` so it keeps the Tab-to-commit work from #2790).

Keyboard Up/Down on the event start/end time pickers jumped to early-morning times (e.g. 12:15 AM) instead of moving one 15-minute interval from the current value (e.g. 5:30 PM → 5:15 PM).

**Cause:** react-select focuses the selected option with reference equality (`options.indexOf(value)`). Compass passes a separately constructed `{ label, value }` object, so focus fell back to the first option while visual scroll still showed the selected time.

**Fix:** Resolve the select `value` to the matching object from `options` before rendering. Custom (typed) times are inserted into the menu list in chronological order so they remain focusable too.

## Simplicity

One helper used only at the CreatableSelect boundary. Tab/IME/aria-live behavior from #2790 is unchanged.

## Automated validation

Focused TimePicker tests: 12 pass, 0 fail. `bun run type-check` and `bun run lint` pass (lint has only pre-existing warnings). The original #2769 type-check failure (`TimeOption | undefined` into `expect().toBe()`) is fixed.

## Independent review

Reapplied onto current `main` rather than rebasing the stale #2769 branch, which would have dropped `optionFromFocusedMenu` Tab commit handling.

## Test plan

```
bun run test:web -- packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/
bun run type-check
bun run lint
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4a862c0f-5505-4947-acc6-22ead734a981?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4a862c0f-5505-4947-acc6-22ead734a981&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

