### PR TITLE
fix(ci): grant id-token permission so the error-autofix agent can authenticate

### DIFF
--- a/.github/workflows/error-autofix.yml
+++ b/.github/workflows/error-autofix.yml
@@ -30,6 +30,10 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
+      # Required by claude-code-action's OIDC exchange: with no github_token
+      # passed (see below), it authenticates via the runner's OIDC token to
+      # mint the Claude GitHub App installation token.
+      id-token: write
     outputs:
       proceed: ${{ steps.preflight.outputs.proceed }}
     steps:

--- a/.github/workflows/error-autofix.yml
+++ b/.github/workflows/error-autofix.yml
@@ -11,9 +11,19 @@ name: Error autofix
 #   pr:     open a fix PR, human merges.
 #   merge:  open a fix PR and auto-merge it when the agent is confident and
 #           the deterministic gate below agrees.
+# Manual re-runs: "Re-run jobs" on a failed run reuses the workflow file
+# snapshot from that run, so fixes to this file never apply — dispatch a
+# fresh run instead, passing the PostHog issue number. Remove the issue's
+# autofix label first or preflight will skip it as already handled.
 on:
   issues:
     types: [opened]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: "PostHog error issue number to (re-)run the autofix flow for"
+        required: true
+        type: string
 
 concurrency:
   group: error-autofix
@@ -21,9 +31,14 @@ concurrency:
 
 jobs:
   autofix:
+    # workflow_dispatch skips the posthog[bot] author check: dispatching
+    # already requires write access, and the operator names the issue.
     if: >-
       vars.ERROR_AUTOFIX_ENABLED == 'true' &&
-      github.event.issue.user.login == 'posthog[bot]'
+      (github.event_name == 'workflow_dispatch' ||
+       github.event.issue.user.login == 'posthog[bot]')
+    env:
+      ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue_number }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
     permissions:
@@ -47,7 +62,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           DISCORD_ERRORS_WEBHOOK_URL: ${{ secrets.DISCORD_ERRORS_WEBHOOK_URL }}
-        run: .github/scripts/autofix-preflight.sh "${{ github.event.issue.number }}"
+        run: .github/scripts/autofix-preflight.sh "${ISSUE_NUMBER}"
 
       - name: Write PostHog MCP config
         if: steps.preflight.outputs.proceed == 'true'
@@ -70,7 +85,7 @@ jobs:
           prompt: |
             Read .github/prompts/error-autofix.md and follow it exactly.
             Mode: ${{ vars.AUTOFIX_MODE }}
-            Target issue: #${{ github.event.issue.number }}
+            Target issue: #${{ env.ISSUE_NUMBER }}
           claude_args: |
             --max-turns 80
             --allowedTools "Bash,Read,Write,Edit,Glob,Grep,mcp__posthog__*"
@@ -92,4 +107,4 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.AUTOFIX_GITHUB_TOKEN }}
           DISCORD_ERRORS_WEBHOOK_URL: ${{ secrets.DISCORD_ERRORS_WEBHOOK_URL }}
-        run: .github/scripts/autofix-merge-guard.sh "${{ github.event.issue.number }}"
+        run: .github/scripts/autofix-merge-guard.sh "${{ github.event.issue.number || inputs.issue_number }}"


### PR DESCRIPTION
## Summary

The error-autofix flow died on its first real firing (run [32201440568](https://github.com/KeepSoftwareSimple/compass-calendar/actions/runs/32201440568/job/95915942766), triggered by issue #2805) with:

```
Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable
Could not fetch an OIDC token. Did you remember to add `id-token: write` to your workflow permissions?
```

Two changes:

1. **`id-token: write` on the `autofix` job.** `error-autofix.yml` deliberately omits `github_token` so `anthropics/claude-code-action` mints its own Claude GitHub App installation token (whose events trigger CI, unlike the default `GITHUB_TOKEN`'s). That exchange authenticates the runner to Anthropic's backend via a GitHub OIDC token, which requires `id-token: write` on the job — a permission the workflow never had since it was introduced in #2796, because the explicit job-level `permissions:` block overrides the defaults.

2. **A `workflow_dispatch` trigger taking an `issue_number` input.** GitHub's "Re-run jobs" replays the workflow file snapshot from the original run, so a run that failed because of a workflow bug can never be replayed with the fix applied — and `issues: opened` cannot be re-delivered. The dispatch path lets an operator re-fire the flow for a given issue (needed to re-run #2805 once this merges). Dispatch skips the `posthog[bot]` author check since dispatching already requires write access; the issue number flows to preflight, the agent prompt, and the merge guard via `github.event.issue.number || inputs.issue_number`.

## Simplicity

The permission fix is a one-line grant. The dispatch trigger reuses the existing issue-number plumbing (all three consumers already take the number as a parameter), so no script changes were needed — only the workflow's `if:` and a shared `ISSUE_NUMBER` job env.

## Automated validation

Not exercisable outside Actions: the failure occurs during the action's OIDC handshake, which only exists on a real runner. Diagnosis is taken directly from the failing job log, and the missing permission matches the action's own error message and documented requirements. The dispatch path will be exercised by re-firing the flow for #2805 after merge.

## Independent review

Re-read the diff against the failing log: the error originates in `@actions/core`'s `getIDToken` (`ACTIONS_ID_TOKEN_REQUEST_URL` unset), which GitHub only injects when the job has `id-token: write`. For the dispatch path: `inputs` is empty on `issues` events and `github.event.issue` is absent on dispatch, so the `||` fallback selects the right source in both cases; `gate-and-merge`'s conditions (`vars.AUTOFIX_MODE`, `needs.autofix.outputs.proceed`) are event-independent. No permission was removed.

## Test plan

Validated the YAML parses with `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/error-autofix.yml'))"`. The OIDC fix itself is only testable on a real runner; it will be confirmed by dispatching the flow for #2805 after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CwCdyshXD1JyLdTsgQYHuW