### PR TITLE
fix(web): show end-before-start time picker validation

### DIFF
--- a/packages/web/src/common/utils/datetime/web.date.util.test.ts
+++ b/packages/web/src/common/utils/datetime/web.date.util.test.ts
@@ -13,6 +13,7 @@ import {
   mapToBackend,
   parseUserTime,
   toUTCOffset,
+  tryMapToBackend,
 } from "@web/common/utils/datetime/web.date.util";
 import { getFormDates } from "@web/views/Forms/EventForm/DateControlsSection/DateTimeSection/form.datetime.util";
 import {
@@ -581,5 +582,19 @@ describe("mapToBackend timed overnight", () => {
     expect(schedule.kind).toBe("timed");
     if (schedule.kind !== "timed") return;
     expect(dayjs(schedule.end).isAfter(dayjs(schedule.start))).toBe(true);
+  });
+
+  it("does not throw when timed end is before start; tryMapToBackend reports failure", () => {
+    const day = dayjs("2026-08-11T00:00:00");
+    const selected = {
+      startDate: day.toDate(),
+      endDate: day.toDate(),
+      startTime: getTimeOptionByValue(day.hour(15).minute(0)),
+      endTime: getTimeOptionByValue(day.hour(14).minute(0)),
+      isAllDay: false,
+    };
+
+    expect(() => mapToBackend(selected)).toThrow();
+    expect(tryMapToBackend(selected).ok).toBe(false);
   });
 });

--- a/packages/web/src/common/utils/datetime/web.date.util.ts
+++ b/packages/web/src/common/utils/datetime/web.date.util.ts
@@ -1,3 +1,4 @@
+import { ZodError } from "zod/v4";
 import {
   HOURS_AM_FORMAT,
   HOURS_AM_SHORT_FORMAT,
@@ -235,6 +236,20 @@ export const mapToBackend = (s: SelectedDates): EventSchedule => {
     end: endDate,
     timeZone,
   });
+};
+
+export type MapToBackendResult =
+  | { ok: true; schedule: EventSchedule }
+  | { ok: false };
+
+/** Same as `mapToBackend`, but returns a result instead of throwing on schema failure. */
+export const tryMapToBackend = (s: SelectedDates): MapToBackendResult => {
+  try {
+    return { ok: true, schedule: mapToBackend(s) };
+  } catch (error) {
+    if (error instanceof ZodError) return { ok: false };
+    throw error;
+  }
 };
 
 // uses inferred timezone and shortened string to

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/TimePickers.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/TimePickers.test.tsx
@@ -174,4 +174,31 @@ describe("TimePickers", () => {
     expect(screen.queryByRole("alert")).not.toBeInTheDocument();
     expectDraft("2026-04-24T14:00:00+00:00", "2026-04-24T16:00:00+00:00");
   });
+
+  it("clears the inline error when the current valid end time is chosen again", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+
+    await pick(user, "End time", "1 PM");
+    expect(screen.getByRole("alert")).toHaveTextContent(END_TIME_ORDER_ERROR);
+
+    await pick(user, "End time", "3 PM");
+
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    expectDraft("2026-04-24T14:00:00+00:00", "2026-04-24T15:00:00+00:00");
+  });
+
+  it("does not reject a later overnight end just because the clock is before start", async () => {
+    const user = userEvent.setup();
+    render(
+      <Harness
+        start={new Date("2026-04-24T22:00:00.000Z")}
+        end={new Date("2026-04-25T06:00:00.000Z")}
+      />,
+    );
+
+    await pick(user, "End time", "5 AM");
+
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
 });

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/TimePickers.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/TimePickers.test.tsx
@@ -10,7 +10,7 @@ import {
   timedGridSchedule,
 } from "@web/events/grid-event-draft.adapter";
 import { getFormDates } from "../form.datetime.util";
-import { TimePickers } from "./TimePickers";
+import { END_TIME_ORDER_ERROR, TimePickers } from "./TimePickers";
 import { describe, expect, it } from "bun:test";
 
 const START_DATE = new Date("2026-04-24T14:00:00.000Z");
