### PR TITLE
fix(web): cycle Tab edge focus on keyboard-place drafts

### DIFF
--- a/packages/web/src/grid/shortcuts/useGridEventEditShortcuts.ts
+++ b/packages/web/src/grid/shortcuts/useGridEventEditShortcuts.ts
@@ -10,7 +10,10 @@ import { useDefaultTargetCalendar } from "@web/calendars/useDefaultTargetCalenda
 import { ID_SIDEBAR } from "@web/common/constants/web.constants";
 import { type GridEvent } from "@web/common/types/web.event.types";
 import { getVisibleGridStartMinute } from "@web/common/utils/draft/draft.util";
-import { refocusEventElement } from "@web/common/utils/event/event.util";
+import {
+  getCalendarEventIdFromElement,
+  refocusEventElement,
+} from "@web/common/utils/event/event.util";
 import {
   convertAllDayToTimedDates,
   type EventEdge,
@@ -25,7 +28,13 @@ import {
   isEditableKeyboardTarget,
   isEventFormKeyboardTarget,
 } from "@web/common/utils/form/form.util";
-import { duplicateGridEventDraft } from "@web/events/grid-event-draft.adapter";
+import { type GridEventDraft } from "@web/events/event-draft.types";
+import {
+  duplicateGridEventDraft,
+  getGridDraftId,
+  gridEventDraftToGridEvent,
+  replaceGridDraftSchedule,
+} from "@web/events/grid-event-draft.adapter";
 import { commitDuplicateEvent } from "@web/events/mutations/duplicate-event";
 import {
   type EventMutationDependencies,
@@ -70,6 +79,40 @@ const isArrowKey = (
   key === "ArrowDown" ||
   key === "ArrowLeft" ||
   key === "ArrowRight";
+
+/**
+ * Form-closed grid draft whose card currently has DOM focus. Drafts stamp
+ * interaction ids but are not registered as saved drag/resize targets, so
+ * `targeting.getFocused()` cannot see them.
+ */
+const getFocusedFormClosedDraft = (): GridEvent | null => {
+  if (isEventFormOpen()) return null;
+
+  const { gridDraft } = useDraftStore.getState();
+  if (!gridDraft) return null;
+
+  const draftId = getGridDraftId(gridDraft);
+  if (!draftId) return null;
+
+  const active = document.activeElement;
+  if (!(active instanceof HTMLElement)) return null;
+  if (getCalendarEventIdFromElement(active) !== draftId) return null;
+
+  return gridEventDraftToGridEvent(gridDraft);
+};
+
+const applyNudgedDatesToDraft = (
+  draft: GridEventDraft,
+  nudgedEvent: GridEvent,
+) => {
+  const start = dayjs(nudgedEvent.startDate).toDate();
+  const end = dayjs(nudgedEvent.endDate).toDate();
+  const schedule =
+    draft.values.schedule.kind === "allDay"
+      ? { kind: "allDay" as const, start, end }
+      : { ...draft.values.schedule, start, end };
+  return replaceGridDraftSchedule(draft, schedule);
+};
 
 export type GridEventEditDayBoundary =
   | {
@@ -213,6 +256,33 @@ export function useGridEventEditShortcuts({
     return `${edgeName} ${label}`;
   };
 
+  const wouldAllDayEdgeLeaveVisibleWeek = (
+    event: GridEvent,
+    edge: EventEdge,
+    movement: { days: number },
+  ) => {
+    if (dayBoundary.kind !== "clamp" || !event.isAllDay) return false;
+
+    const { weekDays } = dayBoundary;
+    // All-day endDate is stored exclusive (the day after the last occupied
+    // day), so it's shifted back a day to compare against the inclusive
+    // weekDays window — matching nudgeAllDayEdgeDates's own inclusiveEnd.
+    const edgeDate =
+      edge === "startDate"
+        ? dayjs(event.startDate)
+        : dayjs(event.endDate).subtract(1, "day");
+    if (movement.days === -1 && !edgeDate.isAfter(weekDays[0], "day")) {
+      return true;
+    }
+    if (
+      movement.days === 1 &&
+      !edgeDate.isBefore(weekDays[weekDays.length - 1], "day")
+    ) {
+      return true;
+    }
+    return false;
+  };
+
   const moveFocusedEventEdge = (
     keyboardEvent: KeyboardEvent,
     event: GridEvent,
@@ -225,26 +295,7 @@ export function useGridEventEditShortcuts({
       Boolean(event.isAllDay),
     );
     if (!movement) return;
-
-    if (dayBoundary.kind === "clamp" && event.isAllDay) {
-      const { weekDays } = dayBoundary;
-      // All-day endDate is stored exclusive (the day after the last occupied
-      // day), so it's shifted back a day to compare against the inclusive
-      // weekDays window — matching nudgeAllDayEdgeDates's own inclusiveEnd.
-      const edgeDate =
-        edge === "startDate"
-          ? dayjs(event.startDate)
-          : dayjs(event.endDate).subtract(1, "day");
-      if (movement.days === -1 && !edgeDate.isAfter(weekDays[0], "day")) {
-        return;
-      }
-      if (
-        movement.days === 1 &&
-        !edgeDate.isBefore(weekDays[weekDays.length - 1], "day")
-      ) {
-        return;
-      }
-    }
+    if (wouldAllDayEdgeLeaveVisibleWeek(event, edge, movement)) return;
 
     nudgeEventEdgeFromKeyboard({
       edge,
@@ -259,6 +310,48 @@ export function useGridEventEditShortcuts({
           nextEdge,
           describeEdgeDate(nudgedEvent, nextEdge),
         );
+      },
+    });
+  };
+
+  const moveFocusedDraftEdge = (
+    keyboardEvent: KeyboardEvent,
+    event: GridEvent,
+    edge: EventEdge,
+  ) => {
+    if (!event._id) return;
+
+    const { gridDraft } = useDraftStore.getState();
+    if (!gridDraft) return;
+
+    const movement = getArrowKeyMovement(
+      keyboardEvent.key,
+      Boolean(event.isAllDay),
+    );
+    if (!movement) return;
+    if (wouldAllDayEdgeLeaveVisibleWeek(event, edge, movement)) return;
+
+    const previousStart = dayjs(event.startDate).startOf("day");
+
+    nudgeEventEdgeFromKeyboard({
+      edge,
+      event,
+      keyboardEvent,
+      onNudge: (nudgedEvent, nextEdge) => {
+        draftActions.setGridDraft(
+          applyNudgedDatesToDraft(gridDraft, nudgedEvent),
+        );
+        edgeFocusActions.setEdge(
+          event._id!,
+          nextEdge,
+          describeEdgeDate(nudgedEvent, nextEdge),
+        );
+        if (dayBoundary.kind === "follow") {
+          const nextStart = dayjs(nudgedEvent.startDate).startOf("day");
+          if (!nextStart.isSame(previousStart, "day")) {
+            dayBoundary.onCrossed(nextStart);
+          }
+        }
       },
     });
   };
@@ -327,9 +420,19 @@ export function useGridEventEditShortcuts({
       return;
     }
 
-    // No focused mutable saved event: reposition a form-closed draft, or
+    // No focused mutable saved event: if a form-closed draft has an edge
+    // focused, nudge that edge. Otherwise reposition the whole draft, or
     // place one when the grid is idle. Do not place over an existing draft
     // (failed clamp/midnight move) or while a read-only/draft card is focused.
+    const draftEvent = getFocusedFormClosedDraft();
+    if (draftEvent?._id) {
+      const edgeFocus = useEdgeFocusStore.getState();
+      if (edgeFocus.eventId === draftEvent._id && edgeFocus.edge) {
+        moveFocusedDraftEdge(keyboardEvent, draftEvent, edgeFocus.edge);
+        return;
+      }
+    }
+
     const didMoveDraft = repositionDraftByKey(keyboardEvent.key);
     if (didMoveDraft) {
       keyboardEvent.preventDefault();
@@ -348,7 +451,8 @@ export function useGridEventEditShortcuts({
     if (isEventFormOpen() || isEditableKeyboardTarget(keyboardEvent)) return;
     if (isFocusInSidebar()) return;
 
-    const event = getFocusedMutableCalendarEvent();
+    const event =
+      getFocusedMutableCalendarEvent() ?? getFocusedFormClosedDraft();
     if (!event?._id) return;
 
     const forward = !keyboardEvent.shiftKey;
@@ -402,14 +506,20 @@ export function useGridEventEditShortcuts({
   // on nothing (the brief focus-to-body gap mid-remount) is ambiguous, so
   // that case alone waits a tick for refocusEventElement to restore focus
   // before treating it as "focus left the event".
+  // Draft cards are not registered, so targeting.getFocused() is null while
+  // a draft is still focused — resolve those via the draft store + DOM id.
   useEffect(() => {
     let timer = 0;
+    const resolveFocusedEventId = () =>
+      targetingRef.current.getFocused()?.eventId ??
+      getFocusedFormClosedDraft()?._id ??
+      null;
     const checkAfterDelay = () => {
       window.clearTimeout(timer);
       timer = window.setTimeout(() => {
         const { eventId } = useEdgeFocusStore.getState();
         if (!eventId) return;
-        if (targetingRef.current.getFocused()?.eventId !== eventId) {
+        if (resolveFocusedEventId() !== eventId) {
           edgeFocusActions.reset();
         }
       }, 0);
@@ -418,12 +528,12 @@ export function useGridEventEditShortcuts({
       const { eventId } = useEdgeFocusStore.getState();
       if (!eventId) return;
 
-      const focused = targetingRef.current.getFocused();
-      if (!focused) {
+      const focusedId = resolveFocusedEventId();
+      if (!focusedId) {
         checkAfterDelay();
         return;
       }
-      if (focused.eventId !== eventId) {
+      if (focusedId !== eventId) {
         window.clearTimeout(timer);
         edgeFocusActions.reset();
       }

--- a/packages/web/src/views/Day/hooks/shortcuts/useDayEventNudgeShortcuts.test.tsx
+++ b/packages/web/src/views/Day/hooks/shortcuts/useDayEventNudgeShortcuts.test.tsx
@@ -31,7 +31,10 @@ import {
   initialEdgeFocusState,
   useEdgeFocusStore,
 } from "@web/grid/shortcuts/edge-focus.store";
-import { dayEventRegistry } from "@web/views/Day/interaction/registry/day-event.registry";
+import {
+  dayEventRegistry,
+  getDayInteractionTargetAttributes,
+} from "@web/views/Day/interaction/registry/day-event.registry";
 import { useDayEventNudgeShortcuts } from "./useDayEventNudgeShortcuts";
 import {
   afterEach,
@@ -46,6 +49,7 @@ import {
 const TIMED_EVENT_ID = "aaaaaaaaaaaaaaaaaaaaaaaa";
 const LATER_TIMED_EVENT_ID = "cccccccccccccccccccccccc";
 const ALL_DAY_EVENT_ID = "bbbbbbbbbbbbbbbbbbbbbbbb";
+const DRAFT_ID = "dddddddddddddddddddddddd";
 
 const timedEvent: GridEvent = {
   _id: TIMED_EVENT_ID,
@@ -118,6 +122,33 @@ const focusCalendarTarget = (
     eventId,
     eventType,
   });
+  button.focus();
+  return button;
+};
+
+const seedFocusedKeyboardPlaceDraft = () => {
+  const draft = createGridEventDraft(
+    timedGridSchedule(
+      new Date("2026-05-20T09:00:00.000"),
+      new Date("2026-05-20T10:00:00.000"),
+    ),
+    EventIdSchema.parse(DRAFT_ID),
+  );
+  draftActions.startGridDraft({ activity: "keyboardPlace", draft });
+  const button = document.createElement("button");
+  Object.defineProperty(button, "offsetParent", {
+    configurable: true,
+    get: () => document.body,
+  });
+  const attributes = getDayInteractionTargetAttributes({
+    eventId: DRAFT_ID,
+    eventType: "timed",
+  });
+  for (const [key, value] of Object.entries(attributes)) {
+    if (value !== undefined) button.setAttribute(key, value);
+  }
+  button.setAttribute("data-grid-event-surface", "draft");
+  document.body.appendChild(button);
   button.focus();
   return button;
 };
@@ -838,5 +869,66 @@ describe("useDayEventNudgeShortcuts", () => {
     });
 
     expect(useEdgeFocusStore.getState().eventId).toBeNull();
+  });
+
+  it("cycles edge focus with Tab on a form-closed keyboardPlace draft", () => {
+    seedFocusedKeyboardPlaceDraft();
+    renderEditShortcuts();
+
+    pressKey("Tab");
+    expect(useEdgeFocusStore.getState()).toMatchObject({
+      eventId: DRAFT_ID,
+      edge: "startDate",
+    });
+
+    pressKey("Tab");
+    expect(useEdgeFocusStore.getState().edge).toBe("endDate");
+  });
+
+  it("lets Tab leave a draft natively past the end edge instead of trapping focus", () => {
+    seedFocusedKeyboardPlaceDraft();
+    renderEditShortcuts();
+
+    pressKey("Tab");
+    pressKey("Tab");
+    expect(useEdgeFocusStore.getState().edge).toBe("endDate");
+
+    const thirdTab = new KeyboardEvent("keydown", {
+      bubbles: true,
+      cancelable: true,
+      key: "Tab",
+    });
+    document.dispatchEvent(thirdTab);
+
+    expect(thirdTab.defaultPrevented).toBe(false);
+    expect(useEdgeFocusStore.getState().edge).toBeNull();
+  });
+
+  it("does not cycle edge focus on a draft while the form is open", () => {
+    seedFocusedKeyboardPlaceDraft();
+    draftActions.setFormOpen(true);
+    renderEditShortcuts();
+
+    pressKey("Tab");
+
+    expect(useEdgeFocusStore.getState().eventId).toBeNull();
+  });
+
+  it("moves only the draft start edge with Shift+ArrowUp when that edge is focused", () => {
+    seedFocusedKeyboardPlaceDraft();
+    const { queryClient } = renderEditShortcuts();
+    pressKey("Tab");
+
+    pressKey("ArrowUp", shiftKey);
+
+    const schedule = useDraftStore.getState().gridDraft?.values.schedule;
+    expect(dayjs(schedule?.start).format()).toBe(
+      dayjs("2026-05-20T09:00:00.000").subtract(15, "minutes").format(),
+    );
+    expect(dayjs(schedule?.end).format()).toBe(
+      dayjs("2026-05-20T10:00:00.000").format(),
+    );
+    expect(useEdgeFocusStore.getState().edge).toBe("startDate");
+    expect(getEditMutation(queryClient)).toBeUndefined();
   });
 });

--- a/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcutOwner.test.tsx
+++ b/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcutOwner.test.tsx
@@ -20,7 +20,11 @@ import { ID_EVENT_FORM, ID_SIDEBAR } from "@web/common/constants/web.constants";
 import { getBrowserTimeZone } from "@web/common/utils/datetime/web.date.util";
 import { emitViewCommand } from "@web/common/utils/dom/view-command-bus";
 import { createObjectIdString } from "@web/common/utils/id/object-id.util";
-import { getGridDraftId } from "@web/events/grid-event-draft.adapter";
+import {
+  createGridEventDraft,
+  getGridDraftId,
+  timedGridSchedule,
+} from "@web/events/grid-event-draft.adapter";
 import { eventQueryKeys } from "@web/events/queries/event.query.keys";
 import { draftActions, useDraftStore } from "@web/events/stores/draft.store";
 import { initialViewState, useViewStore } from "@web/events/stores/view.store";
@@ -29,7 +33,10 @@ import {
   useEdgeFocusStore,
 } from "@web/grid/shortcuts/edge-focus.store";
 import { DraftContext } from "@web/views/Week/components/Draft/context/DraftContext";
-import { weekEventRegistry } from "@web/views/Week/interaction/registry/week-event.registry";
+import {
+  getWeekInteractionTargetAttributes,
+  weekEventRegistry,
+} from "@web/views/Week/interaction/registry/week-event.registry";
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 
 // Fixed 24-hex-char ids so fixtures satisfy EventIdSchema (real ObjectId
@@ -37,6 +44,7 @@ import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 const EVENT_1_ID = EventIdSchema.parse("aaaaaaaaaaaaaaaaaaaaaaaa");
 const ALL_DAY_EVENT_1_ID = EventIdSchema.parse("bbbbbbbbbbbbbbbbbbbbbbbb");
 const LEFTMOST_EVENT_ID = EventIdSchema.parse("665f0c2f8b3e4a1d9c2b7a01");
+const DRAFT_ID = EventIdSchema.parse("dddddddddddddddddddddddd");
 
 const editableEvent = createMockEvent({
   id: EVENT_1_ID,
@@ -186,6 +194,38 @@ const addCalendarTarget = (
     eventId,
     eventType,
   });
+  return button;
+};
+
+const addDraftTarget = (
+  eventId: string,
+  eventType: "all-day" | "timed" = "timed",
+) => {
+  const button = document.createElement("button");
+  Object.defineProperty(button, "offsetParent", {
+    configurable: true,
+    get: () => document.body,
+  });
+  const attributes = getWeekInteractionTargetAttributes({ eventId, eventType });
+  for (const [key, value] of Object.entries(attributes)) {
+    if (value !== undefined) button.setAttribute(key, value);
+  }
+  button.setAttribute("data-grid-event-surface", "draft");
+  document.body.appendChild(button);
+  return button;
+};
+
+const seedFocusedKeyboardPlaceDraft = () => {
+  const draft = createGridEventDraft(
+    timedGridSchedule(
+      new Date("2026-05-20T09:00:00.000"),
+      new Date("2026-05-20T10:00:00.000"),
+    ),
+    DRAFT_ID,
+  );
+  draftActions.startGridDraft({ activity: "keyboardPlace", draft });
+  const button = addDraftTarget(DRAFT_ID);
+  button.focus();
   return button;
 };
 
@@ -875,6 +915,70 @@ describe("useWeekShortcutOwner edge focus", () => {
     };
     expect(input.schedule.start).toBe("2026-05-22");
     expect(input.schedule.end).toBe("2026-05-25");
+  });
+});
+
+describe("useWeekShortcutOwner draft edge focus", () => {
+  it("cycles edge focus with Tab on a form-closed keyboardPlace draft", () => {
+    seedFocusedKeyboardPlaceDraft();
+    renderShortcuts();
+
+    pressKey("Tab");
+    expect(useEdgeFocusStore.getState()).toMatchObject({
+      eventId: DRAFT_ID,
+      edge: "startDate",
+    });
+
+    pressKey("Tab");
+    expect(useEdgeFocusStore.getState().edge).toBe("endDate");
+  });
+
+  it("lets Tab leave a draft natively past the end edge instead of trapping focus", () => {
+    seedFocusedKeyboardPlaceDraft();
+    renderShortcuts();
+
+    pressKey("Tab");
+    pressKey("Tab");
+    expect(useEdgeFocusStore.getState().edge).toBe("endDate");
+
+    const thirdTab = new KeyboardEvent("keydown", {
+      bubbles: true,
+      cancelable: true,
+      key: "Tab",
+    });
+    document.dispatchEvent(thirdTab);
+
+    expect(thirdTab.defaultPrevented).toBe(false);
+    expect(useEdgeFocusStore.getState().edge).toBeNull();
+  });
+
+  it("does not cycle edge focus on a draft while the form is open", () => {
+    seedFocusedKeyboardPlaceDraft();
+    draftActions.setFormOpen(true);
+    renderShortcuts();
+
+    pressKey("Tab");
+
+    expect(useEdgeFocusStore.getState().eventId).toBeNull();
+  });
+
+  it("moves only the draft start edge with Shift+ArrowUp when that edge is focused", () => {
+    seedFocusedKeyboardPlaceDraft();
+    const { queryClient } = renderShortcuts();
+
+    pressKey("Tab");
+    pressKey("ArrowUp", shiftKey);
+
+    const schedule = useDraftStore.getState().gridDraft?.values.schedule;
+    expect(dayjs(schedule?.start).format()).toBe(
+      dayjs("2026-05-20T09:00:00.000").subtract(15, "minutes").format(),
+    );
+    expect(dayjs(schedule?.end).format()).toBe(
+      dayjs("2026-05-20T10:00:00.000").format(),
+    );
+    expect(useEdgeFocusStore.getState().edge).toBe("startDate");
+    expect(getEditMutation(queryClient)).toBeUndefined();
+    expect(repositionDraftByKeyboard).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Tab on a form-closed Shift+Arrow place-create draft now follows the same edge-focus cycle as a focused saved event: whole event → start → end, then native Tab. Previously `cycleEdgeFocus` only resolved registered saved events, so Tab left the draft card and landed on the sidebar resize handle.

Drafts stay unregistered as saved drag/resize targets. The shared shortcut hook resolves a focused form-closed draft from the draft store plus the card's interaction id. When a draft edge is focused, Shift+Arrow nudges that edge on the draft instead of moving the whole event or calling `updateEvent`.

## Simplicity

Localized to `useGridEventEditShortcuts`. Shared week-clamp logic was extracted for saved and draft edge moves. Duplicate `moveFocusedEventEdge` / `moveFocusedDraftEdge` persist paths were left separate because one commits via `updateEvent` and the other via `setGridDraft`. No new React state; the existing focus-settle `useEffect` now also resolves unregistered draft cards. Cards already paint edge rings; the status bar already yields the keyboard-place hint to edge focus.

## Automated validation

- Focused Week and Day shortcut-owner suites: 85 pass, 0 fail (173 expects), including draft Tab cycle, native exit past the end edge, form-open ignore, and start-edge Shift+Arrow.
- `bun run lint`: no new issues on this diff.
- Browser (anonymous week view at http://localhost:9080/week): Shift+Arrow place-create, Tab cycles start then end (“Editing start time” / “Editing end time”), Shift+Tab returns to start, Shift+ArrowUp moves only the start by 15 minutes. Sidebar resize handle never takes focus.
- CI on the PR: lint, type-check, knip, unit (core/web/backend/sync/scripts), e2e, CodeQL all pass. Merge state CLEAN.

## Independent review

Fresh read-only review of `origin/main...HEAD`: no confirmed actionable findings. Non-blocking notes only: timed edge nudges stay on the minute axis (same as saved events); Day `onCrossed` does not fire for timed keyboard-place minute nudges.

## Test plan

- `bun run test:web -- packages/web/src/views/Week/hooks/shortcuts/useWeekShortcutOwner.test.tsx packages/web/src/views/Day/hooks/shortcuts/useDayEventNudgeShortcuts.test.tsx` — 85 pass
- `bun run lint` — no new issues
- Manual: `bun run dev:web` at http://localhost:9080/week, Shift+Arrow then Tab / Shift+Tab / Shift+ArrowUp on a form-closed draft
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1d349aef-dece-450b-8589-319ca5534a76?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1d349aef-dece-450b-8589-319ca5534a76&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

