### PR TITLE
fix(dev): fill sync.* config placeholders in backend bootstrap

### DIFF
--- a/.cursor/bootstrap-backend.sh
+++ b/.cursor/bootstrap-backend.sh
@@ -19,6 +19,8 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT"
 
 MONGO_URI="${MONGO_URI:-mongodb://localhost:27017/dev_calendar?replicaSet=rs0}"
+# Sync uses an isolated database on the same local replica set.
+SYNC_MONGO_URI="${SYNC_MONGO_URI:-mongodb://localhost:27017/compass_sync?replicaSet=rs0}"
 
 # 1. compass.yaml -----------------------------------------------------------
 if [ ! -f compass.yaml ]; then
@@ -28,9 +30,13 @@ if [ ! -f compass.yaml ]; then
     -e "s#REPLACE_WITH_COMPASS_TOKEN#${COMPASS_TOKEN:-local-dev-compass-token}#" \
     -e "s#REPLACE_WITH_SUPERTOKENS_URI#${SUPERTOKENS_URI:-http://localhost:3567}#" \
     -e "s#REPLACE_WITH_SUPERTOKENS_KEY#${SUPERTOKENS_KEY:-local-dev-supertokens-key}#" \
+    -e "s#REPLACE_WITH_SYNC_INTERNAL_AUTH_TOKEN#${SYNC_INTERNAL_AUTH_TOKEN:-local-dev-sync-internal-auth-token}#" \
     compass.yaml
   # Replace the whole mongo.uri line (the example ships an Atlas placeholder).
   sed -i "s#^  uri: mongodb.*#  uri: ${MONGO_URI//#/\\#}#" compass.yaml
+  # The sync service needs an isolated database on the same local replica set.
+  # Replace the sync.mongoUri line (the example ships an Atlas placeholder).
+  sed -i "s#^  mongoUri: mongodb.*#  mongoUri: ${SYNC_MONGO_URI//#/\\#}#" compass.yaml
 
   if [ -n "${GOOGLE_CLIENT_ID:-}" ] && [ -n "${GOOGLE_CLIENT_SECRET:-}" ]; then
     echo "[bootstrap] enabling Google integration from environment"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,12 +143,19 @@ everything runs through Bun, so that mismatch is not a blocker.
   `compass.yaml` and install/start a single-node MongoDB replica set, then
   `bun run dev:backend` (serves http://localhost:3000/api). The script is
   idempotent and reads `SUPERTOKENS_URI`, `SUPERTOKENS_KEY`, `GOOGLE_CLIENT_ID`,
-  and `GOOGLE_CLIENT_SECRET` from the environment when set (otherwise dummy
-  local auth values, Google disabled). Non-obvious: the backend uses
-  transactions, so Mongo must be a replica set and `mongo.uri` must include
-  `replicaSet=...` — a standalone `mongod` will not work. `GET /api/health`
-  returning `200 {"status":"ok"}` confirms the backend is up and Mongo is
-  reachable.
+  `GOOGLE_CLIENT_SECRET`, `SYNC_MONGO_URI`, and `SYNC_INTERNAL_AUTH_TOKEN` from
+  the environment when set (otherwise dummy local values, Google disabled). The
+  required `sync.*` config block is filled with local defaults — `sync.mongoUri`
+  points at an isolated `compass_sync` database on the same local replica set.
+  Non-obvious: the backend uses transactions, so Mongo must be a replica set and
+  both `mongo.uri` and `sync.mongoUri` must include `replicaSet=...` — a
+  standalone `mongod` will not work. `GET /api/health` returning
+  `200 {"status":"ok"}` confirms the backend is up and Mongo is reachable.
+- The Sync service (`bun run dev:sync`) is a separate, optional process. When it
+  is not running, the backend logs recurring
+  `app:sse.sync-change-feed: Sync global change-feed poll failed: unavailable`
+  warnings — these are expected and harmless for core event CRUD work; only start
+  `dev:sync` when working on Google sync/SSE.
 - Auth/login and real Google Calendar sync are gated on external services not
   provisioned by default: a SuperTokens instance and Google OAuth. Provide them
   as environment secrets so `bootstrap-backend.sh` wires them into


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Supersedes #2757 (rebased onto current `main` so it does not delete the later Claude Code worktree `AGENTS.md` section).

`.cursor/bootstrap-backend.sh` was stale relative to `compass.example.yaml`. The example config ships a required `sync:` block with `REPLACE_WITH_SYNC_MONGO_PASSWORD` and `REPLACE_WITH_SYNC_INTERNAL_AUTH_TOKEN` placeholders, but the bootstrap script only filled the older `backend`, `supertokens`, and `mongo.uri` values. The config validator rejects any remaining `REPLACE_WITH_` value, so `dev:web` and `dev:backend` abort at startup.

This PR:

- Fills `sync.mongoUri` (isolated `compass_sync` database on the same local replica set) and `sync.internalAuthToken` in `bootstrap-backend.sh`, with optional `SYNC_MONGO_URI` / `SYNC_INTERNAL_AUTH_TOKEN` env overrides.
- Documents those env vars, the `sync.mongoUri` replica-set requirement, and the expected `sync-change-feed ... unavailable` warnings when `dev:sync` is not running.

No application code changed. `compass.yaml` remains gitignored.

## Simplicity

Two additional `sed` substitutions plus one default variable, matching the existing script pattern. `AGENTS.md` updates only in the Cursor Cloud backend bullets.

## Automated validation

Simulated the bootstrap substitutions against `compass.example.yaml`. Remaining `REPLACE_WITH_` strings are comment-only (google/email/posthog/stripe), which the validator ignores. `sync.mongoUri` and `sync.internalAuthToken` are filled with local replica-set defaults.

## Independent review

Preserved the Claude Code worktree section that #2757 would have removed.

## Test plan

```
# simulate bootstrap sed against compass.example.yaml
# remaining REPLACE_WITH_ values are comments only
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4a862c0f-5505-4947-acc6-22ead734a981?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4a862c0f-5505-4947-acc6-22ead734a981&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

