### PR TITLE
fix(web): drop phantom dead clicks and put signup before the shortcut practice

### DIFF
--- a/docs/acceptance/shortcuts.md
+++ b/docs/acceptance/shortcuts.md
@@ -7,7 +7,7 @@ This runbook covers keyboard shortcut parity in Compass. The principle: anything
 Two files matter, at different depths:
 
 - `packages/web/src/shortcuts/shortcuts.registry.ts` is the display registry: every shortcut's legend entry (label, keys, section, context). When adding a shortcut, update the registry and it appears in the legend overlay (opened with `?`), which is searchable and context-aware.
-- `packages/web/src/shortcuts/keymap.ts` is the runtime binding source for the shortcuts the onboarding Shortcut Showcase teaches (create, save, arrow focus, edit sequence, event jump, move, edge cycle, undo/redo, hardcore). The real handlers, the showcase, and its hint keycaps all import these bindings, and `keymap.test.ts` pins the registry rows against them. Remapping a taught shortcut means editing `keymap.ts` plus the registry row; the test fails if they disagree. Shortcuts outside the keymap still bind via literals at their handler sites.
+- `packages/web/src/shortcuts/keymap.ts` is the runtime binding source for the shortcuts the onboarding flow teaches — the Shortcut Showcase gates its exit on create and save, and its practice arena plus the post-showcase checklist cover arrow focus, edit sequence, event jump, move, edge cycle, undo/redo, and hardcore. The real handlers, the showcase, and its hint keycaps all import these bindings, and `keymap.test.ts` pins the registry rows against them. Remapping a taught shortcut means editing `keymap.ts` plus the registry row; the test fails if they disagree. Shortcuts outside the keymap still bind via literals at their handler sites.
 
 ## Scope
 

--- a/docs/development/feature-file-map.md
+++ b/docs/development/feature-file-map.md
@@ -74,8 +74,8 @@ labels outside the registry.
 Anonymous calendar onboarding is three stacked surfaces, all mounted from
 `RootShell` except on `/life` (see `isLifePathname`).
 
-- Welcome modal (**Start Now** / Escape both hand off to the showcase): `packages/web/src/components/WelcomeModal/WelcomeModal.tsx`
-- Shortcut Showcase (takeover practice calendar): `packages/web/src/components/ShortcutShowcase/` (`showcase.steps.ts` is the taught-step order)
+- Welcome modal (**Continue with Google** / **Sign up with email** / **Explore without an account**; only signup queues the showcase): `packages/web/src/components/WelcomeModal/WelcomeModal.tsx`
+- Shortcut Showcase (takeover practice calendar, entered post-signup or from the palette): `packages/web/src/components/ShortcutShowcase/` (`showcase.steps.ts` is the taught-step order)
 - Post-showcase checklist over real events: `packages/web/src/components/OnboardingChecklist/`
 - Replay from the command palette (“Practice shortcuts”, “Show welcome guide”): `packages/web/src/components/CommandPalette/navigation.cmd.constants.ts`
 - Legacy tour seen-flag is honored once so established users are not ambushed: `packages/web/src/components/ShortcutShowcase/showcase.storage.ts`

--- a/docs/frontend/frontend-runtime-flow.md
+++ b/docs/frontend/frontend-runtime-flow.md
@@ -73,9 +73,15 @@ Welcome → showcase → checklist contract:
 - Log In / Sign Up hand off to auth; a pending showcase offer can still run
   after signup (`showcase.storage.ts`)
 - showcase step order lives in `showcase.steps.ts`; taught keycaps come from
-  `packages/web/src/shortcuts/keymap.ts`
+  `packages/web/src/shortcuts/keymap.ts`. Two lessons gate the exit (create,
+  save); the arena still answers every other shortcut, it just does not make
+  them a condition of leaving
+- every showcase step offers **Skip to sign up** (straight to the signup form)
+  and **Skip** (straight to the calendar); Escape does the latter. There is no
+  confirm in the way
 - after the showcase, `OnboardingChecklist` is practice missions on the real
-  calendar (not an app-lock modal)
+  calendar (not an app-lock modal), and it re-teaches the shortcuts the
+  showcase no longer walks through
 - command palette can reopen practice (“Practice shortcuts”) or the welcome
   guide (“Show welcome guide”)
 - users who already finished or skipped the retired guided tour are treated as
@@ -133,6 +139,30 @@ Responsibilities:
 - avoid blocking unauthenticated users
 - show a session-expired toast on auth failures
 - identify the user in PostHog when enabled
+
+## Analytics Capture Filters
+
+Files:
+
+- `packages/web/src/auth/posthog/posthog.bootstrap.ts`
+- `packages/web/src/auth/posthog/posthog-exception-filter.util.ts`
+- `packages/web/src/auth/posthog/posthog-dead-click-filter.util.ts`
+
+PostHog's `before_send` runs two filters, in order:
+
+- unactionable exception signatures (SuperTokens/browser network blips,
+  CefSharp scanner noise, opaque "Script error.", ResizeObserver loop warnings)
+- dead clicks posthog's own mutation clock mis-scored. posthog-js timestamps a
+  click in a bubble-phase `window` listener, but React has already flushed the
+  update and the MutationObserver microtask has already run by then, so the
+  click's own re-render is recorded as happening *before* it. On a screen that
+  goes quiet afterwards — the welcome FAQ, the Shortcut Showcase — nothing ever
+  corrects that, and posthog reports a working button as dead. The filter drops
+  exactly that shape: no mutation credited to the gesture, yet the last mutation
+  on the page landed within 50ms *before* it
+
+Neither filter touches `$rageclick`: repeated clicking is real frustration
+whatever the DOM did.
 
 ## Client Version Polling
 

--- a/docs/frontend/frontend-runtime-flow.md
+++ b/docs/frontend/frontend-runtime-flow.md
@@ -65,23 +65,30 @@ Files:
 checklist, global navigation / calendar-shell shortcuts, and Hardcore Mode.
 Those calendar-onboarding overlays are skipped on `/life`.
 
-Welcome → showcase → checklist contract:
+Welcome → signup → checklist contract:
 
 - unauthenticated users who have not seen welcome get `WelcomeModal`
-- **Start Now** and backdrop / Escape both start the Shortcut Showcase (neither
-  path dumps the user onto a blank calendar)
-- Log In / Sign Up hand off to auth; a pending showcase offer can still run
-  after signup (`showcase.storage.ts`)
-- showcase step order lives in `showcase.steps.ts`; taught keycaps come from
-  `packages/web/src/shortcuts/keymap.ts`. Two lessons gate the exit (create,
-  save); the arena still answers every other shortcut, it just does not make
-  them a condition of leaving
-- every showcase step offers **Skip to sign up** (straight to the signup form)
-  and **Skip** (straight to the calendar); Escape does the latter. There is no
-  confirm in the way
-- after the showcase, `OnboardingChecklist` is practice missions on the real
-  calendar (not an app-lock modal), and it re-teaches the shortcuts the
-  showcase no longer walks through
+- the welcome CTA order is **Continue with Google** (`G`, when Google is
+  available), **Sign up with email** (`U`), then **Explore without an account**
+  (`S`). Google leads because the scopes Compass requests include the calendar,
+  so that one round trip signs the user up *and* connects it — the moment the
+  product starts being worth keeping
+- **Explore without an account**, the backdrop, and Escape all land straight on
+  the calendar. None of them starts a takeover
+- signing up (either route) defers a showcase offer via `showcase.storage.ts`;
+  `offerAfterSignupIfPending()` redeems it once, right after signup completes
+- the Shortcut Showcase therefore has exactly two entries: post-signup, and the
+  command palette's "Practice shortcuts". `showcase.steps.ts` holds the order;
+  taught keycaps come from `packages/web/src/shortcuts/keymap.ts`. Two lessons
+  gate the exit (create, save); the arena still answers every other shortcut,
+  it just does not make them a condition of leaving
+- every showcase step offers **Skip to calendar**, and **Skip to sign up** for
+  anyone not already signed in; Escape does the former. There is no confirm in
+  the way
+- `OnboardingChecklist` is practice missions on the real calendar (not an
+  app-lock modal), shown once the showcase has been seen *or* skipped past —
+  including the explore-without-an-account path. It re-teaches the shortcuts
+  the showcase no longer walks through
 - command palette can reopen practice (“Practice shortcuts”) or the welcome
   guide (“Show welcome guide”)
 - users who already finished or skipped the retired guided tour are treated as
@@ -163,6 +170,13 @@ PostHog's `before_send` runs two filters, in order:
 
 Neither filter touches `$rageclick`: repeated clicking is real frustration
 whatever the DOM did.
