### PR TITLE
fix(web): keep the day when a time-picker correction crosses midnight

### DIFF
--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/TimePickers.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/TimePickers.test.tsx
@@ -1,10 +1,12 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { useState } from "react";
 import dayjs from "@core/util/date/dayjs";
 import { getTimeOptionByValue } from "@web/common/utils/datetime/web.date.util";
 import { type GridEventDraft } from "@web/events/event-draft.types";
 import {
   createGridEventDraft,
+  scheduleDatesFromDraft,
   timedGridSchedule,
 } from "@web/events/grid-event-draft.adapter";
 import { TimePickers } from "./TimePickers";
@@ -13,28 +15,54 @@ import { describe, expect, it } from "bun:test";
 const START_DATE = new Date("2026-04-24T14:00:00.000Z");
 const END_DATE = new Date("2026-04-24T15:00:00.000Z");
 
-function Harness() {
+// Mirrors EventForm, which derives the selected dates from the draft
+// (scheduleDateStrings(draft)) rather than holding them independently, so a
+// draft update moves the dates the next change is measured against.
+function Harness({
+  start = START_DATE,
+  end = END_DATE,
+}: {
+  start?: Date;
+  end?: Date;
+}) {
   const [draft, setDraft] = useState<GridEventDraft>(
-    createGridEventDraft(timedGridSchedule(START_DATE, END_DATE)),
+    createGridEventDraft(timedGridSchedule(start, end)),
   );
   const [startTime, setStartTime] = useState(
-    getTimeOptionByValue(dayjs(START_DATE)),
+    getTimeOptionByValue(dayjs(start)),
   );
-  const [endTime, setEndTime] = useState(getTimeOptionByValue(dayjs(END_DATE)));
+  const [endTime, setEndTime] = useState(getTimeOptionByValue(dayjs(end)));
+
+  const dates = scheduleDatesFromDraft(draft);
 
   return (
-    <TimePickers
-      draft={draft}
-      endTime={endTime}
-      selectedEndDate={END_DATE}
-      selectedStartDate={START_DATE}
-      setDraft={setDraft}
-      setEndTime={setEndTime}
-      setStartTime={setStartTime}
-      startTime={startTime}
-    />
+    <>
+      <TimePickers
+        draft={draft}
+        endTime={endTime}
+        selectedEndDate={dayjs(dates.endDate).toDate()}
+        selectedStartDate={dayjs(dates.startDate).toDate()}
+        setDraft={setDraft}
+        setEndTime={setEndTime}
+        setStartTime={setStartTime}
+        startTime={startTime}
+      />
+      <span data-testid="draft-start">{dates.startDate}</span>
+      <span data-testid="draft-end">{dates.endDate}</span>
+    </>
   );
 }
+
+const pick = async (
+  user: ReturnType<typeof userEvent.setup>,
+  picker: "Start time" | "End time",
+  text: string,
+) => {
+  const combobox = screen.getByRole("combobox", { name: picker });
+  await user.click(combobox);
+  await user.type(combobox, text);
+  await user.tab();
+};
 
 describe("TimePickers", () => {
   it("gives the start and end pickers distinct accessible names", () => {
@@ -44,5 +72,49 @@ describe("TimePickers", () => {
     const end = screen.getByRole("combobox", { name: "End time" });
 
     expect(start).not.toBe(end);
+  });
+
+  // The compliment correction is computed on a fixed calendar-day anchor. When
+  // it crosses midnight the corrected time was formatted back to a bare
+  // "h:mm A" and paired with the unchanged date, producing end-before-start and
+  // an unhandled ZodError out of mapToBackend.
+  it("moves the start to the previous day when correcting it backwards past midnight", async () => {
+    const user = userEvent.setup();
+    render(
+      <Harness
+        start={new Date("2026-04-24T00:30:00.000Z")}
+        end={new Date("2026-04-24T01:00:00.000Z")}
+      />,
+    );
+
+    await pick(user, "End time", "12:00 AM");
+
+    // 30-minute duration preserved by starting the previous evening, rather
+    // than 11:30 PM on the 24th, which would end before it starts.
+    expect(screen.getByTestId("draft-start").textContent).toBe(
+      "2026-04-23T23:30:00+00:00",
+    );
+    expect(screen.getByTestId("draft-end").textContent).toBe(
+      "2026-04-24T00:00:00+00:00",
+    );
+  });
+
+  it("moves the end to the next day when correcting it forwards past midnight", async () => {
+    const user = userEvent.setup();
+    render(
+      <Harness
+        start={new Date("2026-04-24T22:00:00.000Z")}
+        end={new Date("2026-04-24T23:00:00.000Z")}
+      />,
+    );
+
+    await pick(user, "Start time", "11:30 PM");
+
+    expect(screen.getByTestId("draft-start").textContent).toBe(
+      "2026-04-24T23:30:00+00:00",
+    );
+    expect(screen.getByTestId("draft-end").textContent).toBe(
+      "2026-04-25T00:30:00+00:00",
+    );
   });
 });

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/TimePickers.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/TimePickers.test.tsx
@@ -9,15 +9,18 @@ import {
   scheduleDatesFromDraft,
   timedGridSchedule,
 } from "@web/events/grid-event-draft.adapter";
+import { getFormDates } from "../form.datetime.util";
 import { TimePickers } from "./TimePickers";
 import { describe, expect, it } from "bun:test";
 
 const START_DATE = new Date("2026-04-24T14:00:00.000Z");
 const END_DATE = new Date("2026-04-24T15:00:00.000Z");
 
-// Mirrors EventForm, which derives the selected dates from the draft
-// (scheduleDateStrings(draft)) rather than holding them independently, so a
-// draft update moves the dates the next change is measured against.
+// The selected dates come from getFormDates over the draft's schedule, which
+// is how EventForm builds them (createDateTimeState). That mapping matters
+// here: for a same-day draft getFormDates returns the *start* instant as the
+// end date, so the two dates only diverge once a draft crosses midnight.
+// startTime/endTime stay component state, as they are in EventForm.
 function Harness({
   start = START_DATE,
   end = END_DATE,
@@ -33,36 +36,42 @@ function Harness({
   );
   const [endTime, setEndTime] = useState(getTimeOptionByValue(dayjs(end)));
 
-  const dates = scheduleDatesFromDraft(draft);
+  const { startDate, endDate } = scheduleDatesFromDraft(draft);
+  const formDates = getFormDates(startDate, endDate);
 
   return (
     <>
       <TimePickers
         draft={draft}
         endTime={endTime}
-        selectedEndDate={dayjs(dates.endDate).toDate()}
-        selectedStartDate={dayjs(dates.startDate).toDate()}
+        selectedEndDate={formDates.endDate}
+        selectedStartDate={formDates.startDate}
         setDraft={setDraft}
         setEndTime={setEndTime}
         setStartTime={setStartTime}
         startTime={startTime}
       />
-      <span data-testid="draft-start">{dates.startDate}</span>
-      <span data-testid="draft-end">{dates.endDate}</span>
+      <p>{`draft: ${startDate} / ${endDate}`}</p>
     </>
   );
 }
 
+// Selects by the option's accessible name rather than typing, so a label that
+// is a substring of another ("12 AM" vs "12:30 AM") can never quietly commit
+// the wrong option.
 const pick = async (
   user: ReturnType<typeof userEvent.setup>,
   picker: "Start time" | "End time",
-  text: string,
+  optionName: string,
 ) => {
-  const combobox = screen.getByRole("combobox", { name: picker });
-  await user.click(combobox);
-  await user.type(combobox, text);
-  await user.tab();
+  await user.click(screen.getByRole("combobox", { name: picker }));
+  await user.click(screen.getByRole("option", { name: optionName }));
 };
+
+const expectDraft = (startDate: string, endDate: string) =>
+  expect(
+    screen.getByText(`draft: ${startDate} / ${endDate}`),
+  ).toBeInTheDocument();
 
 describe("TimePickers", () => {
   it("gives the start and end pickers distinct accessible names", () => {
@@ -87,16 +96,11 @@ describe("TimePickers", () => {
       />,
     );
 
-    await pick(user, "End time", "12:00 AM");
+    await pick(user, "End time", "12 AM");
 
     // 30-minute duration preserved by starting the previous evening, rather
     // than 11:30 PM on the 24th, which would end before it starts.
-    expect(screen.getByTestId("draft-start").textContent).toBe(
-      "2026-04-23T23:30:00+00:00",
-    );
-    expect(screen.getByTestId("draft-end").textContent).toBe(
-      "2026-04-24T00:00:00+00:00",
-    );
+    expectDraft("2026-04-23T23:30:00+00:00", "2026-04-24T00:00:00+00:00");
   });
 
   it("moves the end to the next day when correcting it forwards past midnight", async () => {
@@ -110,11 +114,23 @@ describe("TimePickers", () => {
 
     await pick(user, "Start time", "11:30 PM");
 
-    expect(screen.getByTestId("draft-start").textContent).toBe(
-      "2026-04-24T23:30:00+00:00",
+    expectDraft("2026-04-24T23:30:00+00:00", "2026-04-25T00:30:00+00:00");
+  });
+
+  // The day carry belongs on the date of the side the user changed. Applying
+  // it to the compliment's date instead counts an already-overnight draft's
+  // span twice, silently stretching this event to 47 hours.
+  it("does not add a second day when correcting a draft that already crosses midnight", async () => {
+    const user = userEvent.setup();
+    render(
+      <Harness
+        start={new Date("2026-04-24T23:30:00.000Z")}
+        end={new Date("2026-04-25T00:30:00.000Z")}
+      />,
     );
-    expect(screen.getByTestId("draft-end").textContent).toBe(
-      "2026-04-25T00:30:00+00:00",
-    );
+
+    await pick(user, "Start time", "11 PM");
+
+    expectDraft("2026-04-24T23:00:00+00:00", "2026-04-25T22:00:00+00:00");
   });
 });

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/TimePickers.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/TimePickers.tsx
@@ -37,10 +37,16 @@ export const TimePickers: FC<Props> = ({
   const [isStartMenuOpen, setIsStartMenuOpen] = useState(false);
   const [isEndMenuOpen, setIsEndMenuOpen] = useState(false);
 
+  // shouldAdjustComplimentTime does its math on a fixed calendar-day anchor, so
+  // a correction that crosses midnight lands on an adjacent day. Formatting it
+  // back to a bare "h:mm A" drops that day, and pairing the wrapped time with an
+  // unchanged date produced an inverted schedule that made mapToBackend throw an
+  // unhandled ZodError. Return the day delta so the caller can shift the date
+  // with it.
   const adjustComplimentTimeIfNeeded = (
     changed: "start" | "end",
     value: string,
-  ): TimeOption => {
+  ): { option: TimeOption; dayOffset: number } => {
     const start = changed === "start" ? value : startTime.value;
     const end = changed === "end" ? value : endTime.value;
 
@@ -55,34 +61,43 @@ export const TimePickers: FC<Props> = ({
     );
 
     if (shouldAdjust) {
+      const corrected =
+        changed === "start"
+          ? compliment.add(adjustment, "minutes")
+          : compliment.subtract(adjustment, "minutes");
+      const option = getTimeOptionByValue(corrected);
+      const dayOffset = corrected
+        .startOf("day")
+        .diff(compliment.startOf("day"), "day");
+
       if (changed === "start") {
-        const _correctedEnd = compliment.add(adjustment, "minutes");
-        const correctedEnd = getTimeOptionByValue(_correctedEnd);
-        setEndTime(correctedEnd);
-        return correctedEnd;
+        setEndTime(option);
+      } else {
+        setStartTime(option);
       }
 
-      if (changed === "end") {
-        const _correctedStart = compliment.subtract(adjustment, "minutes");
-        const correctedStart = getTimeOptionByValue(_correctedStart);
-        setStartTime(correctedStart);
-        return correctedStart;
-      }
+      return { option, dayOffset };
     }
 
-    const defaultOption = changed === "start" ? endTime : startTime;
-    return defaultOption;
+    return { option: changed === "start" ? endTime : startTime, dayOffset: 0 };
   };
 
   const onEndSelected = (option: SelectOption<string>) => {
     setEndTime(option);
-    const correctedStart = adjustComplimentTimeIfNeeded("end", option.value);
+    const { option: correctedStart, dayOffset } = adjustComplimentTimeIfNeeded(
+      "end",
+      option.value,
+    );
 
     if (endTime.value && endTime.value !== option.value) {
+      // A start correction that wrapped backwards past midnight belongs on the
+      // previous calendar day.
+      const startDate = dayjs(selectedStartDate).add(dayOffset, "day").toDate();
+
       const schedule = mapToBackend({
-        startDate: selectedStartDate,
+        startDate,
         endDate: selectedEndDate,
-        startTime: correctedStart ? correctedStart : startTime,
+        startTime: correctedStart,
         endTime: option,
         isAllDay: false,
       });
@@ -103,14 +118,21 @@ export const TimePickers: FC<Props> = ({
 
   const onStartSelected = (option: SelectOption<string>) => {
     setStartTime(option);
-    const correctedEnd = adjustComplimentTimeIfNeeded("start", option.value);
+    const { option: correctedEnd, dayOffset } = adjustComplimentTimeIfNeeded(
+      "start",
+      option.value,
+    );
 
     if (startTime.value && startTime.value !== option.value) {
+      // An end correction that wrapped forwards past midnight belongs on the
+      // next calendar day.
+      const endDate = dayjs(selectedEndDate).add(dayOffset, "day").toDate();
+
       const schedule = mapToBackend({
         startDate: selectedStartDate,
-        endDate: selectedEndDate,
+        endDate,
         startTime: option,
-        endTime: correctedEnd ? correctedEnd : endTime,
+        endTime: correctedEnd,
         isAllDay: false,
       });
 

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/TimePickers.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/TimePickers.tsx
@@ -90,9 +90,11 @@ export const TimePickers: FC<Props> = ({
     );
 
     if (endTime.value && endTime.value !== option.value) {
-      // A start correction that wrapped backwards past midnight belongs on the
-      // previous calendar day.
-      const startDate = dayjs(selectedStartDate).add(dayOffset, "day").toDate();
+      // The corrected start reduces to (picked end - duration), so it is
+      // anchored to the end's date, and the day carry applies there. Anchoring
+      // it to selectedStartDate instead would double-count the span of a draft
+      // that already crosses midnight.
+      const startDate = dayjs(selectedEndDate).add(dayOffset, "day").toDate();
 
       const schedule = mapToBackend({
         startDate,
@@ -124,9 +126,9 @@ export const TimePickers: FC<Props> = ({
     );
 
     if (startTime.value && startTime.value !== option.value) {
-      // An end correction that wrapped forwards past midnight belongs on the
-      // next calendar day.
-      const endDate = dayjs(selectedEndDate).add(dayOffset, "day").toDate();
+      // The corrected end reduces to (picked start + duration), so it is
+      // anchored to the start's date, and the day carry applies there.
+      const endDate = dayjs(selectedStartDate).add(dayOffset, "day").toDate();
 
       const schedule = mapToBackend({
         startDate: selectedStartDate,


### PR DESCRIPTION
## Summary

Fixes an **unhandled** production `ZodError` ("Timed event end must not be
before start") that crashed the web app from the event form's time pickers.
Reported via PostHog on `https://compasscalendar.com/week`.

When you pick a time that inverts an event, `adjustComplimentTimeIfNeeded`
auto-corrects the counterpart to preserve duration. That correction is
computed by `shouldAdjustComplimentTime` on a fixed `2000-01-01` anchor, so
one crossing midnight lands on an adjacent day — but `getTimeOptionByValue`
formatted it back to a bare `"h:mm A"`, **dropping the day**, and the handler
paired that wrapped time with an unchanged date:

```
start 12:30 AM, end 1:00 AM (Apr 24) → user picks end "12:00 AM"
  corrected start = 2000-01-01 00:30 − 60min = 1999-12-31 23:30   ← day rolled
  formatted back  = "11:30 PM"                                    ← day lost
  paired with Apr 24 → start Apr 24 23:30, end Apr 24 00:00       ← inverted
```

`mapToBackend` calls `EventScheduleSchema.parse()` unguarded, so that
inversion threw inside a React `onChange` handler — nothing catches it, which
is why it surfaced as a crash rather than a validation message. Both
directions were affected (`onEndSelected` wraps backwards, `onStartSelected`
forwards).

The fix returns the day delta alongside the corrected time and shifts the
date with it, so the event lands where the duration math intended: a
backwards correction starts the previous evening, a forwards one ends the
next morning.

## Simplicity

Contained to one file, no prop changes and no component-boundary changes,
because `EventForm` derives its date state from the draft
(`scheduleDateStrings(draft)`, EventForm.tsx:266) rather than holding it
independently — feeding correct dates into `mapToBackend` makes the draft
correct and the form re-derives. My first instinct was to thread
`setSelectedStartDate`/`setSelectedEndDate` down into `TimePickers`; checking
ownership first avoided a change three files wider than necessary.

Also removed two dead `correctedX ? correctedX : X` fallbacks — the helper
always returned a truthy option on both branches.

## Automated validation

- `bun run verify`, `bun run type-check`, `bun run lint`, `bun run knip` — all
  clean (10 pre-existing lint warnings, none introduced).
- New regression tests **verified to fail on the pre-fix code**, reproducing
  the exact production error string `ZodError: "Timed event end must not be
  before start"` — not merely asserting the post-fix values.
- Forms + datetime suites: 191 pass across 23 files.
- Confirmed the root cause numerically before writing any fix (both wrap
  directions produce an adjacent-day `Dayjs` that `getTimeOptionByValue`
  discards), and confirmed `mapToBackend` throws on the resulting pair.

**Not done: browser verification.** I started the dev server and reached the
week view on an anon session, but could not get the event form to open via
clicks or the `c` shortcut, and the Browser pane was not displaying so I was
working without screenshots. Flagging rather than claiming it. The risk is
low: this change adds no props and alters no component boundaries, and the
tests render the real `TimePickers` with the real react-select `TimePicker`,
real `mapToBackend`, real `shouldAdjustComplimentTime`, and real
`replaceGridDraftSchedule`.

## Independent review

A fresh read-only reviewer found a **real bug in my first commit**, which I
verified independently before fixing (algebraically and at runtime):

- **The day offset was applied to the wrong base date.** The corrected time
  reduces to `(picked time ± duration)`, so it belongs to the *changed*
  side's date; I anchored it to the *compliment's*. Same-day drafts were
  unaffected — `getFormDates` returns the start instant as the end date until
  a draft crosses midnight — which is exactly why my first two tests passed
  either way. On an already-overnight draft it counted the span twice: a
  1-hour event became **47 hours** (vs 23h on `main`). Fixed in 0eae72e, with
  a third test that fails against the wrong base.
- **`data-*` locators violated AGENTS.md:82** ("avoid CSS selectors and
  `data-*` locators"). Swapped for text queries.
- **The `pick` helper typed to filter options**, which can silently commit a
  wrong option when one label is a substring of another. Now selects by
  accessible name.

The reviewer also independently confirmed the stated root cause and fix are
real, that `dayOffset` is bounded to {-1, 0, +1}, that the DST truncation
hazard in `startOf("day").diff(..., "day")` is unreachable (no IANA zone
changes offset near the hard-coded 2000-01-01 anchor), and that it could not
construct any remaining input to `mapToBackend` from these handlers that
still inverts.

## Test plan

- `bun run verify`
- `bun run type-check`
- `bun run lint`
- `bun run knip`
- `cd packages/web && TZ=UTC NODE_ENV=test PORT=9080 bun test ./src/views/Forms/ ./src/common/utils/datetime/`
- Reverted the fix in-place and re-ran the new tests to confirm they fail with
  the original uncaught `ZodError`; reverted only the base-date correction to
  confirm the overnight test fails with the wrong base

## Known limitations (pre-existing, not introduced here)

`shouldAdjustComplimentTime` compares **times of day only**, so an overnight
draft's duration is computed as 23h rather than 1h and it reports
`shouldAdjust` even for a valid schedule. That is why the overnight case
yields a 23-hour event above — this PR restores `main`'s behavior there
rather than fixing it, since changing it risks regressing the overnight
handling that web.date.util.ts:260 was specifically fixed for. Worth a
follow-up.
