### PR TITLE
fix(web): discard unused keyboard-place drafts on escape

### DIFF
--- a/packages/web/src/components/Sidebar/SidebarStatusBar.test.tsx
+++ b/packages/web/src/components/Sidebar/SidebarStatusBar.test.tsx
@@ -5,9 +5,30 @@ import { createStoreWrapper } from "@web/__tests__/render-with-store";
 import { seedPendingEventMutations } from "@web/__tests__/utils/event-query-test-data";
 import { createMockConnection } from "@web/__tests__/utils/factories/calendar.factory";
 import { type GoogleUiState } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle.types";
+import {
+  createGridEventDraft,
+  timedGridSchedule,
+} from "@web/events/grid-event-draft.adapter";
+import { draftActions } from "@web/events/stores/draft.store";
+import {
+  edgeFocusActions,
+  initialEdgeFocusState,
+  useEdgeFocusStore,
+} from "@web/grid/shortcuts/edge-focus.store";
 import { settingsActions } from "@web/settings/settings.store";
 import {
+  initialKeyboardOnlyState,
+  keyboardOnlyActions,
+  useKeyboardOnlyStore,
+} from "@web/shortcuts/keyboard-only/keyboard-only.store";
+import {
+  eventJumpActions,
+  initialEventJumpState,
+  useEventJumpStore,
+} from "@web/shortcuts/shift-hint/event-jump.store";
+import {
   afterAll,
+  afterEach,
   beforeEach,
   describe,
   expect,
@@ -74,6 +95,17 @@ describe("SidebarStatusBar", () => {
     isConnecting = false;
     connection = null;
     isSseDegraded = false;
+    draftActions.discard();
+    useKeyboardOnlyStore.setState(initialKeyboardOnlyState, true);
+    useEventJumpStore.setState(initialEventJumpState, true);
+    useEdgeFocusStore.setState(initialEdgeFocusState, true);
+  });
+
+  afterEach(() => {
+    draftActions.discard();
+    useKeyboardOnlyStore.setState(initialKeyboardOnlyState, true);
+    useEventJumpStore.setState(initialEventJumpState, true);
+    useEdgeFocusStore.setState(initialEdgeFocusState, true);
   });
 
   it("shows 'Saving changes…' when a mutation is pending", () => {
@@ -267,5 +299,111 @@ describe("SidebarStatusBar", () => {
     render(<SidebarStatusBar />, { wrapper });
 
     expect(screen.getByRole("status")).toHaveTextContent("Saving changes…");
+  });
+
+  it("shows Enter to open and Esc to discard while a form-closed keyboardPlace draft exists", () => {
+    draftActions.startGridDraft({
+      activity: "keyboardPlace",
+      draft: createGridEventDraft(
+        timedGridSchedule(
+          new Date("2026-05-20T09:00:00.000"),
+          new Date("2026-05-20T10:00:00.000"),
+        ),
+      ),
+    });
+    const { wrapper } = createStoreWrapper();
+
+    render(<SidebarStatusBar />, { wrapper });
+
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Enter to open · Esc to discard",
+    );
+  });
+
+  it("hides the keyboardPlace hint once the form is open", () => {
+    draftActions.startGridDraft({
+      activity: "keyboardPlace",
+      draft: createGridEventDraft(
+        timedGridSchedule(
+          new Date("2026-05-20T09:00:00.000"),
+          new Date("2026-05-20T10:00:00.000"),
+        ),
+      ),
+    });
+    draftActions.setFormOpen(true);
+    const { wrapper } = createStoreWrapper();
+
+    render(<SidebarStatusBar />, { wrapper });
+
+    expect(
+      screen.queryByText("Enter to open · Esc to discard"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("yields the keyboardPlace hint to Hardcore Mode", () => {
+    draftActions.startGridDraft({
+      activity: "keyboardPlace",
+      draft: createGridEventDraft(
+        timedGridSchedule(
+          new Date("2026-05-20T09:00:00.000"),
+          new Date("2026-05-20T10:00:00.000"),
+        ),
+      ),
+    });
+    keyboardOnlyActions.enter();
+    const { wrapper } = createStoreWrapper();
+
+    render(<SidebarStatusBar />, { wrapper });
+
+    expect(screen.getByRole("status")).toHaveTextContent("Hardcore Mode · Esc");
+    expect(
+      screen.queryByText("Enter to open · Esc to discard"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("yields the keyboardPlace hint to event jump", () => {
+    draftActions.startGridDraft({
+      activity: "keyboardPlace",
+      draft: createGridEventDraft(
+        timedGridSchedule(
+          new Date("2026-05-20T09:00:00.000"),
+          new Date("2026-05-20T10:00:00.000"),
+        ),
+      ),
+    });
+    eventJumpActions.setActive(true);
+    const { wrapper } = createStoreWrapper();
+
+    render(<SidebarStatusBar />, { wrapper });
+
+    expect(screen.getByRole("status")).toHaveTextContent("Event jump · Esc");
+    expect(
+      screen.queryByText("Enter to open · Esc to discard"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("yields the keyboardPlace hint to edge focus", () => {
+    draftActions.startGridDraft({
+      activity: "keyboardPlace",
+      draft: createGridEventDraft(
+        timedGridSchedule(
+          new Date("2026-05-20T09:00:00.000"),
+          new Date("2026-05-20T10:00:00.000"),
+        ),
+      ),
+    });
+    edgeFocusActions.setEdge(
+      "aaaaaaaaaaaaaaaaaaaaaaaa",
+      "startDate",
+      "Editing start time",
+    );
+    const { wrapper } = createStoreWrapper();
+
+    render(<SidebarStatusBar />, { wrapper });
+
+    expect(screen.getByRole("status")).toHaveTextContent("Editing start time");
+    expect(
+      screen.queryByText("Enter to open · Esc to discard"),
+    ).not.toBeInTheDocument();
   });
 });

--- a/packages/web/src/components/Sidebar/SidebarStatusBar.test.tsx
+++ b/packages/web/src/components/Sidebar/SidebarStatusBar.test.tsx
@@ -15,6 +15,7 @@ import {
   initialEdgeFocusState,
   useEdgeFocusStore,
 } from "@web/grid/shortcuts/edge-focus.store";
+import { KEYBOARD_PLACE_HINT_PARTS } from "@web/grid/shortcuts/KeyboardPlaceIndicator";
 import { settingsActions } from "@web/settings/settings.store";
 import {
   initialKeyboardOnlyState,
@@ -26,6 +27,7 @@ import {
   initialEventJumpState,
   useEventJumpStore,
 } from "@web/shortcuts/shift-hint/event-jump.store";
+import { getPartsPlainText } from "@web/shortcuts/tips/shortcut-tips.data";
 import {
   afterAll,
   afterEach,
@@ -88,6 +90,20 @@ const statusBarModuleUrl = new URL(
 const { SidebarStatusBar } = (await import(
   statusBarModuleUrl.href
 )) as typeof import("./SidebarStatusBar");
+
+const seedKeyboardPlaceDraft = () => {
+  draftActions.startGridDraft({
+    activity: "keyboardPlace",
+    draft: createGridEventDraft(
+      timedGridSchedule(
+        new Date("2026-05-20T09:00:00.000"),
+        new Date("2026-05-20T10:00:00.000"),
+      ),
+    ),
+  });
+};
+
+const KEYBOARD_PLACE_HINT = getPartsPlainText(KEYBOARD_PLACE_HINT_PARTS);
 
 describe("SidebarStatusBar", () => {
   beforeEach(() => {
@@ -302,96 +318,48 @@ describe("SidebarStatusBar", () => {
   });
 
   it("shows Enter to open and Esc to discard while a form-closed keyboardPlace draft exists", () => {
-    draftActions.startGridDraft({
-      activity: "keyboardPlace",
-      draft: createGridEventDraft(
-        timedGridSchedule(
-          new Date("2026-05-20T09:00:00.000"),
-          new Date("2026-05-20T10:00:00.000"),
-        ),
-      ),
-    });
+    seedKeyboardPlaceDraft();
     const { wrapper } = createStoreWrapper();
 
     render(<SidebarStatusBar />, { wrapper });
 
-    expect(screen.getByRole("status")).toHaveTextContent(
-      "Enter to open · Esc to discard",
-    );
+    expect(screen.getByRole("status")).toHaveTextContent(KEYBOARD_PLACE_HINT);
   });
 
   it("hides the keyboardPlace hint once the form is open", () => {
-    draftActions.startGridDraft({
-      activity: "keyboardPlace",
-      draft: createGridEventDraft(
-        timedGridSchedule(
-          new Date("2026-05-20T09:00:00.000"),
-          new Date("2026-05-20T10:00:00.000"),
-        ),
-      ),
-    });
+    seedKeyboardPlaceDraft();
     draftActions.setFormOpen(true);
     const { wrapper } = createStoreWrapper();
 
     render(<SidebarStatusBar />, { wrapper });
 
-    expect(
-      screen.queryByText("Enter to open · Esc to discard"),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText(KEYBOARD_PLACE_HINT)).not.toBeInTheDocument();
   });
 
   it("yields the keyboardPlace hint to Hardcore Mode", () => {
-    draftActions.startGridDraft({
-      activity: "keyboardPlace",
-      draft: createGridEventDraft(
-        timedGridSchedule(
-          new Date("2026-05-20T09:00:00.000"),
-          new Date("2026-05-20T10:00:00.000"),
-        ),
-      ),
-    });
+    seedKeyboardPlaceDraft();
     keyboardOnlyActions.enter();
     const { wrapper } = createStoreWrapper();
 
     render(<SidebarStatusBar />, { wrapper });
 
     expect(screen.getByRole("status")).toHaveTextContent("Hardcore Mode · Esc");
-    expect(
-      screen.queryByText("Enter to open · Esc to discard"),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText(KEYBOARD_PLACE_HINT)).not.toBeInTheDocument();
   });
 
   it("yields the keyboardPlace hint to event jump", () => {
-    draftActions.startGridDraft({
-      activity: "keyboardPlace",
-      draft: createGridEventDraft(
-        timedGridSchedule(
-          new Date("2026-05-20T09:00:00.000"),
-          new Date("2026-05-20T10:00:00.000"),
-        ),
-      ),
-    });
+    seedKeyboardPlaceDraft();
     eventJumpActions.setActive(true);
     const { wrapper } = createStoreWrapper();
 
     render(<SidebarStatusBar />, { wrapper });
 
     expect(screen.getByRole("status")).toHaveTextContent("Event jump · Esc");
-    expect(
-      screen.queryByText("Enter to open · Esc to discard"),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText(KEYBOARD_PLACE_HINT)).not.toBeInTheDocument();
   });
 
   it("yields the keyboardPlace hint to edge focus", () => {
-    draftActions.startGridDraft({
-      activity: "keyboardPlace",
-      draft: createGridEventDraft(
-        timedGridSchedule(
-          new Date("2026-05-20T09:00:00.000"),
-          new Date("2026-05-20T10:00:00.000"),
-        ),
-      ),
-    });
+    seedKeyboardPlaceDraft();
     edgeFocusActions.setEdge(
       "aaaaaaaaaaaaaaaaaaaaaaaa",
       "startDate",
@@ -402,8 +370,6 @@ describe("SidebarStatusBar", () => {
     render(<SidebarStatusBar />, { wrapper });
 
     expect(screen.getByRole("status")).toHaveTextContent("Editing start time");
-    expect(
-      screen.queryByText("Enter to open · Esc to discard"),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText(KEYBOARD_PLACE_HINT)).not.toBeInTheDocument();
   });
 });

--- a/packages/web/src/components/Sidebar/SidebarStatusBar.tsx
+++ b/packages/web/src/components/Sidebar/SidebarStatusBar.tsx
@@ -10,12 +10,18 @@ import { TrialCountdownChip } from "@web/billing/TrialCountdownChip";
 import { useAppAccess } from "@web/billing/useAppAccess";
 import { SYNC_STATUS_VARIANT_CLASSNAME } from "@web/calendars/sync-status.types";
 import { useHasPendingEventMutations } from "@web/events/mutations/useEventPending";
+import {
+  selectDraftActivity,
+  selectIsEventFormOpen,
+  useDraftStore,
+} from "@web/events/stores/draft.store";
 import { EdgeFocusIndicator } from "@web/grid/shortcuts/EdgeFocusIndicator";
 import {
   selectEdgeFocusActive,
   selectEdgeFocusAnnouncement,
   useEdgeFocusStore,
 } from "@web/grid/shortcuts/edge-focus.store";
+import { KeyboardPlaceIndicator } from "@web/grid/shortcuts/KeyboardPlaceIndicator";
 import { settingsActions } from "@web/settings/settings.store";
 import { KeyboardOnlyIndicator } from "@web/shortcuts/keyboard-only/KeyboardOnlyIndicator";
 import {
@@ -59,6 +65,9 @@ export const SidebarStatusBar: FC = () => {
   const isEdgeFocus = useEdgeFocusStore(selectEdgeFocusActive);
   const edgeFocusAnnouncement = useEdgeFocusStore(selectEdgeFocusAnnouncement);
   const showEdgeFocus = isEdgeFocus || Boolean(edgeFocusAnnouncement);
+  const isKeyboardPlace =
+    useDraftStore(selectDraftActivity) === "keyboardPlace" &&
+    !useDraftStore(selectIsEventFormOpen);
   const isSaving = useHasPendingEventMutations();
   // The unscoped hook's `connection` is the primary connection (the one
   // whose own state matches the aggregate) - without it, an account's
@@ -98,6 +107,10 @@ export const SidebarStatusBar: FC = () => {
       ) : showEdgeFocus ? (
         <div className="flex h-full min-w-0 flex-1 items-center">
           <EdgeFocusIndicator />
+        </div>
+      ) : isKeyboardPlace ? (
+        <div className="flex h-full min-w-0 flex-1 items-center">
+          <KeyboardPlaceIndicator />
         </div>
       ) : !status && activeTipId ? (
         <div className="flex h-full min-w-0 flex-1 items-center">

--- a/packages/web/src/components/Sidebar/SidebarStatusBar.tsx
+++ b/packages/web/src/components/Sidebar/SidebarStatusBar.tsx
@@ -65,9 +65,9 @@ export const SidebarStatusBar: FC = () => {
   const isEdgeFocus = useEdgeFocusStore(selectEdgeFocusActive);
   const edgeFocusAnnouncement = useEdgeFocusStore(selectEdgeFocusAnnouncement);
   const showEdgeFocus = isEdgeFocus || Boolean(edgeFocusAnnouncement);
-  const isKeyboardPlace =
-    useDraftStore(selectDraftActivity) === "keyboardPlace" &&
-    !useDraftStore(selectIsEventFormOpen);
+  const draftActivity = useDraftStore(selectDraftActivity);
+  const isDraftFormOpen = useDraftStore(selectIsEventFormOpen);
+  const isKeyboardPlace = draftActivity === "keyboardPlace" && !isDraftFormOpen;
   const isSaving = useHasPendingEventMutations();
   // The unscoped hook's `connection` is the primary connection (the one
   // whose own state matches the aggregate) - without it, an account's

--- a/packages/web/src/grid/shortcuts/KeyboardPlaceIndicator.tsx
+++ b/packages/web/src/grid/shortcuts/KeyboardPlaceIndicator.tsx
@@ -1,0 +1,28 @@
+import { type FC } from "react";
+import { ShortcutTipParts } from "@web/shortcuts/tips/ShortcutTipParts";
+import { type ShortcutTipPart } from "@web/shortcuts/tips/shortcut-tips.data";
+
+export const KEYBOARD_PLACE_HINT_PARTS: readonly ShortcutTipPart[] = [
+  { key: "Enter" },
+  " to open",
+  " · ",
+  { key: "Esc" },
+  " to discard",
+];
+
+/**
+ * Contextual sidebar hint while a Shift+Arrow place-create draft is on the
+ * grid with the form still closed: Enter opens details, Esc discards.
+ */
+export const KeyboardPlaceIndicator: FC = () => {
+  return (
+    <span
+      aria-live="polite"
+      className="truncate text-text-muted text-xs opacity-80"
+      data-keyboard-place-indicator=""
+      role="status"
+    >
+      <ShortcutTipParts parts={KEYBOARD_PLACE_HINT_PARTS} />
+    </span>
+  );
+};

--- a/packages/web/src/grid/shortcuts/useGridEventEditShortcuts.ts
+++ b/packages/web/src/grid/shortcuts/useGridEventEditShortcuts.ts
@@ -49,6 +49,7 @@ import {
   getChronologicallyAdjacentTarget,
   getSpatiallyAdjacentTarget,
 } from "@web/grid/shortcuts/focus-adjacent-grid-event";
+import { isHigherEscapeOwner } from "@web/shortcuts/escape-ownership";
 import { KEYMAP } from "@web/shortcuts/keymap";
 import { useAppShortcut } from "@web/shortcuts/useAppShortcut";
 import { deleteEventAndDiscardDraft } from "@web/views/Forms/hooks/useDeleteEvent";
@@ -369,9 +370,21 @@ export function useGridEventEditShortcuts({
     edgeFocusActions.cycle(event._id, forward ? "forward" : "backward");
   };
 
-  const clearEdgeFocus = () => {
-    if (!useEdgeFocusStore.getState().eventId) return;
-    edgeFocusActions.reset();
+  const onEscape = () => {
+    if (isHigherEscapeOwner()) return;
+    if (useEdgeFocusStore.getState().eventId) {
+      edgeFocusActions.reset();
+      return;
+    }
+
+    const { gridDraft, status } = useDraftStore.getState();
+    if (
+      status?.activity === "keyboardPlace" &&
+      !status.isFormOpen &&
+      gridDraft
+    ) {
+      draftActions.discard();
+    }
   };
 
   // `targeting` is a fresh object every render for some callers (Day/Week
@@ -522,5 +535,5 @@ export function useGridEventEditShortcuts({
     DRAFT_MOVEMENT_HOTKEY_OPTIONS,
   );
   useAppShortcut("Shift+Tab", cycleEdgeFocus, DRAFT_MOVEMENT_HOTKEY_OPTIONS);
-  useAppShortcut("Escape", clearEdgeFocus, DRAFT_MOVEMENT_HOTKEY_OPTIONS);
+  useAppShortcut("Escape", onEscape, DRAFT_MOVEMENT_HOTKEY_OPTIONS);
 }

--- a/packages/web/src/shortcuts/data/shortcuts.data.test.ts
+++ b/packages/web/src/shortcuts/data/shortcuts.data.test.ts
@@ -136,6 +136,16 @@ describe("shortcuts.data", () => {
           label: "Place timed draft on grid",
         },
       );
+      expect(stripMetadata(findCreate("day")?.shortcuts ?? [])).toContainEqual({
+        keys: ["Escape"],
+        label: "Discard placed draft",
+      });
+      expect(stripMetadata(findCreate("week")?.shortcuts ?? [])).toContainEqual(
+        {
+          keys: ["Escape"],
+          label: "Discard placed draft",
+        },
+      );
     });
 
     it("lists u/i focus shortcuts per view", () => {

--- a/packages/web/src/shortcuts/shortcuts.registry.ts
+++ b/packages/web/src/shortcuts/shortcuts.registry.ts
@@ -119,6 +119,12 @@ export const SHORTCUTS_REGISTRY: Shortcut[] = [
     label: "Place timed draft on grid",
     section: "create",
   },
+  {
+    id: "create-place-discard",
+    keys: ["Escape"],
+    label: "Discard placed draft",
+    section: "create",
+  },
 
   // Focus
   {

--- a/packages/web/src/shortcuts/tips/useShortcutTipTrigger.test.tsx
+++ b/packages/web/src/shortcuts/tips/useShortcutTipTrigger.test.tsx
@@ -1,6 +1,11 @@
 import { act, renderHook } from "@testing-library/react";
 import { dispatchMissingKey } from "@web/__tests__/utils/keyboard.test.util";
 import {
+  createGridEventDraft,
+  timedGridSchedule,
+} from "@web/events/grid-event-draft.adapter";
+import { draftActions } from "@web/events/stores/draft.store";
+import {
   CALENDAR_VIEW_INTERACTION_ID_ATTRIBUTES,
   calendarEventIdElementSelector,
 } from "@web/grid/interaction/view-event-registry";
@@ -31,10 +36,12 @@ const focusCalendarEvent = () => {
 describe("useShortcutTipTrigger", () => {
   beforeEach(() => {
     resetStore();
+    draftActions.discard();
   });
 
   afterEach(() => {
     resetStore();
+    draftActions.discard();
     document.body.innerHTML = "";
   });
 
@@ -69,5 +76,22 @@ describe("useShortcutTipTrigger", () => {
 
     // A missing key normalizes to "", not "e", so the tip stays active.
     expect(useShortcutTipsStore.getState().activeTipId).toBe("edit-sequence");
+  });
+
+  it("does not rotate a generic tip during a form-closed keyboardPlace draft", () => {
+    focusCalendarEvent();
+    draftActions.startGridDraft({
+      activity: "keyboardPlace",
+      draft: createGridEventDraft(
+        timedGridSchedule(
+          new Date("2026-05-20T09:00:00.000"),
+          new Date("2026-05-20T10:00:00.000"),
+        ),
+      ),
+    });
+
+    renderHook(() => useShortcutTipTrigger());
+
+    expect(useShortcutTipsStore.getState().activeTipId).toBeNull();
   });
 });

--- a/packages/web/src/shortcuts/tips/useShortcutTipTrigger.ts
+++ b/packages/web/src/shortcuts/tips/useShortcutTipTrigger.ts
@@ -13,8 +13,9 @@ import {
 import { useIsAnyCalendarEventFocused } from "@web/shortcuts/tips/useIsAnyCalendarEventFocused";
 
 /**
- * Drives the quiet sidebar tip: eligible only when an event is focused and
- * the form is closed, and biased by recent mouse-vs-keyboard edit activity.
+ * Drives the quiet sidebar tip: eligible only when an event is focused, the
+ * form is closed, and the user is not in Shift+Arrow place-create. Biased by
+ * recent mouse-vs-keyboard edit activity.
  */
 export function useShortcutTipTrigger() {
   const eventFocused = useIsAnyCalendarEventFocused();
@@ -27,12 +28,12 @@ export function useShortcutTipTrigger() {
   }, [activity]);
 
   useEffect(() => {
-    if (eventFocused && !isFormOpen) {
+    if (eventFocused && !isFormOpen && activity !== "keyboardPlace") {
       shortcutTipsActions.maybeRotate();
     } else {
       shortcutTipsActions.hide();
     }
-  }, [eventFocused, isFormOpen]);
+  }, [activity, eventFocused, isFormOpen]);
 
   // Encouragement-based, like the shortcut showcase's advance detection: the
   // matching keypress counts as "acted on" without verifying the resulting

--- a/packages/web/src/views/Day/hooks/shortcuts/useDayEventNudgeShortcuts.test.tsx
+++ b/packages/web/src/views/Day/hooks/shortcuts/useDayEventNudgeShortcuts.test.tsx
@@ -422,6 +422,58 @@ describe("useDayEventNudgeShortcuts", () => {
     ).toBe(dayjs("2026-05-20T09:00:00.000").format());
   });
 
+  it("discards a form-closed keyboardPlace draft on Escape", () => {
+    const placeTimedDraft = mock(() => {
+      createTimedDraft(true, dayjs("2026-05-20T00:00:00.000"), "keyboardPlace");
+    });
+    renderEditShortcuts({ placeTimedDraft });
+
+    pressKey("ArrowDown", shiftKey);
+    expect(useDraftStore.getState().status?.activity).toBe("keyboardPlace");
+
+    pressKey("Escape");
+
+    expect(useDraftStore.getState().gridDraft).toBeNull();
+    expect(useDraftStore.getState().status?.isDrafting).toBe(false);
+  });
+
+  it("discards a repositioned keyboardPlace draft on Escape", () => {
+    const placeTimedDraft = mock(() => {
+      createTimedDraft(
+        false,
+        dayjs("2026-05-20T00:00:00.000"),
+        "keyboardPlace",
+      );
+    });
+    renderEditShortcuts({ placeTimedDraft });
+
+    pressKey("ArrowDown", shiftKey);
+    pressKey("ArrowDown", shiftKey);
+    expect(useDraftStore.getState().status?.activity).toBe("keyboardPlace");
+
+    pressKey("Escape");
+
+    expect(useDraftStore.getState().gridDraft).toBeNull();
+    expect(useDraftStore.getState().status?.isDrafting).toBe(false);
+  });
+
+  it("does not discard a keyboardPlace draft on Escape while the form is open", () => {
+    const draft = createGridEventDraft(
+      timedGridSchedule(
+        new Date("2026-05-20T09:00:00.000"),
+        new Date("2026-05-20T10:00:00.000"),
+      ),
+    );
+    draftActions.startGridDraft({ activity: "keyboardPlace", draft });
+    draftActions.setFormOpen(true);
+    renderEditShortcuts();
+
+    pressKey("Escape");
+
+    expect(useDraftStore.getState().status?.activity).toBe("keyboardPlace");
+    expect(useDraftStore.getState().gridDraft).not.toBeNull();
+  });
+
   it("deletes the focused timed calendar event with Delete", () => {
     focusCalendarTarget(TIMED_EVENT_ID, "timed");
     const { queryClient } = renderEditShortcuts();

--- a/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcutOwner.test.tsx
+++ b/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcutOwner.test.tsx
@@ -740,6 +740,59 @@ describe("useWeekShortcutOwner shift+arrow event moves", () => {
     expect(getGridDraftId(useDraftStore.getState().gridDraft!)).toBe(placedId);
     expect(useDraftStore.getState().status?.activity).toBe("keyboardPlace");
   });
+
+  it("discards a form-closed keyboardPlace draft on Escape", async () => {
+    renderShortcuts();
+
+    pressKey("ArrowDown", shiftKey);
+
+    await waitFor(() => {
+      expect(useDraftStore.getState().status?.activity).toBe("keyboardPlace");
+    });
+
+    pressKey("Escape");
+
+    expect(useDraftStore.getState().gridDraft).toBeNull();
+    expect(useDraftStore.getState().status?.isDrafting).toBe(false);
+  });
+
+  it("discards a repositioned keyboardPlace draft on Escape", async () => {
+    repositionDraftByKeyboard = mock(() =>
+      Boolean(useDraftStore.getState().gridDraft),
+    );
+    renderShortcuts();
+
+    pressKey("ArrowDown", shiftKey);
+
+    await waitFor(() => {
+      expect(useDraftStore.getState().status?.activity).toBe("keyboardPlace");
+    });
+
+    pressKey("ArrowDown", shiftKey);
+    pressKey("Escape");
+
+    expect(useDraftStore.getState().gridDraft).toBeNull();
+    expect(useDraftStore.getState().status?.isDrafting).toBe(false);
+  });
+
+  it("does not discard a keyboardPlace draft on Escape while the form is open", async () => {
+    renderShortcuts();
+
+    pressKey("ArrowDown", shiftKey);
+
+    await waitFor(() => {
+      expect(useDraftStore.getState().status?.activity).toBe("keyboardPlace");
+    });
+
+    act(() => {
+      draftActions.setFormOpen(true);
+    });
+
+    pressKey("Escape");
+
+    expect(useDraftStore.getState().status?.activity).toBe("keyboardPlace");
+    expect(useDraftStore.getState().gridDraft).not.toBeNull();
+  });
 });
 
 describe("useWeekShortcutOwner edge focus", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Shift+Arrow place-create left a form-closed draft that Escape could not cancel. Escape now discards that draft (after higher Escape owners and edge-focus), and the sidebar status bar shows **Enter to open · Esc to discard** instead of a generic rotating tip.

## Simplicity

The existing grid Escape handler in `useGridEventEditShortcuts` now owns discard, so Day and Week pick it up without a second binding. The status bar reuses the same keycap parts pattern as other mode badges. Status-bar tests share one draft seed helper and assert against the production hint parts. No new `useEffect` / `useRef` / `useState` in production; `KeyboardPlaceIndicator` is presentational.

## Automated validation

Focused `bun test:web` on Week/Day shortcut, sidebar status, tip trigger, and legend tests: **113 pass, 0 fail**. After the test-fixture refactor, SidebarStatusBar tests: **18 pass**. `bun run lint` exits 0 (pre-existing warnings only).

Manual week-view pass at `http://localhost:9080/week`: Shift+ArrowDown places a form-closed draft, sidebar shows Enter/Esc, Escape removes the draft. Form stays closed until Enter. Extra cases: Escape after a later Shift+Arrow still discards; Escape while the form is open does not steal discard from the form owner.

## Independent review

Fresh read-only review of `origin/main...HEAD`: **no confirmed findings**. Escape stands down for higher owners and edge-focus before discarding `keyboardPlace`; Day/Week and status-bar tests exercise those contracts.

## Test plan

- `bun test:web` on Week/Day shortcut, sidebar status, tip trigger, and legend files — 113 pass
- `bun test:web packages/web/src/components/Sidebar/SidebarStatusBar.test.tsx` after fixture refactor — 18 pass
- `bun run lint` — 0 errors in this change
- Browser: Shift+ArrowDown → hint → Escape discard on week view
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-28d67302-ab22-46a9-a4ce-916e615b12c6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-28d67302-ab22-46a9-a4ce-916e615b12c6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