+
+`calendar_connected` has two sources, distinguished by a `source` property:
+`signup_google` from `GoogleAuthCallback` (a new user whose Google grant
+included the calendar scopes) and `connect_redirect` from
+`google-connect-status.util.ts` (the sync service's add-account round trip).
+Only the second used to fire, so the activation metric missed the path most new
+users actually take.
 
 ## Client Version Polling
 

--- a/e2e/onboarding/first-run.spec.ts
+++ b/e2e/onboarding/first-run.spec.ts
@@ -9,8 +9,8 @@ import {
 // Most E2E coverage skips onboarding to keep the calendar tests focused. This
 // spec deliberately starts with empty browser storage so a new user's path is
 // exercised end to end. Shortcut Showcase itself is covered in
-// shortcut-showcase.spec.ts — here we skip it so sample events and create
-// persistence remain the focus.
+// shortcut-showcase.spec.ts — here the no-account path is the focus, so
+// sample events and create persistence get the attention.
 test.use({ storageState: { cookies: [], origins: [] } });
 test.use({ viewport: { width: 1600, height: 900 } });
 
@@ -22,13 +22,15 @@ test("welcomes a first-time user and seeds sample events", async ({ page }) => {
   });
   await expect(welcomeDialog).toBeVisible();
 
-  await welcomeDialog.getByRole("button", { name: "Start Now" }).click();
+  await welcomeDialog
+    .getByRole("button", { name: "Explore without an account" })
+    .click();
   await expect(welcomeDialog).toBeHidden();
 
-  const showcase = page.getByRole("region", { name: "Shortcut practice" });
-  await expect(showcase).toContainText("Create with the keyboard");
-  await showcase.getByRole("button", { name: "Skip to calendar" }).click();
-  await expect(showcase).toHaveCount(0);
+  // Nothing stands between the welcome screen and the calendar any more.
+  await expect(
+    page.getByRole("region", { name: "Shortcut practice" }),
+  ).toHaveCount(0);
 
   await expect(
     page.getByText(/Sample events to help you explore/i),

--- a/e2e/onboarding/first-run.spec.ts
+++ b/e2e/onboarding/first-run.spec.ts
@@ -27,9 +27,7 @@ test("welcomes a first-time user and seeds sample events", async ({ page }) => {
 
   const showcase = page.getByRole("region", { name: "Shortcut practice" });
   await expect(showcase).toContainText("Create with the keyboard");
-  await page.keyboard.press("Escape");
-  await expect(showcase).toContainText("Skip the shortcuts?");
-  await showcase.getByRole("button", { name: "Skip anyway" }).click();
+  await showcase.getByRole("button", { name: "Skip to calendar" }).click();
   await expect(showcase).toHaveCount(0);
 
   await expect(

--- a/e2e/onboarding/shortcut-showcase.spec.ts
+++ b/e2e/onboarding/shortcut-showcase.spec.ts
@@ -23,41 +23,8 @@ test("Start Now runs the Shortcut Showcase happy path", async ({ page }) => {
   // The practice title editor autofocuses; Enter commits it.
   await page.keyboard.type("Practice Event");
   await page.keyboard.press("Enter");
-  await expect(showcase).toContainText("Move between events");
-  await expect(showcase).toContainText("Practice Event");
-
-  // The saved draft sits on the middle day; ArrowLeft lands on Monday.
-  await page.keyboard.press("ArrowLeft");
-  await expect(showcase).toContainText("Jump straight to a field");
-
-  await page.keyboard.press("e");
-  await page.keyboard.press("t");
-  await expect(showcase).toContainText("Jump to any event");
-
-  // S flashes the real day-prefix chips; t1 is Tuesday's first block.
-  await page.keyboard.press("s");
-  await page.keyboard.press("t");
-  await page.keyboard.press("1");
-  await expect(showcase).toContainText("Reschedule in a keystroke");
-
-  await page.keyboard.press("Shift+ArrowDown");
-  await expect(showcase).toContainText("Stretch the end time");
-
-  // The step seeds edge focus to start, so one Tab reaches the end edge.
-  await page.keyboard.press("Tab");
-  await page.keyboard.press("Shift+ArrowDown");
-  await expect(showcase).toContainText("Place a block anywhere");
-
-  // The step clears focus on entry, so Shift+Arrow drops a fresh block.
-  await page.keyboard.press("Shift+ArrowRight");
-  await expect(showcase).toContainText("Never stress a mistake");
-
-  await page.keyboard.press("ControlOrMeta+z");
-  await page.keyboard.press("ControlOrMeta+Shift+z");
-  await expect(showcase).toContainText("Try Hardcore Mode");
-
-  await page.keyboard.press("h");
   await expect(showcase).toContainText("young cap'n");
+  await expect(showcase).toContainText("Practice Event");
 
   await page.keyboard.press("Enter");
   await expect(showcase).toHaveCount(0);
@@ -73,7 +40,7 @@ test("Start Now runs the Shortcut Showcase happy path", async ({ page }) => {
   ).toHaveCount(0);
 });
 
-test("Skipping the showcase confirms once and never auto-replays", async ({
+test("Skip to sign up leaves the showcase for the signup form on step 1", async ({
   page,
 }) => {
   await page.goto("/week", { waitUntil: "domcontentloaded" });
@@ -86,9 +53,24 @@ test("Skipping the showcase confirms once and never auto-replays", async ({
   const showcase = page.getByRole("region", { name: "Shortcut practice" });
   await expect(showcase).toContainText("Create with the keyboard");
 
+  // One click, from the first step, with no lesson finished and no confirm.
+  await showcase.getByRole("button", { name: "Skip to sign up" }).click();
+  await expect(showcase).toHaveCount(0);
+  await expect(page).toHaveURL(/auth=signup/);
+});
+
+test("Skipping the showcase never auto-replays", async ({ page }) => {
+  await page.goto("/week", { waitUntil: "domcontentloaded" });
+
+  const welcomeDialog = page.getByRole("dialog", {
+    name: "Welcome to Compass Calendar",
+  });
+  await welcomeDialog.getByRole("button", { name: "Start Now" }).click();
+
+  const showcase = page.getByRole("region", { name: "Shortcut practice" });
+  await expect(showcase).toContainText("Create with the keyboard");
+
   await page.keyboard.press("Escape");
-  await expect(showcase).toContainText("Skip the shortcuts?");
-  await showcase.getByRole("button", { name: "Skip anyway" }).click();
   await expect(showcase).toHaveCount(0);
 
   // Skipping still reveals the practice checklist in the real app.

--- a/e2e/onboarding/shortcut-showcase.spec.ts
+++ b/e2e/onboarding/shortcut-showcase.spec.ts
@@ -1,18 +1,54 @@
-import { expect, test } from "@playwright/test";
+import { expect, type Page, test } from "@playwright/test";
 
-// Empty storage so Welcome + Start Now launch the Shortcut Showcase.
+// Empty storage so the welcome modal runs, and the practice has not been seen.
 test.use({ storageState: { cookies: [], origins: [] } });
 test.use({ viewport: { width: 1600, height: 900 } });
 
-test("Start Now runs the Shortcut Showcase happy path", async ({ page }) => {
-  await page.goto("/week", { waitUntil: "domcontentloaded" });
+/**
+ * Signing up is the only other way in, and that needs a real backend, so the
+ * palette is how e2e reaches the practice arena.
+ */
+const openPracticeFromPalette = async (page: Page) => {
+  await page.keyboard.press("ControlOrMeta+k");
+  const search = page.getByLabel("Command palette search");
+  await expect(search).toBeVisible();
+  await search.fill("Practice shortcuts");
+  await page.getByRole("option", { name: /Practice shortcuts/ }).click();
+};
 
+const leaveWelcome = async (page: Page) => {
   const welcomeDialog = page.getByRole("dialog", {
     name: "Welcome to Compass Calendar",
   });
   await expect(welcomeDialog).toBeVisible();
-  await welcomeDialog.getByRole("button", { name: "Start Now" }).click();
+  await welcomeDialog
+    .getByRole("button", { name: "Explore without an account" })
+    .click();
   await expect(welcomeDialog).toBeHidden();
+};
+
+test("exploring without an account lands on the calendar, not the practice", async ({
+  page,
+}) => {
+  await page.goto("/week", { waitUntil: "domcontentloaded" });
+  await leaveWelcome(page);
+
+  // The takeover is an educational layer for people who committed, so it no
+  // longer stands between the welcome screen and the app.
+  await expect(
+    page.getByRole("region", { name: "Shortcut practice" }),
+  ).toHaveCount(0);
+  await expect(
+    page.getByRole("complementary", { name: "Shortcut practice checklist" }),
+  ).toBeVisible();
+});
+
+test("the palette runs the two-lesson practice happy path", async ({
+  page,
+}) => {
+  await page.goto("/week", { waitUntil: "domcontentloaded" });
+  await leaveWelcome(page);
+  await openPracticeFromPalette(page);
 
   const showcase = page.getByRole("region", { name: "Shortcut practice" });
   await expect(showcase).toContainText("Create with the keyboard");
@@ -33,22 +69,14 @@ test("Start Now runs the Shortcut Showcase happy path", async ({ page }) => {
   await expect(
     page.getByRole("complementary", { name: "Shortcut practice checklist" }),
   ).toBeVisible();
-
-  await page.reload({ waitUntil: "domcontentloaded" });
-  await expect(
-    page.getByRole("region", { name: "Shortcut practice" }),
-  ).toHaveCount(0);
 });
 
-test("Skip to sign up leaves the showcase for the signup form on step 1", async ({
+test("Skip to sign up leaves the practice for the signup form on step 1", async ({
   page,
 }) => {
   await page.goto("/week", { waitUntil: "domcontentloaded" });
-
-  const welcomeDialog = page.getByRole("dialog", {
-    name: "Welcome to Compass Calendar",
-  });
-  await welcomeDialog.getByRole("button", { name: "Start Now" }).click();
+  await leaveWelcome(page);
+  await openPracticeFromPalette(page);
 
   const showcase = page.getByRole("region", { name: "Shortcut practice" });
   await expect(showcase).toContainText("Create with the keyboard");
@@ -59,13 +87,12 @@ test("Skip to sign up leaves the showcase for the signup form on step 1", async 
   await expect(page).toHaveURL(/auth=signup/);
 });
 
-test("Skipping the showcase never auto-replays", async ({ page }) => {
+test("Escape leaves the practice and it never auto-replays", async ({
+  page,
+}) => {
   await page.goto("/week", { waitUntil: "domcontentloaded" });
-
-  const welcomeDialog = page.getByRole("dialog", {
-    name: "Welcome to Compass Calendar",
-  });
-  await welcomeDialog.getByRole("button", { name: "Start Now" }).click();
+  await leaveWelcome(page);
+  await openPracticeFromPalette(page);
 
   const showcase = page.getByRole("region", { name: "Shortcut practice" });
   await expect(showcase).toContainText("Create with the keyboard");
@@ -73,14 +100,11 @@ test("Skipping the showcase never auto-replays", async ({ page }) => {
   await page.keyboard.press("Escape");
   await expect(showcase).toHaveCount(0);
 
-  // Skipping still reveals the practice checklist in the real app.
-  await expect(
-    page.getByRole("complementary", { name: "Shortcut practice checklist" }),
-  ).toBeVisible();
-
   await page.reload({ waitUntil: "domcontentloaded" });
   await expect(
     page.getByRole("region", { name: "Shortcut practice" }),
   ).toHaveCount(0);
-  await expect(welcomeDialog).toBeHidden();
+  await expect(
+    page.getByRole("dialog", { name: "Welcome to Compass Calendar" }),
+  ).toBeHidden();
 });

--- a/packages/web/src/auth/google/authorization/google-connect-status.util.ts
+++ b/packages/web/src/auth/google/authorization/google-connect-status.util.ts
@@ -64,7 +64,7 @@ function fireGoogleConnectStatusToast(status: GoogleConnectStatus): void {
   const toast = getToast();
   switch (status) {
     case "connected":
-      track("calendar_connected");
+      track("calendar_connected", { source: "connect_redirect" });
       toast.success("Google Calendar connected.", {
         ...getToastDefaultOptions(),
         toastId: CONNECT_SUCCESS_TOAST_ID,

--- a/packages/web/src/auth/posthog/posthog-dead-click-filter.util.test.ts
+++ b/packages/web/src/auth/posthog/posthog-dead-click-filter.util.test.ts
@@ -1,0 +1,97 @@
+import { type CaptureResult } from "posthog-js";
+import { filterPosthogDeadClick } from "./posthog-dead-click-filter.util";
+import { describe, expect, it } from "bun:test";
+
+const CLICK_AT = 1_755_000_000_000;
+
+const deadClickEvent = (
+  properties: Record<string, unknown>,
+  event = "$dead_click",
+): CaptureResult =>
+  ({
+    uuid: "test-uuid",
+    event,
+    properties: {
+      [`${event}_event_timestamp`]: CLICK_AT,
+      ...properties,
+    },
+  }) as CaptureResult;
+
+describe("filterPosthogDeadClick", () => {
+  it("passes through non-dead-gesture events", () => {
+    const event = {
+      uuid: "1",
+      event: "$rageclick",
+      properties: { $dead_click_last_mutation_timestamp: CLICK_AT - 1 },
+    } as CaptureResult;
+    expect(filterPosthogDeadClick(event)).toBe(event);
+  });
+
+  it("passes through a null event", () => {
+    expect(filterPosthogDeadClick(null)).toBeNull();
+  });
+
+  it("drops a click whose own re-render landed just before it was timestamped", () => {
+    expect(
+      filterPosthogDeadClick(
+        deadClickEvent({
+          $dead_click_last_mutation_timestamp: CLICK_AT - 1,
+          $dead_click_absolute_timeout: true,
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  it("drops the same inversion when the visibility check reported it first", () => {
+    expect(
+      filterPosthogDeadClick(
+        deadClickEvent({
+          $dead_click_last_mutation_timestamp: CLICK_AT - 7,
+          $dead_click_absolute_timeout: false,
+          $dead_click_visibility_changed_timeout: true,
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  it("drops an inverted dead swipe using its own property prefix", () => {
+    expect(
+      filterPosthogDeadClick(
+        deadClickEvent(
+          { $dead_swipe_last_mutation_timestamp: CLICK_AT - 2 },
+          "$dead_swipe",
+        ),
+      ),
+    ).toBeNull();
+  });
+
+  it("keeps a click the page never responded to", () => {
+    const event = deadClickEvent({
+      $dead_click_last_mutation_timestamp: CLICK_AT - 8_477,
+      $dead_click_absolute_timeout: true,
+    });
+    expect(filterPosthogDeadClick(event)).toBe(event);
+  });
+
+  it("keeps a click posthog did measure a mutation delay for", () => {
+    const event = deadClickEvent({
+      $dead_click_last_mutation_timestamp: CLICK_AT + 2_800,
+      $dead_click_mutation_delay_ms: 2_800,
+      $dead_click_mutation_timeout: true,
+    });
+    expect(filterPosthogDeadClick(event)).toBe(event);
+  });
+
+  it("keeps a click with no last-mutation timestamp to compare against", () => {
+    const event = deadClickEvent({ $dead_click_absolute_timeout: true });
+    expect(filterPosthogDeadClick(event)).toBe(event);
+  });
+
+  it("keeps a click just outside the inversion window", () => {
+    const event = deadClickEvent({
+      $dead_click_last_mutation_timestamp: CLICK_AT - 79,
+      $dead_click_absolute_timeout: true,
+    });
+    expect(filterPosthogDeadClick(event)).toBe(event);
+  });
+});

--- a/packages/web/src/auth/posthog/posthog-dead-click-filter.util.ts
+++ b/packages/web/src/auth/posthog/posthog-dead-click-filter.util.ts
@@ -1,0 +1,78 @@
+import { type CaptureResult } from "posthog-js";
+
+/**
+ * How long after a click a same-task re-render can still be credited to it.
+ *
+ * posthog-js stamps a dead-click candidate inside a *bubble-phase* `window`
+ * click listener. React reaches its own root listener first, flushes the state
+ * update synchronously (clicks are discrete events), and the MutationObserver
+ * microtask feeding `_lastMutation` runs before the event finishes bubbling up
+ * to `window`. The click's own re-render therefore lands a millisecond or two
+ * *before* the timestamp posthog compares it against, `mutation_delay_ms` comes
+ * back undefined, and the click is judged dead.
+ *
+ * A page that keeps mutating afterwards still rescues the click. The onboarding
+ * overlays never do: the welcome FAQ and the Shortcut Showcase are static
+ * between keystrokes, so whether their buttons look alive is a coin flip on a
+ * 1ms clock. Observed on 2026-08-14: 115 of 216 dead clicks reported a last
+ * mutation 1-7ms before the click, every one of them alongside the
+ * `$autocapture` and product event proving the handler had run.
+ *
+ * 50ms leaves an order of magnitude of headroom over that cluster while staying
+ * far below a genuine dead click, where the page sits untouched for hundreds to
+ * tens of thousands of milliseconds.
+ */
+const SYNC_RENDER_INVERSION_MS = 50;
+
+/** Dead-gesture events; each one prefixes its own diagnostic properties. */
+const DEAD_GESTURE_EVENTS = ["$dead_click", "$dead_swipe"] as const;
+
+/**
+ * Timestamps arrive as epoch milliseconds from posthog-js, but tolerate the
+ * serialized shapes a replayed or rehydrated payload can carry.
+ */
+const toEpochMs = (value: unknown): number | undefined => {
+  if (typeof value === "number")
+    return Number.isFinite(value) ? value : undefined;
+  if (value instanceof Date) return value.getTime();
+  if (typeof value === "string") {
+    const parsed = Date.parse(value);
+    return Number.isNaN(parsed) ? undefined : parsed;
+  }
+  return undefined;
+};
+
+/**
+ * Drop `$dead_click` / `$dead_swipe` events that only look dead because of the
+ * timestamp inversion described above: posthog credited the gesture with no
+ * mutation at all, yet the last mutation on the page landed in the handful of
+ * milliseconds before it — which is the gesture's own synchronous re-render.
+ */
+export function filterPosthogDeadClick(
+  event: CaptureResult | null,
+): CaptureResult | null {
+  if (!event) return event;
+
+  const prefix = DEAD_GESTURE_EVENTS.find((name) => name === event.event);
+  if (!prefix) return event;
+
+  const properties = event.properties;
+  if (!properties) return event;
+
+  // posthog omits the delay entirely when it saw no mutation after the gesture;
+  // a present value means it measured one and this is not the inversion.
+  const mutationDelayMs = properties[`${prefix}_mutation_delay_ms`];
+  if (mutationDelayMs !== undefined && mutationDelayMs !== null) return event;
+
+  const gestureAt = toEpochMs(properties[`${prefix}_event_timestamp`]);
+  const lastMutationAt = toEpochMs(
+    properties[`${prefix}_last_mutation_timestamp`],
+  );
+  if (gestureAt === undefined || lastMutationAt === undefined) return event;
+
+  const mutationLeadMs = gestureAt - lastMutationAt;
+  const isInverted =
+    mutationLeadMs >= 0 && mutationLeadMs <= SYNC_RENDER_INVERSION_MS;
+
+  return isInverted ? null : event;
+}

--- a/packages/web/src/auth/posthog/posthog.bootstrap.ts
+++ b/packages/web/src/auth/posthog/posthog.bootstrap.ts
@@ -1,5 +1,6 @@
 import { type PostHog } from "posthog-js";
 import { isPosthogEnabled } from "@web/auth/posthog/posthog.util";
+import { filterPosthogDeadClick } from "@web/auth/posthog/posthog-dead-click-filter.util";
 import { filterPosthogBeforeSend } from "@web/auth/posthog/posthog-exception-filter.util";
 import { ENV_WEB } from "@web/common/constants/env.constants";
 
@@ -37,8 +38,9 @@ export function initPosthog(): PostHog | undefined {
     },
     // Drop known-unactionable exception signatures (SuperTokens/browser
     // network blips, CefSharp scanner noise, opaque "Script error.") before
-    // they become issues.
-    before_send: filterPosthogBeforeSend,
+    // they become issues, then the dead clicks posthog's own mutation clock
+    // mis-scores on our static onboarding overlays.
+    before_send: [filterPosthogBeforeSend, filterPosthogDeadClick],
     opt_in_site_apps: true,
     person_profiles: "always",
   });

--- a/packages/web/src/components/OnboardingChecklist/OnboardingChecklist.tsx
+++ b/packages/web/src/components/OnboardingChecklist/OnboardingChecklist.tsx
@@ -16,6 +16,7 @@ import { useChecklistDetection } from "@web/components/OnboardingChecklist/useCh
 import { hasSeenShortcutShowcase } from "@web/components/ShortcutShowcase/showcase.storage";
 import {
   selectShowcaseActive,
+  selectShowcaseSeenRevision,
   useShortcutShowcaseStore,
 } from "@web/components/ShortcutShowcase/showcase.store";
 import { ShortcutKeys } from "@web/components/Shortcuts/ShortcutKeys";
@@ -145,6 +146,10 @@ const ChecklistCard: FC = () => {
  */
 export const OnboardingChecklist: FC = () => {
   const isShowcaseActive = useShortcutShowcaseStore(selectShowcaseActive);
+  // Subscribed for the signal, not the value: the seen flag lives in storage,
+  // which notifies nobody, and someone who skipped past the practice entirely
+  // would otherwise wait for an unrelated render before the card appeared.
+  useShortcutShowcaseStore(selectShowcaseSeenRevision);
   const isDone = useChecklistStore(selectChecklistDone);
   // Without storage (private mode), progress and dismissal can never
   // persist, so the card would haunt every reload; better to not show it.

--- a/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.test.tsx
+++ b/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.test.tsx
@@ -78,10 +78,11 @@ describe("ShortcutShowcase", () => {
     expect(screen.getByLabelText("Shortcut practice")).toBeTruthy();
   });
 
-  it("advances through every lesson by doing, and graduates on Enter", async () => {
+  it("teaches create then save, and graduates on Enter", async () => {
     const user = userEvent.setup();
     render(<ShortcutShowcase />);
     act(() => shortcutShowcaseActions.start());
+    expect(currentStepId()).toBe("create");
 
     // create: C opens a draft with its title editor.
     pressKey("c");
@@ -92,48 +93,8 @@ describe("ShortcutShowcase", () => {
       screen.getByLabelText("Event title"),
       "Coffee with Alex{Enter}",
     );
-    expect(currentStepId()).toBe("moveFocus");
-    expect(screen.getByText("Coffee with Alex")).toBeTruthy();
-
-    // moveFocus: an arrow that lands on a different block advances.
-    pressKey("ArrowLeft");
-    expect(currentStepId()).toBe("editTitle");
-
-    // editTitle: e then t opens the focused block's title editor.
-    pressKey("e");
-    pressKey("t");
-    expect(currentStepId()).toBe("eventJump");
-
-    // eventJump: S flashes the real day-prefix chips; typing one jumps.
-    pressKey("s");
-    pressKey("t");
-    pressKey("1");
-    expect(currentStepId()).toBe("moveEvent");
-
-    // moveEvent: Shift+Arrow slides the focused block.
-    pressKey("ArrowDown", { shiftKey: true });
-    expect(currentStepId()).toBe("resizeEdge");
-
-    // resizeEdge: entry seeds the start edge, Tab lands on end, resize.
-    pressKey("Tab");
-    pressKey("ArrowDown", { shiftKey: true });
-    expect(currentStepId()).toBe("placeDraft");
-
-    // placeDraft: nothing focused, Shift+Arrow drops a block.
-    pressKey("ArrowRight", { shiftKey: true });
-    expect(currentStepId()).toBe("undoRedo");
-    expect(screen.getByText("Focus time")).toBeTruthy();
-
-    // undoRedo: Mod+Z takes the block away, Mod+Shift+Z brings it back.
-    pressKey("z", { metaKey: true });
-    expect(screen.queryByText("Focus time")).toBeNull();
-    pressKey("z", { metaKey: true, shiftKey: true });
-    expect(currentStepId()).toBe("hardcore");
-    expect(screen.getByText("Focus time")).toBeTruthy();
-
-    // hardcore: H flips the simulated badge.
-    pressKey("h");
     expect(currentStepId()).toBe("graduation");
+    expect(screen.getByText("Coffee with Alex")).toBeTruthy();
     expect(screen.getByText(/young cap'n/)).toBeTruthy();
 
     pressKey("Enter");
@@ -155,6 +116,24 @@ describe("ShortcutShowcase", () => {
     expect(
       persistentBrowserStore.get(STORAGE_KEYS.HAS_SEEN_SHORTCUT_SHOWCASE),
     ).toBe("true");
+  });
+
+  it("keeps answering the shortcuts it no longer gates the exit on", () => {
+    render(<ShortcutShowcase />);
+    act(() => shortcutShowcaseActions.start());
+
+    // S flashes the day-prefix chips, typing one jumps, and none of it
+    // advances a lesson any more.
+    pressKey("s");
+    pressKey("t");
+    pressKey("1");
+    expect(currentStepId()).toBe("create");
+
+    // e then t opens a title editor on a board no lesson seated focus on.
+    pressKey("e");
+    pressKey("t");
+    expect(screen.getByLabelText("Event title")).toBeTruthy();
+    expect(currentStepId()).toBe("create");
   });
 
   it("fades the takeover on Enter Compass, then unmounts", async () => {
@@ -224,62 +203,35 @@ describe("ShortcutShowcase", () => {
     expect(screen.getByRole("button", { name: "Enter Compass" })).toBeTruthy();
   });
 
-  it("shows the stretch hint one phase at a time: Tab, then Shift+Arrow", async () => {
+  it("offers 'Skip to sign up' from the first step and leaves on the first click", async () => {
     const user = userEvent.setup();
     render(<ShortcutShowcase />);
-    showStep("resizeEdge");
+    act(() => shortcutShowcaseActions.start());
+    expect(currentStepId()).toBe("create");
 
-    // Phase one: only the key that moves focus onto the end time.
-    expect(screen.getByTestId("tab-icon")).toBeTruthy();
-    expect(screen.queryByTestId("shift-icon")).toBeNull();
-    expect(screen.queryByTestId("arrowdown-icon")).toBeNull();
-
-    pressKey("Tab");
-
-    // Phase two: the end edge has focus, so the chord replaces Tab.
-    expect(screen.queryByTestId("tab-icon")).toBeNull();
-    expect(screen.getByTestId("shift-icon")).toBeTruthy();
-    expect(screen.getByTestId("arrowdown-icon")).toBeTruthy();
-
-    // Leaving and returning re-seeds the start edge, so the lesson restarts
-    // at phase one rather than stranding the user on the chord.
-    pressKey("ArrowDown", { shiftKey: true });
-    expect(currentStepId()).toBe("placeDraft");
-    await user.click(screen.getByRole("button", { name: "Previous" }));
-    expect(currentStepId()).toBe("resizeEdge");
-    expect(screen.getByTestId("tab-icon")).toBeTruthy();
-    expect(screen.queryByTestId("shift-icon")).toBeNull();
+    // No confirm in the way, and no lesson to finish first.
+    await user.click(screen.getByRole("button", { name: "Skip to sign up" }));
+    expect(useShortcutShowcaseStore.getState().isActive).toBe(false);
+    expect(screen.queryByLabelText("Shortcut practice")).toBeNull();
+    expect(
+      persistentBrowserStore.get(STORAGE_KEYS.HAS_SEEN_SHORTCUT_SHOWCASE),
+    ).toBe("true");
   });
 
-  it("puts undo and redo chips in the undoRedo sentence, not a duplicate row", () => {
-    render(<ShortcutShowcase />);
-    showStep("undoRedo");
-
-    expect(screen.getByText("to undo your last change, then")).toBeTruthy();
-    expect(screen.getByText("to bring it back.")).toBeTruthy();
-    expect(screen.getAllByTestId("z-icon")).toHaveLength(2);
-    expect(screen.getByTestId("shift-icon")).toBeTruthy();
-  });
-
-  it("Escape confirms once, lesson keys fall through, second Escape skips", () => {
+  it("Skip to calendar leaves straight away, without a confirm", async () => {
+    const user = userEvent.setup();
     render(<ShortcutShowcase />);
     act(() => shortcutShowcaseActions.start());
 
-    pressKey("Escape");
-    expect(screen.getByText("Skip the shortcuts?")).toBeTruthy();
-    expect(useShortcutShowcaseStore.getState().isActive).toBe(true);
+    await user.click(screen.getByRole("button", { name: "Skip to calendar" }));
+    expect(useShortcutShowcaseStore.getState().isActive).toBe(false);
+    expect(screen.queryByLabelText("Shortcut practice")).toBeNull();
+  });
 
-    // A lesson key cancels the confirm and still counts as the lesson.
-    pressKey("c");
-    expect(screen.queryByText("Skip the shortcuts?")).toBeNull();
-    expect(currentStepId()).toBe("save");
+  it("Escape skips the showcase outright", () => {
+    render(<ShortcutShowcase />);
+    act(() => shortcutShowcaseActions.start());
 
-    // C opened the title editor, so this Escape only closes the editor.
-    pressKey("Escape");
-    expect(screen.queryByLabelText("Event title")).toBeNull();
-    expect(useShortcutShowcaseStore.getState().isActive).toBe(true);
-
-    // The confirm already ran once this entry: Escape now skips directly.
     pressKey("Escape");
     expect(useShortcutShowcaseStore.getState().isActive).toBe(false);
   });
@@ -306,8 +258,6 @@ describe("ShortcutShowcase", () => {
     render(<ShortcutShowcase />);
     act(() => shortcutShowcaseActions.start());
 
-    // Burn the one skip confirm, then keep practicing.
-    pressKey("Escape");
     pressKey("c");
     expect(currentStepId()).toBe("save");
 
@@ -318,7 +268,7 @@ describe("ShortcutShowcase", () => {
     expect(useShortcutShowcaseStore.getState().isActive).toBe(true);
     expect(screen.getByText("Standup prep")).toBeTruthy();
 
-    // With no editor open, Escape now skips directly (confirm already seen).
+    // With no editor open, Escape now leaves.
     pressKey("Escape");
     expect(useShortcutShowcaseStore.getState().isActive).toBe(false);
   });

--- a/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.test.tsx
+++ b/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.test.tsx
@@ -56,7 +56,7 @@ describe("ShortcutShowcase", () => {
     expect(screen.queryByLabelText("Shortcut practice")).toBeNull();
     expect(isAppLocked()).toBe(false);
 
-    act(() => shortcutShowcaseActions.start());
+    act(() => shortcutShowcaseActions.replay());
     expect(screen.getByLabelText("Shortcut practice")).toBeTruthy();
     expect(isAppLocked()).toBe(true);
 
@@ -67,7 +67,7 @@ describe("ShortcutShowcase", () => {
 
   it("ignores KeyboardEvents with no key instead of throwing", () => {
     render(<ShortcutShowcase />);
-    act(() => shortcutShowcaseActions.start());
+    act(() => shortcutShowcaseActions.replay());
 
     expect(() => {
       act(() => {
@@ -81,7 +81,7 @@ describe("ShortcutShowcase", () => {
   it("teaches create then save, and graduates on Enter", async () => {
     const user = userEvent.setup();
     render(<ShortcutShowcase />);
-    act(() => shortcutShowcaseActions.start());
+    act(() => shortcutShowcaseActions.replay());
     expect(currentStepId()).toBe("create");
 
     // create: C opens a draft with its title editor.
@@ -120,7 +120,7 @@ describe("ShortcutShowcase", () => {
 
   it("keeps answering the shortcuts it no longer gates the exit on", () => {
     render(<ShortcutShowcase />);
-    act(() => shortcutShowcaseActions.start());
+    act(() => shortcutShowcaseActions.replay());
 
     // S flashes the day-prefix chips, typing one jumps, and none of it
     // advances a lesson any more.
@@ -192,7 +192,7 @@ describe("ShortcutShowcase", () => {
   it("offers 'Do it for me' from the first step, and swaps it out at graduation", async () => {
     const user = userEvent.setup();
     render(<ShortcutShowcase />);
-    act(() => shortcutShowcaseActions.start());
+    act(() => shortcutShowcaseActions.replay());
 
     // No idle wait or failed attempt required: the way out is always offered.
     await user.click(screen.getByRole("button", { name: "Do it for me" }));
@@ -206,7 +206,7 @@ describe("ShortcutShowcase", () => {
   it("offers 'Skip to sign up' from the first step and leaves on the first click", async () => {
     const user = userEvent.setup();
     render(<ShortcutShowcase />);
-    act(() => shortcutShowcaseActions.start());
+    act(() => shortcutShowcaseActions.replay());
     expect(currentStepId()).toBe("create");
 
     // No confirm in the way, and no lesson to finish first.
@@ -221,7 +221,7 @@ describe("ShortcutShowcase", () => {
   it("Skip to calendar leaves straight away, without a confirm", async () => {
     const user = userEvent.setup();
     render(<ShortcutShowcase />);
-    act(() => shortcutShowcaseActions.start());
+    act(() => shortcutShowcaseActions.replay());
 
     await user.click(screen.getByRole("button", { name: "Skip to calendar" }));
     expect(useShortcutShowcaseStore.getState().isActive).toBe(false);
@@ -230,7 +230,7 @@ describe("ShortcutShowcase", () => {
 
   it("Escape skips the showcase outright", () => {
     render(<ShortcutShowcase />);
-    act(() => shortcutShowcaseActions.start());
+    act(() => shortcutShowcaseActions.replay());
 
     pressKey("Escape");
     expect(useShortcutShowcaseStore.getState().isActive).toBe(false);
@@ -239,7 +239,7 @@ describe("ShortcutShowcase", () => {
   it("Previous restores the prior step's board so it can be redone", async () => {
     const user = userEvent.setup();
     render(<ShortcutShowcase />);
-    act(() => shortcutShowcaseActions.start());
+    act(() => shortcutShowcaseActions.replay());
 
     pressKey("c");
     expect(currentStepId()).toBe("save");
@@ -256,7 +256,7 @@ describe("ShortcutShowcase", () => {
   it("Escape inside the title editor closes the editor, not the showcase", async () => {
     const user = userEvent.setup();
     render(<ShortcutShowcase />);
-    act(() => shortcutShowcaseActions.start());
+    act(() => shortcutShowcaseActions.replay());
 
     pressKey("c");
     expect(currentStepId()).toBe("save");

--- a/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.tsx
+++ b/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.tsx
@@ -1,11 +1,13 @@
 import {
   type FC,
   useCallback,
+  useContext,
   useEffect,
   useLayoutEffect,
   useRef,
   useState,
 } from "react";
+import { SessionContext } from "@web/auth/compass/session/session.context";
 import { track } from "@web/auth/posthog/track";
 import { SHOWCASE_REVEAL_MS } from "@web/common/constants/motion.constants";
 import { Z_INDEX_MODAL } from "@web/common/constants/web.constants";
@@ -35,7 +37,6 @@ import {
   getShowcaseStep,
   SHOWCASE_STEP_IDS,
 } from "@web/components/ShortcutShowcase/showcase.steps";
-import { markShortcutShowcaseSeen } from "@web/components/ShortcutShowcase/showcase.storage";
 import {
   selectShowcaseActive,
   selectShowcaseStepIndex,
@@ -84,6 +85,9 @@ const ShowcaseTakeover: FC = () => {
   const closingRef = useRef(false);
   closingRef.current = closing;
   const { openModal } = useAuthModal();
+  // Post-signup is now the showcase's main entry, and "sign up" is not an exit
+  // for someone who just did.
+  const { authenticated } = useContext(SessionContext);
 
   // The takeover owns the keyboard: silence every real app handler
   // (useAppShortcut, the e-sequence, bare-letter s/h) while it is up.
@@ -92,7 +96,7 @@ const ShowcaseTakeover: FC = () => {
   const graduate = () => {
     // Persist before the curtain so a reload during the reveal does not
     // relaunch the takeover. finish() marks seen again when it unmounts.
-    markShortcutShowcaseSeen();
+    shortcutShowcaseActions.markSeen();
     beginDismiss(() => shortcutShowcaseActions.finish());
   };
   const graduateRef = useRef(graduate);
@@ -395,13 +399,15 @@ const ShowcaseTakeover: FC = () => {
                 >
                   Do it for me
                 </button>
-                <button
-                  type="button"
-                  className={SECONDARY_BUTTON_CLASS}
-                  onClick={skipToSignup}
-                >
-                  Skip to sign up
-                </button>
+                {!authenticated && (
+                  <button
+                    type="button"
+                    className={SECONDARY_BUTTON_CLASS}
+                    onClick={skipToSignup}
+                  >
+                    Skip to sign up
+                  </button>
+                )}
               </>
             )}
             {stepIndex > 0 && stepId !== "graduation" && (

--- a/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.tsx
+++ b/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.tsx
@@ -10,9 +10,9 @@ import { track } from "@web/auth/posthog/track";
 import { SHOWCASE_REVEAL_MS } from "@web/common/constants/motion.constants";
 import { Z_INDEX_MODAL } from "@web/common/constants/web.constants";
 import { useDismissTransition } from "@web/common/hooks/useDismissTransition";
+import { useAuthModal } from "@web/components/AuthModal/hooks/useAuthModal";
 import { PracticeCalendar } from "@web/components/ShortcutShowcase/PracticeCalendar";
 import {
-  clearFocus,
   commitTitle,
   createDraft,
   cycleEdge,
@@ -27,7 +27,6 @@ import {
   placeDraft,
   redo,
   resizeFocusedEdge,
-  setEdge,
   toggleHardcore,
   toggleJumpChips,
   undo,
@@ -35,12 +34,10 @@ import {
 import {
   getShowcaseStep,
   SHOWCASE_STEP_IDS,
-  STRETCH_KEYCAPS,
 } from "@web/components/ShortcutShowcase/showcase.steps";
 import { markShortcutShowcaseSeen } from "@web/components/ShortcutShowcase/showcase.storage";
 import {
   selectShowcaseActive,
-  selectShowcaseConfirmingSkip,
   selectShowcaseStepIndex,
   shortcutShowcaseActions,
   stepIdAt,
@@ -60,6 +57,8 @@ const TEXT_BUTTON_CLASS =
   "c-focus-ring rounded-md px-2 py-1 text-text-muted text-xs hover:bg-surface-overlay hover:text-text";
 const PRIMARY_BUTTON_CLASS =
   "c-button c-button-primary rounded-full px-4 py-1.5 text-xs";
+const SECONDARY_BUTTON_CLASS =
+  "c-button c-button-secondary rounded-full px-4 py-1.5 text-xs";
 
 const ARROW_DIRECTIONS: Record<string, PracticeDirection> = {
   ArrowUp: "up",
@@ -73,17 +72,18 @@ const ARROW_DIRECTIONS: Record<string, PracticeDirection> = {
  * calendar. Bindings come from KEYMAP (shared with the real handlers);
  * behavior is a deliberately simplified reimplementation against ephemeral
  * practice state, so nothing here touches storage or the real grid stores.
+ *
+ * Two lessons gate the exit (see showcase.steps.ts), but every shortcut the
+ * arena ever answered still works here for anyone who wants to poke around.
  */
 const ShowcaseTakeover: FC = () => {
   const stepIndex = useShortcutShowcaseStore(selectShowcaseStepIndex);
-  const isConfirmingSkip = useShortcutShowcaseStore(
-    selectShowcaseConfirmingSkip,
-  );
   const stepId = stepIdAt(stepIndex);
   const step = getShowcaseStep(stepId);
   const { closing, beginDismiss } = useDismissTransition(SHOWCASE_REVEAL_MS);
   const closingRef = useRef(false);
   closingRef.current = closing;
+  const { openModal } = useAuthModal();
 
   // The takeover owns the keyboard: silence every real app handler
   // (useAppShortcut, the e-sequence, bare-letter s/h) while it is up.
@@ -97,6 +97,14 @@ const ShowcaseTakeover: FC = () => {
   };
   const graduateRef = useRef(graduate);
   graduateRef.current = graduate;
+
+  // The showcase is the last thing between a curious visitor and the flow that
+  // actually matters, so it always offers the door rather than guarding it.
+  const skipToSignup = () => {
+    shortcutShowcaseActions.skip("signup");
+    track("signup_started", { source: "shortcut_showcase" });
+    openModal("signUp");
+  };
 
   const [practice, setPractice] = useState(initialPracticeState);
   const practiceRef = useRef(practice);
@@ -113,7 +121,6 @@ const ShowcaseTakeover: FC = () => {
   // Practice state at each step's entry, so Back can restore and redo.
   const entrySnapshotsRef = useRef<Record<number, PracticeState>>({});
   const editSequenceArmedUntilRef = useRef(0);
-  const undoDoneRef = useRef(false);
   // Typed-so-far jump key while the S chips are showing ("t" awaiting "t1").
   const jumpBufferRef = useRef("");
 
@@ -129,32 +136,22 @@ const ShowcaseTakeover: FC = () => {
     [apply],
   );
 
-  // Step-entry effects: snapshot for Back, then stage the board so the
-  // taught keystroke lands (mirrors the tour's enterDentistMission trick).
-  // Layout, not passive: a step advances from inside a keydown handler, so a
-  // passive effect would run after the browser is free to deliver the next
-  // keystroke. The lesson key would then land in a title editor this effect
-  // has not closed yet (silently appending to the title instead of teaching).
+  // Step-entry effects: snapshot for Back, then close any editor left open by
+  // the previous step. Layout, not passive: a step advances from inside a
+  // keydown handler, so a passive effect would run after the browser is free
+  // to deliver the next keystroke. The lesson key would then land in a title
+  // editor this effect has not closed yet (silently appending to the title
+  // instead of teaching).
   // biome-ignore lint/correctness/useExhaustiveDependencies: runs per step change by design
   useLayoutEffect(() => {
     entrySnapshotsRef.current[stepIndex] ??= practiceRef.current;
-    undoDoneRef.current = false;
 
-    // A still-open editor from a previous step would swallow lesson keys.
     // The editor input is uncontrolled, so read the typed text off the DOM.
     if (practiceRef.current.editor && stepId !== "save") {
       const input = document.querySelector<HTMLInputElement>(
         "[data-practice-title-input]",
       );
       apply((state) => commitTitle(state, input?.value ?? ""));
-    }
-
-    if (stepId === "moveFocus" || stepId === "editTitle") {
-      apply(focusFallback);
-    } else if (stepId === "resizeEdge") {
-      apply((state) => setEdge(focusFallback(state), "start"));
-    } else if (stepId === "placeDraft") {
-      apply(clearFocus);
     }
   }, [stepIndex]);
 
@@ -181,17 +178,6 @@ const ShowcaseTakeover: FC = () => {
       }
       const currentStepId = stepIdAt(store.stepIndex);
 
-      if (store.isConfirmingSkip) {
-        if (event.key === "Enter") {
-          event.preventDefault();
-          event.stopPropagation();
-          shortcutShowcaseActions.skip();
-          return;
-        }
-        // Any other key keeps practicing and still counts as the lesson key.
-        shortcutShowcaseActions.cancelSkipConfirm();
-      }
-
       // Let the title editor own typing; only Escape passes through it.
       const target = event.target;
       if (
@@ -206,9 +192,8 @@ const ShowcaseTakeover: FC = () => {
         event.preventDefault();
         event.stopPropagation();
         // Escape inside the title editor closes the editor, never the
-        // showcase; a reflexive Escape after the confirm was seen would
-        // otherwise end the whole practice with no prompt. The editor input
-        // is uncontrolled, so the typed text lives in the DOM, not in state.
+        // showcase. The editor input is uncontrolled, so the typed text lives
+        // in the DOM, not in state.
         if (practiceRef.current.editor) {
           const input = document.querySelector<HTMLInputElement>(
             "[data-practice-title-input]",
@@ -216,7 +201,7 @@ const ShowcaseTakeover: FC = () => {
           apply((state) => commitTitle(state, input?.value ?? ""));
           return;
         }
-        shortcutShowcaseActions.requestSkipConfirm();
+        shortcutShowcaseActions.skip();
         return;
       }
 
@@ -229,7 +214,6 @@ const ShowcaseTakeover: FC = () => {
       // e -> t sequence (arm, then fire within the window).
       if (
         isBareLetterKey(event, KEYMAP.editTitle.sequence.leader) &&
-        practiceRef.current.focusedId &&
         !practiceRef.current.editor
       ) {
         editSequenceArmedUntilRef.current = Date.now() + ARM_WINDOW_MS;
@@ -242,8 +226,9 @@ const ShowcaseTakeover: FC = () => {
       ) {
         editSequenceArmedUntilRef.current = 0;
         event.preventDefault();
-        const next = apply(openTitleEditor);
-        if (next.editor && currentStepId === "editTitle") advance();
+        // No lesson seats focus any more, so the chord picks a block itself
+        // rather than silently doing nothing on a cold board.
+        apply((state) => openTitleEditor(focusFallback(state)));
         return;
       }
 
@@ -279,7 +264,6 @@ const ShowcaseTakeover: FC = () => {
         if (hints.includes(typed)) {
           jumpBufferRef.current = "";
           apply((state) => jumpToChipHint(state, typed));
-          if (currentStepId === "eventJump") advance();
         } else if (hints.some((hint) => hint.startsWith(typed))) {
           jumpBufferRef.current = typed;
         } else {
@@ -297,8 +281,7 @@ const ShowcaseTakeover: FC = () => {
 
       if (isBareLetterKey(event, KEYMAP.hardcore.bareLetter)) {
         event.preventDefault();
-        const next = apply(toggleHardcore);
-        if (currentStepId === "hardcore" && next.hardcoreOn) advance();
+        apply(toggleHardcore);
         return;
       }
 
@@ -314,20 +297,7 @@ const ShowcaseTakeover: FC = () => {
         keyboardKey(event).toLowerCase() === "z"
       ) {
         event.preventDefault();
-        const before = practiceRef.current;
-        if (event.shiftKey) {
-          const next = apply(redo);
-          if (
-            currentStepId === "undoRedo" &&
-            undoDoneRef.current &&
-            next !== before
-          ) {
-            advance();
-          }
-        } else {
-          const next = apply(undo);
-          if (next !== before) undoDoneRef.current = true;
-        }
+        apply(event.shiftKey ? redo : undo);
         return;
       }
 
@@ -343,30 +313,14 @@ const ShowcaseTakeover: FC = () => {
       const before = practiceRef.current;
       if (event.shiftKey) {
         if (before.edge && before.focusedId) {
-          const next = apply((state) => resizeFocusedEdge(state, direction));
-          if (
-            currentStepId === "resizeEdge" &&
-            before.edge === "end" &&
-            next !== before
-          ) {
-            advance();
-          }
+          apply((state) => resizeFocusedEdge(state, direction));
         } else if (before.focusedId) {
-          const next = apply((state) => moveFocusedEvent(state, direction));
-          if (currentStepId === "moveEvent" && next !== before) advance();
+          apply((state) => moveFocusedEvent(state, direction));
         } else {
           apply(placeDraft);
-          if (currentStepId === "placeDraft") advance();
         }
       } else {
-        const next = apply((state) => moveFocus(state, direction));
-        if (
-          currentStepId === "moveFocus" &&
-          before.focusedId &&
-          next.focusedId !== before.focusedId
-        ) {
-          advance();
-        }
+        apply((state) => moveFocus(state, direction));
       }
     };
 
@@ -384,51 +338,11 @@ const ShowcaseTakeover: FC = () => {
       case "save":
         apply((state) => commitTitle(state, "Coffee with Alex"));
         break;
-      case "moveFocus":
-        apply((state) => {
-          const next = moveFocus(state, "right");
-          return next !== state ? next : moveFocus(state, "left");
-        });
-        break;
-      case "editTitle":
-        apply((state) => openTitleEditor(focusFallback(state)));
-        break;
-      case "eventJump":
-        apply((state) => {
-          const withChips = state.jumpChips ? state : toggleJumpChips(state);
-          const entries = Object.entries(withChips.jumpChips ?? {});
-          const target =
-            entries.find(([id]) => id !== withChips.focusedId) ?? entries[0];
-          return target ? jumpToChipHint(withChips, target[1]) : withChips;
-        });
-        break;
-      case "moveEvent":
-        apply((state) => moveFocusedEvent(focusFallback(state), "down"));
-        break;
-      case "resizeEdge":
-        apply((state) =>
-          resizeFocusedEdge(setEdge(focusFallback(state), "end"), "down"),
-        );
-        break;
-      case "placeDraft":
-        apply(placeDraft);
-        break;
-      case "undoRedo":
-        apply(undo);
-        apply(redo);
-        break;
-      case "hardcore":
-        apply((state) => (state.hardcoreOn ? state : toggleHardcore(state)));
-        break;
     }
     advance();
   };
 
   const progressPercent = ((stepIndex + 1) / SHOWCASE_STEP_IDS.length) * 100;
-  // The stretch lesson teaches Tab first, then the chord, so it hints one
-  // press at a time rather than showing all three keys at once.
-  const isStretchPhase = stepId === "resizeEdge" && practice.edge === "end";
-  const keycaps = isStretchPhase ? STRETCH_KEYCAPS : step.keycaps;
 
   return (
     <section
@@ -442,94 +356,73 @@ const ShowcaseTakeover: FC = () => {
         className={`flex h-[80vh] max-h-160 w-full max-w-5xl gap-8 px-8 ${closing ? "c-showcase-enter-stage" : ""}`}
       >
         <aside className="flex w-80 shrink-0 flex-col justify-center gap-4">
-          {isConfirmingSkip ? (
-            <>
-              <h2 className="font-semibold text-lg text-text">
-                Skip the shortcuts?
-              </h2>
-              <p className="text-sm text-text-muted">
-                Compass is built around these shortcuts. Without them, it's just
-                another calendar app.
-              </p>
-              <div className="flex items-center gap-2">
+          <div className="flex flex-col gap-1">
+            <span className="text-text-muted text-xs">
+              Step {stepIndex + 1} of {SHOWCASE_STEP_IDS.length}
+            </span>
+            <div className="h-1 w-full overflow-hidden rounded-full bg-surface-overlay">
+              <div
+                className="h-full rounded-full bg-accent transition-all duration-300"
+                style={{ width: `${progressPercent}%` }}
+              />
+            </div>
+          </div>
+          <h2 className="font-semibold text-lg text-text">{step.title}</h2>
+          <p className="text-sm text-text-muted">
+            {typeof step.body === "string" ? (
+              step.body
+            ) : (
+              <ShortcutTipParts parts={step.body} />
+            )}
+          </p>
+          {step.keycaps && <ShortcutKeys keys={[...step.keycaps]} />}
+          <div className="flex flex-wrap items-center gap-2 pt-2">
+            {stepId === "graduation" ? (
+              <button
+                type="button"
+                className={PRIMARY_BUTTON_CLASS}
+                disabled={closing}
+                onClick={graduate}
+              >
+                Enter Compass
+              </button>
+            ) : (
+              <>
                 <button
                   type="button"
                   className={PRIMARY_BUTTON_CLASS}
-                  onClick={shortcutShowcaseActions.cancelSkipConfirm}
+                  onClick={doItForMe}
                 >
-                  Keep practicing
+                  Do it for me
                 </button>
                 <button
                   type="button"
-                  className={TEXT_BUTTON_CLASS}
-                  onClick={shortcutShowcaseActions.skip}
+                  className={SECONDARY_BUTTON_CLASS}
+                  onClick={skipToSignup}
                 >
-                  Skip anyway
+                  Skip to sign up
                 </button>
-              </div>
-            </>
-          ) : (
-            <>
-              <div className="flex flex-col gap-1">
-                <span className="text-text-muted text-xs">
-                  Step {stepIndex + 1} of {SHOWCASE_STEP_IDS.length}
-                </span>
-                <div className="h-1 w-full overflow-hidden rounded-full bg-surface-overlay">
-                  <div
-                    className="h-full rounded-full bg-accent transition-all duration-300"
-                    style={{ width: `${progressPercent}%` }}
-                  />
-                </div>
-              </div>
-              <h2 className="font-semibold text-lg text-text">{step.title}</h2>
-              <p className="text-sm text-text-muted">
-                {typeof step.body === "string" ? (
-                  step.body
-                ) : (
-                  <ShortcutTipParts parts={step.body} />
-                )}
-              </p>
-              {keycaps && <ShortcutKeys keys={[...keycaps]} />}
-              <div className="flex items-center gap-2 pt-2">
-                {stepId === "graduation" ? (
-                  <button
-                    type="button"
-                    className={PRIMARY_BUTTON_CLASS}
-                    disabled={closing}
-                    onClick={graduate}
-                  >
-                    Enter Compass
-                  </button>
-                ) : (
-                  <button
-                    type="button"
-                    className={PRIMARY_BUTTON_CLASS}
-                    onClick={doItForMe}
-                  >
-                    Do it for me
-                  </button>
-                )}
-                {stepIndex > 0 && stepId !== "graduation" && (
-                  <button
-                    type="button"
-                    className={TEXT_BUTTON_CLASS}
-                    onClick={goBack}
-                  >
-                    Previous
-                  </button>
-                )}
-                {stepId !== "graduation" && (
-                  <button
-                    type="button"
-                    className={TEXT_BUTTON_CLASS}
-                    onClick={shortcutShowcaseActions.requestSkipConfirm}
-                  >
-                    Skip
-                  </button>
-                )}
-              </div>
-            </>
-          )}
+              </>
+            )}
+            {stepIndex > 0 && stepId !== "graduation" && (
+              <button
+                type="button"
+                className={TEXT_BUTTON_CLASS}
+                onClick={goBack}
+              >
+                Previous
+              </button>
+            )}
+            {stepId !== "graduation" && (
+              <button
+                type="button"
+                className={TEXT_BUTTON_CLASS}
+                onClick={() => shortcutShowcaseActions.skip()}
+              >
+                Skip to calendar
+              </button>
+            )}
+          </div>
         </aside>
         <div className="min-w-0 flex-1 rounded-xl border border-border bg-surface p-4 shadow-xl">
           <PracticeCalendar

--- a/packages/web/src/components/ShortcutShowcase/showcase.steps.ts
+++ b/packages/web/src/components/ShortcutShowcase/showcase.steps.ts
@@ -2,23 +2,19 @@ import { KEYMAP } from "@web/shortcuts/keymap";
 import { type ShortcutTipPart } from "@web/shortcuts/tips/shortcut-tips.data";
 
 /**
- * Single source of truth for showcase step order. Every shortcut concept the
- * app teaches lives here; the checklist in the real app only re-practices
- * them. "graduation" is the exit, not a lesson.
+ * Single source of truth for showcase step order.
+ *
+ * Two lessons, deliberately. The ten-lesson version lost 40% of the people who
+ * cleared step one before graduation (113 -> 68 over 30 days) while the
+ * checklist re-taught jump, move, stretch, place and undo on real events
+ * anyway. What is left is the one loop nothing else covers and nothing else
+ * can: put an event on the calendar without touching the mouse.
+ *
+ * The practice arena still answers every shortcut it ever did — a curious user
+ * can press S, H, Tab or Shift+Arrow and watch it work — those simply are not
+ * gates on the way out any more. "graduation" is the exit, not a lesson.
  */
-const STEP_IDS = [
-  "create",
-  "save",
-  "moveFocus",
-  "editTitle",
-  "eventJump",
-  "moveEvent",
-  "resizeEdge",
-  "placeDraft",
-  "undoRedo",
-  "hardcore",
-  "graduation",
-] as const;
+const STEP_IDS = ["create", "save", "graduation"] as const;
 
 export type ShowcaseStepId = (typeof STEP_IDS)[number];
 
@@ -29,21 +25,12 @@ export type ShowcaseStep = {
   title: string;
   /**
    * Plain copy, or the same parts model as shortcut tips so a step can put
-   * real keycap chips in the sentence. Only undoRedo needs that; converting
-   * every body would duplicate the chip row already rendered from `keycaps`.
+   * real keycap chips in the sentence.
    */
   body: string | readonly ShortcutTipPart[];
   /** One keycap per entry, rendered via ShortcutKeys. */
   keycaps?: readonly string[];
 };
-
-/**
- * Second half of the resizeEdge lesson, swapped in once the end edge has
- * focus so the row never reads as one three-key press. Stretching reuses the
- * Shift+Arrow family bound by KEYMAP.moveEvent; the arrow stays literal
- * because it demonstrates one direction, and only up/down stretch.
- */
-export const STRETCH_KEYCAPS: readonly string[] = ["Shift", "ArrowDown"];
 
 /**
  * Keycaps reference KEYMAP so a remap updates the hints automatically;
@@ -60,58 +47,9 @@ const STEP_CONTENT: Record<ShowcaseStepId, Omit<ShowcaseStep, "id">> = {
     body: "Type a title, then press Enter to save.",
     keycaps: KEYMAP.saveDraft.keycaps,
   },
-  moveFocus: {
-    title: "Move between events",
-    body: "Press an arrow key to move focus onto a different event, no mouse needed.",
-    keycaps: KEYMAP.moveFocus.keycaps,
-  },
-  editTitle: {
-    title: "Jump straight to a field",
-    body: "Press E, then T, to open the focused event's title. Every field has its own letter.",
-    keycaps: KEYMAP.editTitle.keycaps,
-  },
-  eventJump: {
-    title: "Jump to any event",
-    body: "Tap S to flash a key over every event, then type its key to jump straight to it.",
-    keycaps: KEYMAP.eventJump.keycaps,
-  },
-  moveEvent: {
-    title: "Reschedule in a keystroke",
-    body: "Hold Shift and press an arrow key to slide the focused event to a new time or day.",
-    keycaps: KEYMAP.moveEvent.keycaps,
-  },
-  resizeEdge: {
-    // Two phases: the hint swaps to Shift+Arrow once the end edge has focus,
-    // so the keycaps here only cover the first press.
-    title: "Stretch the end time",
-    body: "Press Tab to focus the event's end time, then hold Shift and press the up or down arrow to stretch it. The start stays put.",
-    keycaps: KEYMAP.edgeFocus.keycaps,
-  },
-  placeDraft: {
-    title: "Place a block anywhere",
-    body: "With nothing focused, hold Shift and press an arrow key to place a new block right on the grid.",
-    keycaps: KEYMAP.moveEvent.keycaps,
-  },
-  undoRedo: {
-    title: "Never stress a mistake",
-    // Chips live in the sentence so both chords render; a second keycap row
-    // would duplicate undo and still hide redo.
-    body: [
-      "Press ",
-      { keys: KEYMAP.undo.keycaps },
-      " to undo your last change, then ",
-      { keys: KEYMAP.redo.keycaps },
-      " to bring it back.",
-    ],
-  },
-  hardcore: {
-    title: "Try Hardcore Mode",
-    body: "Press H to go keyboard-only. In the real app, clicks stay off until you exit.",
-    keycaps: KEYMAP.hardcore.keycaps,
-  },
   graduation: {
     title: "You've shown great control, young cap'n.",
-    body: "Now you're ready to steer the real vessel. Sample events are waiting on your calendar, and you can replay this practice anytime from the command palette.",
+    body: "Now you're ready to steer the real vessel. Sample events are waiting on your calendar, and the checklist there picks up where this left off.",
   },
 };
 

--- a/packages/web/src/components/ShortcutShowcase/showcase.store.test.ts
+++ b/packages/web/src/components/ShortcutShowcase/showcase.store.test.ts
@@ -25,7 +25,7 @@ describe("shortcutShowcaseActions", () => {
   });
 
   it("starts and advances through every step, finishing at the end", () => {
-    shortcutShowcaseActions.start();
+    shortcutShowcaseActions.replay();
     expect(useShortcutShowcaseStore.getState().isActive).toBe(true);
     expect(useShortcutShowcaseStore.getState().stepIndex).toBe(0);
 
@@ -42,12 +42,14 @@ describe("shortcutShowcaseActions", () => {
     ).toBe("true");
   });
 
-  it("never auto-starts once seen, but replay always works", () => {
-    shortcutShowcaseActions.start();
+  it("never offers itself twice after signup, but replay always works", () => {
+    shortcutShowcaseActions.markSkippedWithoutStarting({ pendingSignup: true });
+    shortcutShowcaseActions.replay();
     shortcutShowcaseActions.skip();
     expect(useShortcutShowcaseStore.getState().isActive).toBe(false);
 
-    shortcutShowcaseActions.start();
+    // The offer is still pending, but the practice has now been seen.
+    shortcutShowcaseActions.offerAfterSignupIfPending();
     expect(useShortcutShowcaseStore.getState().isActive).toBe(false);
 
     shortcutShowcaseActions.replay();
@@ -57,12 +59,13 @@ describe("shortcutShowcaseActions", () => {
 
   it("treats legacy tour finishers as having seen the showcase", () => {
     localStorage.setItem(LEGACY_TOUR_SEEN_KEY, "true");
-    shortcutShowcaseActions.start();
+    shortcutShowcaseActions.markSkippedWithoutStarting({ pendingSignup: true });
+    shortcutShowcaseActions.offerAfterSignupIfPending();
     expect(useShortcutShowcaseStore.getState().isActive).toBe(false);
   });
 
   it("steps back to redo a lesson and no-ops on the first step", () => {
-    shortcutShowcaseActions.start();
+    shortcutShowcaseActions.replay();
     shortcutShowcaseActions.advance();
     expect(useShortcutShowcaseStore.getState().stepIndex).toBe(1);
 
@@ -73,7 +76,7 @@ describe("shortcutShowcaseActions", () => {
   });
 
   it("skips on the first request, from any step and either exit", () => {
-    shortcutShowcaseActions.start();
+    shortcutShowcaseActions.replay();
     shortcutShowcaseActions.advance();
     shortcutShowcaseActions.skip("signup");
     expect(useShortcutShowcaseStore.getState().isActive).toBe(false);
@@ -100,12 +103,12 @@ describe("shortcutShowcaseActions", () => {
     expect(useShortcutShowcaseStore.getState().isActive).toBe(false);
   });
 
-  it("burns the offer on plain dismiss or log-in handoff", () => {
+  it("burns the offer when exploring without an account or logging in", () => {
     shortcutShowcaseActions.markSkippedWithoutStarting();
     expect(
       persistentBrowserStore.get(STORAGE_KEYS.HAS_SEEN_SHORTCUT_SHOWCASE),
     ).toBe("true");
-    shortcutShowcaseActions.start();
+    shortcutShowcaseActions.offerAfterSignupIfPending();
     expect(useShortcutShowcaseStore.getState().isActive).toBe(false);
   });
 });

--- a/packages/web/src/components/ShortcutShowcase/showcase.store.test.ts
+++ b/packages/web/src/components/ShortcutShowcase/showcase.store.test.ts
@@ -19,7 +19,7 @@ describe("shortcutShowcaseActions", () => {
   });
 
   // Module-level singleton shared across the bun process: never leave the
-  // showcase active (or mid-confirm) for suites that run after this file.
+  // showcase active for suites that run after this file.
   afterEach(() => {
     useShortcutShowcaseStore.setState(initialShortcutShowcaseState);
   });
@@ -72,33 +72,18 @@ describe("shortcutShowcaseActions", () => {
     expect(useShortcutShowcaseStore.getState().stepIndex).toBe(0);
   });
 
-  it("confirms the first skip request, then skips directly after that", () => {
+  it("skips on the first request, from any step and either exit", () => {
     shortcutShowcaseActions.start();
-    shortcutShowcaseActions.requestSkipConfirm();
-    expect(useShortcutShowcaseStore.getState().isConfirmingSkip).toBe(true);
-
-    shortcutShowcaseActions.cancelSkipConfirm();
-    expect(useShortcutShowcaseStore.getState().isConfirmingSkip).toBe(false);
-    expect(useShortcutShowcaseStore.getState().isActive).toBe(true);
-
-    // The confirm already ran once this entry: the next request skips.
-    shortcutShowcaseActions.requestSkipConfirm();
+    shortcutShowcaseActions.advance();
+    shortcutShowcaseActions.skip("signup");
     expect(useShortcutShowcaseStore.getState().isActive).toBe(false);
+    expect(
+      persistentBrowserStore.get(STORAGE_KEYS.HAS_SEEN_SHORTCUT_SHOWCASE),
+    ).toBe("true");
 
-    // A fresh entry resets the once-per-entry memory.
-    shortcutShowcaseActions.replay();
-    shortcutShowcaseActions.requestSkipConfirm();
-    expect(useShortcutShowcaseStore.getState().isConfirmingSkip).toBe(true);
-    expect(useShortcutShowcaseStore.getState().isActive).toBe(true);
-  });
-
-  it("blocks advance and back while the skip confirm is showing", () => {
-    shortcutShowcaseActions.start();
-    shortcutShowcaseActions.advance();
-    shortcutShowcaseActions.requestSkipConfirm();
-    shortcutShowcaseActions.advance();
-    shortcutShowcaseActions.back();
-    expect(useShortcutShowcaseStore.getState().stepIndex).toBe(1);
+    // Skipping an inactive showcase is a no-op, not a second skip event.
+    shortcutShowcaseActions.skip();
+    expect(useShortcutShowcaseStore.getState().isActive).toBe(false);
   });
 
   it("defers the offer through signup and redeems it exactly once", () => {

--- a/packages/web/src/components/ShortcutShowcase/showcase.store.ts
+++ b/packages/web/src/components/ShortcutShowcase/showcase.store.ts
@@ -11,11 +11,19 @@ import {
 export type ShortcutShowcaseState = {
   isActive: boolean;
   stepIndex: number;
+  /**
+   * Bumped every time the showcase is marked seen. Storage stays the source of
+   * truth; this is the re-render signal for components that read it, because a
+   * localStorage write notifies nobody. Without it the checklist stayed hidden
+   * until the next render for anyone who skipped past the practice entirely.
+   */
+  seenRevision: number;
 };
 
 export const initialShortcutShowcaseState: ShortcutShowcaseState = {
   isActive: false,
   stepIndex: 0,
+  seenRevision: 0,
 };
 
 /** Where a user who left early went next, so the funnel can tell them apart. */
@@ -28,32 +36,37 @@ export const useShortcutShowcaseStore = create<ShortcutShowcaseState>()(() => ({
 export const stepIdAt = (index: number) =>
   SHOWCASE_STEP_IDS[index] ?? SHOWCASE_STEP_IDS[0];
 
-/** Shared by finish/skip: mark seen so it never auto-launches again. */
-const endShowcase = () => {
+/** Persist the seen flag and wake everyone reading it. */
+const markSeen = () => {
   markShortcutShowcaseSeen();
-  useShortcutShowcaseStore.setState({ ...initialShortcutShowcaseState });
+  useShortcutShowcaseStore.setState((state) => ({
+    seenRevision: state.seenRevision + 1,
+  }));
 };
 
-const activate = (
-  entry: "start_now" | "escape" | "post_signup" | "palette",
-) => {
-  useShortcutShowcaseStore.setState({
-    ...initialShortcutShowcaseState,
-    isActive: true,
-  });
+/** Shared by finish/skip: mark seen so it never auto-launches again. */
+const endShowcase = () => {
+  markSeen();
+  useShortcutShowcaseStore.setState({ isActive: false, stepIndex: 0 });
+};
+
+/**
+ * Only two ways in now. The welcome modal used to launch the takeover before
+ * anyone had committed to anything; signing up and connecting a calendar comes
+ * first, and the practice is offered once there is a real calendar behind it.
+ */
+const activate = (entry: "post_signup" | "palette") => {
+  useShortcutShowcaseStore.setState({ isActive: true, stepIndex: 0 });
   track("shortcut_showcase_started", { entry });
 };
 
 export const shortcutShowcaseActions = {
-  /** Welcome modal Start Now / Escape: launch unless already seen. */
-  start: (entry: "start_now" | "escape" = "start_now") => {
-    if (hasSeenShortcutShowcase()) return;
-    activate(entry);
-  },
   /** Palette re-entry: always allowed, always from the first step. */
   replay: () => {
     activate("palette");
   },
+  /** Graduation persists the flag before its reveal animation finishes. */
+  markSeen,
   advance: () => {
     const { isActive, stepIndex } = useShortcutShowcaseStore.getState();
     if (!isActive) return;
@@ -87,15 +100,15 @@ export const shortcutShowcaseActions = {
     endShowcase();
   },
   /**
-   * Welcome-modal auth handoff: signing up defers the offer to right after
-   * signup completes; log-in and plain dismiss burn it immediately.
+   * Welcome-modal exit: signing up defers the offer to right after signup
+   * completes; log-in and exploring without an account burn it immediately.
    */
   markSkippedWithoutStarting: (options?: { pendingSignup?: boolean }) => {
     if (options?.pendingSignup) {
       markShowcaseOfferPending();
       return;
     }
-    markShortcutShowcaseSeen();
+    markSeen();
   },
   /** Called once, right after signup completes, to redeem a pending offer. */
   offerAfterSignupIfPending: () => {
@@ -110,3 +123,6 @@ export const selectShowcaseActive = (state: ShortcutShowcaseState) =>
 
 export const selectShowcaseStepIndex = (state: ShortcutShowcaseState) =>
   state.stepIndex;
+
+export const selectShowcaseSeenRevision = (state: ShortcutShowcaseState) =>
+  state.seenRevision;

--- a/packages/web/src/components/ShortcutShowcase/showcase.store.ts
+++ b/packages/web/src/components/ShortcutShowcase/showcase.store.ts
@@ -11,18 +11,15 @@ import {
 export type ShortcutShowcaseState = {
   isActive: boolean;
   stepIndex: number;
-  /** True while the "skip the shortcuts?" inline confirm is showing. */
-  isConfirmingSkip: boolean;
-  /** Once per entry: after the first confirm, Escape skips directly. */
-  hasShownSkipConfirm: boolean;
 };
 
 export const initialShortcutShowcaseState: ShortcutShowcaseState = {
   isActive: false,
   stepIndex: 0,
-  isConfirmingSkip: false,
-  hasShownSkipConfirm: false,
 };
+
+/** Where a user who left early went next, so the funnel can tell them apart. */
+export type ShowcaseExit = "calendar" | "signup";
 
 export const useShortcutShowcaseStore = create<ShortcutShowcaseState>()(() => ({
   ...initialShortcutShowcaseState,
@@ -58,9 +55,8 @@ export const shortcutShowcaseActions = {
     activate("palette");
   },
   advance: () => {
-    const { isActive, stepIndex, isConfirmingSkip } =
-      useShortcutShowcaseStore.getState();
-    if (!isActive || isConfirmingSkip) return;
+    const { isActive, stepIndex } = useShortcutShowcaseStore.getState();
+    if (!isActive) return;
     track("shortcut_showcase_step_completed", { step: stepIdAt(stepIndex) });
     if (stepIndex >= SHOWCASE_STEP_IDS.length - 1) {
       shortcutShowcaseActions.finish();
@@ -70,9 +66,8 @@ export const shortcutShowcaseActions = {
   },
   /** Step back to redo the previous lesson; no-op on the first step. */
   back: () => {
-    const { isActive, stepIndex, isConfirmingSkip } =
-      useShortcutShowcaseStore.getState();
-    if (!isActive || isConfirmingSkip || stepIndex === 0) return;
+    const { isActive, stepIndex } = useShortcutShowcaseStore.getState();
+    if (!isActive || stepIndex === 0) return;
     track("shortcut_showcase_step_redone", { step: stepIdAt(stepIndex - 1) });
     useShortcutShowcaseStore.setState({ stepIndex: stepIndex - 1 });
   },
@@ -80,30 +75,16 @@ export const shortcutShowcaseActions = {
     track("shortcut_showcase_finished");
     endShowcase();
   },
-  skip: () => {
-    const { stepIndex } = useShortcutShowcaseStore.getState();
-    track("shortcut_showcase_skipped", { step: stepIdAt(stepIndex) });
-    endShowcase();
-  },
   /**
-   * Escape or the Skip button. First time this entry: show the
-   * keyboard-first confirm. Once the user has seen it, skip directly.
+   * Leaving before graduation. There is no "are you sure?" in the way: the
+   * showcase is an offer, and the flow it guards (sign up, connect a calendar)
+   * matters more than the two lessons.
    */
-  requestSkipConfirm: () => {
-    const { isActive, hasShownSkipConfirm } =
-      useShortcutShowcaseStore.getState();
+  skip: (exit: ShowcaseExit = "calendar") => {
+    const { isActive, stepIndex } = useShortcutShowcaseStore.getState();
     if (!isActive) return;
-    if (hasShownSkipConfirm) {
-      shortcutShowcaseActions.skip();
-      return;
-    }
-    useShortcutShowcaseStore.setState({
-      isConfirmingSkip: true,
-      hasShownSkipConfirm: true,
-    });
-  },
-  cancelSkipConfirm: () => {
-    useShortcutShowcaseStore.setState({ isConfirmingSkip: false });
+    track("shortcut_showcase_skipped", { step: stepIdAt(stepIndex), exit });
+    endShowcase();
   },
   /**
    * Welcome-modal auth handoff: signing up defers the offer to right after
@@ -129,6 +110,3 @@ export const selectShowcaseActive = (state: ShortcutShowcaseState) =>
 
 export const selectShowcaseStepIndex = (state: ShortcutShowcaseState) =>
   state.stepIndex;
-
-export const selectShowcaseConfirmingSkip = (state: ShortcutShowcaseState) =>
-  state.isConfirmingSkip;

--- a/packages/web/src/components/WelcomeModal/WelcomeModal.test.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeModal.test.tsx
@@ -3,7 +3,23 @@ import userEvent from "@testing-library/user-event";
 import { createContext } from "react";
 import { dispatchMissingKey } from "@web/__tests__/utils/keyboard.test.util";
 import { type CompassSession } from "@web/auth/compass/session/session.types";
-import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
+import {
+  registerUseStartGoogleAuthorizationForTests,
+  resetUseStartGoogleAuthorizationForTests,
+} from "@web/auth/google/authorization/useStartGoogleAuthorization";
+import {
+  resetGoogleAvailabilityForTests,
+  setGoogleAvailabilityForTests,
+} from "@web/auth/google/hooks/useIsGoogleAvailable/useIsGoogleAvailable";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  mock,
+} from "bun:test";
 
 const mockOpenModal = mock();
 const mockCloseModal = mock();
@@ -185,13 +201,13 @@ describe("WelcomeModal", () => {
     expect(answer).toHaveAttribute("data-state", "closed");
   });
 
-  it("shows shortcut keycaps on auth and start actions without hover", () => {
+  it("shows shortcut keycaps on auth and explore actions without hover", () => {
     render(<WelcomeModal />);
 
     for (const [name, key] of [
       ["Sign up", "U"],
       ["Log in", "I"],
-      ["Start Now", "S"],
+      ["Explore without an account", "S"],
     ] as const) {
       const hint = within(screen.getByRole("button", { name })).getByText(key);
       expect(hint.className).not.toMatch(/opacity-0/);
@@ -218,13 +234,35 @@ describe("WelcomeModal", () => {
     expect(localStorage.getItem(STORAGE_KEYS.HAS_SEEN_WELCOME)).toBe("true");
   });
 
-  it("dismisses with the S shortcut", async () => {
+  it("explores without an account on S, and never queues the takeover", async () => {
     const user = userEvent.setup();
     render(<WelcomeModal />);
 
     await user.keyboard("s");
 
     expect(localStorage.getItem(STORAGE_KEYS.HAS_SEEN_WELCOME)).toBe("true");
+    // Straight to the calendar: the practice is for people who committed.
+    expect(localStorage.getItem(STORAGE_KEYS.HAS_SEEN_SHORTCUT_SHOWCASE)).toBe(
+      "true",
+    );
+    expect(
+      localStorage.getItem(STORAGE_KEYS.HAS_PENDING_SHOWCASE_OFFER),
+    ).toBeNull();
+  });
+
+  it("defers the practice offer to after signup", async () => {
+    const user = userEvent.setup();
+    render(<WelcomeModal />);
+
+    await user.click(screen.getByRole("button", { name: "Sign up" }));
+
+    expect(mockOpenModal).toHaveBeenCalledWith("signUp");
+    expect(localStorage.getItem(STORAGE_KEYS.HAS_PENDING_SHOWCASE_OFFER)).toBe(
+      "true",
+    );
+    expect(
+      localStorage.getItem(STORAGE_KEYS.HAS_SEEN_SHORTCUT_SHOWCASE),
+    ).not.toBe("true");
   });
 
   it("ignores KeyboardEvents with no key instead of throwing", () => {
@@ -251,7 +289,7 @@ describe("WelcomeModal", () => {
     expect(localStorage.getItem(STORAGE_KEYS.HAS_SEEN_WELCOME)).toBeNull();
   });
 
-  it("focuses the first control and keeps Tab inside the dialog", async () => {
+  it("focuses the sign up CTA and keeps Tab inside the dialog", async () => {
     const user = userEvent.setup();
 
     render(
@@ -261,6 +299,8 @@ describe("WelcomeModal", () => {
       </>,
     );
 
+    // Not the panel's first focusable (Log in): the primary action is signing
+    // up, so that is where focus lands.
     const signUp = screen.getByRole("button", { name: "Sign up" });
     expect(signUp).toHaveFocus();
 
@@ -269,9 +309,67 @@ describe("WelcomeModal", () => {
     expect(terms).toHaveFocus();
 
     await user.tab();
-    expect(signUp).toHaveFocus();
+    expect(screen.getByRole("button", { name: "Log in" })).toHaveFocus();
     expect(
       screen.getByRole("button", { name: "Outside calendar" }),
     ).not.toHaveFocus();
+  });
+
+  describe("with Google available", () => {
+    const startGoogleAuthorization = mock();
+
+    beforeEach(() => {
+      startGoogleAuthorization.mockClear();
+      registerUseStartGoogleAuthorizationForTests(() => ({
+        loading: false,
+        startGoogleAuthorization,
+      }));
+      resetGoogleAvailabilityForTests();
+      setGoogleAvailabilityForTests("available");
+    });
+
+    afterEach(() => {
+      resetUseStartGoogleAuthorizationForTests();
+      resetGoogleAvailabilityForTests();
+    });
+
+    it("leads with the Google round trip that also connects the calendar", () => {
+      render(<WelcomeModal />);
+
+      expect(
+        screen.getByRole("button", { name: "Continue with Google" }),
+      ).toBeTruthy();
+      expect(
+        screen.getByText(/Signs you up and connects your Google Calendar/),
+      ).toBeTruthy();
+      // Email signup steps aside to a clearly secondary label.
+      expect(
+        screen.getByRole("button", { name: "Sign up with email" }),
+      ).toBeTruthy();
+    });
+
+    it("starts Google auth from the button and queues the practice offer", async () => {
+      const user = userEvent.setup();
+      render(<WelcomeModal />);
+
+      await user.click(
+        screen.getByRole("button", { name: "Continue with Google" }),
+      );
+
+      expect(startGoogleAuthorization).toHaveBeenCalled();
+      expect(localStorage.getItem(STORAGE_KEYS.HAS_SEEN_WELCOME)).toBe("true");
+      expect(
+        localStorage.getItem(STORAGE_KEYS.HAS_PENDING_SHOWCASE_OFFER),
+      ).toBe("true");
+    });
+
+    it("starts Google auth with the G shortcut", async () => {
+      const user = userEvent.setup();
+      render(<WelcomeModal />);
+
+      await user.keyboard("g");
+
+      expect(startGoogleAuthorization).toHaveBeenCalled();
+    });
   });
 });

--- a/packages/web/src/components/WelcomeModal/WelcomeModal.test.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeModal.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen, within } from "@testing-library/react";
+import { act, cleanup, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createContext } from "react";
 import { dispatchMissingKey } from "@web/__tests__/utils/keyboard.test.util";
@@ -329,6 +329,11 @@ describe("WelcomeModal", () => {
     });
 
     afterEach(() => {
+      // Unmount before restoring the seams. resetGoogleAvailabilityForTests
+      // emits synchronously, so a still-mounted modal would re-render against
+      // the real hook after the mock had already rendered without one, and
+      // React would throw "Should have a queue" on the hook-count change.
+      cleanup();
       resetUseStartGoogleAuthorizationForTests();
       resetGoogleAvailabilityForTests();
     });

--- a/packages/web/src/components/WelcomeModal/WelcomeModal.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeModal.tsx
@@ -5,10 +5,13 @@ import {
 } from "@phosphor-icons/react";
 import { useContext, useEffect, useRef, useState } from "react";
 import { SessionContext } from "@web/auth/compass/session/session.context";
+import { useStartGoogleAuthorization } from "@web/auth/google/authorization/useStartGoogleAuthorization";
+import { useIsGoogleAvailable } from "@web/auth/google/hooks/useIsGoogleAvailable/useIsGoogleAvailable";
 import { track } from "@web/auth/posthog/track";
 import { MODAL_DISMISS_MS } from "@web/common/constants/motion.constants";
 import { SOCIAL_LINKS } from "@web/common/constants/social.constants";
 import { useDismissTransition } from "@web/common/hooks/useDismissTransition";
+import { GoogleButton } from "@web/components/AuthModal/components/GoogleButton";
 import { useAuthModal } from "@web/components/AuthModal/hooks/useAuthModal";
 import { OverlayPanel } from "@web/components/OverlayPanel/OverlayPanel";
 import { shortcutShowcaseActions } from "@web/components/ShortcutShowcase/showcase.store";
@@ -27,6 +30,9 @@ const SOCIAL_ICONS = {
 export function WelcomeModal() {
   const { authenticated } = useContext(SessionContext);
   const { openModal, isOpen: isAuthModalOpen } = useAuthModal();
+  const isGoogleAvailable = useIsGoogleAvailable();
+  const { loading: isGoogleAuthLoading, startGoogleAuthorization } =
+    useStartGoogleAuthorization({ intent: "signIn" });
   const [isOpen, setIsOpen] = useState(
     () => !authenticated && !hasSeenWelcome(),
   );
@@ -34,6 +40,10 @@ export function WelcomeModal() {
   // Suppress OverlayPanel's unmount restore when handing off to Auth — Auth
   // seats its own focus; restoring the underlay first causes a focus flash.
   const skipFocusRestoreRef = useRef(false);
+  // Seat focus on the email signup button rather than the panel's first
+  // focusable (now Log in) or the Google button: Enter on an OAuth redirect
+  // would fling a first-time visitor off-site before they read anything.
+  const signUpButtonRef = useRef<HTMLButtonElement>(null);
 
   // The auth modal's openness lives in the URL (?auth=), so the welcome
   // screen simply hides while it is open and reappears when the browser
@@ -55,29 +65,16 @@ export function WelcomeModal() {
 
   // Fade the backdrop and gently scale the panel before unmounting, so the
   // first reveal of the sidebar underneath feels smooth rather than abrupt.
-  const dismiss = (cta: "start_now" | "dismissed" = "dismissed") => {
+  const dismiss = (cta: "explore" | "dismissed" = "dismissed") => {
     if (closing) return;
     markWelcomeSeen();
-    // Backdrop / Escape never traps the user in this modal, but it also
-    // never dead-ends into a blank calendar: both paths start the showcase.
-    shortcutShowcaseActions.start(cta === "start_now" ? "start_now" : "escape");
+    // Exploring without an account lands straight on the calendar. The
+    // shortcut practice is an educational layer for people who have a real
+    // calendar to practice on, so it waits for signup (or the palette); the
+    // checklist teaches the same moves on the sample events meanwhile.
+    shortcutShowcaseActions.markSkippedWithoutStarting();
     track("welcome_modal_dismissed", { cta });
     beginDismiss(() => setIsOpen(false));
-  };
-
-  const handleShortcutKey = (e: React.KeyboardEvent) => {
-    if (e.metaKey || e.ctrlKey || e.altKey) return;
-    const key = keyboardKey(e).toLowerCase();
-    if (key === "u") {
-      e.preventDefault();
-      handOffToAuth("sign_up");
-    } else if (key === "i") {
-      e.preventDefault();
-      handOffToAuth("log_in");
-    } else if (key === "s") {
-      e.preventDefault();
-      dismiss("start_now");
-    }
   };
 
   const handOffToAuth = (cta: "log_in" | "sign_up") => {
@@ -93,12 +90,43 @@ export function WelcomeModal() {
     openModal(cta === "log_in" ? "login" : "signUp");
   };
 
+  // The shortest path to the thing that makes Compass worth keeping: one
+  // round trip that signs the user up and grants calendar access together,
+  // because the Google scopes Compass asks for include the calendar.
+  const handOffToGoogle = () => {
+    skipFocusRestoreRef.current = true;
+    markWelcomeSeen();
+    shortcutShowcaseActions.markSkippedWithoutStarting({ pendingSignup: true });
+    track("welcome_modal_dismissed", { cta: "sign_up_google" });
+    track("signup_started", { source: "welcome_modal_google" });
+    void startGoogleAuthorization();
+  };
+
+  const handleShortcutKey = (e: React.KeyboardEvent) => {
+    if (e.metaKey || e.ctrlKey || e.altKey) return;
+    const key = keyboardKey(e).toLowerCase();
+    if (key === "g" && isGoogleAvailable) {
+      e.preventDefault();
+      handOffToGoogle();
+    } else if (key === "u") {
+      e.preventDefault();
+      handOffToAuth("sign_up");
+    } else if (key === "i") {
+      e.preventDefault();
+      handOffToAuth("log_in");
+    } else if (key === "s") {
+      e.preventDefault();
+      dismiss("explore");
+    }
+  };
+
   return (
     <OverlayPanel
       align="start"
       ariaLabel="Welcome to Compass Calendar"
       backdropClassName="overflow-y-auto py-8"
       closing={closing}
+      initialFocusRef={signUpButtonRef}
       onDismiss={dismiss}
       skipFocusRestoreRef={skipFocusRestoreRef}
       widthClassName="w-120"
@@ -122,14 +150,6 @@ export function WelcomeModal() {
           <div className="flex shrink-0 items-center gap-2">
             <button
               type="button"
-              onClick={() => handOffToAuth("sign_up")}
-              className="c-button-compact c-button-primary rounded-3xl px-4 py-1.5 text-xs"
-            >
-              Sign up
-              <ShortcutHint className="ml-2">U</ShortcutHint>
-            </button>
-            <button
-              type="button"
               onClick={() => handOffToAuth("log_in")}
               className="c-button-compact c-button-secondary rounded-3xl px-4 py-1.5 text-xs"
             >
@@ -141,14 +161,40 @@ export function WelcomeModal() {
 
         <WelcomeGuideBody />
 
-        {/* CTA */}
-        <div className="flex justify-center">
+        {/* CTA: connecting a calendar is the moment Compass starts being
+            useful, so the Google round trip - which signs up and grants
+            calendar access at once - leads, and everything else is a fallback
+            from it. */}
+        <div className="flex w-full flex-col items-center gap-3">
+          {isGoogleAvailable && (
+            <>
+              <GoogleButton
+                onClick={handOffToGoogle}
+                disabled={isGoogleAuthLoading}
+                label="Continue with Google"
+                style={{ width: "100%" }}
+              />
+              <p className="text-center text-text-muted text-xs">
+                Signs you up and connects your Google Calendar.
+                <ShortcutHint className="ml-2">G</ShortcutHint>
+              </p>
+            </>
+          )}
           <button
             type="button"
-            onClick={() => dismiss("start_now")}
+            ref={signUpButtonRef}
+            onClick={() => handOffToAuth("sign_up")}
             className="c-button c-button-primary c-button-elevated inline-flex items-center rounded-full px-10"
           >
-            Start Now
+            {isGoogleAvailable ? "Sign up with email" : "Sign up"}
+            <ShortcutHint className="ml-2">U</ShortcutHint>
+          </button>
+          <button
+            type="button"
+            onClick={() => dismiss("explore")}
+            className="c-focus-ring inline-flex items-center rounded-md px-2 py-1 text-text-muted text-xs hover:bg-surface-overlay hover:text-text"
+          >
+            Explore without an account
             <ShortcutHint className="ml-2">S</ShortcutHint>
           </button>
         </div>

--- a/packages/web/src/shortcuts/keymap.test.ts
+++ b/packages/web/src/shortcuts/keymap.test.ts
@@ -73,27 +73,8 @@ describe("keymap ↔ showcase hint parity", () => {
   it("showcase hints reference the keymap's keycaps, not copies", () => {
     expect(getShowcaseStep("create").keycaps).toBe(KEYMAP.createEvent.keycaps);
     expect(getShowcaseStep("save").keycaps).toBe(KEYMAP.saveDraft.keycaps);
-    expect(getShowcaseStep("moveFocus").keycaps).toBe(KEYMAP.moveFocus.keycaps);
-    expect(getShowcaseStep("editTitle").keycaps).toBe(KEYMAP.editTitle.keycaps);
-    expect(getShowcaseStep("eventJump").keycaps).toBe(KEYMAP.eventJump.keycaps);
-    expect(getShowcaseStep("moveEvent").keycaps).toBe(KEYMAP.moveEvent.keycaps);
-    expect(getShowcaseStep("resizeEdge").keycaps).toBe(
-      KEYMAP.edgeFocus.keycaps,
-    );
-    expect(getShowcaseStep("placeDraft").keycaps).toBe(
-      KEYMAP.moveEvent.keycaps,
-    );
-    expect(getShowcaseStep("hardcore").keycaps).toBe(KEYMAP.hardcore.keycaps);
-
-    const undoRedoBody = getShowcaseStep("undoRedo").body;
-    expect(Array.isArray(undoRedoBody)).toBe(true);
-    const undoRedoChords = (
-      undoRedoBody as readonly { keys?: readonly string[] }[]
-    )
-      .filter((part) => typeof part !== "string" && "keys" in part)
-      .map((part) => part.keys);
-    expect(undoRedoChords[0]).toBe(KEYMAP.undo.keycaps);
-    expect(undoRedoChords[1]).toBe(KEYMAP.redo.keycaps);
+    // graduation is the exit, not a lesson, so it hints no chord.
+    expect(getShowcaseStep("graduation").keycaps).toBeUndefined();
   });
 });
 

--- a/packages/web/src/views/GoogleAuthCallback/GoogleAuthCallback.tsx
+++ b/packages/web/src/views/GoogleAuthCallback/GoogleAuthCallback.tsx
@@ -31,6 +31,12 @@ export async function completeGoogleAuthCallback({
     showErrorToast(result.message);
   } else if (result.isNewUser) {
     track("signup_completed", { method: "google" });
+    // completeGoogleAuthorization only reports "completed" once Google granted
+    // every required scope, calendar included, so signing up with Google *is*
+    // the connect. Only the sync service's redirect-after-connect used to fire
+    // this, which is why activation looked like it barely happened: the path
+    // most new users actually take never reported it.
+    track("calendar_connected", { source: "signup_google" });
     shortcutShowcaseActions.offerAfterSignupIfPending();
   } else {
     track("login_completed", { method: "google" });


### PR DESCRIPTION
## Summary

Two PostHog findings, one root system: the Shortcut Showcase.

**The Aug 14 spike was not a broken element.** 216 dead clicks and 51 rage clicks landed that day against a 4–61 / 0–6 baseline, but 72 distinct users were on the site instead of the usual 2–6. Every dead-clicked control fired its handler in the same millisecond — each `$dead_click` on `Do it for me` sits beside an `$autocapture` **and** a `shortcut_showcase_assist_used` + `shortcut_showcase_step_completed` for the step it just advanced. Nothing froze, no deploy in the Aug 12–14 window broke a listener, and there was no error spike (10 `$exception` events from 2 users).

Two separate things produced the numbers:

**1. posthog-js mis-scores synchronous React re-renders.** It timestamps a click in a bubble-phase `window` listener. React reaches its own root listener first, flushes the update synchronously (clicks are discrete events), and the MutationObserver microtask feeding `_lastMutation` runs before the event finishes bubbling. The click's own re-render is therefore recorded 1–7 ms *before* the timestamp it is compared against, `mutation_delay_ms` comes back undefined, and 2750 ms later the absolute timeout fires. Anything that keeps mutating afterwards rescues the click; the welcome FAQ and the showcase go completely quiet, so they never do. Reproduced in Chromium against the real app — the mutation lands at `click.timestamp` ±1 ms, making it a coin flip on a 1 ms clock.

The delta is bimodal in production, which is what makes the filter safe:

| `click_ts − last_mutation` | events |
|---|---|
| 1–7 ms (the inversion) | 115 |
| 20 ms – 30 s (genuine) | the rest |

`before_send` now drops exactly that shape — no mutation credited to the gesture, yet the last mutation landed within 50 ms *before* it. `$rageclick` is deliberately untouched: repeated clicking is real frustration whatever the DOM did. Reported upstream to PostHog, along with a second finding: `_lastVisibilityChange` is never cleared, so after one tab refocus the visibility check votes "dead" on every subsequent click for the life of the page (67 more of that day's events).

**2. The showcase invited the mashing.** Eleven steps, one primary button that never moved or changed label. 23 users rage-clicked `Do it for me`; ~40% of the users on *every* step pressed the button instead of the key. Over 30 days it also lost 40% of the people who cleared step one:

| Step | Users completing |
|---|---|
| create | 113 |
| save | 99 |
| moveFocus → hardcore | 96 → 68 |

…while `OnboardingChecklist` re-taught jump, move, stretch, place and undo on real events anyway.

### Option C + A — the practice is two lessons with a real exit

The showcase gates its exit on the one loop nothing else covers — `C` to create, type, `Enter` to save. Every step offers **Skip to sign up** (straight into the signup form) and **Skip to calendar**; Escape does the latter. The "Skip the shortcuts? Without them, it's just another calendar app" confirm is gone — 16 dead clicks landed on its `Skip anyway`, and the flow it guarded matters more than two lessons. The practice arena still answers every shortcut it ever did; those are simply no longer conditions of leaving.

### Option B — signup and calendar connect come first

The welcome CTA order is now **Continue with Google** (`G`), **Sign up with email** (`U`), **Explore without an account** (`S`). Google leads because the scopes Compass already requests include `calendar.readonly` and `calendar.events`, so that one round trip signs the user up *and* connects the calendar — the activation moment, one click from the first screen, instead of buried behind a modal. Focus seats on the email button rather than the Google one on purpose: Enter on an OAuth redirect would fling a first-time visitor off-site before they read anything.

Exploring without an account lands straight on the calendar. The showcase now has exactly two entries — post-signup (via the pending-offer machinery every signup route primes) and the palette's "Practice shortcuts" — so `start()` and its `start_now`/`escape` entries are gone from the store. "Skip to sign up" hides for anyone already signed in, since that is now who the practice is for.

**`calendar_connected` was under-reporting, not just low.** It only ever fired from the sync service's add-account redirect. Signing up with Google never emitted it, even though `completeGoogleAuthorization` refuses to complete unless Google granted the calendar scopes. In the last 30 days that is **6 of 9 Google signups with no activation event at all**, and the 3 that have one got it from a separate Settings reconnect. Both call sites now fire with a `source` (`signup_google` / `connect_redirect`) so they stay distinguishable.

On the `<10/day` goal: that target conflates rate with volume. Per active user, Aug 14 was already the *lowest* dead-click day in the window (3.0/user vs 30/user on Aug 5); the filter takes it to 1.4/user, which is single digits at baseline traffic. What survives is mostly genuine — people clicking the practice calendar's event blocks and keycaps, which are keyboard-only by design and which a 2-step showcase puts in front of them for seconds rather than minutes.

Events kept intact: `welcome_modal_shown`, `shortcut_showcase_started`, `shortcut_showcase_finished`, `shortcut_showcase_skipped` (now carrying `exit: "calendar" | "signup"`), `checklist_item_completed`, `signup_completed`, `calendar_connected`.

**Known edge, unchanged in shape but now on the primary path:** abandoning the Google consent screen returns to the calendar with no checklist, because the pending offer leaves the practice unseen. The old "Sign up" pill behaved the same way. Detecting abandonment properly is the real fix; the cheap alternatives all risk floating the checklist over an open auth modal.

## Simplicity

Removing eight lessons removed the per-step board staging (`focusFallback`/`setEdge`/`clearFocus` seeding), the two-phase stretch hint, and every `currentStepId === "…" && advance()` branch in the keydown handler. Removing the skip confirm removed two store fields, two actions, a selector, and a whole branch of the render tree. Option B removed `start()` and narrowed the entry union to what actually exists. The `e→t` chord now seats its own focus instead of relying on a lesson to do it, so free practice works on a cold board.

The dead-click filter is one pure function with no state, composed into `before_send` via posthog's array form rather than wrapped around the existing exception filter.

## Automated validation

Reproduced the root cause in a real browser before writing any fix: a probe replicating posthog-js's exact ordering (MutationObserver on `document.body`, bubble-phase `window` click listener, both stamping `Date.now()`) against the running app.

| Button | mutation vs click timestamp | posthog verdict |
|---|---|---|
| `Start Now` | −1 ms | **dead** |
| `Do it for me` | 0 ms | alive |
| `Skip` | 0 ms | alive (0 further mutations in 2.75 s) |
| `Who is Compass for?` | 0 ms | alive |

The probe files were removed once the mechanism was confirmed.

Modelled the filter against 18 days of production `$dead_click` events before shipping it: 115 of 216 Aug 14 events match the inversion signature; the surviving 101 are grid background, practice event blocks and keycaps — real dead clicks, correctly kept.

## Independent review

Self-reviewed the diff for the failure modes that matter here:

- **Filter over-reach** — narrowed the predicate twice after checking real data. Requires `mutation_delay_ms` absent *and* the lead within 50 ms; the nearest genuine dead click in the window sits at 79 ms.
- **Removed a mouse escape hatch** — a first draft replaced `Skip` with `Skip to sign up` only, stranding mouse users who don't want an account. Restored as `Skip to calendar`.
- **A signup exit shown to signed-up users** — Option B makes post-signup the main entry, so `Skip to sign up` would have opened a signup modal for someone who just signed up. Gated on session state.
- **Stale checklist gate (caught by e2e, not unit tests)** — the checklist reads the seen flag from `localStorage`, which notifies nobody; the showcase's store transition happened to force the re-render. With no showcase in the way that re-render never came, so the card stayed hidden for anyone who skipped straight past. The store now carries a `seenRevision` the checklist subscribes to, with storage still the source of truth.
- **Hook-count crash in the test seams (caught by CI, not by me)** — the WelcomeModal Google tests reset `useStartGoogleAuthorization` while a modal was still mounted, so the next synchronous emit re-rendered it against the real three-hook implementation right after a zero-hook mock. React threw "Should have a queue" three times. Bun counts those as *errors*, separately from failures, and exits non-zero — but the summary still reads "0 fail", which is how it survived a local check. Fixed by unmounting first; `bun test:web` now exits 0, verified by exit code rather than by reading the summary line.
- **Dead code from the narrowed union** — `STRETCH_KEYCAPS` and the unreachable `graduation` case in `doItForMe` removed; `knip`-visible exports checked.

## Test plan

```
bun test:web        # 2269 pass, 0 fail, 0 errors, exit 0
bun run type-check  # clean
bun run lint        # clean (10 pre-existing warnings, none in changed files)
bunx playwright test --workers=1   # 32 passed, 1 container-only failure
```

The single local e2e failure is `oauth/google-auth-callback.spec.ts`: `[role="status"][aria-live="polite"]` matches two sidebar spans once the callback has navigated to `/week`, so the assertion races the navigation. It reproduces identically on `origin/main` and **passes on CI**, so it is a pre-existing race that only loses on this slow container — left alone rather than widening this PR.

That container also needs `timeout: 120_000` and `executablePath: /opt/pw-browsers/chromium` locally; every onboarding spec sits near the repo's 30 s budget, including specs this branch barely touches. CI's own e2e job is green.