### PR TITLE
fix(sync): watch the Google calendar list so subcalendar renames reach Compass

### DIFF
--- a/packages/sync/src/domain/calendar-list-sync.service.db.test.ts
+++ b/packages/sync/src/domain/calendar-list-sync.service.db.test.ts
@@ -438,6 +438,47 @@ describe("syncCalendarList", () => {
     expect(team?.active).toBe(true);
   });
 
+  it("updates the stored display name when rediscovery reports a rename", async () => {
+    const conn = connection();
+    await syncCalendarList(
+      deps(
+        new FakeDiscovery([
+          {
+            calendars: [
+              { ...discovered("mens-group"), displayName: "mens-group" },
+            ],
+            cursor: "cur-1",
+          },
+        ]),
+      ),
+      conn,
+      now,
+    );
+
+    await syncCalendarList(
+      deps(
+        new FakeDiscovery([
+          {
+            calendars: [
+              {
+                ...discovered("mens-group"),
+                displayName: "journey-mens-group",
+              },
+            ],
+            cursor: "cur-2",
+          },
+        ]),
+      ),
+      conn,
+      now,
+    );
+
+    const renamed = (await calendarDocs(conn)).find(
+      (d) => d.providerCalendarId === "mens-group",
+    );
+    expect(renamed?.displayName).toBe("journey-mens-group");
+  });
+
   it("re-lists in full when the incremental cursor has expired", async () => {
     const conn = connection();
     await syncCalendarList(

--- a/packages/sync/src/domain/calendar-list-sync.service.db.test.ts
+++ b/packages/sync/src/domain/calendar-list-sync.service.db.test.ts
@@ -133,7 +133,15 @@ describe("syncCalendarList", () => {
 
     const result = await syncCalendarList(deps(discovery), conn, now);
 
-    expect(result).toEqual({ discovered: 3, imported: 2 });
+    expect(result).toMatchObject({
+      discovered: 3,
+      imported: 2,
+      changedDuringSync: false,
+    });
+    // The returned resource is the post-pass read, so the caller can gate the
+    // watch followup on its subscription fields.
+    expect(result.resource.resourceKind).toBe("calendarList");
+    expect(result.resource.syncCursor).toBe("cur-1");
     expect(await calendarDocs(conn)).toHaveLength(3);
     // One initial import per ACTIVE calendar (2), none for the inactive one.
     const enqueued = await importJobs();
@@ -477,6 +485,70 @@ describe("syncCalendarList", () => {
       (d) => d.providerCalendarId === "mens-group",
     );
     expect(renamed?.displayName).toBe("journey-mens-group");
+  });
+
+  it("clears a change marker the pass has served", async () => {
+    const conn = connection();
+    await syncCalendarList(
+      deps(
+        new FakeDiscovery([
+          { calendars: [discovered("primary")], cursor: "cur-1" },
+        ]),
+      ),
+      conn,
+      now,
+    );
+    // A webhook stamped the marker before this pass claimed the job.
+    const resource = await calendarListResource(conn);
+    await resources.markChangeNotified(
+      conn.tenantId,
+      conn.principalId,
+      String(resource?._id),
+      now(),
+    );
+
+    const result = await syncCalendarList(
+      deps(new FakeDiscovery([{ calendars: [], cursor: "cur-2" }])),
+      conn,
+      now,
+    );
+
+    expect(result.changedDuringSync).toBe(false);
+    expect((await calendarListResource(conn))?.changeNotifiedAt).toBeNull();
+  });
+
+  it("keeps the marker and reports changedDuringSync when a notification lands mid-pass", async () => {
+    const conn = connection();
+    const inner = new FakeDiscovery([
+      { calendars: [discovered("primary")], cursor: "cur-1" },
+    ]);
+    const midPassStamp = new Date("2026-07-10T00:00:05.000Z");
+    // A notification arriving while the provider is being read moves the
+    // marker AFTER the pass captured it, so the compare-and-clear must fail.
+    const discovery: ProviderCalendarAdapter = {
+      provider: "google",
+      discoverCalendars: async (input) => {
+        const resource = await calendarListResource(conn);
+        await resources.markChangeNotified(
+          conn.tenantId,
+          conn.principalId,
+          String(resource?._id),
+          midPassStamp,
+        );
+        return inner.discoverCalendars(input);
+      },
+    };
+
+    const result = await syncCalendarList(
+      { calendars, resources, jobs, discovery, custody },
+      conn,
+      now,
+    );
+
+    expect(result.changedDuringSync).toBe(true);
+    expect((await calendarListResource(conn))?.changeNotifiedAt).toEqual(
+      midPassStamp,
+    );
   });
 
   it("re-lists in full when the incremental cursor has expired", async () => {

--- a/packages/sync/src/domain/calendar-list-sync.service.ts
+++ b/packages/sync/src/domain/calendar-list-sync.service.ts
@@ -6,6 +6,7 @@ import {
 } from "@sync/providers/provider-calendar.port";
 import { JOB_PRIORITY } from "@sync/storage/contracts/job.contracts";
 import { type ProviderConnectionRecord } from "@sync/storage/contracts/provider-connection.contracts";
+import { type SyncResourceRecord } from "@sync/storage/contracts/sync-resource.contracts";
 import { type JobRepository } from "@sync/storage/repositories/job.repository";
 import { type ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
 import { type SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
@@ -28,6 +29,13 @@ export interface CalendarListSyncResult {
   readonly discovered: number;
   // How many active calendars had an initial import enqueued.
   readonly imported: number;
+  // The connection's calendarList resource, re-read after the pass so the
+  // caller sees the subscription fields as this pass left them.
+  readonly resource: SyncResourceRecord;
+  // A change notification landed while this pass was reading the provider, so
+  // the pass may have listed a snapshot that predates it. The marker is left in
+  // place; the caller owns going round again.
+  readonly changedDuringSync: boolean;
 }
 
 // Discover a connection's calendars and bootstrap their sync. This is the front
@@ -67,6 +75,12 @@ export async function syncCalendarList(
   // every sweep cycle (the 2026-07-29 dead-credential tie-break pathology,
   // here for calendarList instead of events).
   await deps.resources.markAttempt(tenantId, principalId, resource._id, now());
+
+  // Read the change marker BEFORE the provider read, mirroring the events
+  // pull: everything this pass observes is a snapshot at or after this
+  // instant, so a marker still holding this value at the end means no change
+  // arrived that this pass could have missed.
+  const notifiedAtStart = resource.changeNotifiedAt;
 
   const accessToken = await deps.custody.getValidAccessToken(connectionId);
 
@@ -223,5 +237,26 @@ export async function syncCalendarList(
     now(),
   );
 
-  return { discovered: discovery.calendars.length, imported };
+  // Retire the change this pass served — but only if nothing moved the marker
+  // while the provider was being read. A failed match means a notification
+  // landed mid-pass (its enqueue coalesced onto this very job and vanished);
+  // leave the newer marker in place and tell the caller to go round again.
+  const served = await deps.resources.clearChangeNotifiedIfUnchanged(
+    tenantId,
+    principalId,
+    resource._id,
+    notifiedAtStart,
+  );
+
+  const updated = await deps.resources.findById(
+    tenantId,
+    principalId,
+    resource._id,
+  );
+  return {
+    discovered: discovery.calendars.length,
+    imported,
+    resource: updated ?? resource,
+    changedDuringSync: !served,
+  };
 }

--- a/packages/sync/src/domain/resource-sweep-enqueue.subscription.db.test.ts
+++ b/packages/sync/src/domain/resource-sweep-enqueue.subscription.db.test.ts
@@ -119,6 +119,35 @@ describe("subscription-maintenance sweep (enqueueForResources + listExpiringSubs
     expect(await jobCount()).toBe(0);
   });
 
+  it("enqueues a maintain job for an expiring calendar-list channel", async () => {
+    const tenantId = objectId() as SyncResourceRecord["tenantId"];
+    const principalId = objectId() as SyncResourceRecord["principalId"];
+    const resource = await resources.ensure({
+      tenantId,
+      principalId,
+      connectionId: objectId() as SyncResourceRecord["connectionId"],
+      resourceKind: "calendarList",
+      calendarId: null,
+    });
+    await resources.updateSubscription(tenantId, principalId, resource._id, {
+      subscriptionId: `channel-${resource._id}`,
+      subscriptionResourceId: `res-${resource._id}`,
+      subscriptionToken: "token",
+      subscriptionExpiresAt: new Date("2026-07-10T01:00:00.000Z"),
+    });
+
+    const enqueued = await maintainExpiringSubscriptions(
+      deps(),
+      renewBefore,
+      now,
+    );
+
+    expect(enqueued).toBe(1);
+    const job = await jobByKey(`subscriptionMaintain:${resource._id}`);
+    expect(job?.kind).toBe("subscriptionMaintain");
+    expect(job?.resourceId).toBe(resource._id);
+  });
+
   it("coalesces repeated sweeps into one job per resource", async () => {
     const expiring = await seedResource(new Date("2026-07-10T01:00:00.000Z"));
 

--- a/packages/sync/src/domain/subscription-maintenance.service.db.test.ts
+++ b/packages/sync/src/domain/subscription-maintenance.service.db.test.ts
@@ -20,7 +20,12 @@ const now = () => new Date("2026-07-10T00:00:00.000Z");
 // error, so a test drives the adapter without a network round-trip.
 class FakeNotifications implements ProviderNotificationAdapter {
   readonly provider = "google" as const;
-  watched: Array<{ channelId: string; token: string; calendarId: string }> = [];
+  watched: Array<{
+    channelId: string;
+    token: string;
+    calendarId?: string;
+    kind: "events" | "calendarList";
+  }> = [];
   stopped: Array<{ channelId: string; resourceId: string }> = [];
   #channel: NotificationChannel | null;
   #watchError: ProviderNotificationError | null;
@@ -47,9 +52,28 @@ class FakeNotifications implements ProviderNotificationAdapter {
       channelId: input.channelId,
       token: input.token,
       calendarId: input.calendarId,
+      kind: "events",
     });
     if (this.#watchError) throw this.#watchError;
     // Echo the caller's channel id, as the real adapter does.
+    return {
+      ...(this.#channel as NotificationChannel),
+      channelId: input.channelId,
+    };
+  };
+
+  watchCalendarList = async (input: {
+    accessToken: string;
+    channelId: string;
+    token: string;
+    callbackUrl: string;
+  }): Promise<NotificationChannel> => {
+    this.watched.push({
+      channelId: input.channelId,
+      token: input.token,
+      kind: "calendarList",
+    });
+    if (this.#watchError) throw this.#watchError;
     return {
       ...(this.#channel as NotificationChannel),
       channelId: input.channelId,
@@ -396,5 +420,36 @@ describe("maintainSubscription", () => {
     expect(outcome).toEqual({ status: "renewed" });
     const saved = await reload(resource);
     expect(saved?.subscriptionResourceId).toBe("res-3");
+  });
+
+  it("opens a calendar-list channel without watching a calendar's events", async () => {
+    const tenantId = objectId() as ProviderCalendarRecord["tenantId"];
+    const principalId = objectId() as ProviderCalendarRecord["principalId"];
+    const connectionId = objectId() as ConnectionId;
+    const resource = await resources.ensure({
+      tenantId,
+      principalId,
+      connectionId,
+      resourceKind: "calendarList",
+      calendarId: null,
+    });
+    const expiresAt = new Date("2026-07-17T00:00:00.000Z");
+    const notifications = new FakeNotifications({
+      channel: { channelId: "", resourceId: "res-list", expiresAt },
+    });
+
+    const outcome = await maintainSubscription(
+      { resources, notifications, custody, callbackUrl: "https://sync/cb" },
+      null,
+      resource,
+      now,
+    );
+
+    expect(outcome).toEqual({ status: "watched" });
+    expect(notifications.watched).toEqual([
+      expect.objectContaining({ kind: "calendarList" }),
+    ]);
+    const saved = await resources.findById(tenantId, principalId, resource._id);
+    expect(saved?.subscriptionResourceId).toBe("res-list");
   });
 });

--- a/packages/sync/src/domain/subscription-maintenance.service.ts
+++ b/packages/sync/src/domain/subscription-maintenance.service.ts
@@ -50,8 +50,9 @@ export type SubscriptionMaintenanceOutcome =
 // this, or vice versa, changes that window — keep the two in step.
 const DEFAULT_RENEW_BEFORE_MS = 24 * 60 * 60 * 1000;
 
-// Ensure a calendar's events resource has a live push channel: open one if it
-// has none, or replace one that is near expiry. The new channel is persisted
+// Ensure a resource has a live push channel: events.watch for a calendar, or
+// calendarList.watch for the connection's calendar list. Open one if it has
+// none, or replace one that is near expiry. The new channel is persisted
 // BEFORE the old one is stopped, so a callback is always matchable — the reverse
 // order would open a window where neither the old nor the new channel delivers.
 //
@@ -67,7 +68,7 @@ const DEFAULT_RENEW_BEFORE_MS = 24 * 60 * 60 * 1000;
 // PostHog exceptions across 20 attempts before failing).
 export async function maintainSubscription(
   deps: SubscriptionMaintenanceDeps,
-  calendar: ProviderCalendarRecord,
+  calendar: ProviderCalendarRecord | null,
   resource: SyncResourceRecord,
   now: () => Date,
   options: SubscriptionMaintenanceOptions = {},
@@ -85,7 +86,7 @@ export async function maintainSubscription(
   }
 
   const accessToken = await deps.custody.getValidAccessToken(
-    calendar.connectionId,
+    resource.connectionId,
   );
 
   // The channel id and per-channel token are chosen here so the association is
@@ -96,13 +97,27 @@ export async function maintainSubscription(
 
   let channel: Awaited<ReturnType<ProviderNotificationAdapter["watchEvents"]>>;
   try {
-    channel = await deps.notifications.watchEvents({
-      accessToken,
-      calendarId: calendar.providerCalendarId,
-      channelId,
-      token: channelToken,
-      callbackUrl: deps.callbackUrl,
-    });
+    if (resource.resourceKind === "calendarList") {
+      channel = await deps.notifications.watchCalendarList({
+        accessToken,
+        channelId,
+        token: channelToken,
+        callbackUrl: deps.callbackUrl,
+      });
+    } else {
+      if (!calendar) {
+        throw new Error(
+          `events subscription for resource ${resource._id} is missing its calendar`,
+        );
+      }
+      channel = await deps.notifications.watchEvents({
+        accessToken,
+        calendarId: calendar.providerCalendarId,
+        channelId,
+        token: channelToken,
+        callbackUrl: deps.callbackUrl,
+      });
+    }
   } catch (error) {
     if (error instanceof ProviderNotificationError) {
       if (
@@ -134,7 +149,7 @@ export async function maintainSubscription(
         return { status: "unsupported" };
       }
       if (error.reason === "authorizationRevoked") {
-        await deps.custody.discardRevoked(calendar.connectionId);
+        await deps.custody.discardRevoked(resource.connectionId);
         return { status: "authRevoked" };
       }
     }

--- a/packages/sync/src/domain/sync-job-dispatch.service.db.test.ts
+++ b/packages/sync/src/domain/sync-job-dispatch.service.db.test.ts
@@ -1095,6 +1095,97 @@ describe("dispatchSyncJob", () => {
     expect(invalidationCount).toBe(1);
   });
 
+  it("re-lists when a notification lands mid-discovery, then clears the marker", async () => {
+    const tenantId = objectId();
+    const principalId = objectId();
+    const connectionId = objectId();
+    stubbedConnection = {
+      _id: connectionId,
+      tenantId,
+      principalId,
+    } as ProviderConnectionRecord;
+    // The first pass gets a change notification while it is reading the
+    // provider (its enqueue coalesced onto this very job and vanished); the
+    // moved marker must make dispatch go round again.
+    let calls = 0;
+    const restlessDiscovery: SyncJobDispatchDeps["discovery"] = {
+      provider: "google" as const,
+      discoverCalendars: async () => {
+        calls += 1;
+        if (calls === 1) {
+          const resource = await storage
+            .db()
+            .collection(SYNC_COLLECTIONS.syncResources)
+            .findOne({ connectionId, resourceKind: "calendarList" });
+          await resources.markChangeNotified(
+            tenantId as SyncResourceRecord["tenantId"],
+            principalId as SyncResourceRecord["principalId"],
+            String(resource?._id),
+            new Date("2026-07-10T00:00:05.000Z"),
+          );
+        }
+        return discovery.discoverCalendars();
+      },
+    };
+
+    const outcome = await dispatchSyncJob(
+      deps(new FakeReader([]), tokenSource, notifications, restlessDiscovery),
+      calendarListJob(connectionId, tenantId, principalId),
+      now,
+    );
+
+    expect(outcome).toMatchObject({ result: "done" });
+    expect(calls).toBe(2);
+    // The second pass served the mid-pass change and retired its marker.
+    const resource = await storage
+      .db()
+      .collection(SYNC_COLLECTIONS.syncResources)
+      .findOne({ connectionId, resourceKind: "calendarList" });
+    expect(resource?.changeNotifiedAt).toBeNull();
+  });
+
+  it("skips the watch followup when the provider refused calendar-list watch", async () => {
+    const tenantId = objectId();
+    const principalId = objectId();
+    const connectionId = objectId();
+    stubbedConnection = {
+      _id: connectionId,
+      tenantId,
+      principalId,
+    } as ProviderConnectionRecord;
+    // Seed a cursored calendarList resource marked unwatchable: the pass runs
+    // incrementally (no full-pass clear of the verdict), so the followup gate
+    // must leave the refused watch to the daily rediscovery cadence.
+    const resource = await resources.ensure({
+      tenantId: tenantId as SyncResourceRecord["tenantId"],
+      principalId: principalId as SyncResourceRecord["principalId"],
+      connectionId: connectionId as SyncResourceRecord["connectionId"],
+      resourceKind: "calendarList",
+      calendarId: null,
+    });
+    await resources.advanceCursor(
+      resource.tenantId,
+      resource.principalId,
+      resource._id,
+      "cursor-0",
+      now(),
+    );
+    await resources.markWatchUnsupported(
+      resource.tenantId,
+      resource.principalId,
+      resource._id,
+      now(),
+    );
+
+    const outcome = await dispatchSyncJob(
+      deps(new FakeReader([])),
+      calendarListJob(connectionId, tenantId, principalId),
+      now,
+    );
+
+    expect(outcome).toEqual({ result: "done" });
+  });
+
   it("drops a calendarListSync whose connection no longer exists", async () => {
     stubbedConnection = null; // findById returns nothing
 

--- a/packages/sync/src/domain/sync-job-dispatch.service.db.test.ts
+++ b/packages/sync/src/domain/sync-job-dispatch.service.db.test.ts
@@ -114,11 +114,20 @@ const tokenSource = {
 const notifications = {
   provider: "google" as const,
   watched: [] as string[],
+  calendarListWatched: [] as string[],
   watchEvents: async (input: { channelId: string }) => {
     notifications.watched.push(input.channelId);
     return {
       channelId: input.channelId,
       resourceId: "provider-resource",
+      expiresAt: new Date("2026-07-17T00:00:00.000Z"),
+    };
+  },
+  watchCalendarList: async (input: { channelId: string }) => {
+    notifications.calendarListWatched.push(input.channelId);
+    return {
+      channelId: input.channelId,
+      resourceId: "provider-calendar-list",
       expiresAt: new Date("2026-07-17T00:00:00.000Z"),
     };
   },
@@ -1060,7 +1069,10 @@ describe("dispatchSyncJob", () => {
       now,
     );
 
-    expect(outcome).toEqual({ result: "done" });
+    expect(outcome).toMatchObject({
+      result: "done",
+      followup: { kind: "subscriptionMaintain" },
+    });
     // Discovery persisted the calendar and enqueued its initial import.
     const persisted = await calendars.listByConnection(
       tenantId as ProviderCalendarRecord["tenantId"],
@@ -1073,6 +1085,14 @@ describe("dispatchSyncJob", () => {
       .collection(SYNC_COLLECTIONS.jobs)
       .countDocuments({ kind: "initialImport" });
     expect(importCount).toBe(1);
+    const invalidationCount = await storage
+      .db()
+      .collection(SYNC_COLLECTIONS.invalidations)
+      .countDocuments({
+        "invalidation.kind": "connection",
+        "invalidation.connectionId": connectionId,
+      });
+    expect(invalidationCount).toBe(1);
   });
 
   it("drops a calendarListSync whose connection no longer exists", async () => {

--- a/packages/sync/src/domain/sync-job-dispatch.service.ts
+++ b/packages/sync/src/domain/sync-job-dispatch.service.ts
@@ -218,7 +218,26 @@ async function runSyncJob(
     if (!connection) {
       return { result: "drop", reason: "connection no longer exists" };
     }
-    await syncCalendarList(deps, connection, now);
+    // Re-list while notifications land mid-pass, mirroring pullUntilQuiet: a
+    // webhook that arrives while this job is CLAIMED coalesces onto it and
+    // vanishes, so the moved change marker is the only signal that this pass
+    // listed a snapshot from before the change. Bounded for the same reason as
+    // pulls; on giving up the marker stays set and the daily rediscovery sweep
+    // covers the remainder.
+    let list = await syncCalendarList(deps, connection, now);
+    let passes = 1;
+    while (list.changedDuringSync && passes < MAX_PULL_PASSES) {
+      deps.log?.info?.(
+        `Sync connection ${job.connectionId}: notification landed mid-discovery, re-listing (pass ${passes + 1}/${MAX_PULL_PASSES})`,
+      );
+      list = await syncCalendarList(deps, connection, now);
+      passes += 1;
+    }
+    if (list.changedDuringSync) {
+      deps.log?.warn(
+        `Sync connection ${job.connectionId}: still receiving calendar-list notifications after ${MAX_PULL_PASSES} discovery passes; leaving the rest to the rediscovery sweep`,
+      );
+    }
     // Discovery upserts display names, colors, and membership. Without a
     // connection invalidation the open SPA keeps the stale calendar list
     // (S40 gap: event pulls already invalidate, calendar-list sync did not).
@@ -231,19 +250,17 @@ async function runSyncJob(
       },
       emittedAt: now(),
     });
-    const calendarList = (
-      await deps.resources.listByConnection(
-        job.tenantId,
-        job.principalId,
-        job.connectionId,
-      )
-    ).find((resource) => resource.resourceKind === "calendarList");
-    // Open a calendar-list push channel once. Renewals are the expiry sweep;
-    // a rediscovery that already has a live channel must not churn it.
-    if (calendarList && calendarList.subscriptionId === null) {
+    // Open a calendar-list push channel once. Renewals are the expiry sweep; a
+    // rediscovery that already has a live channel must not churn it, and one
+    // the provider refused (watchUnsupportedAt) polls via the daily sweep until
+    // the next full pass clears the verdict for a fresh attempt.
+    if (
+      list.resource.subscriptionId === null &&
+      list.resource.watchUnsupportedAt === null
+    ) {
       return {
         result: "done",
-        followup: subscriptionFollowup(calendarList, now),
+        followup: subscriptionFollowup(list.resource, now),
       };
     }
     return { result: "done" };

--- a/packages/sync/src/domain/sync-job-dispatch.service.ts
+++ b/packages/sync/src/domain/sync-job-dispatch.service.ts
@@ -219,6 +219,33 @@ async function runSyncJob(
       return { result: "drop", reason: "connection no longer exists" };
     }
     await syncCalendarList(deps, connection, now);
+    // Discovery upserts display names, colors, and membership. Without a
+    // connection invalidation the open SPA keeps the stale calendar list
+    // (S40 gap: event pulls already invalidate, calendar-list sync did not).
+    await deps.invalidations.append({
+      tenantId: job.tenantId,
+      principalId: job.principalId,
+      invalidation: {
+        kind: "connection",
+        connectionId: job.connectionId,
+      },
+      emittedAt: now(),
+    });
+    const calendarList = (
+      await deps.resources.listByConnection(
+        job.tenantId,
+        job.principalId,
+        job.connectionId,
+      )
+    ).find((resource) => resource.resourceKind === "calendarList");
+    // Open a calendar-list push channel once. Renewals are the expiry sweep;
+    // a rediscovery that already has a live channel must not churn it.
+    if (calendarList && calendarList.subscriptionId === null) {
+      return {
+        result: "done",
+        followup: subscriptionFollowup(calendarList, now),
+      };
+    }
     return { result: "done" };
   }
 
@@ -232,6 +259,16 @@ async function runSyncJob(
   );
   if (!resource) {
     return { result: "drop", reason: "resource no longer exists" };
+  }
+  if (resource.resourceKind === "calendarList") {
+    if (job.kind !== "subscriptionMaintain") {
+      return {
+        result: "drop",
+        reason: "calendar-list resource only accepts subscriptionMaintain",
+      };
+    }
+    await maintainSubscription(deps, null, resource, now);
+    return { result: "done" };
   }
   if (!resource.calendarId) {
     return { result: "drop", reason: "resource has no calendar" };

--- a/packages/sync/src/domain/sync-job-worker.service.db.test.ts
+++ b/packages/sync/src/domain/sync-job-worker.service.db.test.ts
@@ -140,6 +140,9 @@ describe("SyncJobWorker", () => {
       watchEvents: async () => {
         throw new Error("watch not used in worker tests");
       },
+      watchCalendarList: async () => {
+        throw new Error("watch not used in worker tests");
+      },
       stopChannel: async () => {},
       parseCallback: () => null,
     },

--- a/packages/sync/src/providers/google/google-notifications.adapter.test.ts
+++ b/packages/sync/src/providers/google/google-notifications.adapter.test.ts
@@ -18,10 +18,17 @@ type Behavior = calendar_v3.Schema$Channel | Error | undefined;
 
 class FakeChannelsApi implements GoogleChannelsApi {
   watchCalls: Parameters<GoogleChannelsApi["watchEvents"]>[0][] = [];
+  calendarListWatchCalls: Parameters<
+    GoogleChannelsApi["watchCalendarList"]
+  >[0][] = [];
   stopCalls: Parameters<GoogleChannelsApi["stopChannel"]>[0][] = [];
 
   constructor(
-    private readonly behavior: { watch?: Behavior; stop?: Error } = {},
+    private readonly behavior: {
+      watch?: Behavior;
+      calendarListWatch?: Behavior;
+      stop?: Error;
+    } = {},
   ) {}
 
   async watchEvents(
@@ -32,6 +39,22 @@ class FakeChannelsApi implements GoogleChannelsApi {
     return (
       this.behavior.watch ?? {
         resourceId: "res-1",
+        expiration: "1767312000000",
+      }
+    );
+  }
+
+  async watchCalendarList(
+    params: Parameters<GoogleChannelsApi["watchCalendarList"]>[0],
+  ): Promise<calendar_v3.Schema$Channel> {
+    this.calendarListWatchCalls.push(params);
+    if (this.behavior.calendarListWatch instanceof Error) {
+      throw this.behavior.calendarListWatch;
+    }
+    return (
+      this.behavior.calendarListWatch ??
+      this.behavior.watch ?? {
+        resourceId: "res-list-1",
         expiration: "1767312000000",
       }
     );
@@ -93,6 +116,37 @@ describe("GoogleNotificationAdapter watch/stop", () => {
     expect(channel).toEqual({
       channelId: "chan-1",
       resourceId: "res-1",
+      expiresAt: new Date("2026-01-02T00:00:00Z"),
+    });
+  });
+
+  it("opens a calendar-list web_hook channel without a calendar id", async () => {
+    const api = new FakeChannelsApi({
+      calendarListWatch: {
+        resourceId: "res-list-1",
+        expiration: "1767312000000",
+      },
+    });
+    const { adapter } = adapterWith(api);
+
+    const channel = await adapter.watchCalendarList({
+      accessToken: "at",
+      channelId: "chan-list",
+      token: "chan-token",
+      callbackUrl: "https://sync.example.com/callbacks/google",
+    });
+
+    expect(api.watchCalls).toHaveLength(0);
+    expect(api.calendarListWatchCalls[0]?.requestBody).toEqual({
+      id: "chan-list",
+      type: "web_hook",
+      address: "https://sync.example.com/callbacks/google",
+      token: "chan-token",
+      expiration: String(new Date("2026-01-03T00:00:00Z").getTime()),
+    });
+    expect(channel).toEqual({
+      channelId: "chan-list",
+      resourceId: "res-list-1",
       expiresAt: new Date("2026-01-02T00:00:00Z"),
     });
   });

--- a/packages/sync/src/providers/google/google-notifications.adapter.ts
+++ b/packages/sync/src/providers/google/google-notifications.adapter.ts
@@ -19,6 +19,9 @@ export interface GoogleChannelsApi {
     calendarId: string;
     requestBody: calendar_v3.Schema$Channel;
   }): Promise<calendar_v3.Schema$Channel>;
+  watchCalendarList(params: {
+    requestBody: calendar_v3.Schema$Channel;
+  }): Promise<calendar_v3.Schema$Channel>;
   stopChannel(params: {
     requestBody: calendar_v3.Schema$Channel;
   }): Promise<void>;
@@ -41,6 +44,10 @@ const defaultApiFactory: GoogleChannelsApiFactory = (accessToken) => {
       const { data } = await gcal.events.watch({ calendarId, requestBody });
       return data;
     },
+    async watchCalendarList({ requestBody }) {
+      const { data } = await gcal.calendarList.watch({ requestBody });
+      return data;
+    },
     async stopChannel({ requestBody }) {
       await gcal.channels.stop({ requestBody });
     },
@@ -61,6 +68,24 @@ const defaultApiFactory: GoogleChannelsApiFactory = (accessToken) => {
 // maintainSubscription persists the replacement BEFORE stopping the old channel
 // so a renewal never opens a delivery gap.
 const DEFAULT_TTL_MS = 48 * 60 * 60 * 1000;
+
+function channelBody(
+  input: {
+    channelId: string;
+    token: string;
+    callbackUrl: string;
+  },
+  expirationMs: number,
+): calendar_v3.Schema$Channel {
+  return {
+    id: input.channelId,
+    type: "web_hook",
+    address: input.callbackUrl,
+    token: input.token,
+    // Google expects an absolute expiration in epoch milliseconds.
+    expiration: String(expirationMs),
+  };
+}
 
 // Google callback headers, lower-cased (Node lower-cases request headers).
 const HEADER_CHANNEL_ID = "x-goog-channel-id";
@@ -94,21 +119,49 @@ export class GoogleNotificationAdapter implements ProviderNotificationAdapter {
     ttlMs?: number;
   }): Promise<NotificationChannel> {
     const api = this.#makeApi(input.accessToken);
-    const expiration = this.#now().getTime() + (input.ttlMs ?? DEFAULT_TTL_MS);
+    const expirationMs = this.#expirationMs(input.ttlMs);
+    return this.#openChannel(
+      () =>
+        api.watchEvents({
+          calendarId: input.calendarId,
+          requestBody: channelBody(input, expirationMs),
+        }),
+      input.channelId,
+      expirationMs,
+    );
+  }
 
+  async watchCalendarList(input: {
+    accessToken: string;
+    channelId: string;
+    token: string;
+    callbackUrl: string;
+    ttlMs?: number;
+  }): Promise<NotificationChannel> {
+    const api = this.#makeApi(input.accessToken);
+    const expirationMs = this.#expirationMs(input.ttlMs);
+    return this.#openChannel(
+      () =>
+        api.watchCalendarList({
+          requestBody: channelBody(input, expirationMs),
+        }),
+      input.channelId,
+      expirationMs,
+    );
+  }
+
+  #expirationMs(ttlMs?: number): number {
+    return this.#now().getTime() + (ttlMs ?? DEFAULT_TTL_MS);
+  }
+
+  async #openChannel(
+    watch: () => Promise<calendar_v3.Schema$Channel>,
+    channelId: string,
+    expirationMs: number,
+  ): Promise<NotificationChannel> {
     let channel: calendar_v3.Schema$Channel;
     try {
-      channel = await api.watchEvents({
-        calendarId: input.calendarId,
-        requestBody: {
-          id: input.channelId,
-          type: "web_hook",
-          address: input.callbackUrl,
-          token: input.token,
-          // Google expects an absolute expiration in epoch milliseconds.
-          expiration: String(expiration),
-        },
-      });
+      channel = await watch();
     } catch (error) {
       throw classifyWatchError(error);
     }
@@ -120,11 +173,11 @@ export class GoogleNotificationAdapter implements ProviderNotificationAdapter {
       );
     }
     return {
-      channelId: input.channelId,
+      channelId,
       resourceId: channel.resourceId,
       // Google's returned expiration wins over the requested one; fall back to
       // the requested expiry only if it omitted one.
-      expiresAt: parseExpiration(channel.expiration, expiration),
+      expiresAt: parseExpiration(channel.expiration, expirationMs),
     };
   }
 

--- a/packages/sync/src/providers/provider-notifications.port.ts
+++ b/packages/sync/src/providers/provider-notifications.port.ts
@@ -55,6 +55,17 @@ export interface ProviderNotificationAdapter {
     readonly ttlMs?: number;
   }): Promise<NotificationChannel>;
 
+  // Open a push channel for the account's calendar list so a rename, add,
+  // hide, or unshare is delivered without waiting for the daily rediscovery
+  // sweep. Same channel association contract as watchEvents.
+  watchCalendarList(input: {
+    readonly accessToken: string;
+    readonly channelId: string;
+    readonly token: string;
+    readonly callbackUrl: string;
+    readonly ttlMs?: number;
+  }): Promise<NotificationChannel>;
+
   // Stop a channel. Idempotent: stopping an already-gone channel resolves.
   stopChannel(input: {
     readonly accessToken: string;

--- a/packages/sync/src/server/notification.routes.db.test.ts
+++ b/packages/sync/src/server/notification.routes.db.test.ts
@@ -61,6 +61,7 @@ describe("POST /sync/notifications/google", () => {
   const seedSubscription = async (
     expiresAt = new Date(Date.now() + 60 * 60 * 1000),
     token = TOKEN,
+    kind: "events" | "calendarList" = "events",
   ) => {
     const tenantId = objectId() as TenantId;
     const principalId = objectId() as PrincipalId;
@@ -68,8 +69,8 @@ describe("POST /sync/notifications/google", () => {
       tenantId,
       principalId,
       connectionId: objectId() as ConnectionId,
-      resourceKind: "calendarList",
-      calendarId: null,
+      resourceKind: kind,
+      calendarId: kind === "events" ? objectId() : null,
     });
     await resources.updateSubscription(tenantId, principalId, resource._id, {
       subscriptionId: CHANNEL,
@@ -77,7 +78,7 @@ describe("POST /sync/notifications/google", () => {
       subscriptionToken: token,
       subscriptionExpiresAt: expiresAt,
     });
-    return resource._id;
+    return resource;
   };
 
   const post = (headers: Record<string, string>) =>
@@ -98,7 +99,7 @@ describe("POST /sync/notifications/google", () => {
   });
 
   it("enqueues one pull for an authentic change, coalescing duplicates", async () => {
-    const resourceId = await seedSubscription();
+    const { _id: resourceId } = await seedSubscription();
     await startService();
 
     const first = await post(googHeaders());
@@ -115,7 +116,7 @@ describe("POST /sync/notifications/google", () => {
     // including the claimed row of a running pull that has already read the
     // provider. The marker is the only thing that survives that, and the pull's
     // compare-and-clear is what turns it back into a second pass.
-    const resourceId = await seedSubscription();
+    const { _id: resourceId } = await seedSubscription();
     await startService();
 
     const res = await post(googHeaders());
@@ -128,7 +129,7 @@ describe("POST /sync/notifications/google", () => {
   });
 
   it("does not stamp the change marker on a rejected notification", async () => {
-    const resourceId = await seedSubscription();
+    const { _id: resourceId } = await seedSubscription();
     await startService();
 
     await post(googHeaders({ "x-goog-channel-token": "wrong" }));
@@ -140,7 +141,7 @@ describe("POST /sync/notifications/google", () => {
   });
 
   it("does not enqueue on the initial sync handshake", async () => {
-    const resourceId = await seedSubscription();
+    const { _id: resourceId } = await seedSubscription();
     await startService();
 
     const res = await post(googHeaders({ "x-goog-resource-state": "sync" }));
@@ -150,7 +151,7 @@ describe("POST /sync/notifications/google", () => {
   });
 
   it("rejects a spoofed token: accepts the request but enqueues nothing", async () => {
-    const resourceId = await seedSubscription();
+    const { _id: resourceId } = await seedSubscription();
     await startService();
 
     const res = await post(googHeaders({ "x-goog-channel-token": "wrong" }));
@@ -172,7 +173,7 @@ describe("POST /sync/notifications/google", () => {
   });
 
   it("enqueues nothing for a resource-id that does not match the subscription", async () => {
-    const resourceId = await seedSubscription();
+    const { _id: resourceId } = await seedSubscription();
     await startService();
 
     const res = await post(googHeaders({ "x-goog-resource-id": "other-res" }));
@@ -182,7 +183,9 @@ describe("POST /sync/notifications/google", () => {
   });
 
   it("enqueues nothing once the subscription has expired", async () => {
-    const resourceId = await seedSubscription(new Date(Date.now() - 1000));
+    const { _id: resourceId } = await seedSubscription(
+      new Date(Date.now() - 1000),
+    );
     await startService();
 
     const res = await post(googHeaders());
@@ -199,8 +202,23 @@ describe("POST /sync/notifications/google", () => {
     expect(res.status).toBe(400);
   });
 
+  it("enqueues calendarListSync for a calendar-list channel change, not a pull", async () => {
+    const resource = await seedSubscription(
+      new Date(Date.now() + 60 * 60 * 1000),
+      TOKEN,
+      "calendarList",
+    );
+    await startService();
+
+    const res = await post(googHeaders());
+
+    expect(res.status).toBe(200);
+    expect(await jobCount(`calendarListSync:${resource.connectionId}`)).toBe(1);
+    expect(await jobCount(`incrementalPull:${resource._id}`)).toBe(0);
+  });
+
   it("accepts and drops notifications in passive mode", async () => {
-    const resourceId = await seedSubscription();
+    const { _id: resourceId } = await seedSubscription();
     await startService(testConfig({ EXECUTION: "passive" }));
 
     const res = await post(googHeaders());

--- a/packages/sync/src/server/notification.routes.ts
+++ b/packages/sync/src/server/notification.routes.ts
@@ -91,10 +91,12 @@ export function registerNotificationRoutes(
         // Stamp BEFORE enqueuing. The enqueue below no-ops whenever a job
         // already holds this coalescing key — including the CLAIMED row of a
         // job already in flight, which may have read the provider before this
-        // change existed. The marker is what survives that: an events pull's
-        // compare-and-clear fails against it and the pull goes round again.
-        // A calendar-list rediscovery does not yet consume the marker; the
-        // next webhook or daily sweep covers a rename that lands mid-pass.
+        // change existed. The marker is what survives that: the running job's
+        // compare-and-clear (events pull and calendar-list sync alike) fails
+        // against it and the job goes round again. Stamping first also keeps
+        // the ordering safe if the enqueue throws — a marker with no job is
+        // recovered by the sweeps, whereas a job with no marker could clear a
+        // change it never read.
         await resources.markChangeNotified(
           resource.tenantId,
           resource.principalId,

--- a/packages/sync/src/server/notification.routes.ts
+++ b/packages/sync/src/server/notification.routes.ts
@@ -90,32 +90,46 @@ export function registerNotificationRoutes(
       if (verdict.status === "process" && resource) {
         // Stamp BEFORE enqueuing. The enqueue below no-ops whenever a job
         // already holds this coalescing key — including the CLAIMED row of a
-        // pull already in flight, which may have read the provider before this
-        // change existed. The marker is what survives that: the running pull's
+        // job already in flight, which may have read the provider before this
+        // change existed. The marker is what survives that: an events pull's
         // compare-and-clear fails against it and the pull goes round again.
-        // Stamping first also keeps the ordering safe if the enqueue throws —
-        // a marker with no job is recovered by the reconcile sweep, whereas a
-        // job with no marker could clear a change it never read.
+        // A calendar-list rediscovery does not yet consume the marker; the
+        // next webhook or daily sweep covers a rename that lands mid-pass.
         await resources.markChangeNotified(
           resource.tenantId,
           resource.principalId,
           resource._id,
           now,
         );
-        await new JobRepository(deps.mongo.db).enqueue({
-          tenantId: resource.tenantId,
-          principalId: resource.principalId,
-          connectionId: resource.connectionId,
-          resourceId: resource._id,
-          commandId: null,
-          kind: "incrementalPull",
-          // Background on purpose: webhooks are provider-paced. Promoting them
-          // to user priority would make the entire steady state urgent and
-          // defeat the tier that protects Refresh / post-OAuth work.
-          priority: JOB_PRIORITY.background,
-          runAfter: now,
-          coalescingKey: `incrementalPull:${resource._id}`,
-        });
+        const job =
+          resource.resourceKind === "calendarList"
+            ? {
+                tenantId: resource.tenantId,
+                principalId: resource.principalId,
+                connectionId: resource.connectionId,
+                resourceId: null,
+                commandId: null,
+                kind: "calendarListSync" as const,
+                priority: JOB_PRIORITY.background,
+                runAfter: now,
+                coalescingKey: `calendarListSync:${resource.connectionId}`,
+              }
+            : {
+                tenantId: resource.tenantId,
+                principalId: resource.principalId,
+                connectionId: resource.connectionId,
+                resourceId: resource._id,
+                commandId: null,
+                kind: "incrementalPull" as const,
+                // Background on purpose: webhooks are provider-paced. Promoting
+                // them to user priority would make the entire steady state
+                // urgent and defeat the tier that protects Refresh / post-OAuth
+                // work.
+                priority: JOB_PRIORITY.background,
+                runAfter: now,
+                coalescingKey: `incrementalPull:${resource._id}`,
+              };
+        await new JobRepository(deps.mongo.db).enqueue(job);
       }
       res.status(Status.OK).end();
     } catch (error) {

--- a/packages/sync/src/storage/repositories/sync-resource.repository.ts
+++ b/packages/sync/src/storage/repositories/sync-resource.repository.ts
@@ -523,21 +523,18 @@ export class SyncResourceRepository {
     return records.map((r) => SyncResourceRecordSchema.parse(r));
   }
 
-  // Events resources whose push subscription expires before `before` (soonest
-  // first, bounded). This is the subscription-maintenance sweep's input, so like
-  // listStaleEvents it is a GLOBAL scan across owners (system liveness, not a
-  // user request) — each returned resource carries its own (tenantId,
-  // principalId) for the job the caller enqueues. Only resources that ALREADY
-  // hold a channel are returned; a resource with no subscription is bootstrapped
-  // by the initialImport followup, not here, so an unwatchable calendar is not
-  // re-selected forever. Uses the subscription_expiry index.
+  // Resources whose push subscription expires before `before` (soonest
+  // first, bounded). Events channels and the connection's calendar-list
+  // channel share this sweep. Only resources that ALREADY hold a channel are
+  // returned; a resource with no subscription is bootstrapped by the import
+  // (events) or calendarListSync (calendar list) followup, not here.
   async listExpiringSubscriptions(
     before: Date,
     limit: number,
   ): Promise<SyncResourceRecord[]> {
     const records = await this.collection
       .find({
-        resourceKind: "events",
+        resourceKind: { $in: ["events", "calendarList"] },
         subscriptionId: { $ne: null },
         subscriptionExpiresAt: { $lt: before },
       })


### PR DESCRIPTION
Supersedes #2802 (same first commit, cherry-picked onto `main`; #2802 will be retired).

## Summary

A Google subcalendar rename (e.g. `mens-group` → `journey-mens-group`) did not reach Compass until the daily calendar-list rediscovery sweep — renames change no events, so no events webhook fires, and there was no `calendarList.watch` channel. Even after a sync ran, no invalidation was appended, so the open SPA kept the stale name.

Commit 1 (from #2802): open a `calendarList.watch` push channel per connection (`watchCalendarList` as a sibling of `watchEvents` on the notification port and Google adapter), route calendar-list webhooks to a coalesced `calendarListSync` job, bootstrap the channel via a `subscriptionMaintain` followup after discovery, renew it on the existing expiry sweep, and append a `connection` invalidation after discovery so the sidebar refetches.

Commit 2 (new) closes two gaps in that design:

- **Consume the change marker.** The webhook stamps `changeNotifiedAt`, but nothing read it for calendarList resources: a notification landing while a `calendarListSync` job was CLAIMED coalesced onto that job's row and vanished, and if the pass had already listed the provider, the change silently waited up to 24h for the sweep — the exact lost-update race the events path defends against with `pullUntilQuiet`. `syncCalendarList` now compare-and-clears the marker and dispatch re-lists (bounded) while notifications keep landing mid-pass.
- **Gate the watch followup on `watchUnsupportedAt`.** A connection whose provider refuses `calendarList.watch` no longer burns one futile watch attempt per discovery; the daily full pass still clears the verdict for a fresh attempt.

Existing connections pick up the watch on their next Refresh, reconnect, or daily rediscovery — no migration.

## Simplicity

Reuses the existing subscription, notification, coalescing, and rediscovery machinery instead of introducing a new job kind or resource shape. The mid-pass re-list mirrors the established `pullUntilQuiet` pattern rather than inventing a second recovery mechanism, and `syncCalendarList` returning its post-pass resource let dispatch drop an extra `listByConnection` round-trip.

## Automated validation

Full sync package suite: 932 pass, 0 fail (74 files). The six focused suites below cover adapter watch, subscription maintenance (calendarList branch), rename upsert, marker compare-and-clear and mid-pass re-list, dispatch followup gating, notification routing, and the expiry sweep: 97 pass, 0 fail.

## Independent review

This PR is itself an independent review pass over #2802: verified its design against the sync service's coalescing/marker invariants, confirmed the lost-update race and the followup gap, and fixed both with tests reproducing each (marker moved mid-pass → `changedDuringSync`; refused watch → no followup).

## Test plan

- `bun run test:sync` (full package): 932 pass, 0 fail
- `bun run test:sync -- <the six touched test files>`: 97 pass, 0 fail
- `bun run type-check`: clean
- `bun run lint`: no new findings (10 pre-existing warnings in untouched files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QDLT5wDZKqdXAtAZLAUH9f

---
_Generated by [Claude Code](https://claude.ai/code/session_01QDLT5wDZKqdXAtAZLAUH9f)_