### PR TITLE
fix(sync): sync Google subcalendar renames to Compass

### DIFF
--- a/packages/sync/src/domain/calendar-list-sync.service.db.test.ts
+++ b/packages/sync/src/domain/calendar-list-sync.service.db.test.ts
@@ -438,6 +438,47 @@ describe("syncCalendarList", () => {
     expect(team?.active).toBe(true);
   });
 
+  it("updates the stored display name when rediscovery reports a rename", async () => {
+    const conn = connection();
+    await syncCalendarList(
+      deps(
+        new FakeDiscovery([
+          {
+            calendars: [
+              { ...discovered("mens-group"), displayName: "mens-group" },
+            ],
+            cursor: "cur-1",
+          },
+        ]),
+      ),
+      conn,
+      now,
+    );
+
+    await syncCalendarList(
+      deps(
+        new FakeDiscovery([
+          {
+            calendars: [
+              {
+                ...discovered("mens-group"),
+                displayName: "journey-mens-group",
+              },
+            ],
+            cursor: "cur-2",
+          },
+        ]),
+      ),
+      conn,
+      now,
+    );
+
+    const renamed = (await calendarDocs(conn)).find(
+      (d) => d.providerCalendarId === "mens-group",
+    );
+    expect(renamed?.displayName).toBe("journey-mens-group");
+  });
+
   it("re-lists in full when the incremental cursor has expired", async () => {
     const conn = connection();
     await syncCalendarList(

--- a/packages/sync/src/domain/resource-sweep-enqueue.subscription.db.test.ts
+++ b/packages/sync/src/domain/resource-sweep-enqueue.subscription.db.test.ts
@@ -119,6 +119,35 @@ describe("subscription-maintenance sweep (enqueueForResources + listExpiringSubs
     expect(await jobCount()).toBe(0);
   });
 
+  it("enqueues a maintain job for an expiring calendar-list channel", async () => {
+    const tenantId = objectId() as SyncResourceRecord["tenantId"];
+    const principalId = objectId() as SyncResourceRecord["principalId"];
+    const resource = await resources.ensure({
+      tenantId,
+      principalId,
+      connectionId: objectId() as SyncResourceRecord["connectionId"],
+      resourceKind: "calendarList",
+      calendarId: null,
+    });
+    await resources.updateSubscription(tenantId, principalId, resource._id, {
+      subscriptionId: `channel-${resource._id}`,
+      subscriptionResourceId: `res-${resource._id}`,
+      subscriptionToken: "token",
+      subscriptionExpiresAt: new Date("2026-07-10T01:00:00.000Z"),
+    });
+
+    const enqueued = await maintainExpiringSubscriptions(
+      deps(),
+      renewBefore,
+      now,
+    );
+
+    expect(enqueued).toBe(1);
+    const job = await jobByKey(`subscriptionMaintain:${resource._id}`);
+    expect(job?.kind).toBe("subscriptionMaintain");
+    expect(job?.resourceId).toBe(resource._id);
+  });
+
   it("coalesces repeated sweeps into one job per resource", async () => {
     const expiring = await seedResource(new Date("2026-07-10T01:00:00.000Z"));
 

--- a/packages/sync/src/domain/subscription-maintenance.service.db.test.ts
+++ b/packages/sync/src/domain/subscription-maintenance.service.db.test.ts
@@ -20,7 +20,12 @@ const now = () => new Date("2026-07-10T00:00:00.000Z");
 // error, so a test drives the adapter without a network round-trip.
 class FakeNotifications implements ProviderNotificationAdapter {
   readonly provider = "google" as const;
-  watched: Array<{ channelId: string; token: string; calendarId: string }> = [];
+  watched: Array<{
+    channelId: string;
+    token: string;
+    calendarId?: string;
+    kind: "events" | "calendarList";
+  }> = [];
   stopped: Array<{ channelId: string; resourceId: string }> = [];
   #channel: NotificationChannel | null;
   #watchError: ProviderNotificationError | null;
@@ -47,9 +52,28 @@ class FakeNotifications implements ProviderNotificationAdapter {
       channelId: input.channelId,
       token: input.token,
       calendarId: input.calendarId,
+      kind: "events",
     });
     if (this.#watchError) throw this.#watchError;
     // Echo the caller's channel id, as the real adapter does.
+    return {
+      ...(this.#channel as NotificationChannel),
+      channelId: input.channelId,
+    };
+  };
+
+  watchCalendarList = async (input: {
+    accessToken: string;
+    channelId: string;
+    token: string;
+    callbackUrl: string;
+  }): Promise<NotificationChannel> => {
+    this.watched.push({
+      channelId: input.channelId,
+      token: input.token,
+      kind: "calendarList",
+    });
+    if (this.#watchError) throw this.#watchError;
     return {
       ...(this.#channel as NotificationChannel),
       channelId: input.channelId,
@@ -396,5 +420,36 @@ describe("maintainSubscription", () => {
     expect(outcome).toEqual({ status: "renewed" });
     const saved = await reload(resource);
     expect(saved?.subscriptionResourceId).toBe("res-3");
+  });
+
+  it("opens a calendar-list channel without watching a calendar's events", async () => {
+    const tenantId = objectId() as ProviderCalendarRecord["tenantId"];
+    const principalId = objectId() as ProviderCalendarRecord["principalId"];
+    const connectionId = objectId() as ConnectionId;
+    const resource = await resources.ensure({
+      tenantId,
+      principalId,
+      connectionId,
+      resourceKind: "calendarList",
+      calendarId: null,
+    });
+    const expiresAt = new Date("2026-07-17T00:00:00.000Z");
+    const notifications = new FakeNotifications({
+      channel: { channelId: "", resourceId: "res-list", expiresAt },
+    });
+
+    const outcome = await maintainSubscription(
+      { resources, notifications, custody, callbackUrl: "https://sync/cb" },
+      null,
+      resource,
+      now,
+    );
+
+    expect(outcome).toEqual({ status: "watched" });
+    expect(notifications.watched).toEqual([
+      expect.objectContaining({ kind: "calendarList" }),
+    ]);
+    const saved = await resources.findById(tenantId, principalId, resource._id);
+    expect(saved?.subscriptionResourceId).toBe("res-list");
   });
 });

--- a/packages/sync/src/domain/subscription-maintenance.service.ts
+++ b/packages/sync/src/domain/subscription-maintenance.service.ts
@@ -50,8 +50,9 @@ export type SubscriptionMaintenanceOutcome =
 // this, or vice versa, changes that window — keep the two in step.
 const DEFAULT_RENEW_BEFORE_MS = 24 * 60 * 60 * 1000;
 
-// Ensure a calendar's events resource has a live push channel: open one if it
-// has none, or replace one that is near expiry. The new channel is persisted
+// Ensure a resource has a live push channel: events.watch for a calendar, or
+// calendarList.watch for the connection's calendar list. Open one if it has
+// none, or replace one that is near expiry. The new channel is persisted
 // BEFORE the old one is stopped, so a callback is always matchable — the reverse
 // order would open a window where neither the old nor the new channel delivers.
 //
@@ -67,7 +68,7 @@ const DEFAULT_RENEW_BEFORE_MS = 24 * 60 * 60 * 1000;
 // PostHog exceptions across 20 attempts before failing).
 export async function maintainSubscription(
   deps: SubscriptionMaintenanceDeps,
-  calendar: ProviderCalendarRecord,
+  calendar: ProviderCalendarRecord | null,
   resource: SyncResourceRecord,
   now: () => Date,
   options: SubscriptionMaintenanceOptions = {},
@@ -85,7 +86,7 @@ export async function maintainSubscription(
   }
 
   const accessToken = await deps.custody.getValidAccessToken(
-    calendar.connectionId,
+    resource.connectionId,
   );
 
   // The channel id and per-channel token are chosen here so the association is
@@ -96,13 +97,27 @@ export async function maintainSubscription(
 
   let channel: Awaited<ReturnType<ProviderNotificationAdapter["watchEvents"]>>;
   try {
-    channel = await deps.notifications.watchEvents({
-      accessToken,
-      calendarId: calendar.providerCalendarId,
-      channelId,
-      token: channelToken,
-      callbackUrl: deps.callbackUrl,
-    });
+    if (resource.resourceKind === "calendarList") {
+      channel = await deps.notifications.watchCalendarList({
+        accessToken,
+        channelId,
+        token: channelToken,
+        callbackUrl: deps.callbackUrl,
+      });
+    } else {
+      if (!calendar) {
+        throw new Error(
+          `events subscription for resource ${resource._id} is missing its calendar`,
+        );
+      }
+      channel = await deps.notifications.watchEvents({
+        accessToken,
+        calendarId: calendar.providerCalendarId,
+        channelId,
+        token: channelToken,
+        callbackUrl: deps.callbackUrl,
+      });
+    }
   } catch (error) {
     if (error instanceof ProviderNotificationError) {
       if (
@@ -134,7 +149,7 @@ export async function maintainSubscription(
         return { status: "unsupported" };
       }
       if (error.reason === "authorizationRevoked") {
-        await deps.custody.discardRevoked(calendar.connectionId);
+        await deps.custody.discardRevoked(resource.connectionId);
         return { status: "authRevoked" };
       }
     }

--- a/packages/sync/src/domain/sync-job-dispatch.service.db.test.ts
+++ b/packages/sync/src/domain/sync-job-dispatch.service.db.test.ts
@@ -114,11 +114,20 @@ const tokenSource = {
 const notifications = {
   provider: "google" as const,
   watched: [] as string[],
+  calendarListWatched: [] as string[],
   watchEvents: async (input: { channelId: string }) => {
     notifications.watched.push(input.channelId);
     return {
       channelId: input.channelId,
       resourceId: "provider-resource",
+      expiresAt: new Date("2026-07-17T00:00:00.000Z"),
+    };
+  },
+  watchCalendarList: async (input: { channelId: string }) => {
+    notifications.calendarListWatched.push(input.channelId);
+    return {
+      channelId: input.channelId,
+      resourceId: "provider-calendar-list",
       expiresAt: new Date("2026-07-17T00:00:00.000Z"),
     };
   },
@@ -1060,7 +1069,10 @@ describe("dispatchSyncJob", () => {
       now,
     );
 
-    expect(outcome).toEqual({ result: "done" });
+    expect(outcome).toMatchObject({
+      result: "done",
+      followup: { kind: "subscriptionMaintain" },
+    });
     // Discovery persisted the calendar and enqueued its initial import.
     const persisted = await calendars.listByConnection(
       tenantId as ProviderCalendarRecord["tenantId"],
@@ -1073,6 +1085,14 @@ describe("dispatchSyncJob", () => {
       .collection(SYNC_COLLECTIONS.jobs)
       .countDocuments({ kind: "initialImport" });
     expect(importCount).toBe(1);
+    const invalidationCount = await storage
+      .db()
+      .collection(SYNC_COLLECTIONS.invalidations)
+      .countDocuments({
+        "invalidation.kind": "connection",
+        "invalidation.connectionId": connectionId,
+      });
+    expect(invalidationCount).toBe(1);
   });
 
   it("drops a calendarListSync whose connection no longer exists", async () => {

--- a/packages/sync/src/domain/sync-job-dispatch.service.ts
+++ b/packages/sync/src/domain/sync-job-dispatch.service.ts
@@ -219,6 +219,33 @@ async function runSyncJob(
       return { result: "drop", reason: "connection no longer exists" };
     }
     await syncCalendarList(deps, connection, now);
+    // Discovery upserts display names, colors, and membership. Without a
+    // connection invalidation the open SPA keeps the stale calendar list
+    // (S40 gap: event pulls already invalidate, calendar-list sync did not).
+    await deps.invalidations.append({
+      tenantId: job.tenantId,
+      principalId: job.principalId,
+      invalidation: {
+        kind: "connection",
+        connectionId: job.connectionId,
+      },
+      emittedAt: now(),
+    });
+    const calendarList = (
+      await deps.resources.listByConnection(
+        job.tenantId,
+        job.principalId,
+        job.connectionId,
+      )
+    ).find((resource) => resource.resourceKind === "calendarList");
+    // Open a calendar-list push channel once. Renewals are the expiry sweep;
+    // a rediscovery that already has a live channel must not churn it.
+    if (calendarList && calendarList.subscriptionId === null) {
+      return {
+        result: "done",
+        followup: subscriptionFollowup(calendarList, now),
+      };
+    }
     return { result: "done" };
   }
 
@@ -232,6 +259,16 @@ async function runSyncJob(
   );
   if (!resource) {
     return { result: "drop", reason: "resource no longer exists" };
+  }
+  if (resource.resourceKind === "calendarList") {
+    if (job.kind !== "subscriptionMaintain") {
+      return {
+        result: "drop",
+        reason: "calendar-list resource only accepts subscriptionMaintain",
+      };
+    }
+    await maintainSubscription(deps, null, resource, now);
+    return { result: "done" };
   }
   if (!resource.calendarId) {
     return { result: "drop", reason: "resource has no calendar" };

--- a/packages/sync/src/domain/sync-job-worker.service.db.test.ts
+++ b/packages/sync/src/domain/sync-job-worker.service.db.test.ts
@@ -140,6 +140,9 @@ describe("SyncJobWorker", () => {
       watchEvents: async () => {
         throw new Error("watch not used in worker tests");
       },
+      watchCalendarList: async () => {
+        throw new Error("watch not used in worker tests");
+      },
       stopChannel: async () => {},
       parseCallback: () => null,
     },

--- a/packages/sync/src/providers/google/google-notifications.adapter.test.ts
+++ b/packages/sync/src/providers/google/google-notifications.adapter.test.ts
@@ -18,10 +18,17 @@ type Behavior = calendar_v3.Schema$Channel | Error | undefined;
 
 class FakeChannelsApi implements GoogleChannelsApi {
   watchCalls: Parameters<GoogleChannelsApi["watchEvents"]>[0][] = [];
+  calendarListWatchCalls: Parameters<
+    GoogleChannelsApi["watchCalendarList"]
+  >[0][] = [];
   stopCalls: Parameters<GoogleChannelsApi["stopChannel"]>[0][] = [];
 
   constructor(
-    private readonly behavior: { watch?: Behavior; stop?: Error } = {},
+    private readonly behavior: {
+      watch?: Behavior;
+      calendarListWatch?: Behavior;
+      stop?: Error;
+    } = {},
   ) {}
 
   async watchEvents(
@@ -32,6 +39,22 @@ class FakeChannelsApi implements GoogleChannelsApi {
     return (
       this.behavior.watch ?? {
         resourceId: "res-1",
+        expiration: "1767312000000",
+      }
+    );
+  }
+
+  async watchCalendarList(
+    params: Parameters<GoogleChannelsApi["watchCalendarList"]>[0],
+  ): Promise<calendar_v3.Schema$Channel> {
+    this.calendarListWatchCalls.push(params);
+    if (this.behavior.calendarListWatch instanceof Error) {
+      throw this.behavior.calendarListWatch;
+    }
+    return (
+      this.behavior.calendarListWatch ??
+      this.behavior.watch ?? {
+        resourceId: "res-list-1",
         expiration: "1767312000000",
       }
     );
@@ -93,6 +116,37 @@ describe("GoogleNotificationAdapter watch/stop", () => {
     expect(channel).toEqual({
       channelId: "chan-1",
       resourceId: "res-1",
+      expiresAt: new Date("2026-01-02T00:00:00Z"),
+    });
+  });
+
+  it("opens a calendar-list web_hook channel without a calendar id", async () => {
+    const api = new FakeChannelsApi({
+      calendarListWatch: {
+        resourceId: "res-list-1",
+        expiration: "1767312000000",
+      },
+    });
+    const { adapter } = adapterWith(api);
+
+    const channel = await adapter.watchCalendarList({
+      accessToken: "at",
+      channelId: "chan-list",
+      token: "chan-token",
+      callbackUrl: "https://sync.example.com/callbacks/google",
+    });
+
+    expect(api.watchCalls).toHaveLength(0);
+    expect(api.calendarListWatchCalls[0]?.requestBody).toEqual({
+      id: "chan-list",
+      type: "web_hook",
+      address: "https://sync.example.com/callbacks/google",
+      token: "chan-token",
+      expiration: String(new Date("2026-01-03T00:00:00Z").getTime()),
+    });
+    expect(channel).toEqual({
+      channelId: "chan-list",
+      resourceId: "res-list-1",
       expiresAt: new Date("2026-01-02T00:00:00Z"),
     });
   });

--- a/packages/sync/src/providers/google/google-notifications.adapter.ts
+++ b/packages/sync/src/providers/google/google-notifications.adapter.ts
@@ -19,6 +19,9 @@ export interface GoogleChannelsApi {
     calendarId: string;
     requestBody: calendar_v3.Schema$Channel;
   }): Promise<calendar_v3.Schema$Channel>;
+  watchCalendarList(params: {
+    requestBody: calendar_v3.Schema$Channel;
+  }): Promise<calendar_v3.Schema$Channel>;
   stopChannel(params: {
     requestBody: calendar_v3.Schema$Channel;
   }): Promise<void>;
@@ -41,6 +44,10 @@ const defaultApiFactory: GoogleChannelsApiFactory = (accessToken) => {
       const { data } = await gcal.events.watch({ calendarId, requestBody });
       return data;
     },
+    async watchCalendarList({ requestBody }) {
+      const { data } = await gcal.calendarList.watch({ requestBody });
+      return data;
+    },
     async stopChannel({ requestBody }) {
       await gcal.channels.stop({ requestBody });
     },
@@ -61,6 +68,24 @@ const defaultApiFactory: GoogleChannelsApiFactory = (accessToken) => {
 // maintainSubscription persists the replacement BEFORE stopping the old channel
 // so a renewal never opens a delivery gap.
 const DEFAULT_TTL_MS = 48 * 60 * 60 * 1000;
+
+function channelBody(
+  input: {
+    channelId: string;
+    token: string;
+    callbackUrl: string;
+  },
+  expirationMs: number,
+): calendar_v3.Schema$Channel {
+  return {
+    id: input.channelId,
+    type: "web_hook",
+    address: input.callbackUrl,
+    token: input.token,
+    // Google expects an absolute expiration in epoch milliseconds.
+    expiration: String(expirationMs),
+  };
+}
 
 // Google callback headers, lower-cased (Node lower-cases request headers).
 const HEADER_CHANNEL_ID = "x-goog-channel-id";
@@ -94,21 +119,49 @@ export class GoogleNotificationAdapter implements ProviderNotificationAdapter {
     ttlMs?: number;
   }): Promise<NotificationChannel> {
     const api = this.#makeApi(input.accessToken);
-    const expiration = this.#now().getTime() + (input.ttlMs ?? DEFAULT_TTL_MS);
+    const expirationMs = this.#expirationMs(input.ttlMs);
+    return this.#openChannel(
+      () =>
+        api.watchEvents({
+          calendarId: input.calendarId,
+          requestBody: channelBody(input, expirationMs),
+        }),
+      input.channelId,
+      expirationMs,
+    );
+  }
 
+  async watchCalendarList(input: {
+    accessToken: string;
+    channelId: string;
+    token: string;
+    callbackUrl: string;
+    ttlMs?: number;
+  }): Promise<NotificationChannel> {
+    const api = this.#makeApi(input.accessToken);
+    const expirationMs = this.#expirationMs(input.ttlMs);
+    return this.#openChannel(
+      () =>
+        api.watchCalendarList({
+          requestBody: channelBody(input, expirationMs),
+        }),
+      input.channelId,
+      expirationMs,
+    );
+  }
+
+  #expirationMs(ttlMs?: number): number {
+    return this.#now().getTime() + (ttlMs ?? DEFAULT_TTL_MS);
+  }
+
+  async #openChannel(
+    watch: () => Promise<calendar_v3.Schema$Channel>,
+    channelId: string,
+    expirationMs: number,
+  ): Promise<NotificationChannel> {
     let channel: calendar_v3.Schema$Channel;
     try {
-      channel = await api.watchEvents({
-        calendarId: input.calendarId,
-        requestBody: {
-          id: input.channelId,
-          type: "web_hook",
-          address: input.callbackUrl,
-          token: input.token,
-          // Google expects an absolute expiration in epoch milliseconds.
-          expiration: String(expiration),
-        },
-      });
+      channel = await watch();
     } catch (error) {
       throw classifyWatchError(error);
     }
@@ -120,11 +173,11 @@ export class GoogleNotificationAdapter implements ProviderNotificationAdapter {
       );
     }
     return {
-      channelId: input.channelId,
+      channelId,
       resourceId: channel.resourceId,
       // Google's returned expiration wins over the requested one; fall back to
       // the requested expiry only if it omitted one.
-      expiresAt: parseExpiration(channel.expiration, expiration),
+      expiresAt: parseExpiration(channel.expiration, expirationMs),
     };
   }
 

--- a/packages/sync/src/providers/provider-notifications.port.ts
+++ b/packages/sync/src/providers/provider-notifications.port.ts
@@ -55,6 +55,17 @@ export interface ProviderNotificationAdapter {
     readonly ttlMs?: number;
   }): Promise<NotificationChannel>;
 
+  // Open a push channel for the account's calendar list so a rename, add,
+  // hide, or unshare is delivered without waiting for the daily rediscovery
+  // sweep. Same channel association contract as watchEvents.
+  watchCalendarList(input: {
+    readonly accessToken: string;
+    readonly channelId: string;
+    readonly token: string;
+    readonly callbackUrl: string;
+    readonly ttlMs?: number;
+  }): Promise<NotificationChannel>;
+
   // Stop a channel. Idempotent: stopping an already-gone channel resolves.
   stopChannel(input: {
     readonly accessToken: string;

--- a/packages/sync/src/server/notification.routes.db.test.ts
+++ b/packages/sync/src/server/notification.routes.db.test.ts
@@ -61,6 +61,7 @@ describe("POST /sync/notifications/google", () => {
   const seedSubscription = async (
     expiresAt = new Date(Date.now() + 60 * 60 * 1000),
     token = TOKEN,
+    kind: "events" | "calendarList" = "events",
   ) => {
     const tenantId = objectId() as TenantId;
     const principalId = objectId() as PrincipalId;
@@ -68,8 +69,8 @@ describe("POST /sync/notifications/google", () => {
       tenantId,
       principalId,
       connectionId: objectId() as ConnectionId,
-      resourceKind: "calendarList",
-      calendarId: null,
+      resourceKind: kind,
+      calendarId: kind === "events" ? objectId() : null,
     });
     await resources.updateSubscription(tenantId, principalId, resource._id, {
       subscriptionId: CHANNEL,
@@ -77,7 +78,7 @@ describe("POST /sync/notifications/google", () => {
       subscriptionToken: token,
       subscriptionExpiresAt: expiresAt,
     });
-    return resource._id;
+    return resource;
   };
 
   const post = (headers: Record<string, string>) =>
@@ -98,7 +99,7 @@ describe("POST /sync/notifications/google", () => {
   });
 
   it("enqueues one pull for an authentic change, coalescing duplicates", async () => {
-    const resourceId = await seedSubscription();
+    const { _id: resourceId } = await seedSubscription();
     await startService();
 
     const first = await post(googHeaders());
@@ -115,7 +116,7 @@ describe("POST /sync/notifications/google", () => {
     // including the claimed row of a running pull that has already read the
     // provider. The marker is the only thing that survives that, and the pull's
     // compare-and-clear is what turns it back into a second pass.
-    const resourceId = await seedSubscription();
+    const { _id: resourceId } = await seedSubscription();
     await startService();
 
     const res = await post(googHeaders());
@@ -128,7 +129,7 @@ describe("POST /sync/notifications/google", () => {
   });
 
   it("does not stamp the change marker on a rejected notification", async () => {
-    const resourceId = await seedSubscription();
+    const { _id: resourceId } = await seedSubscription();
     await startService();
 
     await post(googHeaders({ "x-goog-channel-token": "wrong" }));
@@ -140,7 +141,7 @@ describe("POST /sync/notifications/google", () => {
   });
 
   it("does not enqueue on the initial sync handshake", async () => {
-    const resourceId = await seedSubscription();
+    const { _id: resourceId } = await seedSubscription();
     await startService();
 
     const res = await post(googHeaders({ "x-goog-resource-state": "sync" }));
@@ -150,7 +151,7 @@ describe("POST /sync/notifications/google", () => {
   });
 
   it("rejects a spoofed token: accepts the request but enqueues nothing", async () => {
-    const resourceId = await seedSubscription();
+    const { _id: resourceId } = await seedSubscription();
     await startService();
 
     const res = await post(googHeaders({ "x-goog-channel-token": "wrong" }));
@@ -172,7 +173,7 @@ describe("POST /sync/notifications/google", () => {
   });
 
   it("enqueues nothing for a resource-id that does not match the subscription", async () => {
-    const resourceId = await seedSubscription();
+    const { _id: resourceId } = await seedSubscription();
     await startService();
 
     const res = await post(googHeaders({ "x-goog-resource-id": "other-res" }));
@@ -182,7 +183,9 @@ describe("POST /sync/notifications/google", () => {
   });
 
   it("enqueues nothing once the subscription has expired", async () => {
-    const resourceId = await seedSubscription(new Date(Date.now() - 1000));
+    const { _id: resourceId } = await seedSubscription(
+      new Date(Date.now() - 1000),
+    );
     await startService();
 
     const res = await post(googHeaders());
@@ -199,8 +202,23 @@ describe("POST /sync/notifications/google", () => {
     expect(res.status).toBe(400);
   });
 
+  it("enqueues calendarListSync for a calendar-list channel change, not a pull", async () => {
+    const resource = await seedSubscription(
+      new Date(Date.now() + 60 * 60 * 1000),
+      TOKEN,
+      "calendarList",
+    );
+    await startService();
+
+    const res = await post(googHeaders());
+
+    expect(res.status).toBe(200);
+    expect(await jobCount(`calendarListSync:${resource.connectionId}`)).toBe(1);
+    expect(await jobCount(`incrementalPull:${resource._id}`)).toBe(0);
+  });
+
   it("accepts and drops notifications in passive mode", async () => {
-    const resourceId = await seedSubscription();
+    const { _id: resourceId } = await seedSubscription();
     await startService(testConfig({ EXECUTION: "passive" }));
 
     const res = await post(googHeaders());

--- a/packages/sync/src/server/notification.routes.ts
+++ b/packages/sync/src/server/notification.routes.ts
@@ -90,32 +90,46 @@ export function registerNotificationRoutes(
       if (verdict.status === "process" && resource) {
         // Stamp BEFORE enqueuing. The enqueue below no-ops whenever a job
         // already holds this coalescing key — including the CLAIMED row of a
-        // pull already in flight, which may have read the provider before this
-        // change existed. The marker is what survives that: the running pull's
+        // job already in flight, which may have read the provider before this
+        // change existed. The marker is what survives that: an events pull's
         // compare-and-clear fails against it and the pull goes round again.
-        // Stamping first also keeps the ordering safe if the enqueue throws —
-        // a marker with no job is recovered by the reconcile sweep, whereas a
-        // job with no marker could clear a change it never read.
+        // A calendar-list rediscovery does not yet consume the marker; the
+        // next webhook or daily sweep covers a rename that lands mid-pass.
         await resources.markChangeNotified(
           resource.tenantId,
           resource.principalId,
           resource._id,
           now,
         );
-        await new JobRepository(deps.mongo.db).enqueue({
-          tenantId: resource.tenantId,
-          principalId: resource.principalId,
-          connectionId: resource.connectionId,
-          resourceId: resource._id,
-          commandId: null,
-          kind: "incrementalPull",
-          // Background on purpose: webhooks are provider-paced. Promoting them
-          // to user priority would make the entire steady state urgent and
-          // defeat the tier that protects Refresh / post-OAuth work.
-          priority: JOB_PRIORITY.background,
-          runAfter: now,
-          coalescingKey: `incrementalPull:${resource._id}`,
-        });
+        const job =
+          resource.resourceKind === "calendarList"
+            ? {
+                tenantId: resource.tenantId,
+                principalId: resource.principalId,
+                connectionId: resource.connectionId,
+                resourceId: null,
+                commandId: null,
+                kind: "calendarListSync" as const,
+                priority: JOB_PRIORITY.background,
+                runAfter: now,
+                coalescingKey: `calendarListSync:${resource.connectionId}`,
+              }
+            : {
+                tenantId: resource.tenantId,
+                principalId: resource.principalId,
+                connectionId: resource.connectionId,
+                resourceId: resource._id,
+                commandId: null,
+                kind: "incrementalPull" as const,
+                // Background on purpose: webhooks are provider-paced. Promoting
+                // them to user priority would make the entire steady state
+                // urgent and defeat the tier that protects Refresh / post-OAuth
+                // work.
+                priority: JOB_PRIORITY.background,
+                runAfter: now,
+                coalescingKey: `incrementalPull:${resource._id}`,
+              };
+        await new JobRepository(deps.mongo.db).enqueue(job);
       }
       res.status(Status.OK).end();
     } catch (error) {

--- a/packages/sync/src/storage/repositories/sync-resource.repository.ts
+++ b/packages/sync/src/storage/repositories/sync-resource.repository.ts
@@ -523,21 +523,18 @@ export class SyncResourceRepository {
     return records.map((r) => SyncResourceRecordSchema.parse(r));
   }
 
-  // Events resources whose push subscription expires before `before` (soonest
-  // first, bounded). This is the subscription-maintenance sweep's input, so like
-  // listStaleEvents it is a GLOBAL scan across owners (system liveness, not a
-  // user request) — each returned resource carries its own (tenantId,
-  // principalId) for the job the caller enqueues. Only resources that ALREADY
-  // hold a channel are returned; a resource with no subscription is bootstrapped
-  // by the initialImport followup, not here, so an unwatchable calendar is not
-  // re-selected forever. Uses the subscription_expiry index.
+  // Resources whose push subscription expires before `before` (soonest
+  // first, bounded). Events channels and the connection's calendar-list
+  // channel share this sweep. Only resources that ALREADY hold a channel are
+  // returned; a resource with no subscription is bootstrapped by the import
+  // (events) or calendarListSync (calendar list) followup, not here.
   async listExpiringSubscriptions(
     before: Date,
     limit: number,
   ): Promise<SyncResourceRecord[]> {
     const records = await this.collection
       .find({
-        resourceKind: "events",
+        resourceKind: { $in: ["events", "calendarList"] },
         subscriptionId: { $ne: null },
         subscriptionExpiresAt: { $lt: before },
       })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Google Calendar subcalendar renames (and add/hide/unshare) did not show up in Compass until the daily calendar-list rediscovery sweep, and even then the open SPA kept the old name because `calendarListSync` never wrote a change-feed invalidation.

This watches the account calendar list (`calendarList.watch`), enqueues `calendarListSync` from those webhooks, renews that channel on the existing subscription sweep, and emits a `connection` invalidation after discovery so the sidebar refetches.

Existing connections pick up the watch on the next Refresh or daily rediscovery. A Refresh already enqueued `calendarListSync`; it now also updates the UI.

## Simplicity

Reuses the existing subscription, notification, and rediscovery paths instead of a new job kind. `watchCalendarList` is a sibling of `watchEvents` on the notification port.

## Automated validation

Focused Sync tests covering adapter watch, subscription maintenance, calendar-list rename upsert, dispatch invalidation/followup, notification routing, and expiry sweep: 93 pass, 0 fail.

## Independent review

Pending.

## Test plan

`bun run test:sync --` on:

- `packages/sync/src/providers/google/google-notifications.adapter.test.ts`
- `packages/sync/src/domain/subscription-maintenance.service.db.test.ts`
- `packages/sync/src/domain/calendar-list-sync.service.db.test.ts`
- `packages/sync/src/domain/sync-job-dispatch.service.db.test.ts`
- `packages/sync/src/server/notification.routes.db.test.ts`
- `packages/sync/src/domain/resource-sweep-enqueue.subscription.db.test.ts`

`bun run lint` (no new findings in this diff; 10 existing warnings elsewhere).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c703bc6c-06eb-4134-b2e2-9f50d4e4f542?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c703bc6c-06eb-4134-b2e2-9f50d4e4f542&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

