### PR TITLE
fix(sync): surface an honest error when Google declines an event delete

### DIFF
--- a/packages/backend/src/event/controllers/event.controller.test.ts
+++ b/packages/backend/src/event/controllers/event.controller.test.ts
@@ -362,6 +362,24 @@ describe("EventController", () => {
     });
   });
 
+  it("maps unsupportedCapability to 403 UNSUPPORTED_OPERATION (not retryable)", async () => {
+    // A provider refusal for this specific event (e.g. Google declining a
+    // birthday-occurrence delete) used to share PROVIDER_FAILURE's retryable
+    // 502 — a generic error the client could retry forever without success.
+    mockSyncCommandFailure("unsupportedCapability");
+    const { res, json } = await createViaSync();
+
+    expect((res.status as ReturnType<typeof mock>).mock.calls[0]?.[0]).toBe(
+      Status.FORBIDDEN,
+    );
+    expect(json).toHaveBeenCalledWith({
+      code: "UNSUPPORTED_OPERATION",
+      message:
+        "Google doesn't allow this change for this event (for example birthday or holiday events). Try deleting the entire series, or manage it in Google Calendar.",
+      retryable: false,
+    });
+  });
+
   // The regression lock for invariant 1 ("every write resolves
   // definitively"): a command sync leaves non-terminal must never read as
   // success here. Before this fix, a still-pending outcome returned 200 —

--- a/packages/backend/src/event/controllers/event.controller.ts
+++ b/packages/backend/src/event/controllers/event.controller.ts
@@ -172,6 +172,14 @@ const mapSyncFailure = (reason: SyncCommandFailureReason) => {
         "Google Calendar access expired or was revoked. Reconnect Google Calendar in Compass to resume syncing.",
       );
     case "unsupportedCapability":
