### PR TITLE
feat(web): scroll the timed grid with PageUp and PageDown

### DIFF
--- a/docs/acceptance/shortcuts.md
+++ b/docs/acceptance/shortcuts.md
@@ -16,6 +16,7 @@ Use this guide to validate:
 - navigating between views with the keyboard (D, W)
 - navigating between days in Day view (J, K, T)
 - navigating between weeks in Week view (J, K, T)
+- scrolling the timed grid with PageUp / PageDown, including while an event is focused
 - opening and using the command palette (Cmd+K), including undo/redo rows
 - creating events with keyboard shortcuts (C, A in both Day and Week view)
 - editing events with the same keys in Day and Week (Delete, Shift+arrows, draft arrows)
@@ -59,6 +60,7 @@ Helpful notes:
 | `J`                         | Day view  | Previous day                      |
 | `K`                         | Day view  | Next day                          |
 | `T`                         | Day view  | Go to today                       |
+| `PageUp` / `PageDown`       | Day view  | Scroll the timed grid up/down     |
 | `I`                         | Day view  | Focus sidebar                     |
 | `U`                         | Day view  | Focus first calendar event        |
 | `S`                         | Day view  | Toggle event jump keys            |
@@ -82,6 +84,7 @@ Helpful notes:
 | `J`                         | Week view | Previous week                     |
 | `K`                         | Week view | Next week                         |
 | `T`                         | Week view | Go to today                       |
+| `PageUp` / `PageDown`       | Week view | Scroll the timed grid up/down     |
 | `C`                         | Week view | Create timed event                |
 | `A`                         | Week view | Create all-day event              |
 | `I`                         | Week view | Focus sidebar                     |
@@ -412,6 +415,27 @@ All view-navigation and action shortcuts are suppressed when the user is focused
 
 ---
 
+## Scenario 15: Scroll The Timed Grid With PageUp / PageDown
+
+### UX
+
+PageUp and PageDown always scroll the timed grid by one viewport, even when focus is on an event card, the sidebar, or another control. Arrow keys still move event focus; J/K still change the visible day or week. The shortcuts do not fire while typing in an input.
+
+### Steps
+
+1. Navigate to `/week` (or `/day`).
+2. Click an event so it is focused.
+3. Press PageDown, then PageUp.
+4. Open an event form, focus the title, and press PageDown.
+
+### Expected Results
+
+- PageDown moves the timed grid later in the day; PageUp moves it earlier.
+- The focused event does not change solely because of PageUp / PageDown.
+- PageDown does nothing while the title input is focused.
+
+---
+
 ## Focused Regression Checks
 
 If time is limited, run these checks before shipping shortcut-related changes:
@@ -432,3 +456,4 @@ If time is limited, run these checks before shipping shortcut-related changes:
 14. With a focused event, `E` then `T` opens the form with the title focused; `E` then `A` / `C` jump to account / color; bare `E` alone does nothing.
 15. Pressing `S` shows event jump chips; a day letter + digit focuses that event; Shift+Tab does not show chips.
 16. `H` enters Hardcore Mode (clicks blocked, indicator visible); Esc or another `H` exits. Shift-Shift does not.
+17. PageUp / PageDown scroll the timed grid in Day and Week view even when an event is focused; they do not fire in a text input.

--- a/packages/web/src/grid/shortcuts/scroll-timed-grid.test.ts
+++ b/packages/web/src/grid/shortcuts/scroll-timed-grid.test.ts
@@ -1,0 +1,28 @@
+import { ID_GRID_MAIN } from "@web/common/constants/web.constants";
+import { scrollTimedGridByPage } from "@web/grid/shortcuts/scroll-timed-grid";
+import { afterEach, describe, expect, it, mock } from "bun:test";
+
+describe("scrollTimedGridByPage", () => {
+  afterEach(() => {
+    document.getElementById(ID_GRID_MAIN)?.remove();
+  });
+
+  it("scrolls the timed grid by one viewport in the requested direction", () => {
+    const grid = document.createElement("section");
+    grid.id = ID_GRID_MAIN;
+    Object.defineProperty(grid, "clientHeight", { value: 400 });
+    const scrollBy = mock();
+    grid.scrollBy = scrollBy as typeof grid.scrollBy;
+    document.body.append(grid);
+
+    expect(scrollTimedGridByPage("down")).toBe(true);
+    expect(scrollBy).toHaveBeenCalledWith({ top: 400 });
+
+    expect(scrollTimedGridByPage("up")).toBe(true);
+    expect(scrollBy).toHaveBeenCalledWith({ top: -400 });
+  });
+
+  it("no-ops when the timed grid is not in the document", () => {
+    expect(scrollTimedGridByPage("down")).toBe(false);
+  });
+});

