### PR TITLE
fix: surface first-import failures and stop retrying dead oauth grants

### DIFF
--- a/packages/sync/src/app.ts
+++ b/packages/sync/src/app.ts
@@ -474,11 +474,12 @@ function buildSchedulers(
         // A terminal failure is invisible otherwise: the job sits state:"failed"
         // holding its coalescing key with nothing paging anyone. Alertable so an
         // operator can set a PostHog alert on this event over launch weekend.
-        onFail: (job) => {
+        onFail: (job, error) => {
           logger.error(
             `Sync job ${job.kind} (${job._id}) exhausted retries and failed for resource ${
               job.resourceId ?? "none (connection-wide)"
             } on connection ${job.connectionId}`,
+            error,
           );
           void captureSafely(posthog, {
             event: SYNC_JOB_TERMINAL_FAILURE_EVENT,

--- a/packages/sync/src/credentials/credential-custody.service.db.test.ts
+++ b/packages/sync/src/credentials/credential-custody.service.db.test.ts
@@ -237,6 +237,22 @@ describe("CredentialCustody", () => {
     expect(adapter.revokedTokens).toEqual([]);
   });
 
+  it("increments refreshFailureCount on a transient refresh failure", async () => {
+    const connectionId = objectId() as ConnectionId;
+    const adapter = new FakeAdapter({
+      refreshError: new ProviderAuthError("refreshFailed", "blip"),
+    });
+    const custody = new CredentialCustody(repo, adapter, fixedNow);
+    await custody.store(baseCredential(connectionId));
+
+    await expect(
+      custody.getValidAccessToken(connectionId),
+    ).rejects.toMatchObject({ reason: "refreshFailed" });
+    const after = await repo.findByConnection(connectionId);
+    expect(after?.refreshFailureCount).toBe(1);
+    expect(after?.refreshToken).toBe("stored-refresh-token");
+  });
+
   it("discardRevoked deletes the credential and is idempotent", async () => {
     const connectionId = objectId() as ConnectionId;
     const adapter = new FakeAdapter();

--- a/packages/sync/src/credentials/credential-custody.service.ts
+++ b/packages/sync/src/credentials/credential-custody.service.ts
@@ -111,6 +111,12 @@ export class CredentialCustody {
       ) {
         await this.discardRevoked(connectionId);
       }
+      if (
+        error instanceof ProviderAuthError &&
+        error.reason === "refreshFailed"
+      ) {
+        await this.credentials.incrementRefreshFailure(connectionId);
+      }
       throw error;
     }
     const cached = await this.credentials.cacheAccessToken(

--- a/packages/sync/src/credentials/refresh-failure.constants.ts
+++ b/packages/sync/src/credentials/refresh-failure.constants.ts
@@ -1,0 +1,5 @@
+// Consecutive token-endpoint failures that look transient (5xx / network)
+// before we treat the grant as expired and stop burning the retry ladder.
+// A genuine Google outage should recover before this; a misclassified revoke
+// must not retry 20 times with a dead refresh token (2026-08 incremental 401s).
+export const MAX_REFRESH_FAILED_ATTEMPTS = 3;

--- a/packages/sync/src/domain/calendar-list-sync.service.ts
+++ b/packages/sync/src/domain/calendar-list-sync.service.ts
@@ -1,4 +1,5 @@
 import { type ProviderCalendarSourceId } from "@core/types/sync/identity.contracts";
+import { discoverCalendarsWithAuthRetry } from "@sync/domain/discover-calendars-with-auth-retry";
 import { type AccessTokenSource } from "@sync/domain/provider-write-ladder";
 import {
   type ProviderCalendarAdapter,
@@ -86,23 +87,30 @@ export async function syncCalendarList(
 
   // Resume incrementally from the stored cursor; a cursorExpired verdict means
   // the token is too old, so re-list in full. Both leave `fullList` telling us
-  // whether absence implies removal below.
+  // whether absence implies removal below. 401s remint in-process so a stale
+  // cached access token does not stamp a durable discovery failure.
   let fullList = resource.syncCursor === null;
   let discovery: Awaited<
     ReturnType<ProviderCalendarAdapter["discoverCalendars"]>
   >;
   try {
-    discovery = await deps.discovery.discoverCalendars({
-      accessToken,
-      cursor: resource.syncCursor ?? undefined,
-    });
+    discovery = (
+      await discoverCalendarsWithAuthRetry(deps, connectionId, {
+        accessToken,
+        cursor: resource.syncCursor ?? undefined,
+      })
+    ).discovery;
   } catch (error) {
     if (
       error instanceof ProviderCalendarError &&
       error.reason === "cursorExpired"
     ) {
       fullList = true;
-      discovery = await deps.discovery.discoverCalendars({ accessToken });
+      discovery = (
+        await discoverCalendarsWithAuthRetry(deps, connectionId, {
+          accessToken,
+        })
+      ).discovery;
     } else {
       // transient / discoveryFailed / unexpected: rethrow. Durable discovery
       // refusals (discoveryFailed) are settled as drops in dispatchSyncJob;

--- a/packages/sync/src/domain/connection-state-refresh.service.db.test.ts
+++ b/packages/sync/src/domain/connection-state-refresh.service.db.test.ts
@@ -754,4 +754,15 @@ describe("refreshConnectionState", () => {
     expect(after.state).toBe("actionRequired");
     expect(after.stateReason).toBe("authorizationRevoked");
   });
+
+  it("derives actionRequired/authorizationExpired after consecutive refresh failures", async () => {
+    const connection = await seedImportingConnection();
+    for (let i = 0; i < 3; i += 1) {
+      await credentials.incrementRefreshFailure(connection._id);
+    }
+
+    const after = await refreshConnectionState(deps(), connection);
+    expect(after.state).toBe("actionRequired");
+    expect(after.stateReason).toBe("authorizationExpired");
+  });
 });

--- a/packages/sync/src/domain/connection-state-refresh.service.ts
+++ b/packages/sync/src/domain/connection-state-refresh.service.ts
@@ -1,9 +1,11 @@
+import { MAX_REFRESH_FAILED_ATTEMPTS } from "@sync/credentials/refresh-failure.constants";
 import {
   BOOTSTRAP_STALLED_AFTER_MS,
   type ConnectionStateEvidence,
   type CredentialState,
   deriveConnectionState,
 } from "@sync/domain/connection-state";
+import { type JobRecord } from "@sync/storage/contracts/job.contracts";
 import { type ProviderConnectionRecord } from "@sync/storage/contracts/provider-connection.contracts";
 import { type CredentialRepository } from "@sync/storage/repositories/credential.repository";
 import { type InvalidationRepository } from "@sync/storage/repositories/invalidation.repository";
@@ -184,7 +186,35 @@ function credentialState(
   credential: Awaited<ReturnType<CredentialRepository["findByConnection"]>>,
 ): CredentialState {
   if (!credential?.refreshToken) return "revoked";
+  if (credential.refreshFailureCount >= MAX_REFRESH_FAILED_ATTEMPTS) {
+    return "expired";
+  }
   return "valid";
+}
+
+// Re-derive health after a job drop, retry, or terminal fail so the SPA is
+// not stuck on "importing" / "healthy" until the next metadata poll.
+export async function refreshConnectionStateAfterJob(
+  deps: ConnectionStateRefreshDeps & {
+    log?: { warn: (message: string) => void };
+  },
+  job: Pick<JobRecord, "tenantId" | "principalId" | "connectionId">,
+  now?: () => Date,
+): Promise<void> {
+  try {
+    const connection = await deps.connections.findById(
+      job.tenantId,
+      job.principalId,
+      job.connectionId,
+    );
+    if (!connection) return;
+    await refreshConnectionState(deps, connection, now);
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    deps.log?.warn(
+      `Failed to refresh connection state for connection ${job.connectionId}: ${detail}`,
+    );
+  }
 }
 
 function minDate(...dates: Array<Date | null | undefined>): Date | null {

--- a/packages/sync/src/domain/discover-calendars-with-auth-retry.test.ts
+++ b/packages/sync/src/domain/discover-calendars-with-auth-retry.test.ts
@@ -1,0 +1,148 @@
+import { type ConnectionId } from "@core/types/sync/identity.contracts";
+import { discoverCalendarsWithAuthRetry } from "@sync/domain/discover-calendars-with-auth-retry";
+import { type AccessTokenSource } from "@sync/domain/provider-write-ladder";
+import { ProviderAuthError } from "@sync/providers/provider-auth.port";
+import {
+  type CalendarDiscovery,
+  type ProviderCalendarAdapter,
+  ProviderCalendarError,
+} from "@sync/providers/provider-calendar.port";
+import { describe, expect, it } from "bun:test";
+
+const connectionId = "507f1f77bcf86cd799439011" as ConnectionId;
+
+const emptyDiscovery = (): CalendarDiscovery => ({
+  calendars: [],
+  cursor: "cursor-1",
+});
+
+class ScriptedDiscovery implements ProviderCalendarAdapter {
+  tokens: string[] = [];
+  constructor(private readonly outcomes: Array<CalendarDiscovery | Error>) {}
+  async discoverCalendars(input: {
+    accessToken: string;
+    cursor?: string;
+  }): Promise<CalendarDiscovery> {
+    this.tokens.push(input.accessToken);
+    const next = this.outcomes.shift();
+    if (!next) throw new Error("ScriptedDiscovery: no outcome left");
+    if (next instanceof Error) throw next;
+    return next;
+  }
+}
+
+const custody = (opts: {
+  tokens?: string[];
+  refreshError?: Error;
+}): AccessTokenSource & { invalidated: string[] } => {
+  const tokens = [...(opts.tokens ?? ["fresh-token"])];
+  const invalidated: string[] = [];
+  return {
+    invalidated,
+    getValidAccessToken: async () => {
+      if (opts.refreshError) throw opts.refreshError;
+      const token = tokens.shift();
+      if (!token) throw new Error("custody: no token scripted");
+      return token;
+    },
+    discardRevoked: async () => {},
+    invalidateAccessToken: async (id) => {
+      invalidated.push(id);
+    },
+  };
+};
+
+describe("discoverCalendarsWithAuthRetry", () => {
+  it("returns the discovery unchanged when the read succeeds", async () => {
+    const discovery = emptyDiscovery();
+    const adapter = new ScriptedDiscovery([discovery]);
+    const source = custody({ tokens: ["unused"] });
+
+    const result = await discoverCalendarsWithAuthRetry(
+      { discovery: adapter, custody: source },
+      connectionId,
+      { accessToken: "cached-token" },
+    );
+
+    expect(result).toEqual({ discovery, accessToken: "cached-token" });
+    expect(source.invalidated).toEqual([]);
+    expect(adapter.tokens).toEqual(["cached-token"]);
+  });
+
+  it("rethrows non-auth discovery errors without touching the cache", async () => {
+    const adapter = new ScriptedDiscovery([
+      new ProviderCalendarError("transient", "429"),
+    ]);
+    const source = custody({});
+
+    await expect(
+      discoverCalendarsWithAuthRetry(
+        { discovery: adapter, custody: source },
+        connectionId,
+        { accessToken: "cached-token" },
+      ),
+    ).rejects.toMatchObject({ reason: "transient" });
+    expect(source.invalidated).toEqual([]);
+  });
+
+  it("invalidates the cached token and retries discovery with a fresh one", async () => {
+    const discovery = emptyDiscovery();
+    const adapter = new ScriptedDiscovery([
+      new ProviderCalendarError("authExpired", "401"),
+      discovery,
+    ]);
+    const source = custody({ tokens: ["fresh-token"] });
+
+    const result = await discoverCalendarsWithAuthRetry(
+      { discovery: adapter, custody: source },
+      connectionId,
+      { accessToken: "stale-token" },
+    );
+
+    expect(result).toEqual({ discovery, accessToken: "fresh-token" });
+    expect(source.invalidated).toEqual([connectionId]);
+    expect(adapter.tokens).toEqual(["stale-token", "fresh-token"]);
+  });
+
+  it("surfaces a revoked grant when refresh fails after the 401", async () => {
+    const adapter = new ScriptedDiscovery([
+      new ProviderCalendarError("authExpired", "401"),
+    ]);
+    const source = custody({
+      refreshError: new ProviderAuthError(
+        "authorizationRevoked",
+        "invalid_grant",
+      ),
+    });
+
+    await expect(
+      discoverCalendarsWithAuthRetry(
+        { discovery: adapter, custody: source },
+        connectionId,
+        { accessToken: "stale-token" },
+      ),
+    ).rejects.toMatchObject({ reason: "authorizationRevoked" });
+    expect(source.invalidated).toEqual([connectionId]);
+  });
+
+  it("treats a 401 on the freshly minted token as a dead grant", async () => {
+    const adapter = new ScriptedDiscovery([
+      new ProviderCalendarError("authExpired", "401"),
+      new ProviderCalendarError("authExpired", "401"),
+    ]);
+    const source = custody({ tokens: ["fresh-token"] });
+
+    await expect(
+      discoverCalendarsWithAuthRetry(
+        { discovery: adapter, custody: source },
+        connectionId,
+        { accessToken: "stale-token" },
+      ),
+    ).rejects.toMatchObject({
+      name: "ProviderAuthError",
+      reason: "authorizationRevoked",
+    });
+    expect(source.invalidated).toEqual([connectionId]);
+    expect(adapter.tokens).toEqual(["stale-token", "fresh-token"]);
+  });
+});

--- a/packages/sync/src/domain/discover-calendars-with-auth-retry.ts
+++ b/packages/sync/src/domain/discover-calendars-with-auth-retry.ts
@@ -1,0 +1,57 @@
+import { type ConnectionId } from "@core/types/sync/identity.contracts";
+import { type AccessTokenSource } from "@sync/domain/provider-write-ladder";
+import { ProviderAuthError } from "@sync/providers/provider-auth.port";
+import {
+  type CalendarDiscovery,
+  type ProviderCalendarAdapter,
+  ProviderCalendarError,
+} from "@sync/providers/provider-calendar.port";
+
+export interface CalendarDiscoveryAuthRetryDeps {
+  discovery: ProviderCalendarAdapter;
+  custody: AccessTokenSource;
+}
+
+// Discover calendars, reminting the access token in-process if Google rejects
+// the cached one (401 / authExpired). Same contract as listEventPageWithAuthRetry:
+// a stale cache recovers without a job attempt; a revoked grant surfaces as
+// ProviderAuthError so dispatch drops and the connection asks for reconnect.
+export async function discoverCalendarsWithAuthRetry(
+  deps: CalendarDiscoveryAuthRetryDeps,
+  connectionId: ConnectionId,
+  input: { accessToken: string; cursor?: string },
+): Promise<{ discovery: CalendarDiscovery; accessToken: string }> {
+  try {
+    return {
+      discovery: await deps.discovery.discoverCalendars(input),
+      accessToken: input.accessToken,
+    };
+  } catch (error) {
+    if (!isAuthExpired(error)) throw error;
+  }
+
+  await deps.custody.invalidateAccessToken(connectionId);
+  const accessToken = await deps.custody.getValidAccessToken(connectionId);
+  try {
+    return {
+      discovery: await deps.discovery.discoverCalendars({
+        ...input,
+        accessToken,
+      }),
+      accessToken,
+    };
+  } catch (error) {
+    if (!isAuthExpired(error)) throw error;
+    throw new ProviderAuthError(
+      "authorizationRevoked",
+      "Google rejected a freshly minted access token",
+      { cause: error },
+    );
+  }
+}
+
+function isAuthExpired(error: unknown): error is ProviderCalendarError {
+  return (
+    error instanceof ProviderCalendarError && error.reason === "authExpired"
+  );
+}

--- a/packages/sync/src/domain/job-last-error.ts
+++ b/packages/sync/src/domain/job-last-error.ts
@@ -1,0 +1,14 @@
+import { googleFailureCause } from "@sync/providers/google/google-error";
+
+export const MAX_JOB_LAST_ERROR_LENGTH = 500;
+
+// Operator-facing job error text: response status/reason only, truncated,
+// never request-derived secrets (googleapis attaches the bearer on `config`).
+export function sanitizeJobLastError(error: unknown): string | null {
+  const cause = googleFailureCause(error);
+  const raw = (
+    cause?.message ?? (error instanceof Error ? error.message : String(error))
+  ).trim();
+  if (!raw || raw === "undefined") return null;
+  return raw.slice(0, MAX_JOB_LAST_ERROR_LENGTH);
+}

--- a/packages/sync/src/domain/sync-job-dispatch.service.db.test.ts
+++ b/packages/sync/src/domain/sync-job-dispatch.service.db.test.ts
@@ -549,6 +549,15 @@ describe("dispatchSyncJob", () => {
   it("drops a job after consecutive refreshFailed attempts so 401s do not burn the ladder", async () => {
     const calendar = await seedCalendar();
     const resource = await seedResource(calendar, "cursor-0");
+    await credentials.store({
+      connectionId: calendar.connectionId,
+      provider: "google",
+      refreshToken: "refresh",
+      scopes: ["https://www.googleapis.com/auth/calendar.events"],
+    });
+    for (let i = 0; i < 3; i += 1) {
+      await credentials.incrementRefreshFailure(calendar.connectionId);
+    }
     const reader = new FakeReader([]);
     const discarded: string[] = [];
     const flakyCustody: SyncJobDispatchDeps["custody"] = {
@@ -560,18 +569,50 @@ describe("dispatchSyncJob", () => {
       },
       invalidateAccessToken: async () => {},
     };
-    const job = {
-      ...jobFor(resource, "incrementalPull"),
-      attempt: 3,
-    };
 
-    const outcome = await dispatchSyncJob(deps(reader, flakyCustody), job, now);
+    const outcome = await dispatchSyncJob(
+      deps(reader, flakyCustody),
+      jobFor(resource, "incrementalPull"),
+      now,
+    );
 
     expect(outcome.result).toBe("drop");
     if (outcome.result === "drop") {
-      expect(outcome.reason).toContain("token refresh failed");
+      expect(outcome.reason).toContain("token refresh failed 3 time(s)");
     }
     expect(discarded).toEqual([]);
+    const after = await credentials.findByConnection(calendar.connectionId);
+    expect(after?.refreshFailureCount).toBe(3);
+  });
+
+  it("does not drop a refreshFailed job just because other retries already ran", async () => {
+    const calendar = await seedCalendar();
+    const resource = await seedResource(calendar, "cursor-0");
+    await credentials.store({
+      connectionId: calendar.connectionId,
+      provider: "google",
+      refreshToken: "refresh",
+      scopes: ["https://www.googleapis.com/auth/calendar.events"],
+    });
+    const reader = new FakeReader([]);
+    const job = {
+      ...jobFor(resource, "incrementalPull"),
+      attempt: 5,
+    };
+
+    await expect(
+      dispatchSyncJob(
+        deps(reader, {
+          getValidAccessToken: async () => {
+            throw new ProviderAuthError("refreshFailed", "network blip");
+          },
+          discardRevoked: async () => {},
+          invalidateAccessToken: async () => {},
+        }),
+        job,
+        now,
+      ),
+    ).rejects.toThrow(ProviderAuthError);
   });
 
   it("remints the access token in-process and completes a pull after a one-off 401", async () => {

--- a/packages/sync/src/domain/sync-job-dispatch.service.db.test.ts
+++ b/packages/sync/src/domain/sync-job-dispatch.service.db.test.ts
@@ -546,6 +546,34 @@ describe("dispatchSyncJob", () => {
     expect(discarded).toEqual([]);
   });
 
+  it("drops a job after consecutive refreshFailed attempts so 401s do not burn the ladder", async () => {
+    const calendar = await seedCalendar();
+    const resource = await seedResource(calendar, "cursor-0");
+    const reader = new FakeReader([]);
+    const discarded: string[] = [];
+    const flakyCustody: SyncJobDispatchDeps["custody"] = {
+      getValidAccessToken: async () => {
+        throw new ProviderAuthError("refreshFailed", "network blip");
+      },
+      discardRevoked: async (connectionId) => {
+        discarded.push(connectionId);
+      },
+      invalidateAccessToken: async () => {},
+    };
+    const job = {
+      ...jobFor(resource, "incrementalPull"),
+      attempt: 3,
+    };
+
+    const outcome = await dispatchSyncJob(deps(reader, flakyCustody), job, now);
+
+    expect(outcome.result).toBe("drop");
+    if (outcome.result === "drop") {
+      expect(outcome.reason).toContain("token refresh failed");
+    }
+    expect(discarded).toEqual([]);
+  });
+
   it("remints the access token in-process and completes a pull after a one-off 401", async () => {
     const calendar = await seedCalendar();
     const resource = await seedResource(calendar, "cursor-0");

--- a/packages/sync/src/domain/sync-job-dispatch.service.ts
+++ b/packages/sync/src/domain/sync-job-dispatch.service.ts
@@ -122,13 +122,12 @@ export async function dispatchSyncJob(
       const credential = await deps.credentials.findByConnection(
         job.connectionId,
       );
-      const expired =
-        (credential?.refreshFailureCount ?? 0) >= MAX_REFRESH_FAILED_ATTEMPTS;
-      if (expired || job.attempt >= MAX_REFRESH_FAILED_ATTEMPTS) {
+      const refreshFailures = credential?.refreshFailureCount ?? 0;
+      if (refreshFailures >= MAX_REFRESH_FAILED_ATTEMPTS) {
         await refreshConnectionStateAfterJob(deps, job, now);
         return {
           result: "drop",
-          reason: `token refresh failed ${job.attempt} time(s) for connection ${job.connectionId}; reconnect or retry from the app`,
+          reason: `token refresh failed ${refreshFailures} time(s) for connection ${job.connectionId}; reconnect or retry from the app`,
         };
       }
       throw error;

--- a/packages/sync/src/domain/sync-job-dispatch.service.ts
+++ b/packages/sync/src/domain/sync-job-dispatch.service.ts
@@ -1,8 +1,9 @@
+import { MAX_REFRESH_FAILED_ATTEMPTS } from "@sync/credentials/refresh-failure.constants";
 import { importCalendarEvents } from "@sync/domain/calendar-import.service";
 import { syncCalendarList } from "@sync/domain/calendar-list-sync.service";
 import { pullCalendarChanges } from "@sync/domain/calendar-pull.service";
 import { repairCalendar } from "@sync/domain/calendar-repair.service";
-import { refreshConnectionState } from "@sync/domain/connection-state-refresh.service";
+import { refreshConnectionStateAfterJob } from "@sync/domain/connection-state-refresh.service";
 import { type AccessTokenSource } from "@sync/domain/provider-write-ladder";
 import { maintainSubscription } from "@sync/domain/subscription-maintenance.service";
 import { ProviderAuthError } from "@sync/providers/provider-auth.port";
@@ -107,25 +108,43 @@ export async function dispatchSyncJob(
     ) {
       // Belt and braces: custody already discards on authorizationRevoked.
       await deps.custody.discardRevoked(job.connectionId);
-      // A reasoned drop, not a bare done: settling is identical, but the worker
-      // surfaces drop reasons. This path settled ~100 jobs per sweep invisibly
-      // on 2026-07-29 (credential-less migrated connections), which made the
-      // sweep look broken while it was running fine.
+      await refreshConnectionStateAfterJob(deps, job, now);
       return {
         result: "drop",
         reason: `credential unusable (${error.reason}) for connection ${job.connectionId}; sync resumes on reconnect`,
       };
     }
 
+    if (
+      error instanceof ProviderAuthError &&
+      error.reason === "refreshFailed"
+    ) {
+      const credential = await deps.credentials.findByConnection(
+        job.connectionId,
+      );
+      const expired =
+        (credential?.refreshFailureCount ?? 0) >= MAX_REFRESH_FAILED_ATTEMPTS;
+      if (expired || job.attempt >= MAX_REFRESH_FAILED_ATTEMPTS) {
+        await refreshConnectionStateAfterJob(deps, job, now);
+        return {
+          result: "drop",
+          reason: `token refresh failed ${job.attempt} time(s) for connection ${job.connectionId}; reconnect or retry from the app`,
+        };
+      }
+      throw error;
+    }
+
     // The provider rejected the cached access token (401). Event reads
     // (pull/import/repair) remint in-process via listEventPageWithAuthRetry;
+    // calendar-list discovery remints via discoverCalendarsWithAuthRetry;
     // this fallback covers any path that still throws authExpired. Invalidate
     // so the worker retry mints a fresh token instead of replaying the same
     // rejected one. If the refresh then fails with authorizationRevoked, that
     // surfaces as ProviderAuthError on the next attempt and is handled above.
     if (
-      error instanceof ProviderEventReadError &&
-      error.reason === "authExpired"
+      (error instanceof ProviderEventReadError &&
+        error.reason === "authExpired") ||
+      (error instanceof ProviderCalendarError && error.reason === "authExpired")
     ) {
       await deps.custody.invalidateAccessToken(job.connectionId);
       throw error;
@@ -161,6 +180,7 @@ export async function dispatchSyncJob(
           detail,
         );
       }
+      await refreshConnectionStateAfterJob(deps, job, now);
       return {
         result: "drop",
         reason: `provider durably rejected reads for resource ${job.resourceId} (${detail}); sync resumes once the calendar is readable again`,
@@ -193,6 +213,7 @@ export async function dispatchSyncJob(
           detail,
         );
       }
+      await refreshConnectionStateAfterJob(deps, job, now);
       return {
         result: "drop",
         reason: `provider durably rejected calendar-list discovery for connection ${job.connectionId} (${detail}); sync resumes once the account can list calendars again`,
@@ -473,6 +494,7 @@ async function runSyncJob(
           followup: resourceJob(resource, "bootstrapCatchup", now()),
         };
       }
+      await refreshConnectionStateAfterJob(deps, job, now);
       return { result: "done" };
     }
   }
@@ -576,20 +598,7 @@ async function refreshConnectionStateAfterBootstrap(
   deps: SyncJobDispatchDeps,
   job: JobRecord,
 ): Promise<void> {
-  try {
-    const connection = await deps.connections.findById(
-      job.tenantId,
-      job.principalId,
-      job.connectionId,
-    );
-    if (!connection) return;
-    await refreshConnectionState(deps, connection);
-  } catch (error) {
-    const detail = error instanceof Error ? error.message : String(error);
-    deps.log?.warn(
-      `Failed to refresh connection state after bootstrap for connection ${job.connectionId}: ${detail}`,
-    );
-  }
+  await refreshConnectionStateAfterJob(deps, job);
 }
 
 async function appendCalendarInvalidation(

--- a/packages/sync/src/domain/sync-job-worker.service.db.test.ts
+++ b/packages/sync/src/domain/sync-job-worker.service.db.test.ts
@@ -119,7 +119,7 @@ describe("SyncJobWorker", () => {
   ) => new SyncJobWorker(deps(reader), OWNER, { now, ...options });
 
   const seedCalendar = (
-    overrides: Partial<{ active: boolean }> = {},
+    overrides: Parameters<typeof seedProviderCalendar>[1] = {},
   ): Promise<ProviderCalendarRecord> =>
     seedProviderCalendar(calendars, overrides);
 
@@ -208,6 +208,71 @@ describe("SyncJobWorker", () => {
     expect(
       await jobs.findById(resource.tenantId, resource.principalId, job._id),
     ).toBeNull();
+  });
+
+  it("re-derives connection health after a successful pull settles", async () => {
+    const connection = await connections.upsertByProviderAccount({
+      tenantId: objectId(),
+      principalId: objectId(),
+      provider: "google",
+      account: {
+        providerAccountId: "acct-1",
+        email: "user@example.com",
+        displayName: "User",
+      },
+      capabilities: ["readEvents", "readBusy", "writeEvents"],
+      state: "delayed",
+      stateReason: "providerErrors",
+    });
+    const credentials = new CredentialRepository(storage.db());
+    await credentials.store({
+      connectionId: connection._id,
+      provider: "google",
+      refreshToken: "refresh",
+      scopes: ["https://www.googleapis.com/auth/calendar.events"],
+    });
+    const calendar = await seedCalendar({
+      tenantId: connection.tenantId,
+      principalId: connection.principalId,
+      connectionId: connection._id,
+    });
+    const listResource = await resources.ensure({
+      tenantId: connection.tenantId,
+      principalId: connection.principalId,
+      connectionId: connection._id,
+      resourceKind: "calendarList",
+      calendarId: null,
+    });
+    await resources.advanceCursor(
+      connection.tenantId,
+      connection.principalId,
+      listResource._id,
+      "list-cursor",
+      now(),
+    );
+    const eventsResource = await seedResource(calendar, "cursor-0");
+    await resources.setBootstrapState(
+      connection.tenantId,
+      connection.principalId,
+      eventsResource._id,
+      "ready",
+    );
+    await enqueue(eventsResource, "incrementalPull");
+
+    await worker(
+      new FakeReader([
+        pageOf([single("new-1")], { nextSyncToken: "cursor-1" }),
+      ]),
+    ).runOnce();
+
+    const after = await connections.findById(
+      connection.tenantId,
+      connection.principalId,
+      connection._id,
+    );
+    expect(after?.state).toBe("healthy");
+    expect(after?.stateReason).toBeNull();
+    expect(after?.lastHealthyAt).toBeInstanceOf(Date);
   });
 
   it("hands an expired-cursor pull off by enqueuing a repair and completing the pull", async () => {

--- a/packages/sync/src/domain/sync-job-worker.service.db.test.ts
+++ b/packages/sync/src/domain/sync-job-worker.service.db.test.ts
@@ -303,6 +303,8 @@ describe("SyncJobWorker", () => {
     expect(after?.state).toBe("failed");
     expect(after?.failureClass).toBe("retryableTransient");
     expect(after?.leaseOwner).toBeNull();
+    expect(after?.lastError).toContain("flaky");
+    expect(after?.lastErrorAt).toEqual(now());
   });
 
   it("does not call onFail while a transient failure still has retries left", async () => {
@@ -341,6 +343,27 @@ describe("SyncJobWorker", () => {
 
     expect(failed).toHaveLength(1);
     expect(failed[0]?._id).toEqual(job._id);
+  });
+
+  it("records lastError on a retrying job so connection health can see it", async () => {
+    const calendar = await seedCalendar();
+    const resource = await seedResource(calendar, "cursor-0");
+    const job = await enqueue(resource, "incrementalPull");
+
+    await workerWith(
+      new FakeReader([], new ProviderEventReadError("transient", "flaky")),
+      { maxAttempts: 5 },
+    ).runOnce();
+
+    const after = await jobs.findById(
+      resource.tenantId,
+      resource.principalId,
+      job._id,
+    );
+    expect(after?.state).toBe("pending");
+    expect(after?.failureClass).toBe("retryableTransient");
+    expect(after?.lastError).toContain("flaky");
+    expect(after?.lastErrorAt).toEqual(now());
   });
 
   it("keeps a failed job's coalescing key so enqueue does not replace it", async () => {

--- a/packages/sync/src/domain/sync-job-worker.service.ts
+++ b/packages/sync/src/domain/sync-job-worker.service.ts
@@ -220,6 +220,7 @@ export class SyncJobWorker {
         // first then crashing would drop the followup.
         if (outcome.followup) await this.#deps.jobs.enqueue(outcome.followup);
         await this.#deps.jobs.complete(job._id, this.#owner);
+        await refreshConnectionStateAfterJob(this.#deps, job, this.#now);
         return;
       case "drop":
         // Nothing to do (target vanished, credential unusable); settle so it
@@ -227,6 +228,7 @@ export class SyncJobWorker {
         // a stalled queue.
         this.#onDrop(job, outcome.reason);
         await this.#deps.jobs.complete(job._id, this.#owner);
+        await refreshConnectionStateAfterJob(this.#deps, job, this.#now);
         return;
       case "retry":
         await this.#settleFailure(job, new Error(outcome.reason));

--- a/packages/sync/src/domain/sync-job-worker.service.ts
+++ b/packages/sync/src/domain/sync-job-worker.service.ts
@@ -1,3 +1,5 @@
+import { refreshConnectionStateAfterJob } from "@sync/domain/connection-state-refresh.service";
+import { sanitizeJobLastError } from "@sync/domain/job-last-error";
 import {
   dispatchSyncJob,
   type SyncJobDispatchDeps,
@@ -51,8 +53,8 @@ export interface SyncJobWorkerOptions {
   // failure (before the fail() write). Unlike onError (fires every attempt),
   // this fires exactly once, on the exhausting attempt — the signal worth
   // alerting on, since the job is now wedged until an operator or a manual
-  // refresh revives it.
-  onFail?: (job: JobRecord) => void;
+  // refresh revives it. The error is the last engine throw or retry reason.
+  onFail?: (job: JobRecord, error?: unknown) => void;
   // Reserve this worker away from the given job kinds — see
   // JobRepository.claimDueJob. Used to keep a subset of drains claiming only
   // quick jobs (pulls), so a long initialImport/repair elsewhere can never
@@ -114,7 +116,7 @@ export class SyncJobWorker {
   readonly #now: () => Date;
   readonly #onError: (error: unknown, job: JobRecord) => void;
   readonly #onDrop: (job: JobRecord, reason: string) => void;
-  readonly #onFail: (job: JobRecord) => void;
+  readonly #onFail: (job: JobRecord, error?: unknown) => void;
   readonly #excludeKinds?: JobRecord["kind"][];
 
   constructor(
@@ -206,7 +208,7 @@ export class SyncJobWorker {
         ),
         job,
       );
-      await this.#settleFailure(job);
+      await this.#settleFailure(job, error);
       return;
     }
 
@@ -227,7 +229,7 @@ export class SyncJobWorker {
         await this.#deps.jobs.complete(job._id, this.#owner);
         return;
       case "retry":
-        await this.#settleFailure(job);
+        await this.#settleFailure(job, new Error(outcome.reason));
         return;
     }
   }
@@ -237,17 +239,24 @@ export class SyncJobWorker {
   // so enqueue will not create a replacement until an operator clears it —
   // deliberate backpressure: a persistently-broken resource stops and asks for
   // attention rather than looping (or resurrecting on every sweep, which would
-  // be unlimited retries by another name).
-  async #settleFailure(job: JobRecord): Promise<void> {
+  // be unlimited retries by another name). After either settle, re-derive
+  // connection health so a first import that is retrying or dead-lettered is
+  // not stuck on "importing" in the SPA.
+  async #settleFailure(job: JobRecord, error?: unknown): Promise<void> {
+    const lastError = sanitizeJobLastError(error);
     if (job.attempt >= this.#maxAttempts) {
-      this.#onFail(job);
-      await this.#deps.jobs.fail(job._id, this.#owner);
+      this.#onFail(job, error);
+      await this.#deps.jobs.fail(job._id, this.#owner, lastError, this.#now());
+      await refreshConnectionStateAfterJob(this.#deps, job, this.#now);
       return;
     }
     await this.#deps.jobs.scheduleRetry(
       job._id,
       this.#owner,
       this.#backoff(job.attempt, this.#now()),
+      lastError,
+      this.#now(),
     );
+    await refreshConnectionStateAfterJob(this.#deps, job, this.#now);
   }
 }

--- a/packages/sync/src/providers/google/google-auth.adapter.test.ts
+++ b/packages/sync/src/providers/google/google-auth.adapter.test.ts
@@ -385,6 +385,48 @@ describe("GoogleAuthAdapter", () => {
       expect(error.reason).toBe("authorizationRevoked");
     });
 
+    it.each([
+      "unauthorized_client",
+      "invalid_client",
+    ] as const)("classifies %s as authorizationRevoked", async (code) => {
+      const client = new FakeGoogleClient({
+        refreshError: { response: { data: { error: code } } },
+      });
+      const { adapter } = adapterWith(client);
+
+      const error = (await adapter
+        .refreshAccessToken({ refreshToken: "rt" })
+        .catch((e) => e)) as ProviderAuthError;
+
+      expect(error.reason).toBe("authorizationRevoked");
+    });
+
+    it("classifies an HTTP 401 refresh rejection as authorizationRevoked even without invalid_grant", async () => {
+      const client = new FakeGoogleClient({
+        refreshError: { response: { status: 401 } },
+      });
+      const { adapter } = adapterWith(client);
+
+      const error = (await adapter
+        .refreshAccessToken({ refreshToken: "rt" })
+        .catch((e) => e)) as ProviderAuthError;
+
+      expect(error.reason).toBe("authorizationRevoked");
+    });
+
+    it("classifies an HTTP 400 refresh rejection as authorizationRevoked", async () => {
+      const client = new FakeGoogleClient({
+        refreshError: { response: { status: 400 } },
+      });
+      const { adapter } = adapterWith(client);
+
+      const error = (await adapter
+        .refreshAccessToken({ refreshToken: "rt" })
+        .catch((e) => e)) as ProviderAuthError;
+
+      expect(error.reason).toBe("authorizationRevoked");
+    });
+
     it("classifies any other refresh error as refreshFailed", async () => {
       const client = new FakeGoogleClient({
         refreshError: {

--- a/packages/sync/src/providers/google/google-auth.adapter.ts
+++ b/packages/sync/src/providers/google/google-auth.adapter.ts
@@ -5,6 +5,7 @@ import {
 } from "google-auth-library";
 import { ProviderAccountFactsSchema } from "@core/types/sync/connection.contracts";
 import { GOOGLE_SCOPES } from "@sync/providers/google/google.scopes";
+import { googleStatus } from "@sync/providers/google/google-error";
 import {
   type ProviderAuthAdapter,
   ProviderAuthError,
@@ -143,11 +144,16 @@ export class GoogleAuthAdapter implements ProviderAuthAdapter {
     try {
       ({ credentials } = await client.refreshAccessToken());
     } catch (error) {
-      // invalid_grant means the refresh token itself is revoked or expired, so
-      // no retry will help — surface it as revoked authority for the caller to
-      // move the connection to action-required. Anything else is transient.
+      // A dead grant is not worth the job retry ladder: invalid_grant (and
+      // sibling token-endpoint codes) or HTTP 400/401 mean the refresh token
+      // is revoked, expired, or the client is rejected. 5xx / network stay
+      // refreshFailed so a blip can recover. A 401 whose body isn't exactly
+      // `invalid_grant` used to retry 20 times with the credential still
+      // stored, leaving calendars stale and never prompting reconnect.
       throw new ProviderAuthError(
-        isInvalidGrant(error) ? "authorizationRevoked" : "refreshFailed",
+        isRefreshPermanentlyRejected(error)
+          ? "authorizationRevoked"
+          : "refreshFailed",
         "Google rejected the refresh token",
         { cause: redactedCause(error) },
       );
@@ -205,13 +211,26 @@ export class GoogleAuthAdapter implements ProviderAuthAdapter {
   }
 }
 
-// A Google token-endpoint rejection carries the reason in the response body's
-// `error` field. `invalid_grant` specifically means the refresh token is
-// revoked or expired. Reading the response (not the request) is leak-safe.
-function isInvalidGrant(error: unknown): boolean {
-  const data = (error as { response?: { data?: { error?: string } } })?.response
-    ?.data;
-  return data?.error === "invalid_grant";
+// Token-endpoint codes that mean the stored refresh token cannot be used
+// again — reconnect is required. Reading the response (not the request) is
+// leak-safe.
+const PERMANENT_REFRESH_ERRORS = new Set([
+  "invalid_grant",
+  "unauthorized_client",
+  "invalid_client",
+]);
+
+function tokenEndpointErrorCode(error: unknown): string | undefined {
+  const data = (error as { response?: { data?: { error?: unknown } } })
+    ?.response?.data;
+  return typeof data?.error === "string" ? data.error : undefined;
+}
+
+function isRefreshPermanentlyRejected(error: unknown): boolean {
+  const code = tokenEndpointErrorCode(error);
+  if (code && PERMANENT_REFRESH_ERRORS.has(code)) return true;
+  const status = googleStatus(error);
+  return status === 400 || status === 401;
 }
 
 // Google returns granted scopes as a single space-delimited string. A subset of

--- a/packages/sync/src/providers/google/google-calendar.adapter.test.ts
+++ b/packages/sync/src/providers/google/google-calendar.adapter.test.ts
@@ -400,6 +400,17 @@ describe("GoogleCalendarAdapter", () => {
     expect(second.calendars[0].providerCalendarId).toBe("account-b");
   });
 
+  it("maps a 401 to authExpired so the caller can remint the access token", async () => {
+    const api = new FakeCalendarListApi([], { response: { status: 401 } });
+    const { adapter } = adapterWith(api);
+
+    const error = (await adapter
+      .discoverCalendars({ accessToken: "stale" })
+      .catch((e) => e)) as ProviderCalendarError;
+
+    expect(error.reason).toBe("authExpired");
+  });
+
   it("classifies an expired cursor (410) distinctly from a generic failure", async () => {
     const expired = new FakeCalendarListApi([], {
       response: { status: 410 },

--- a/packages/sync/src/providers/google/google-calendar.adapter.ts
+++ b/packages/sync/src/providers/google/google-calendar.adapter.ts
@@ -241,15 +241,17 @@ function mapAccessRole(
 }
 
 // Map a Google calendarList.list failure to a discovery-error reason. An
-// expired syncToken (410 Gone) forces a full re-list; network / rate-limit /
-// quota / server errors are retryable; other 4xx (including notACalendarUser)
-// are durable refusals. Quota arrives as 403, so status alone cannot separate
-// it from a durable 403 — same TRANSIENT_REASONS set as the watch/writer path.
+// expired syncToken (410 Gone) forces a full re-list. A 401 means the access
+// token was rejected — remint in-process rather than treating it as a durable
+// discoveryFailed (which would stamp lastReadFailureAt and ask the user to
+// Refresh instead of Reconnect). Network / rate-limit / quota / server errors
+// are retryable; other 4xx (notACalendarUser, etc.) are durable refusals.
 function classifyDiscoveryError(
   error: unknown,
-): "cursorExpired" | "transient" | "discoveryFailed" {
+): "cursorExpired" | "authExpired" | "transient" | "discoveryFailed" {
   const status = googleStatus(error);
   if (status === 410) return "cursorExpired";
+  if (status === 401) return "authExpired";
   if (isGoogleTransient(error, status)) return "transient";
   return "discoveryFailed";
 }

--- a/packages/sync/src/providers/provider-calendar.port.ts
+++ b/packages/sync/src/providers/provider-calendar.port.ts
@@ -61,6 +61,7 @@ export interface ProviderCalendarAdapter {
 export type ProviderCalendarErrorReason =
   | "discoveryFailed" // durable: the provider rejected the calendar-list read
   | "transient" // retryable: network, rate limit, quota, or server error
-  | "cursorExpired"; // the incremental cursor is too old; a full re-list is required
+  | "cursorExpired" // the incremental cursor is too old; a full re-list is required
+  | "authExpired"; // 401: the access token was rejected; remint and retry once
 
 export class ProviderCalendarError extends ProviderError<ProviderCalendarErrorReason> {}

--- a/packages/sync/src/storage/contracts/credential.contracts.ts
+++ b/packages/sync/src/storage/contracts/credential.contracts.ts
@@ -21,6 +21,11 @@ export const CredentialRecordSchema = z.strictObject({
   // whenever the cached token has been invalidated.
   accessToken: z.string().min(1).nullable(),
   accessTokenExpiresAt: z.date().nullable(),
+  // Consecutive token-endpoint refreshFailed counts. Reset on a successful
+  // mint. After MAX_REFRESH_FAILED_ATTEMPTS the connection is treated as
+  // authorizationExpired so the UI can prompt reconnect instead of looping
+  // 401s. Defaulted: docs predating this field must still parse.
+  refreshFailureCount: z.number().int().min(0).default(0),
   // The scopes the credential was granted, for capability checks.
   scopes: z.array(z.string()),
   createdAt: z.date(),

--- a/packages/sync/src/storage/contracts/job.contracts.ts
+++ b/packages/sync/src/storage/contracts/job.contracts.ts
@@ -74,6 +74,10 @@ export const JobRecordSchema = z.strictObject({
   // doc already holds a key and re-parses it, so a single unparseable job
   // took down every sweep fleet-wide for 23h (2026-07-31).
   requeuedCount: z.number().int().min(0).default(0),
+  // Sanitized last engine/provider error for operator logs and health. Never
+  // holds tokens. Defaulted so docs predating this field still parse.
+  lastError: z.string().trim().max(500).nullable().default(null),
+  lastErrorAt: z.date().nullable().default(null),
   createdAt: z.date(),
   updatedAt: z.date(),
 });
@@ -87,6 +91,8 @@ export const JobEnqueueSchema = JobRecordSchema.omit({
   leaseExpiresAt: true,
   failureClass: true,
   requeuedCount: true,
+  lastError: true,
+  lastErrorAt: true,
   createdAt: true,
   updatedAt: true,
 });

--- a/packages/sync/src/storage/repositories/credential.repository.ts
+++ b/packages/sync/src/storage/repositories/credential.repository.ts
@@ -37,6 +37,7 @@ export class CredentialRepository {
           scopes: fields.scopes,
           accessToken: null,
           accessTokenExpiresAt: null,
+          refreshFailureCount: 0,
           updatedAt: now,
         },
         // _id comes from the query filter on insert; setting it here too would
@@ -73,6 +74,7 @@ export class CredentialRepository {
         $set: {
           accessToken,
           accessTokenExpiresAt: expiresAt,
+          refreshFailureCount: 0,
           updatedAt: new Date(),
         },
       },
@@ -95,6 +97,21 @@ export class CredentialRepository {
         },
       },
     );
+  }
+
+  // Count a transient token-endpoint failure against the consecutive budget.
+  // Returns the new count, or 0 if the credential was deleted concurrently.
+  async incrementRefreshFailure(connectionId: ConnectionId): Promise<number> {
+    const result = await this.collection.findOneAndUpdate(
+      { _id: connectionId },
+      {
+        $inc: { refreshFailureCount: 1 },
+        $set: { updatedAt: new Date() },
+      },
+      { returnDocument: "after" },
+    );
+    if (!result) return 0;
+    return CredentialRecordSchema.parse(result).refreshFailureCount;
   }
 
   // Remove a connection's credential (disconnect / account deletion). Returns

--- a/packages/sync/src/storage/repositories/job.repository.db.test.ts
+++ b/packages/sync/src/storage/repositories/job.repository.db.test.ts
@@ -699,6 +699,59 @@ describe("JobRepository", () => {
       expect(oldest?.failureClass).toBe("retryableTransient");
     });
 
+    it("keeps a failed job overdue from runAfter even when lastErrorAt is newer", async () => {
+      const connectionId = objectId() as JobEnqueue["connectionId"];
+      const tenantId = objectId() as JobEnqueue["tenantId"];
+      const principalId = objectId() as JobEnqueue["principalId"];
+      const failed = await repo.enqueue(
+        enqueue({
+          tenantId,
+          principalId,
+          connectionId,
+          runAfter: past(60 * 60_000),
+          coalescingKey: "pull:failed-fresh-error",
+        }),
+      );
+      const claimed = await repo.claimDueJob("worker", NOW, 60_000);
+      await repo.fail(claimed!._id, "worker", "HTTP 500", NOW);
+
+      const oldest = await repo.findOldestOverdueByConnection(
+        tenantId,
+        principalId,
+        connectionId,
+        NOW,
+      );
+      expect(oldest?.runAfter).toEqual(failed.runAfter);
+      expect(oldest?.failureClass).toBe("retryableTransient");
+    });
+
+    it("alarms a failed job from lastErrorAt when the last retry was more recent", async () => {
+      const connectionId = objectId() as JobEnqueue["connectionId"];
+      const tenantId = objectId() as JobEnqueue["tenantId"];
+      const principalId = objectId() as JobEnqueue["principalId"];
+      await repo.enqueue(
+        enqueue({
+          tenantId,
+          principalId,
+          connectionId,
+          runAfter: past(1000),
+          coalescingKey: "pull:failed-old-error",
+        }),
+      );
+      const claimed = await repo.claimDueJob("worker", NOW, 60_000);
+      const firstErrorAt = past(3 * 60_000);
+      await repo.fail(claimed!._id, "worker", "HTTP 500", firstErrorAt);
+
+      const oldest = await repo.findOldestOverdueByConnection(
+        tenantId,
+        principalId,
+        connectionId,
+        NOW,
+      );
+      expect(oldest?.runAfter).toEqual(firstErrorAt);
+      expect(oldest?.failureClass).toBe("retryableTransient");
+    });
+
     it("treats a retrying job with lastErrorAt as overdue provider-error work", async () => {
       const connectionId = objectId() as JobEnqueue["connectionId"];
       const tenantId = objectId() as JobEnqueue["tenantId"];

--- a/packages/sync/src/storage/repositories/job.repository.db.test.ts
+++ b/packages/sync/src/storage/repositories/job.repository.db.test.ts
@@ -699,6 +699,39 @@ describe("JobRepository", () => {
       expect(oldest?.failureClass).toBe("retryableTransient");
     });
 
+    it("treats a retrying job with lastErrorAt as overdue provider-error work", async () => {
+      const connectionId = objectId() as JobEnqueue["connectionId"];
+      const tenantId = objectId() as JobEnqueue["tenantId"];
+      const principalId = objectId() as JobEnqueue["principalId"];
+      const job = await repo.enqueue(
+        enqueue({
+          tenantId,
+          principalId,
+          connectionId,
+          runAfter: past(1000),
+          coalescingKey: "pull:retrying-resource",
+        }),
+      );
+      const claimed = await repo.claimDueJob("worker", NOW, 60_000);
+      expect(claimed?._id).toEqual(job._id);
+      await repo.scheduleRetry(
+        claimed!._id,
+        "worker",
+        new Date(NOW.getTime() + 10 * 60_000),
+        "HTTP 500",
+        past(5 * 60_000),
+      );
+
+      const oldest = await repo.findOldestOverdueByConnection(
+        tenantId,
+        principalId,
+        connectionId,
+        NOW,
+      );
+      expect(oldest?.runAfter).toEqual(past(5 * 60_000));
+      expect(oldest?.failureClass).toBe("retryableTransient");
+    });
+
     it("reports no overdue work for a connection with only healthy pending jobs", async () => {
       const connectionId = objectId() as JobEnqueue["connectionId"];
       const tenantId = objectId() as JobEnqueue["tenantId"];

--- a/packages/sync/src/storage/repositories/job.repository.ts
+++ b/packages/sync/src/storage/repositories/job.repository.ts
@@ -145,6 +145,7 @@ export class JobRepository {
           leaseExpiresAt: null,
           failureClass: null,
         },
+        $unset: { lastError: "", lastErrorAt: "" },
         $max: { priority: fields.priority },
         $currentDate: { updatedAt: true },
       },
@@ -309,6 +310,8 @@ export class JobRepository {
     id: SyncJobId,
     owner: string,
     runAfter: Date,
+    lastError?: string | null,
+    at: Date = new Date(),
   ): Promise<boolean> {
     const result = await this.collection.updateOne(
       { _id: id, leaseOwner: owner },
@@ -319,7 +322,9 @@ export class JobRepository {
           leaseOwner: null,
           leaseExpiresAt: null,
           failureClass: "retryableTransient" as const,
+          ...(lastError ? { lastError } : {}),
         },
+        $min: { lastErrorAt: at },
         $currentDate: { updatedAt: true },
       },
     );
@@ -328,7 +333,12 @@ export class JobRepository {
 
   // Mark a job the worker owns as a terminal failure needing attention
   // (retries exhausted).
-  async fail(id: SyncJobId, owner: string): Promise<boolean> {
+  async fail(
+    id: SyncJobId,
+    owner: string,
+    lastError?: string | null,
+    at: Date = new Date(),
+  ): Promise<boolean> {
     const result = await this.collection.updateOne(
       { _id: id, leaseOwner: owner },
       {
@@ -337,7 +347,9 @@ export class JobRepository {
           leaseOwner: null,
           leaseExpiresAt: null,
           failureClass: "retryableTransient" as const,
+          ...(lastError ? { lastError } : {}),
         },
+        $min: { lastErrorAt: at },
         $currentDate: { updatedAt: true },
       },
     );
@@ -417,6 +429,7 @@ export class JobRepository {
           leaseExpiresAt: null,
           failureClass: null,
         },
+        $unset: { lastError: "", lastErrorAt: "" },
         $inc: { requeuedCount: 1 },
         $currentDate: { updatedAt: true },
       },
@@ -521,6 +534,7 @@ export class JobRepository {
           leaseExpiresAt: null,
           failureClass: null,
         },
+        $unset: { lastError: "", lastErrorAt: "" },
         $currentDate: { updatedAt: true },
       },
     );
@@ -535,12 +549,10 @@ export class JobRepository {
   }
 
   // The oldest piece of overdue work for one connection, if any: a pending
-  // job past its runAfter, a claimed job whose lease lapsed, or ANY failed
-  // job (a terminal failure is always overdue — nothing will run it again
-  // without the self-heal sweep or an operator). Feeds
-  // ConnectionStateEvidence.oldestDueWorkAt, which was previously wired to a
-  // hardcoded null — a wedged failed job was invisible to the connection's
-  // own health state (2026-07-30: every signal green with jobs stuck ~25h).
+  // job past its runAfter, a claimed job whose lease lapsed, ANY failed job,
+  // or a retrying job that already recorded lastErrorAt (so first-import
+  // retries surface as delayed after DELAYED_THRESHOLD_MS instead of sitting
+  // on "importing" for the whole 20-attempt ladder).
   async findOldestOverdueByConnection(
     tenantId: TenantId,
     principalId: PrincipalId,
@@ -550,6 +562,31 @@ export class JobRepository {
     runAfter: Date;
     failureClass: JobRecord["failureClass"];
   } | null> {
+    const errored = await this.collection.findOne(
+      {
+        tenantId,
+        principalId,
+        connectionId,
+        lastErrorAt: { $lte: now },
+        $or: [
+          { state: "pending" },
+          { state: "claimed", leaseExpiresAt: { $lt: now } },
+          { state: "failed" },
+        ],
+      },
+      {
+        sort: { lastErrorAt: 1 },
+        projection: { lastErrorAt: 1, failureClass: 1 },
+      },
+    );
+    if (errored && errored["lastErrorAt"] instanceof Date) {
+      return {
+        runAfter: errored["lastErrorAt"],
+        failureClass: (errored["failureClass"] ??
+          "retryableTransient") as JobRecord["failureClass"],
+      };
+    }
+
     const result = await this.collection.findOne(
       {
         tenantId,

--- a/packages/sync/src/storage/repositories/job.repository.ts
+++ b/packages/sync/src/storage/repositories/job.repository.ts
@@ -553,6 +553,11 @@ export class JobRepository {
   // or a retrying job that already recorded lastErrorAt (so first-import
   // retries surface as delayed after DELAYED_THRESHOLD_MS instead of sitting
   // on "importing" for the whole 20-attempt ladder).
+  //
+  // Failed jobs must not use a just-stamped lastErrorAt as their due time —
+  // that would hide a terminal fail behind DELAYED_THRESHOLD_MS. Use the
+  // older of runAfter and lastErrorAt so a dead-letter whose last retry was
+  // recent still alarms from the first error.
   async findOldestOverdueByConnection(
     tenantId: TenantId,
     principalId: PrincipalId,
@@ -562,16 +567,19 @@ export class JobRepository {
     runAfter: Date;
     failureClass: JobRecord["failureClass"];
   } | null> {
-    const errored = await this.collection.findOne(
+    const scope = { tenantId, principalId, connectionId };
+    const candidates: Array<{
+      runAfter: Date;
+      failureClass: JobRecord["failureClass"];
+    }> = [];
+
+    const retrying = await this.collection.findOne(
       {
-        tenantId,
-        principalId,
-        connectionId,
+        ...scope,
         lastErrorAt: { $lte: now },
         $or: [
           { state: "pending" },
           { state: "claimed", leaseExpiresAt: { $lt: now } },
-          { state: "failed" },
         ],
       },
       {
@@ -579,19 +587,17 @@ export class JobRepository {
         projection: { lastErrorAt: 1, failureClass: 1 },
       },
     );
-    if (errored && errored["lastErrorAt"] instanceof Date) {
-      return {
-        runAfter: errored["lastErrorAt"],
-        failureClass: (errored["failureClass"] ??
+    if (retrying?.["lastErrorAt"] instanceof Date) {
+      candidates.push({
+        runAfter: retrying["lastErrorAt"],
+        failureClass: (retrying["failureClass"] ??
           "retryableTransient") as JobRecord["failureClass"],
-      };
+      });
     }
 
     const result = await this.collection.findOne(
       {
-        tenantId,
-        principalId,
-        connectionId,
+        ...scope,
         $or: [
           { state: "pending", runAfter: { $lte: now } },
           { state: "claimed", leaseExpiresAt: { $lt: now } },
@@ -600,14 +606,28 @@ export class JobRepository {
       },
       {
         sort: { runAfter: 1 },
-        projection: { runAfter: 1, failureClass: 1 },
+        projection: { runAfter: 1, lastErrorAt: 1, failureClass: 1, state: 1 },
       },
     );
-    if (!result || !(result["runAfter"] instanceof Date)) return null;
-    return {
-      runAfter: result["runAfter"],
-      failureClass: result["failureClass"] ?? null,
-    };
+    if (result?.["runAfter"] instanceof Date) {
+      const lastErrorAt =
+        result["lastErrorAt"] instanceof Date ? result["lastErrorAt"] : null;
+      const runAfter =
+        result["state"] === "failed" &&
+        lastErrorAt &&
+        lastErrorAt.getTime() < result["runAfter"].getTime()
+          ? lastErrorAt
+          : result["runAfter"];
+      candidates.push({
+        runAfter,
+        failureClass: result["failureClass"] ?? null,
+      });
+    }
+
+    if (candidates.length === 0) return null;
+    return candidates.reduce((oldest, next) =>
+      next.runAfter.getTime() < oldest.runAfter.getTime() ? next : oldest,
+    );
   }
 
   // Outstanding work for one connection (support diagnostics / S45).

--- a/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.util.test.ts
+++ b/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.util.test.ts
@@ -2,9 +2,11 @@ import { type GoogleSyncConnectionSummary } from "@core/types/user.types";
 import {
   formatLastSyncedLabel,
   formatLastUpdatedClause,
+  getCalendarConnectionBannerKind,
   getGoogleConnectionConfig,
   getGoogleSyncStatus,
   getSidebarSyncStatus,
+  isFirstImportFailed,
   isFirstImportInProgress,
 } from "./useConnectGoogle.util";
 import { beforeEach, describe, expect, it, mock } from "bun:test";
@@ -481,6 +483,103 @@ describe("isFirstImportInProgress", () => {
         makeConnection({ state: "actionRequired", lastHealthyAt: null }),
       ),
     ).toBe(false);
+  });
+});
+
+describe("isFirstImportFailed", () => {
+  const makeConnection = (
+    overrides: Partial<GoogleSyncConnectionSummary> = {},
+  ): GoogleSyncConnectionSummary => ({
+    id: "c1",
+    state: "delayed",
+    stateReason: "providerErrors",
+    lastSyncedAt: null,
+    lastHealthyAt: null,
+    accountEmail: "a@example.com",
+    connectionState: "ATTENTION",
+    ...overrides,
+  });
+
+  it("returns false with no connection", () => {
+    expect(isFirstImportFailed(null)).toBe(false);
+    expect(isFirstImportFailed(undefined)).toBe(false);
+  });
+
+  it("returns true for a never-healthy delayed connection", () => {
+    expect(isFirstImportFailed(makeConnection())).toBe(true);
+  });
+
+  it("returns false once the connection has ever gone healthy", () => {
+    expect(
+      isFirstImportFailed(
+        makeConnection({ lastHealthyAt: "2026-07-24T11:45:00.000Z" }),
+      ),
+    ).toBe(false);
+  });
+
+  it("returns false while the first import is still in progress", () => {
+    expect(
+      isFirstImportFailed(
+        makeConnection({
+          state: "importing",
+          stateReason: null,
+          connectionState: "IMPORTING",
+        }),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("getCalendarConnectionBannerKind", () => {
+  const makeConnection = (
+    overrides: Partial<GoogleSyncConnectionSummary> = {},
+  ): GoogleSyncConnectionSummary => ({
+    id: "c1",
+    state: "healthy",
+    stateReason: null,
+    lastSyncedAt: null,
+    lastHealthyAt: "2026-07-24T11:45:00.000Z",
+    accountEmail: "a@example.com",
+    connectionState: "HEALTHY",
+    ...overrides,
+  });
+
+  it("returns reconnect when the product state requires re-auth", () => {
+    expect(
+      getCalendarConnectionBannerKind(
+        "RECONNECT_REQUIRED",
+        makeConnection({
+          state: "actionRequired",
+          stateReason: "authorizationRevoked",
+          connectionState: "RECONNECT_REQUIRED",
+        }),
+      ),
+    ).toBe("reconnect");
+  });
+
+  it("returns importFailed for a never-healthy delayed connection", () => {
+    expect(
+      getCalendarConnectionBannerKind(
+        "ATTENTION",
+        makeConnection({
+          state: "delayed",
+          lastHealthyAt: null,
+          connectionState: "ATTENTION",
+        }),
+      ),
+    ).toBe("importFailed");
+  });
+
+  it("returns delayed for an established connection in ATTENTION", () => {
+    expect(getCalendarConnectionBannerKind("ATTENTION", makeConnection())).toBe(
+      "delayed",
+    );
+  });
+
+  it("returns null when the connection is healthy", () => {
+    expect(
+      getCalendarConnectionBannerKind("HEALTHY", makeConnection()),
+    ).toBeNull();
   });
 });
 

--- a/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.util.ts
+++ b/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.util.ts
@@ -336,6 +336,41 @@ export const isFirstImportInProgress = (
   );
 
 /**
+ * The first-ever import exhausted retries or stalled into delayed/ATTENTION
+ * before the connection was ever healthy. Distinct from an established
+ * account's delayed catch-up (which has lastHealthyAt).
+ */
+export const isFirstImportFailed = (
+  connection?: GoogleSyncConnectionSummary | null,
+): boolean =>
+  Boolean(
+    connection &&
+      !connection.lastHealthyAt &&
+      (connection.state === "delayed" ||
+        connection.connectionState === "ATTENTION"),
+  );
+
+export type CalendarConnectionBannerKind =
+  | "reconnect"
+  | "importFailed"
+  | "delayed";
+
+// Persistent in-calendar banner. Reconnect wins, then a failed first import,
+// then an established account's delayed catch-up. First-import-in-progress
+// stays on the grid overlay, not this banner.
+export const getCalendarConnectionBannerKind = (
+  state: GoogleUiState,
+  connection?: GoogleSyncConnectionSummary | null,
+): CalendarConnectionBannerKind | null => {
+  if (connectionNeedsReconnect(state, connection)) return "reconnect";
+  if (isFirstImportFailed(connection)) return "importFailed";
+  if (state === "ATTENTION" || connection?.state === "delayed") {
+    return "delayed";
+  }
+  return null;
+};
+
+/**
  * The sidebar's take on one account's status. Two rules the sidebar applies
  * that Settings doesn't: a connect/reconnect that has been clicked but hasn't
  * round-tripped yet wins over the (still pre-click) connection summary, and a

--- a/packages/web/src/components/CalendarConnectionBanner/CalendarConnectionBanner.test.tsx
+++ b/packages/web/src/components/CalendarConnectionBanner/CalendarConnectionBanner.test.tsx
@@ -1,0 +1,52 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, mock } from "bun:test";
+import "@testing-library/jest-dom";
+import { CalendarConnectionBanner } from "./CalendarConnectionBanner";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("CalendarConnectionBanner", () => {
+  it("shows a reconnect action for revoked access", async () => {
+    const onAction = mock();
+    const user = userEvent.setup();
+
+    render(<CalendarConnectionBanner kind="reconnect" onAction={onAction} />);
+
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Google Calendar needs reconnecting.",
+    );
+    await user.click(screen.getByRole("button", { name: "Reconnect" }));
+    expect(onAction).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows retry when the first import failed", async () => {
+    const onAction = mock();
+    const user = userEvent.setup();
+
+    render(
+      <CalendarConnectionBanner kind="importFailed" onAction={onAction} />,
+    );
+
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Couldn't add your calendar.",
+    );
+    await user.click(screen.getByRole("button", { name: "Retry" }));
+    expect(onAction).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows refresh when calendar updates are delayed", async () => {
+    const onAction = mock();
+    const user = userEvent.setup();
+
+    render(<CalendarConnectionBanner kind="delayed" onAction={onAction} />);
+
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Calendar updates are delayed.",
+    );
+    await user.click(screen.getByRole("button", { name: "Refresh" }));
+    expect(onAction).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/web/src/components/CalendarConnectionBanner/CalendarConnectionBanner.test.tsx
+++ b/packages/web/src/components/CalendarConnectionBanner/CalendarConnectionBanner.test.tsx
@@ -15,7 +15,7 @@ describe("CalendarConnectionBanner", () => {
 
     render(<CalendarConnectionBanner kind="reconnect" onAction={onAction} />);
 
-    expect(screen.getByRole("status")).toHaveTextContent(
+    expect(screen.getByRole("alert")).toHaveTextContent(
       "Google Calendar needs reconnecting.",
     );
     await user.click(screen.getByRole("button", { name: "Reconnect" }));
@@ -30,7 +30,7 @@ describe("CalendarConnectionBanner", () => {
       <CalendarConnectionBanner kind="importFailed" onAction={onAction} />,
     );
 
-    expect(screen.getByRole("status")).toHaveTextContent(
+    expect(screen.getByRole("alert")).toHaveTextContent(
       "Couldn't add your calendar.",
     );
     await user.click(screen.getByRole("button", { name: "Retry" }));

--- a/packages/web/src/components/CalendarConnectionBanner/CalendarConnectionBanner.tsx
+++ b/packages/web/src/components/CalendarConnectionBanner/CalendarConnectionBanner.tsx
@@ -1,0 +1,53 @@
+import { type FC } from "react";
+import { type CalendarConnectionBannerKind } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle.util";
+
+const COPY: Record<
+  CalendarConnectionBannerKind,
+  { message: string; action: string }
+> = {
+  reconnect: {
+    message: "Google Calendar needs reconnecting.",
+    action: "Reconnect",
+  },
+  importFailed: {
+    message: "Couldn't add your calendar.",
+    action: "Retry",
+  },
+  delayed: {
+    message: "Calendar updates are delayed.",
+    action: "Refresh",
+  },
+};
+
+interface CalendarConnectionBannerProps {
+  kind: CalendarConnectionBannerKind;
+  onAction: () => void;
+}
+
+export const CalendarConnectionBanner: FC<CalendarConnectionBannerProps> = ({
+  kind,
+  onAction,
+}) => {
+  const { message, action } = COPY[kind];
+  const isError = kind === "reconnect" || kind === "importFailed";
+
+  return (
+    <div
+      className={`flex items-center justify-between gap-3 border-b px-4 py-2 text-sm ${
+        isError
+          ? "border-error/40 bg-error/10 text-text"
+          : "border-warning/40 bg-warning/10 text-text"
+      }`}
+      role="status"
+    >
+      <p>{message}</p>
+      <button
+        className="c-focus-ring shrink-0 rounded-xs px-2 py-1 font-medium text-text hover:bg-surface-overlay"
+        onClick={onAction}
+        type="button"
+      >
+        {action}
+      </button>
+    </div>
+  );
+};

--- a/packages/web/src/components/CalendarConnectionBanner/CalendarConnectionBanner.tsx
+++ b/packages/web/src/components/CalendarConnectionBanner/CalendarConnectionBanner.tsx
@@ -38,7 +38,7 @@ export const CalendarConnectionBanner: FC<CalendarConnectionBannerProps> = ({
           ? "border-error/40 bg-error/10 text-text"
           : "border-warning/40 bg-warning/10 text-text"
       }`}
-      role="status"
+      role={isError ? "alert" : "status"}
     >
       <p>{message}</p>
       <button

--- a/packages/web/src/components/CalendarConnectionBanner/CalendarConnectionBannerGate.tsx
+++ b/packages/web/src/components/CalendarConnectionBanner/CalendarConnectionBannerGate.tsx
@@ -1,0 +1,17 @@
+import { type FC } from "react";
+import { useConnectGoogle } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle";
+import { getCalendarConnectionBannerKind } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle.util";
+import { CalendarConnectionBanner } from "@web/components/CalendarConnectionBanner/CalendarConnectionBanner";
+
+export const CalendarConnectionBannerGate: FC = () => {
+  const { connect, connection, refresh, state } = useConnectGoogle();
+  const kind = getCalendarConnectionBannerKind(state, connection);
+  if (!kind) return null;
+
+  return (
+    <CalendarConnectionBanner
+      kind={kind}
+      onAction={kind === "reconnect" ? connect : () => refresh()}
+    />
+  );
+};

--- a/packages/web/src/grid/components/EventGrid.test.tsx
+++ b/packages/web/src/grid/components/EventGrid.test.tsx
@@ -270,7 +270,6 @@ describe("EventGrid", () => {
     );
 
     expect(
-    expect(
       screen.queryByRole("status", { name: "Adding your calendar…" }),
     ).not.toBeInTheDocument();
     expect(

--- a/packages/web/src/grid/components/EventGrid.test.tsx
+++ b/packages/web/src/grid/components/EventGrid.test.tsx
@@ -236,8 +236,8 @@ describe("EventGrid", () => {
     );
 
     const status = screen.getByRole("status");
-    expect(status).toHaveClass("sr-only");
-    expect(status).toHaveTextContent("Looking for events");
+    expect(status).toHaveTextContent("Adding your calendar…");
+    expect(status).not.toHaveClass("sr-only");
     expect(
       screen.getByRole("img", {
         hidden: true,
@@ -270,7 +270,8 @@ describe("EventGrid", () => {
     );
 
     expect(
-      screen.queryByRole("status", { name: "Looking for events" }),
+    expect(
+      screen.queryByRole("status", { name: "Adding your calendar…" }),
     ).not.toBeInTheDocument();
     expect(
       screen.getByRole("status", { name: "Loading events" }),
@@ -295,10 +296,40 @@ describe("EventGrid", () => {
       />,
     );
 
-    expect(screen.queryByText("Looking for events")).not.toBeInTheDocument();
+    expect(screen.queryByText("Adding your calendar…")).not.toBeInTheDocument();
     expect(screen.getByRole("alert")).toHaveTextContent(
       "Couldn't load events.",
     );
+  });
+
+  it("shows a couldn't-add overlay with retry when the first import failed", async () => {
+    const onRetryImport = mock();
+    const user = userEvent.setup();
+
+    render(
+      <EventGrid
+        allDayEventsLayer={<div />}
+        gridRefs={createGridRefs()}
+        isImportFailed
+        onAllDayMouseDown={mock()}
+        onRetryImport={onRetryImport}
+        onTimedMouseDown={mock()}
+        timedEventsLayer={<div />}
+        today={dayjs("2026-05-20T00:00:00.000")}
+        visibleDates={[
+          {
+            date: dayjs("2026-05-20T00:00:00.000"),
+            key: "date-0",
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Couldn't add your calendar.",
+    );
+    await user.click(screen.getByRole("button", { name: "Retry" }));
+    expect(onRetryImport).toHaveBeenCalledTimes(1);
   });
 
   it("shows the loader for first load and for retry after error", () => {

--- a/packages/web/src/grid/components/EventGrid.tsx
+++ b/packages/web/src/grid/components/EventGrid.tsx
@@ -28,7 +28,13 @@ export interface EventGridProps {
    * show a non-blocking scouting indicator instead of a blank grid.
    */
   isImportingEmpty?: boolean;
+  /**
+   * The first Google import failed (or stalled into attention) and the visible
+   * range is still empty — show an error with Retry instead of a blank grid.
+   */
+  isImportFailed?: boolean;
   onRetryEvents?: () => void;
+  onRetryImport?: () => void;
   onAllDayMouseDown: (event: ReactMouseEvent<HTMLElement>) => void;
   onTimedMouseDown: (event: ReactMouseEvent<HTMLElement>) => void;
   timedEventsLayer: ReactNode;
@@ -44,7 +50,9 @@ export const EventGrid: FC<EventGridProps> = ({
   isLoadingEvents = false,
   isErrorEvents = false,
   isImportingEmpty = false,
+  isImportFailed = false,
   onRetryEvents,
+  onRetryImport,
   onAllDayMouseDown,
   onTimedMouseDown,
   timedEventsLayer,
@@ -90,19 +98,42 @@ export const EventGrid: FC<EventGridProps> = ({
         style={{ zIndex: ZIndex.MAX }}
       />
     )}
-    {isImportingEmpty && !isLoadingEvents && !isErrorEvents && (
-      <>
+    {isImportingEmpty &&
+      !isLoadingEvents &&
+      !isErrorEvents &&
+      !isImportFailed && (
         <div
-          aria-hidden="true"
-          className="pointer-events-none absolute inset-0 flex items-center justify-center px-4"
+          className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center gap-3 px-4"
           style={{ zIndex: ZIndex.MAX }}
         >
-          <PixelPirateScouting className="h-16 w-16" />
+          <div aria-hidden="true">
+            <PixelPirateScouting className="h-16 w-16" />
+          </div>
+          <p className="text-sm text-text-muted" role="status">
+            Adding your calendar…
+          </p>
         </div>
-        <span aria-live="polite" className="sr-only" role="status">
-          Looking for events
-        </span>
-      </>
+      )}
+    {isImportFailed && !isLoadingEvents && !isErrorEvents && (
+      <div
+        className="absolute inset-0 flex items-center justify-center bg-background px-4"
+        style={{ zIndex: ZIndex.MAX }}
+      >
+        <div className="flex max-w-sm flex-col items-center gap-3 rounded-md border border-border-strong bg-surface-raised px-5 py-4 text-center shadow-[0_8px_24px_var(--color-shadow-default)]">
+          <p className="text-sm text-text" role="alert">
+            Couldn&apos;t add your calendar.
+          </p>
+          {onRetryImport ? (
+            <button
+              className="c-focus-ring rounded-sm bg-accent px-3 py-1.5 text-on-accent text-sm hover:bg-accent-hover"
+              onClick={onRetryImport}
+              type="button"
+            >
+              Retry
+            </button>
+          ) : null}
+        </div>
+      </div>
     )}
     {isErrorEvents && !isLoadingEvents && (
       <div

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
@@ -10,7 +10,10 @@ import { type CalendarId } from "@core/types/domain-primitives";
 import dayjs from "@core/util/date/dayjs";
 import { shouldShowContextualLoadError } from "@web/api/util/api.util";
 import { useConnectGoogle } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle";
-import { isFirstImportInProgress } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle.util";
+import {
+  isFirstImportFailed,
+  isFirstImportInProgress,
+} from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle.util";
 import { useCalendarsQuery } from "@web/calendars/calendar.query";
 import { getWritableCalendars } from "@web/calendars/calendar.util";
 import {
@@ -117,7 +120,7 @@ export function DayCalendarGrid() {
     showEventsLoadError,
     isFetching,
   );
-  const { connection, state: googleState } = useConnectGoogle();
+  const { connection, refresh, state: googleState } = useConnectGoogle();
   // See Grid.tsx's Week-view equivalent: googleState alone can't tell a
   // first-ever import apart from routine catch-up on an established account.
   const isImportingEmpty =
@@ -126,6 +129,11 @@ export function DayCalendarGrid() {
     dayEvents.length === 0 &&
     googleState === "IMPORTING" &&
     isFirstImportInProgress(connection);
+  const isImportFailed =
+    !isPending &&
+    !showEventsLoadError &&
+    dayEvents.length === 0 &&
+    isFirstImportFailed(connection);
   const {
     calendarColumnIndexById,
     displayedAllDayEvents,
@@ -453,10 +461,12 @@ export function DayCalendarGrid() {
           allDayRowsCount={allDayRowsCount}
           gridRefs={gridRefs}
           isErrorEvents={showEventsLoadError}
+          isImportFailed={isImportFailed}
           isImportingEmpty={isImportingEmpty}
           isLoadingEvents={isLoadingEvents}
           onAllDayMouseDown={handleAllDayMouseDown}
           onRetryEvents={() => void refetch()}
+          onRetryImport={() => refresh()}
           onTimedMouseDown={handleTimedMouseDown}
           timedEventsLayer={timedEventsLayer}
           today={today}

--- a/packages/web/src/views/Day/view/DayViewContent.tsx
+++ b/packages/web/src/views/Day/view/DayViewContent.tsx
@@ -3,6 +3,7 @@ import dayjs from "@core/util/date/dayjs";
 import { ID_MAIN } from "@web/common/constants/web.constants";
 import { useHorizontalNavigation } from "@web/common/hooks/useHorizontalNavigation";
 import { emitViewCommand } from "@web/common/utils/dom/view-command-bus";
+import { CalendarConnectionBannerGate } from "@web/components/CalendarConnectionBanner/CalendarConnectionBannerGate";
 import { CommandPalette } from "@web/components/CommandPalette/CommandPalette";
 import { getCommandPalettePlaceholder } from "@web/components/CommandPalette/more.cmd.constants";
 import { DemoEventsBannerGate } from "@web/components/DemoEventsBanner/DemoEventsBannerGate";
@@ -125,6 +126,7 @@ export const DayViewContent = memo(() => {
         className="flex h-screen flex-1 flex-col overflow-hidden bg-background pt-5 pl-8 transition-[width] duration-200 ease-out motion-reduce:transition-none"
       >
         <Header />
+        <CalendarConnectionBannerGate />
         <DemoEventsBannerGate range={demoEventsRange} />
 
         <div className="flex w-full flex-1 overflow-hidden">

--- a/packages/web/src/views/Week/WeekView.tsx
+++ b/packages/web/src/views/Week/WeekView.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useMemo, useRef } from "react";
 import { ID_MAIN } from "@web/common/constants/web.constants";
 import { useHorizontalNavigation } from "@web/common/hooks/useHorizontalNavigation";
+import { CalendarConnectionBannerGate } from "@web/components/CalendarConnectionBanner/CalendarConnectionBannerGate";
 import { CommandPalette } from "@web/components/CommandPalette/CommandPalette";
 import { getCommandPalettePlaceholder } from "@web/components/CommandPalette/more.cmd.constants";
 import { ContextMenuWrapper } from "@web/components/ContextMenu/GridContextMenuWrapper";
@@ -162,6 +163,7 @@ export const WeekView = () => {
             className="flex h-screen flex-1 flex-col overflow-hidden bg-background pt-5 pr-0 pb-0 pl-8 transition-[width] duration-200 ease-out motion-reduce:transition-none"
           >
             <Header scrollUtil={scrollUtil} weekProps={weekProps} />
+            <CalendarConnectionBannerGate />
             <DemoEventsBannerGate range={demoEventsRange} />
 
             <WeekGridScrollArea>

--- a/packages/web/src/views/Week/components/Grid/Grid.tsx
+++ b/packages/web/src/views/Week/components/Grid/Grid.tsx
@@ -3,7 +3,10 @@ import { YEAR_MONTH_DAY_FORMAT } from "@core/constants/date.constants";
 import { type Dayjs } from "@core/util/date/dayjs";
 import { shouldShowContextualLoadError } from "@web/api/util/api.util";
 import { useConnectGoogle } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle";
-import { isFirstImportInProgress } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle.util";
+import {
+  isFirstImportFailed,
+  isFirstImportInProgress,
+} from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle.util";
 import { useWeekEventViewModel } from "@web/events/queries/useWeekEventsQuery";
 import { selectGridDraft, useDraftStore } from "@web/events/stores/draft.store";
 import { EventGrid, isEventGridLoading } from "@web/grid/components/EventGrid";
@@ -52,7 +55,7 @@ export const Grid: FC<Props> = ({
     startOfView: weekProps.query.startOfView,
     endOfView: weekProps.query.endOfView,
   });
-  const { connection, state: googleState } = useConnectGoogle();
+  const { connection, refresh, state: googleState } = useConnectGoogle();
   // Session expiry already surfaces SessionExpiredToast — don't also show
   // "Couldn't load events" / Retry for the same failure.
   const showEventsLoadError = shouldShowContextualLoadError(
@@ -76,6 +79,8 @@ export const Grid: FC<Props> = ({
     !hasVisibleEvents &&
     googleState === "IMPORTING" &&
     isFirstImportInProgress(connection);
+  const isImportFailed =
+    isSuccess && !hasVisibleEvents && isFirstImportFailed(connection);
 
   useDragEdgeNavigation(mainGridRef, weekProps);
 
@@ -137,10 +142,12 @@ export const Grid: FC<Props> = ({
                 allDayRowsCount={allDayRowsCount}
                 gridRefs={gridRefs}
                 isErrorEvents={showEventsLoadError}
+                isImportFailed={isImportFailed}
                 isImportingEmpty={isImportingEmpty}
                 isLoadingEvents={isLoadingEvents}
                 onAllDayMouseDown={onAllDayMouseDown}
                 onRetryEvents={() => void refetch()}
+                onRetryImport={() => refresh()}
                 onTimedMouseDown={onTimedMouseDown}
                 timedEventsLayer={timedEventsLayer}
                 today={today}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Two production sync failures left users staring at an empty or stale calendar:

1. **`initialImport` exhausted retries** and dead-lettered while the UI stayed on “importing” (or went blank) with no Retry.
2. **Incremental pull 401s** kept retrying when the refresh token was already dead, because only `invalid_grant` was treated as revoked.

This change classifies token-endpoint 400/401 (and sibling permanent codes) as revoked, remints calendar-list 401s in-process, caps consecutive `refreshFailed` on grant health (not mixed job attempts), and re-derives connection health when a job retries, drops, fails, or completes so the app can show a loading state, a first-import error + Retry, or a reconnect/delayed banner — and clear that banner after recovery.

## Simplicity

Reuses existing Refresh/Reconnect actions, connection-state derivation, and grid overlay patterns. Durable failures still drop (so coalescing keys stay free). Access tokens are not force-refreshed on every webhook pull. No new React state/effects. Duplicate event-grid error markup is retained so import-failed stays parallel to the existing fetch-error overlay.

## Automated validation

- `test:sync:fast` auth/discovery/retry: 80 pass
- Focused Mongo sync (dispatch, worker, jobs, custody, connection-state): 125 pass, then 58 pass after the consecutive-refreshFailed / post-settle health fixes
- `test:web`: 2292 pass
- `type-check` and `lint`: pass
- GitHub CI on the previous head: unit (all packages), lint, type-check, knip, e2e, CodeQL — success

Live Google OAuth and webhooks were not exercised (not provisioned here).

## Independent review

A fresh diff review found: (high) `refreshFailed` dropped on `job.attempt` rather than consecutive `refreshFailureCount`; (medium) successful jobs did not re-derive health so a recovered import could stay on “Couldn't add your calendar.” Both are fixed in `5e833196` and confirmed on re-review. Duplicate overlay+banner alerts are intentional.

## Test plan

- `bun run test:sync:fast` — 80 pass
- `bun run test:sync --` dispatch, worker, job.repository, credential-custody, connection-state-refresh — pass
- `bun run test:web` — 2292 pass
- `bun run type-check` — pass
- `bun run lint` — pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f651af9d-7150-472b-ac87-ac43330f7722?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f651af9d-7150-472b-ac87-ac43330f7722&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