@@ -132,5 +132,46 @@ describe("TimePickers", () => {
     await pick(user, "Start time", "11 PM");
 
     expectDraft("2026-04-24T23:00:00+00:00", "2026-04-25T22:00:00+00:00");
+  });
+
+  it("shows an inline error when the mouse picks an end before start, without crashing", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+
+    await pick(user, "End time", "1 PM");
+
+    expect(screen.getByRole("alert")).toHaveTextContent(END_TIME_ORDER_ERROR);
+    expect(screen.getByRole("combobox", { name: "End time" })).toHaveAttribute(
+      "aria-invalid",
+      "true",
+    );
+    expectDraft("2026-04-24T14:00:00+00:00", "2026-04-24T15:00:00+00:00");
+    expect(screen.getByText("3 PM")).toBeInTheDocument();
+  });
+
+  it("shows an inline error when the keyboard commits an end before start, without crashing", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+
+    const end = screen.getByRole("combobox", { name: "End time" });
+    await user.click(end);
+    await user.keyboard("1 PM{Enter}");
+
+    expect(screen.getByRole("alert")).toHaveTextContent(END_TIME_ORDER_ERROR);
+    expectDraft("2026-04-24T14:00:00+00:00", "2026-04-24T15:00:00+00:00");
+    expect(screen.getByText("3 PM")).toBeInTheDocument();
+  });
+
+  it("clears the inline error after a valid end time is chosen", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+
+    await pick(user, "End time", "1 PM");
+    expect(screen.getByRole("alert")).toHaveTextContent(END_TIME_ORDER_ERROR);
+
+    await pick(user, "End time", "4 PM");
+
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    expectDraft("2026-04-24T14:00:00+00:00", "2026-04-24T16:00:00+00:00");
   });
 });

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/TimePickers.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/TimePickers.tsx
@@ -85,6 +85,15 @@ export const TimePickers: FC<Props> = ({
     return { option, dayOffset };
   };
 
+  const closeMenu = (changed: "start" | "end") => {
+    (changed === "start" ? setIsStartMenuOpen : setIsEndMenuOpen)(false);
+  };
+
+  const rejectTimeSelection = (changed: "start" | "end") => {
+    setTimeError(END_TIME_ORDER_ERROR);
+    closeMenu(changed);
+  };
+
   // One handler for both pickers: the picked side keeps its selected date and
   // the corrected compliment reduces to (picked time ± duration), so it is
   // anchored to the picked side's date and the midnight day-carry applies to
@@ -95,57 +104,68 @@ export const TimePickers: FC<Props> = ({
     option: SelectOption<string>,
   ) => {
     const prior = changed === "start" ? startTime : endTime;
+    if (!prior.value || prior.value === option.value) {
+      setTimeError(null);
+      closeMenu(changed);
+      return;
+    }
+
     const { option: corrected, dayOffset } = adjustComplimentTimeIfNeeded(
       changed,
       option.value,
     );
 
-    if (prior.value && prior.value !== option.value) {
-      const userStart = changed === "start" ? option.value : startTime.value;
-      const userEnd = changed === "end" ? option.value : endTime.value;
-      // Same-day invert: duration auto-correct would hide the mistake.
-      // Midnight wrap (dayOffset !== 0) still shifts the compliment date.
-      if (dayOffset === 0 && isEndBeforeStartOnDummyDay(userStart, userEnd)) {
-        setTimeError(END_TIME_ORDER_ERROR);
-        (changed === "start" ? setIsStartMenuOpen : setIsEndMenuOpen)(false);
-        return;
-      }
-
-      const anchorDate =
-        changed === "start" ? selectedStartDate : selectedEndDate;
-      const complimentDate = dayjs(anchorDate).add(dayOffset, "day").toDate();
-
-      const mapped = tryMapToBackend({
-        startDate: changed === "start" ? anchorDate : complimentDate,
-        endDate: changed === "start" ? complimentDate : anchorDate,
-        startTime: changed === "start" ? option : corrected,
-        endTime: changed === "start" ? corrected : option,
-        isAllDay: false,
-      });
-
-      if (!mapped.ok) {
-        setTimeError(END_TIME_ORDER_ERROR);
-        (changed === "start" ? setIsStartMenuOpen : setIsEndMenuOpen)(false);
-        return;
-      }
-
-      setTimeError(null);
-      (changed === "start" ? setStartTime : setEndTime)(option);
-      (changed === "start" ? setEndTime : setStartTime)(corrected);
-
-      // TS guard: isAllDay: false above always yields "timed".
-      if (mapped.schedule.kind === "timed") {
-        setDraft(
-          replaceGridDraftSchedule(draft, {
-            kind: "timed",
-            start: dayjs(mapped.schedule.start).toDate(),
-            end: dayjs(mapped.schedule.end).toDate(),
-            timeZone: mapped.schedule.timeZone,
-          }),
-        );
-      }
+    const userStart = changed === "start" ? option.value : startTime.value;
+    const userEnd = changed === "end" ? option.value : endTime.value;
+    const isSameCalendarDay = dayjs(selectedStartDate).isSame(
+      selectedEndDate,
+      "day",
+    );
+    // Same-day invert: duration auto-correct would hide the mistake.
+    // Overnight drafts already have end-before-start on the clock; midnight
+    // wrap (dayOffset !== 0) still shifts the compliment date.
+    if (
+      isSameCalendarDay &&
+      dayOffset === 0 &&
+      isEndBeforeStartOnDummyDay(userStart, userEnd)
+    ) {
+      rejectTimeSelection(changed);
+      return;
     }
-    (changed === "start" ? setIsStartMenuOpen : setIsEndMenuOpen)(false);
+
+    const anchorDate =
+      changed === "start" ? selectedStartDate : selectedEndDate;
+    const complimentDate = dayjs(anchorDate).add(dayOffset, "day").toDate();
+
+    const mapped = tryMapToBackend({
+      startDate: changed === "start" ? anchorDate : complimentDate,
+      endDate: changed === "start" ? complimentDate : anchorDate,
+      startTime: changed === "start" ? option : corrected,
+      endTime: changed === "start" ? corrected : option,
+      isAllDay: false,
+    });
+
+    if (!mapped.ok) {
+      rejectTimeSelection(changed);
+      return;
+    }
+
+    setTimeError(null);
+    (changed === "start" ? setStartTime : setEndTime)(option);
+    (changed === "start" ? setEndTime : setStartTime)(corrected);
+
+    // TS guard: isAllDay: false above always yields "timed".
+    if (mapped.schedule.kind === "timed") {
+      setDraft(
+        replaceGridDraftSchedule(draft, {
+          kind: "timed",
+          start: dayjs(mapped.schedule.start).toDate(),
+          end: dayjs(mapped.schedule.end).toDate(),
+          timeZone: mapped.schedule.timeZone,
+        }),
+      );
+    }
+    closeMenu(changed);
   };
 
   return (

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/TimePickers.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/TimePickers.tsx
@@ -1,16 +1,25 @@
-import { type FC, useState } from "react";
+import { type FC, useId, useState } from "react";
+import { YMDHAM_FORMAT } from "@core/constants/date.constants";
 import dayjs from "@core/util/date/dayjs";
 import { type SelectOption } from "@web/common/types/component.types";
 import { type TimeOption } from "@web/common/types/util.types";
 import {
   getTimeOptionByValue,
   getTimeOptions,
-  mapToBackend,
+  tryMapToBackend,
 } from "@web/common/utils/datetime/web.date.util";
 import { shouldAdjustComplimentTime } from "@web/common/utils/datetime/web.datetime.util";
 import { type GridEventDraft } from "@web/events/event-draft.types";
 import { replaceGridDraftSchedule } from "@web/events/grid-event-draft.adapter";
 import { TimePicker } from "./TimePicker";
+
+export const END_TIME_ORDER_ERROR = "End time must be after start time";
+
+const isEndBeforeStartOnDummyDay = (startValue: string, endValue: string) => {
+  const startAt = dayjs(`2000-01-01 ${startValue}`, YMDHAM_FORMAT);
+  const endAt = dayjs(`2000-01-01 ${endValue}`, YMDHAM_FORMAT);
+  return startAt.isValid() && endAt.isValid() && endAt.isBefore(startAt);
+};
 
 interface Props {
   draft: GridEventDraft;
@@ -36,13 +45,16 @@ export const TimePickers: FC<Props> = ({
   const timeOptions = getTimeOptions();
   const [isStartMenuOpen, setIsStartMenuOpen] = useState(false);
   const [isEndMenuOpen, setIsEndMenuOpen] = useState(false);
+  const [timeError, setTimeError] = useState<string | null>(null);
+  const timeErrorId = useId();
 
   // shouldAdjustComplimentTime does its math on a fixed calendar-day anchor, so
   // a correction that crosses midnight lands on an adjacent day. Formatting it
   // back to a bare "h:mm A" drops that day, and pairing the wrapped time with an
   // unchanged date produced an inverted schedule that made mapToBackend throw an
   // unhandled ZodError. Return the day delta so the caller can shift the date
-  // with it.
+  // with it. Pure: the caller commits picker state only after the schedule
+  // validates, so a leftover Zod failure cannot desync the form.
   const adjustComplimentTimeIfNeeded = (
     changed: "start" | "end",
     value: string,
@@ -70,7 +82,6 @@ export const TimePickers: FC<Props> = ({
       .startOf("day")
       .diff(result.compliment.startOf("day"), "day");
 
-    (changed === "start" ? setEndTime : setStartTime)(option);
     return { option, dayOffset };
   };
 
@@ -84,18 +95,27 @@ export const TimePickers: FC<Props> = ({
     option: SelectOption<string>,
   ) => {
     const prior = changed === "start" ? startTime : endTime;
-    (changed === "start" ? setStartTime : setEndTime)(option);
     const { option: corrected, dayOffset } = adjustComplimentTimeIfNeeded(
       changed,
       option.value,
     );
 
     if (prior.value && prior.value !== option.value) {
+      const userStart = changed === "start" ? option.value : startTime.value;
+      const userEnd = changed === "end" ? option.value : endTime.value;
+      // Same-day invert: duration auto-correct would hide the mistake.
+      // Midnight wrap (dayOffset !== 0) still shifts the compliment date.
+      if (dayOffset === 0 && isEndBeforeStartOnDummyDay(userStart, userEnd)) {
+        setTimeError(END_TIME_ORDER_ERROR);
+        (changed === "start" ? setIsStartMenuOpen : setIsEndMenuOpen)(false);
+        return;
+      }
+
       const anchorDate =
         changed === "start" ? selectedStartDate : selectedEndDate;
       const complimentDate = dayjs(anchorDate).add(dayOffset, "day").toDate();
 
-      const schedule = mapToBackend({
+      const mapped = tryMapToBackend({
         startDate: changed === "start" ? anchorDate : complimentDate,
         endDate: changed === "start" ? complimentDate : anchorDate,
         startTime: changed === "start" ? option : corrected,
@@ -103,14 +123,24 @@ export const TimePickers: FC<Props> = ({
         isAllDay: false,
       });
 
+      if (!mapped.ok) {
+        setTimeError(END_TIME_ORDER_ERROR);
+        (changed === "start" ? setIsStartMenuOpen : setIsEndMenuOpen)(false);
+        return;
+      }
+
+      setTimeError(null);
+      (changed === "start" ? setStartTime : setEndTime)(option);
+      (changed === "start" ? setEndTime : setStartTime)(corrected);
+
       // TS guard: isAllDay: false above always yields "timed".
-      if (schedule.kind === "timed") {
+      if (mapped.schedule.kind === "timed") {
         setDraft(
           replaceGridDraftSchedule(draft, {
             kind: "timed",
-            start: dayjs(schedule.start).toDate(),
-            end: dayjs(schedule.end).toDate(),
-            timeZone: schedule.timeZone,
+            start: dayjs(mapped.schedule.start).toDate(),
+            end: dayjs(mapped.schedule.end).toDate(),
+            timeZone: mapped.schedule.timeZone,
           }),
         );
       }
@@ -119,28 +149,37 @@ export const TimePickers: FC<Props> = ({
   };
 
   return (
-    <div className="flex items-center">
-      <TimePicker
-        aria-label="Start time"
-        inputId="startTimePicker"
-        isMenuOpen={isStartMenuOpen}
-        onChange={(option) => onTimeSelected("start", option)}
-        openMenuOnFocus
-        options={timeOptions}
-        setIsMenuOpen={setIsStartMenuOpen}
-        value={startTime}
-      />
-      -
-      <TimePicker
-        aria-label="End time"
-        inputId="endTimePicker"
-        isMenuOpen={isEndMenuOpen}
-        onChange={(option) => onTimeSelected("end", option)}
-        openMenuOnFocus
-        options={timeOptions}
-        setIsMenuOpen={setIsEndMenuOpen}
-        value={endTime}
-      />
+    <div className="flex min-w-0 flex-col gap-1">
+      <div className="flex items-center">
+        <TimePicker
+          aria-label="Start time"
+          inputId="startTimePicker"
+          isMenuOpen={isStartMenuOpen}
+          onChange={(option) => onTimeSelected("start", option)}
+          openMenuOnFocus
+          options={timeOptions}
+          setIsMenuOpen={setIsStartMenuOpen}
+          value={startTime}
+        />
+        -
+        <TimePicker
+          aria-describedby={timeError ? timeErrorId : undefined}
+          aria-invalid={timeError ? true : undefined}
+          aria-label="End time"
+          inputId="endTimePicker"
+          isMenuOpen={isEndMenuOpen}
+          onChange={(option) => onTimeSelected("end", option)}
+          openMenuOnFocus
+          options={timeOptions}
+          setIsMenuOpen={setIsEndMenuOpen}
+          value={endTime}
+        />
+      </div>
+      {timeError ? (
+        <p className="text-error text-xs" id={timeErrorId} role="alert">
+          {timeError}
+        </p>
+      ) : null}
     </div>
   );
 };

--- a/packages/web/src/views/Forms/EventForm/EventForm.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.tsx
@@ -26,6 +26,7 @@ import { Categories_Event } from "@web/common/types/web.event.types";
 import {
   getTimeOptionByValue,
   mapToBackend,
+  tryMapToBackend,
 } from "@web/common/utils/datetime/web.date.util";
 import { getVisibleGridStartMinute } from "@web/common/utils/draft/draft.util";
 import {
@@ -479,7 +480,14 @@ export const EventForm: React.FC<GridEventFormProps> = memo(
         isAllDay,
       };
 
-      const schedule = mapToBackend(selectedDateTimes);
+      const mapped = tryMapToBackend(selectedDateTimes);
+      if (!mapped.ok) {
+        showErrorToast(
+          "uff-dah, looks like you got the start & end times mixed up",
+        );
+        return;
+      }
+      const schedule = mapped.schedule;
       const start = dayjs(schedule.start).toDate();
       const end = dayjs(schedule.end).toDate();
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The event form time pickers called `mapToBackend` (which `EventScheduleSchema.parse`s) on every committed change. Typing or selecting an end time before the start threw an unhandled `ZodError` and left picker state out of sync with the draft.

This change:

- Validates the candidate schedule before updating picker or draft state
- Shows an inline `"End time must be after start time"` alert for same-day inverted times (mouse and keyboard)
- Keeps midnight-wrap duration correction and does not treat overnight clock order as an invert
- Clears the inline error when a valid time is chosen, including re-selecting the current value
- Uses `tryMapToBackend` on Save so the same schema failure becomes the existing mixed-up-times toast instead of a crash

Launch-day dead/rage click ranking was not implemented: PostHog MCP failed tool discovery in this environment.

## Simplicity

Extracted `closeMenu` / `rejectTimeSelection` for the shared reject path. Retained `timeError` state (isolated validation UI), existing menu-open state, and `useId` for `aria-describedby`.

## Automated validation

- Focused TimePickers tests: midnight wrap, mouse/keyboard invert, error clearing, re-select current time, overnight end
- `tryMapToBackend` unit test for inverted timed schedules
- `bun test:web`: 2284 pass, 0 fail (pre-review-fix); focused TimePickers 9 pass after review fixes
- `bun lint`: no new issues (8 pre-existing warnings elsewhere)

Manual (anonymous IndexedDB at `http://localhost:9080`): opened a timed event at 5:45–6:15 PM, chose an earlier end time, saw `"End time must be after start time"` with times unchanged, then chose 7:00 PM and the error cleared.

![Inline end-before-start validation](https://cursor.com/artifacts/c/art-614ea490-5ebc-4311-b090-e56a7daa42ee)
![Error cleared after a valid end time](https://cursor.com/artifacts/c/art-8246c9a4-198b-4a1c-8072-91accb346e7e)
<a href="https://cursor.com/agents/bc-1026ab39-556e-4fc6-9cd5-70d0e8256151/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftime_picker_end_before_start_validation.mp4"><img src="https://cursor.com/artifacts/c/art-1a1ae8e8-09ac-490d-aae3-363f4e2de1a3" alt="time_picker_end_before_start_validation.mp4" /></a>

## Independent review

Fresh read-only review of the first commit found:

- High: overnight drafts could be classified as same-day invert — fixed by requiring the selected dates to be the same calendar day
- Medium: `timeError` latched after a rejected pick — fixed by clearing when the current valid time is chosen again

Save still submits the last valid draft while the rejected-attempt alert is showing; that matches the committed field values.

## Test plan

- `bun packages/scripts/src/testing/test-parallel.ts web -- packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/TimePickers.test.tsx packages/web/src/common/utils/datetime/web.date.util.test.ts`
- `bun test:web` (2284 pass on implementation commit)
- `bun lint` (no new issues)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1026ab39-556e-4fc6-9cd5-70d0e8256151?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1026ab39-556e-4fc6-9cd5-70d0e8256151&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