--- a/packages/web/src/grid/shortcuts/scroll-timed-grid.ts
+++ b/packages/web/src/grid/shortcuts/scroll-timed-grid.ts
@@ -1,0 +1,22 @@
+import { ID_GRID_MAIN } from "@web/common/constants/web.constants";
+import { getElemById } from "@web/common/utils/grid/grid.util";
+
+export type TimedGridScrollDirection = "up" | "down";
+
+/**
+ * Pages the timed grid scroller by one viewport. Returns whether a grid
+ * was found so callers can preventDefault only when the shortcut actually
+ * applied.
+ */
+export const scrollTimedGridByPage = (
+  direction: TimedGridScrollDirection,
+): boolean => {
+  const grid = getElemById(ID_GRID_MAIN);
+  if (!grid) return false;
+
+  const delta = grid.clientHeight;
+  if (delta <= 0) return false;
+
+  grid.scrollBy({ top: direction === "down" ? delta : -delta });
+  return true;
+};

--- a/packages/web/src/grid/shortcuts/useGridScrollShortcuts.test.tsx
+++ b/packages/web/src/grid/shortcuts/useGridScrollShortcuts.test.tsx
@@ -1,0 +1,71 @@
+import { HotkeyManager, HotkeysProvider } from "@tanstack/react-hotkeys";
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import { type PropsWithChildren } from "react";
+import { pressKey } from "@web/__tests__/utils/keyboard.test.util";
+import { ID_GRID_MAIN } from "@web/common/constants/web.constants";
+import { useGridScrollShortcuts } from "@web/grid/shortcuts/useGridScrollShortcuts";
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+
+const wrapper = ({ children }: PropsWithChildren) => (
+  <HotkeysProvider>{children}</HotkeysProvider>
+);
+
+describe("useGridScrollShortcuts", () => {
+  let scrollBy: ReturnType<typeof mock>;
+
+  beforeEach(() => {
+    HotkeyManager.resetInstance();
+    const grid = document.createElement("section");
+    grid.id = ID_GRID_MAIN;
+    Object.defineProperty(grid, "clientHeight", { value: 500 });
+    scrollBy = mock();
+    grid.scrollBy = scrollBy as typeof grid.scrollBy;
+    document.body.append(grid);
+  });
+
+  afterEach(() => {
+    cleanup();
+    document.getElementById(ID_GRID_MAIN)?.remove();
+    document.body.innerHTML = "";
+  });
+
+  it("pages the grid with PageDown and PageUp from document focus", async () => {
+    renderHook(() => useGridScrollShortcuts(), { wrapper });
+
+    pressKey("PageDown");
+    await waitFor(() => {
+      expect(scrollBy).toHaveBeenCalledWith({ top: 500 });
+    });
+
+    pressKey("PageUp");
+    await waitFor(() => {
+      expect(scrollBy).toHaveBeenCalledWith({ top: -500 });
+    });
+  });
+
+  it("pages the grid when an event-like control is focused", async () => {
+    const button = document.createElement("button");
+    button.textContent = "Standup";
+    document.body.append(button);
+    button.focus();
+
+    renderHook(() => useGridScrollShortcuts(), { wrapper });
+    pressKey("PageDown", {}, button);
+
+    await waitFor(() => {
+      expect(scrollBy).toHaveBeenCalledWith({ top: 500 });
+    });
+  });
+
+  it("does not scroll while typing in an input", async () => {
+    const input = document.createElement("input");
+    document.body.append(input);
+    input.focus();
+
+    renderHook(() => useGridScrollShortcuts(), { wrapper });
+    pressKey("PageDown", {}, input);
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(scrollBy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/grid/shortcuts/useGridScrollShortcuts.ts
+++ b/packages/web/src/grid/shortcuts/useGridScrollShortcuts.ts
@@ -1,0 +1,26 @@
+import { scrollTimedGridByPage } from "@web/grid/shortcuts/scroll-timed-grid";
+import { useAppShortcut } from "@web/shortcuts/useAppShortcut";
+
+const scrollGridFromShortcut = (
+  direction: "up" | "down",
+  event: KeyboardEvent,
+) => {
+  if (!scrollTimedGridByPage(direction)) return;
+
+  event.preventDefault();
+  event.stopPropagation();
+};
+
+/**
+ * PageUp / PageDown always scroll the timed grid, even when focus is on an
+ * event card or another non-grid control. Arrow keys stay reserved for
+ * event focus; J/K stay reserved for day/week navigation.
+ */
+export function useGridScrollShortcuts() {
+  useAppShortcut("PageUp", (event) => {
+    scrollGridFromShortcut("up", event);
+  });
+  useAppShortcut("PageDown", (event) => {
+    scrollGridFromShortcut("down", event);
+  });
+}

--- a/packages/web/src/shortcuts/data/shortcuts.data.test.ts
+++ b/packages/web/src/shortcuts/data/shortcuts.data.test.ts
@@ -75,6 +75,37 @@ describe("shortcuts.data", () => {
       ]);
     });
 
+    it("lists PageUp/PageDown grid scroll in day and week, not life", () => {
+      for (const view of ["day", "week"] as const) {
+        const [navigate] = getShortcutMenuSections({
+          view,
+          isViewingCurrentPeriod: true,
+        });
+
+        expect(stripMetadata(navigate.shortcuts)).toContainEqual({
+          keys: ["PageUp"],
+          label: "Scroll grid up",
+        });
+        expect(stripMetadata(navigate.shortcuts)).toContainEqual({
+          keys: ["PageDown"],
+          label: "Scroll grid down",
+        });
+      }
+
+      const [lifeNavigate] = getShortcutMenuSections({
+        view: "life",
+        isViewingCurrentPeriod: true,
+      });
+      expect(stripMetadata(lifeNavigate.shortcuts)).not.toContainEqual({
+        keys: ["PageUp"],
+        label: "Scroll grid up",
+      });
+      expect(stripMetadata(lifeNavigate.shortcuts)).not.toContainEqual({
+        keys: ["PageDown"],
+        label: "Scroll grid down",
+      });
+    });
+
     it("lists the Up Next shortcuts in both views", () => {
       for (const view of ["day", "week"] as const) {
         const [navigate] = getShortcutMenuSections({

--- a/packages/web/src/shortcuts/shortcuts.registry.ts
+++ b/packages/web/src/shortcuts/shortcuts.registry.ts
@@ -79,6 +79,18 @@ export const SHORTCUTS_REGISTRY: Shortcut[] = [
     label: "Go to today",
     section: "navigate",
   },
+  {
+    id: "nav-scroll-up",
+    keys: ["PageUp"],
+    label: "Scroll grid up",
+    section: "navigate",
+  },
+  {
+    id: "nav-scroll-down",
+    keys: ["PageDown"],
+    label: "Scroll grid down",
+    section: "navigate",
+  },
 
   // Navigate - View switchers (all views)
   {

--- a/packages/web/src/views/Day/hooks/shortcuts/useDayViewShortcuts.ts
+++ b/packages/web/src/views/Day/hooks/shortcuts/useDayViewShortcuts.ts
@@ -1,3 +1,4 @@
+import { useGridScrollShortcuts } from "@web/grid/shortcuts/useGridScrollShortcuts";
 import { KEYMAP } from "@web/shortcuts/keymap";
 import { useAppShortcutUp } from "@web/shortcuts/useAppShortcut";
 
@@ -21,6 +22,7 @@ interface KeyboardShortcutsConfig {
  * Mirrors the Week view's create/focus semantics: "c" creates a timed event,
  * "a" an all-day event, "u" the calendar. "i" (focus sidebar) is registered
  * separately via useFocusSidebarShortcut, shared with Week.
+ * PageUp/PageDown scroll the timed grid via `useGridScrollShortcuts`.
  */
 export function useDayViewShortcuts(config: KeyboardShortcutsConfig) {
   const {
@@ -31,6 +33,8 @@ export function useDayViewShortcuts(config: KeyboardShortcutsConfig) {
     onPrevDay,
     onGoToToday,
   } = config;
+
+  useGridScrollShortcuts();
 
   useAppShortcutUp("J", () => {
     onPrevDay?.();

--- a/packages/web/src/views/Week/hooks/shortcuts/useWeekViewShortcuts.ts
+++ b/packages/web/src/views/Week/hooks/shortcuts/useWeekViewShortcuts.ts
@@ -1,3 +1,4 @@
+import { useGridScrollShortcuts } from "@web/grid/shortcuts/useGridScrollShortcuts";
 import { KEYMAP } from "@web/shortcuts/keymap";
 import { useAppShortcutUp } from "@web/shortcuts/useAppShortcut";
 
@@ -15,6 +16,7 @@ export interface WeekViewShortcutsConfig {
 /**
  * Registers Week view keyboard shortcuts only. Behavior lives in the owner
  * (see `useWeekShortcutOwner`), matching Day's thin callback boundary.
+ * PageUp/PageDown scroll the timed grid via `useGridScrollShortcuts`.
  */
 export function useWeekViewShortcuts(config: WeekViewShortcutsConfig) {
   const {
@@ -27,6 +29,8 @@ export function useWeekViewShortcuts(config: WeekViewShortcutsConfig) {
     onCreateTimedDraft,
     onFocusCalendar,
   } = config;
+
+  useGridScrollShortcuts();
 
   useAppShortcutUp("J", () => {
     onPreviousWeek?.();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Users can page the timed grid from the keyboard even when focus is on an event card or another control.

**Shortcut:** `PageUp` / `PageDown`

Arrows already move event focus, and `J`/`K` already change the visible day or week, so paging keys are the least conflicting mapping. The handler always targets `#mainGrid` (one viewport per press) and is ignored while typing in an input.

## Simplicity

One shared `useGridScrollShortcuts` hook is mounted from the existing Day and Week shortcut owners. No new letter keys, keymap/showcase changes, extra scroll plumbing, or new React state/effects. Independent simplify pass found nothing to extract or inline without losing the util/hook test split.

## Automated validation

- `bun test:web`: 2262 pass, 0 fail
- Focused: `scroll-timed-grid`, `useGridScrollShortcuts`, `shortcuts.data` — 21 pass
- `bun run lint`: clean for this diff (pre-existing warnings only)
- CI on this PR: Test (lint, knip, type-check, unit core/web/backend/sync/scripts, e2e) and CodeQL succeeded

Browser: with a focused timed event, PageDown/PageUp moved the hour labels later/earlier in the day; the event stayed focused. Legend lists “Scroll grid up/down”.

## Independent review

Fresh read-only review of `origin/main...HEAD`: no confirmed defects. Residual (not defects): PageUp/PageDown on non-input widgets (open listboxes) also page the grid; full-viewport `scrollBy` has no native overlap strip; TanStack default preventDefault already cancels the key.

## Test plan

- `bun test:web -- packages/web/src/grid/shortcuts/scroll-timed-grid.test.ts packages/web/src/grid/shortcuts/useGridScrollShortcuts.test.tsx packages/web/src/shortcuts/data/shortcuts.data.test.ts`
- `bun test:web`
- `bun run lint`
- Manual week-view PageUp/PageDown with a focused event

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fd99189a-47c6-4065-a50a-6220fe9a966b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fd99189a-47c6-4065-a50a-6220fe9a966b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