+      // The provider declined the operation for this specific event (e.g.
+      // Google rejects deleting one occurrence of a contact-linked birthday
+      // event). Retrying can never succeed, so this must not share
+      // PROVIDER_FAILURE's retryable 502.
+      return eventMutationError(
+        "UNSUPPORTED_OPERATION",
+        "Google doesn't allow this change for this event (for example birthday or holiday events). Try deleting the entire series, or manage it in Google Calendar.",
+      );
     case "permanentProviderError":
       return eventMutationError(
         "PROVIDER_FAILURE",

--- a/packages/backend/src/event/event.error.ts
+++ b/packages/backend/src/event/event.error.ts
@@ -27,6 +27,10 @@ const STATUS_BY_CODE: Record<EventMutationErrorCode, Status> = {
   MOVE_UNSUPPORTED: Status.BAD_REQUEST,
   INVALID_INPUT: Status.BAD_REQUEST,
   BILLING_REQUIRED: Status.FORBIDDEN,
+  // 403 like CALENDAR_READ_ONLY: the provider refuses the operation for this
+  // event (e.g. deleting one occurrence of a Google birthday event) — not a
+  // provider outage, so never the retryable 502 it used to surface as.
+  UNSUPPORTED_OPERATION: Status.FORBIDDEN,
 };
 
 const RETRYABLE_BY_CODE: Record<EventMutationErrorCode, boolean> = {
@@ -43,6 +47,7 @@ const RETRYABLE_BY_CODE: Record<EventMutationErrorCode, boolean> = {
   MOVE_UNSUPPORTED: false,
   INVALID_INPUT: false,
   BILLING_REQUIRED: false,
+  UNSUPPORTED_OPERATION: false,
 };
 
 export class EventMutationException extends BaseError {

--- a/packages/core/src/types/event-command.contracts.ts
+++ b/packages/core/src/types/event-command.contracts.ts
@@ -153,6 +153,12 @@ export const EventMutationErrorCodeSchema = z.enum([
   // Sync has no executor for a "move" command yet (unconditionally fails it),
   // so this is rejected before any command is submitted — never retryable.
   "MOVE_UNSUPPORTED",
+  // The provider refuses this operation for this event — e.g. Google rejects
+  // deleting one occurrence of a contact-linked birthday (or other special)
+  // event. The request was well-formed and the provider is healthy, so this
+  // is neither INVALID_INPUT nor PROVIDER_FAILURE; retrying can never
+  // succeed.
+  "UNSUPPORTED_OPERATION",
   // The request body failed contract validation (e.g. an unrecognized key on
   // a strict schema). Always a client-side mistake, never retryable.
   "INVALID_INPUT",

--- a/packages/sync/src/domain/provider-command.service.db.test.ts
+++ b/packages/sync/src/domain/provider-command.service.db.test.ts
@@ -2588,6 +2588,47 @@ describe("provider-linked recurring scopes (this / thisAndFollowing)", () => {
       expect(result.outcome.state).toBe("pending");
     });
 
+    it("fails without tombstoning when the provider declines the delete (unsupportedCapability)", async () => {
+      // Google 400s a well-formed instance delete for special events (e.g. a
+      // contact-linked birthday occurrence). The event still exists at the
+      // provider, so hiding it locally would desync until the next pull
+      // resurrected it — the command fails honestly instead.
+      const { tenantId, principalId, calendar, master } = await seedMaster();
+      const command = await thisScopeCommand(master, "delete");
+      const writer = new FakeRecurringWriter();
+      writer.fetchInstanceResult = providerInstance(
+        "g-inst-1",
+        "Old",
+        "etag-1",
+      );
+      writer.deleteError = new ProviderWriteError(
+        "unsupportedCapability",
+        "declined",
+      );
+
+      const result = await executeProviderOccurrenceDelete(
+        deleteDeps(writer),
+        command,
+        master,
+        calendar,
+        now,
+      );
+
+      expect(result.outcome.state).toBe("failed");
+      expect(
+        result.outcome.state === "failed" && result.outcome.failureReason,
+      ).toBe("unsupportedCapability");
+      // No local trace of the refused delete: no cancelled exception, and the
+      // occurrence still projects.
+      const exceptions = await events.findSeriesExceptions(
+        tenantId,
+        principalId,
+        master._id,
+      );
+      expect(exceptions).toHaveLength(0);
+      expect(await occurrenceStartsFor(master._id)).toContain(SECOND_START_UTC);
+    });
+
     it("still deletes when the resolved instance is identity-only (unreadable content)", async () => {
       const { tenantId, principalId, calendar, master } = await seedMaster();
       const command = await thisScopeCommand(master, "delete");

--- a/packages/sync/src/providers/google/google-event-writer.adapter.test.ts
+++ b/packages/sync/src/providers/google/google-event-writer.adapter.test.ts
@@ -376,6 +376,28 @@ describe("GoogleEventWriter", () => {
     expect(missing.calls.delete).toHaveLength(1);
   });
 
+  it("maps a 400 on delete to unsupportedCapability, not a generic permanent failure", async () => {
+    // Google 400s a well-formed delete when the operation is unsupported for
+    // the event — e.g. cancelling one occurrence of a contact-linked birthday
+    // event. permanentProviderError here surfaced as a retryable 502 the
+    // client could never resolve.
+    const api = new FakeEventsApi({ delete: gError(400) });
+    const { writer } = writerWith(api);
+
+    const error = (await writer
+      .deleteEvent({
+        accessToken: "at",
+        calendarId: "cal",
+        providerEventId: "id00000",
+        expectedVersion: null,
+        invitation: "none",
+      })
+      .catch((e) => e)) as ProviderWriteError;
+
+    expect(error).toBeInstanceOf(ProviderWriteError);
+    expect(error.reason).toBe("unsupportedCapability");
+  });
+
   it("still surfaces a precondition failure on delete", async () => {
     const api = new FakeEventsApi({ delete: gError(412) });
     const { writer } = writerWith(api);

--- a/packages/sync/src/providers/google/google-event-writer.adapter.ts
+++ b/packages/sync/src/providers/google/google-event-writer.adapter.ts
@@ -229,6 +229,19 @@ export class GoogleEventWriter implements ProviderEventWriter {
       // Already gone: a delete of an absent event is a success, so retries and
       // races converge instead of surfacing a spurious failure.
       if (isNotFound(error)) return;
+      // A 400 on a delete-by-known-id is Google declining the operation for
+      // this event, not a malformed request — e.g. cancelling one occurrence
+      // of a contact-linked birthday event is unsupported. Classifying it as
+      // permanentProviderError surfaced a retryable 502 the client could
+      // never resolve; a typed capability refusal maps to an honest,
+      // non-retryable error instead.
+      if (googleStatus(error) === 400) {
+        throw new ProviderWriteError(
+          "unsupportedCapability",
+          "Google declined to delete this event",
+          { cause: redactedCause(error) },
+        );
+      }
       throw classifyWriteError(error);
     }
   }

--- a/packages/sync/src/providers/provider-event-writer.port.ts
+++ b/packages/sync/src/providers/provider-event-writer.port.ts
@@ -132,6 +132,7 @@ export type ProviderWriteErrorReason =
   | "readOnlyCalendar" // the target calendar cannot be written
   | "authorizationRevoked" // the credential is no longer valid
   | "transient" // network / 5xx / rate limit — safe to retry
+  | "unsupportedCapability" // the provider declines this operation for this event
   | "permanentProviderError"; // an unrecoverable provider rejection
 
 export class ProviderWriteError extends ProviderError<ProviderWriteErrorReason> {}

--- a/packages/sync/src/server/command.routes.ts
+++ b/packages/sync/src/server/command.routes.ts
@@ -157,6 +157,16 @@ export function registerCommandRoutes(
           );
         }
 
+        // A failed outcome is a clean 200 to the caller, so without this line
+        // a deterministic provider refusal (e.g. Google declining a birthday
+        // occurrence delete) leaves zero server-side trace — diagnosing one
+        // required correlating client 502s against provider logs by hand.
+        if (command.outcome.state === "failed") {
+          logger.warn(
+            `Command ${command._id} (${command.input.kind} ${command.eventId}) failed: ${command.outcome.failureReason}`,
+          );
+        }
+
         const response: CommandSubmitResponse = {
           command: toSyncCommand(command),
         };

--- a/packages/web/src/common/utils/event/event.util.test.ts
+++ b/packages/web/src/common/utils/event/event.util.test.ts
@@ -186,6 +186,31 @@ describe("handleError", () => {
 
     expect(mockCaptureException).not.toHaveBeenCalled();
   });
+
+  it("shows curated copy for a mutation failure the user can act on, not the catch-all", () => {
+    // A deterministic provider refusal (Google declining a birthday-occurrence
+    // delete) used to show "Something went wrong behind the scenes. Please try
+    // again later." — an invitation to retry something that can never work.
+    const error = createServerError(Status.FORBIDDEN);
+    error.response = {
+      status: Status.FORBIDDEN,
+      data: {
+        code: "UNSUPPORTED_OPERATION",
+        message: "backend contract message, not toast copy",
+        retryable: false,
+      },
+    } as ApiResponse<unknown>;
+
+    handleError(error);
+
+    expect(mockCaptureException).not.toHaveBeenCalled();
+    expect(mocks.error).toHaveBeenCalledTimes(1);
+    const [message] = mocks.error.mock.calls[0] ?? [];
+    expect(message).toContain("Google doesn't allow this change");
+    expect(message).not.toBe(
+      "Something went wrong behind the scenes. Please try again later.",
+    );
+  });
 });
 
 describe("isEventInRange", () => {

--- a/packages/web/src/common/utils/event/event.util.ts
+++ b/packages/web/src/common/utils/event/event.util.ts
@@ -5,7 +5,10 @@ import {
   type BaseEvent,
   type CompassEvent,
 } from "@core/types/compass-event.contracts";
-import { EventMutationErrorSchema } from "@core/types/event-command.contracts";
+import {
+  type EventMutationError,
+  EventMutationErrorSchema,
+} from "@core/types/event-command.contracts";
 import { type WithId } from "@core/types/type.utils";
 import dayjs, { type Dayjs } from "@core/util/date/dayjs";
 import { type ApiError } from "@web/api/api.types";
@@ -208,15 +211,34 @@ export const getWeekDayLabel = (day: Dayjs | Date) => {
  * A known mutation failure authored by the backend. These have user-facing
  * feedback already, so they must not create error-tracking issues.
  */
-const isExpectedMutationError = (error: Error): boolean => {
+const parseExpectedMutationError = (error: Error) => {
   const parsed = EventMutationErrorSchema.safeParse(
     (error as ApiError).response?.data,
   );
-  return parsed.success;
+  return parsed.success ? parsed.data : null;
 };
 
 const CATCHALL_TOAST_MESSAGE =
   "Something went wrong behind the scenes. Please try again later.";
+
+// Curated copy for backend-authored mutation failures the user can act on.
+// Codes without an entry fall back to the catch-all — backend messages are
+// written for the API contract, not for a toast, so they are never shown
+// verbatim. UNSUPPORTED_OPERATION exists because a Google birthday-event
+// occurrence delete used to surface as the catch-all with nothing telling
+// the user why it would never work.
+const MUTATION_ERROR_TOAST_MESSAGES: Partial<
+  Record<EventMutationError["code"], string>
+> = {
+  UNSUPPORTED_OPERATION:
+    "Google doesn't allow this change for this event (like birthdays or holidays). Try deleting the entire series, or manage it in Google Calendar.",
+  CALENDAR_READ_ONLY:
+    "This calendar is read-only, so its events can't be changed from Compass.",
+  RECURRENCE_CONFLICT:
+    "This event was changed somewhere else. Refresh to load the latest version, then try again.",
+  GOOGLE_REVOKED:
+    "Google Calendar access expired or was revoked. Reconnect Google Calendar in Compass to resume syncing.",
+};
 
 const showCatchallToast = (message: string) =>
   showErrorToast(message, { toastId: GENERIC_ERROR_TOAST_ID });
@@ -253,10 +275,16 @@ export const handleError = (error: Error) => {
     return;
   }
 
-  if (isExpectedMutationError(error)) {
-    // The backend authored a known mutation failure. Show its existing UI
-    // feedback without creating an error-tracking issue.
-    showCatchallToast(CATCHALL_TOAST_MESSAGE);
+  const mutationError = parseExpectedMutationError(error);
+  if (mutationError) {
+    // The backend authored a known mutation failure: tell the user what
+    // actually happened when we have copy for it (a generic toast on a
+    // deterministic refusal reads as "try again", which can never work).
+    // No error-tracking capture either way — these are expected outcomes.
+    showCatchallToast(
+      MUTATION_ERROR_TOAST_MESSAGES[mutationError.code] ??
+        CATCHALL_TOAST_MESSAGE,
+    );
     return;
   }
 


### PR DESCRIPTION
## Summary

Deleting one occurrence of "Mike Schwartz's birthday" (`DELETE /event/…::2026-09-16…?scope=this`) returned a retryable **502 PROVIDER_FAILURE** and the generic *"Something went wrong behind the scenes"* toast, and the event survived refresh.

Root cause (confirmed against production logs: two ~700ms 502s on 2026-08-19 00:32/00:34 UTC, both reaching Google and failing deterministically, no sync-side trace): the event is a Google-Contacts **birthday event** (`eventType: "birthday"`). Compass ignores `eventType` and imports it as an ordinary yearly series, but Google refuses per-instance mutations of contact-linked birthday events with a 400. `classifyWriteError` lumped that into `permanentProviderError` → `PROVIDER_FAILURE` → 502 `retryable: true` — an invitation to retry an operation that can never succeed. Notably, if the event had actually been deleted at Google, this path already converges as success (404 → local tombstone → 204); the deterministic non-404 proves the event still exists at the API level and only Google Calendar's UI hides it — so the honest fix is telling the user the truth, not hiding the row locally (a local hide would desync until the next pull resurrected it).

Changes:
- **sync/google adapter**: a 400 on `deleteEvent` now classifies as `unsupportedCapability` (Google declining the operation for this event); 404/410 still converge as success
- **backend**: `unsupportedCapability` maps to a new non-retryable **403 `UNSUPPORTED_OPERATION`** ("Google doesn't allow this change for this event… Try deleting the entire series, or manage it in Google Calendar.") instead of sharing `PROVIDER_FAILURE`'s 502
- **web**: backend-authored mutation failures now show curated per-code toast copy (`UNSUPPORTED_OPERATION`, `CALENDAR_READ_ONLY`, `RECURRENCE_CONFLICT`, `GOOGLE_REVOKED`) with the catch-all only as fallback
- **sync/command route**: failed command outcomes are logged (`warn`) — a clean provider refusal previously left zero server-side trace

## Simplicity

No new services or plumbing: the 400→refusal classification lives only in `deleteEvent`'s catch (create/patch 400s stay `permanentProviderError` — those can be malformed requests), the failure reason `unsupportedCapability` already existed in the sync command contract, and the failed-outcome log sits at the one choke point every cloud/provider command flows through rather than threading a logger into executor deps. The web change reuses the existing catch-all toast path, adding only a code→copy map.

## Automated validation

- New adapter test: Google 400 on delete → `ProviderWriteError("unsupportedCapability")`; 404/410 delete still resolve as success.
- New executor db test: occurrence delete whose provider delete is declined → command `failed`/`unsupportedCapability`, **no** local tombstone, occurrence still projects (the event still exists at Google).
- New controller test: sync outcome `failed(unsupportedCapability)` → `403 {code: "UNSUPPORTED_OPERATION", retryable: false}` with the actionable message.
- New web test: `UNSUPPORTED_OPERATION` body → curated toast copy, not the catch-all; no error-tracking capture.

## Independent review

Fresh diff-first pass found one issue, fixed before pushing: the web toast map was keyed `Record<string, string>`, so a typo'd code would silently fall back to the catch-all — now keyed `Record<EventMutationError["code"], string>` so the compiler rejects unknown codes. Also verified: `mapSyncFailure`'s split keeps TS exhaustiveness; the 404 branch in `handleError` still precedes the mutation-error branch (behavior unchanged); `GOOGLE_REVOKED` (410) is not intercepted earlier, so its curated copy is reachable.

## Test plan

- `bun run test:sync` — 934 pass / 0 fail
- `bun run test:web` — 2299 pass / 0 fail
- `bun run test:core` — 551 pass / 0 fail
- `bun packages/scripts/src/testing/test-parallel.ts backend-fast -- packages/backend/src/event/controllers/event.controller.test.ts` — 12 pass / 0 fail (the full `test:backend:fast` run has 20 pre-existing failures — SSE/supertokens/config suites that fail identically on an unmodified tree in this sandbox, which cannot bind the IPv6 unspecified address)
- `bun run type-check`, `bun run lint`, `bun run format:check` — clean (10 pre-existing lint warnings, identical on baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MP21fMEc7uMYVwPpzYoiBF

---
_Generated by [Claude Code](https://claude.ai/code/session_01MP21fMEc7uMYVwPpzYoiBF)_