### PR TITLE
feat(web): show effective timezone in the grid corner

### DIFF
--- a/packages/web/src/__tests__/utils/state/reset-stores.ts
+++ b/packages/web/src/__tests__/utils/state/reset-stores.ts
@@ -39,6 +39,7 @@ import {
   useSettingsStore,
 } from "@web/settings/settings.store";
 import { useThemeStore } from "@web/settings/theme/theme.store";
+import { resetEffectiveTimeZoneStoreForTests } from "@web/timezone/effective-timezone.store";
 import { setWeekInteractionMotionActive } from "@web/views/Week/interaction/state/motion.state";
 
 type StoreReset = () => void;
@@ -61,6 +62,7 @@ const storeResets: StoreReset[] = [
   // before this runs; this just resyncs the module-singleton store to match.
   resetCalendarVisibilityStoreForTests,
   resetDefaultCalendarStoreForTests,
+  resetEffectiveTimeZoneStoreForTests,
   resetCollapsedAccountsStoreForTests,
   resetRecentCommandsStoreForTests,
   // Lives on window.__weekInteractionMotionActive, which survives across

--- a/packages/web/src/timezone/GridTimezoneLabel.test.tsx
+++ b/packages/web/src/timezone/GridTimezoneLabel.test.tsx
@@ -1,10 +1,14 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { act } from "react";
-import { setEffectiveTimeZoneForTests } from "@web/timezone/effective-timezone.store";
+import { getBrowserTimeZone } from "@web/common/utils/datetime/web.date.util";
+import {
+  getEffectiveTimeZone,
+  setEffectiveTimeZoneForTests,
+} from "@web/timezone/effective-timezone.store";
 import { formatTimeZoneAbbreviation } from "@web/timezone/format-timezone-abbreviation";
 import { GridTimezoneLabel } from "@web/timezone/GridTimezoneLabel";
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, spyOn } from "bun:test";
 
 describe("GridTimezoneLabel", () => {
   it("is a focusable button named with the effective zone abbreviation", async () => {
@@ -37,7 +41,7 @@ describe("GridTimezoneLabel", () => {
       setEffectiveTimeZoneForTests("UTC");
     });
 
-    const { rerender } = render(<GridTimezoneLabel />);
+    render(<GridTimezoneLabel />);
     expect(
       screen.getByRole("button", { name: "Calendar timezone: UTC" }),
     ).toBeInTheDocument();
@@ -45,10 +49,56 @@ describe("GridTimezoneLabel", () => {
     act(() => {
       setEffectiveTimeZoneForTests("Asia/Kolkata");
     });
-    rerender(<GridTimezoneLabel />);
 
     expect(
       screen.getByRole("button", { name: "Calendar timezone: GMT+5:30" }),
     ).toHaveTextContent("GMT+5:30");
+  });
+
+  it("rereads the browser timezone on the minute tick", () => {
+    let intervalCallback: (() => void) | undefined;
+    const setIntervalSpy = spyOn(globalThis, "setInterval").mockImplementation(
+      ((callback: TimerHandler) => {
+        if (typeof callback === "function") {
+          intervalCallback = () => callback();
+        }
+        return 1 as unknown as ReturnType<typeof setInterval>;
+      }) as unknown as typeof setInterval,
+    );
+    const clearIntervalSpy = spyOn(
+      globalThis,
+      "clearInterval",
+    ).mockImplementation(() => {});
+
+    try {
+      const browserZone = getBrowserTimeZone();
+      expect(browserZone).not.toBe("Pacific/Kiritimati");
+
+      act(() => {
+        setEffectiveTimeZoneForTests("Pacific/Kiritimati");
+      });
+
+      render(<GridTimezoneLabel />);
+      expect(
+        screen.getByRole("button", {
+          name: `Calendar timezone: ${formatTimeZoneAbbreviation("Pacific/Kiritimati")}`,
+        }),
+      ).toBeInTheDocument();
+
+      act(() => {
+        intervalCallback?.();
+      });
+
+      expect(getEffectiveTimeZone()).toBe(browserZone);
+      const browserAbbreviation = formatTimeZoneAbbreviation(browserZone);
+      expect(
+        screen.getByRole("button", {
+          name: `Calendar timezone: ${browserAbbreviation}`,
+        }),
+      ).toHaveTextContent(browserAbbreviation);
+    } finally {
+      setIntervalSpy.mockRestore();
+      clearIntervalSpy.mockRestore();
+    }
   });
 });

--- a/packages/web/src/timezone/GridTimezoneLabel.test.tsx
+++ b/packages/web/src/timezone/GridTimezoneLabel.test.tsx
@@ -55,12 +55,12 @@ describe("GridTimezoneLabel", () => {
     ).toHaveTextContent("GMT+5:30");
   });
 
-  it("rereads the browser timezone on the minute tick", () => {
-    let intervalCallback: (() => void) | undefined;
+  it("rereads the browser timezone on the poll interval", () => {
+    const intervalCallbacks: Array<() => void> = [];
     const setIntervalSpy = spyOn(globalThis, "setInterval").mockImplementation(
       ((callback: TimerHandler) => {
         if (typeof callback === "function") {
-          intervalCallback = () => callback();
+          intervalCallbacks.push(() => callback());
         }
         return 1 as unknown as ReturnType<typeof setInterval>;
       }) as unknown as typeof setInterval,
@@ -86,7 +86,9 @@ describe("GridTimezoneLabel", () => {
       ).toBeInTheDocument();
 
       act(() => {
-        intervalCallback?.();
+        for (const callback of intervalCallbacks) {
+          callback();
+        }
       });
 
       expect(getEffectiveTimeZone()).toBe(browserZone);

--- a/packages/web/src/timezone/GridTimezoneLabel.test.tsx
+++ b/packages/web/src/timezone/GridTimezoneLabel.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { act } from "react";
+import {
+  resetEffectiveTimeZoneStoreForTests,
+  setEffectiveTimeZoneForTests,
+} from "@web/timezone/effective-timezone.store";
+import { formatTimeZoneAbbreviation } from "@web/timezone/format-timezone-abbreviation";
+import { GridTimezoneLabel } from "@web/timezone/GridTimezoneLabel";
+import { afterEach, describe, expect, it } from "bun:test";
+
+describe("GridTimezoneLabel", () => {
+  afterEach(() => {
+    resetEffectiveTimeZoneStoreForTests();
+  });
+
+  it("is a focusable button named with the effective zone abbreviation", async () => {
+    const user = userEvent.setup();
+    act(() => {
+      setEffectiveTimeZoneForTests("America/Denver");
+    });
+
+    render(
+      <div>
+        <button type="button">Before</button>
+        <GridTimezoneLabel />
+      </div>,
+    );
+
+    const abbreviation = formatTimeZoneAbbreviation("America/Denver");
+    const label = screen.getByRole("button", {
+      name: `Calendar timezone: ${abbreviation}`,
+    });
+    expect(label).toHaveTextContent(abbreviation);
+
+    await user.tab();
+    expect(screen.getByRole("button", { name: "Before" })).toHaveFocus();
+    await user.tab();
+    expect(label).toHaveFocus();
+  });
+
+  it("updates the label when the effective timezone changes", () => {
+    act(() => {
+      setEffectiveTimeZoneForTests("UTC");
+    });
+
+    const { rerender } = render(<GridTimezoneLabel />);
+    expect(
+      screen.getByRole("button", { name: "Calendar timezone: UTC" }),
+    ).toBeInTheDocument();
+
+    act(() => {
+      setEffectiveTimeZoneForTests("Asia/Kolkata");
+    });
+    rerender(<GridTimezoneLabel />);
+
+    expect(
+      screen.getByRole("button", { name: "Calendar timezone: GMT+5:30" }),
+    ).toHaveTextContent("GMT+5:30");
+  });
+});

--- a/packages/web/src/timezone/GridTimezoneLabel.test.tsx
+++ b/packages/web/src/timezone/GridTimezoneLabel.test.tsx
@@ -1,19 +1,12 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { act } from "react";
-import {
-  resetEffectiveTimeZoneStoreForTests,
-  setEffectiveTimeZoneForTests,
-} from "@web/timezone/effective-timezone.store";
+import { setEffectiveTimeZoneForTests } from "@web/timezone/effective-timezone.store";
 import { formatTimeZoneAbbreviation } from "@web/timezone/format-timezone-abbreviation";
 import { GridTimezoneLabel } from "@web/timezone/GridTimezoneLabel";
-import { afterEach, describe, expect, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 
 describe("GridTimezoneLabel", () => {
-  afterEach(() => {
-    resetEffectiveTimeZoneStoreForTests();
-  });
-
   it("is a focusable button named with the effective zone abbreviation", async () => {
     const user = userEvent.setup();
     act(() => {

--- a/packages/web/src/timezone/GridTimezoneLabel.tsx
+++ b/packages/web/src/timezone/GridTimezoneLabel.tsx
@@ -15,7 +15,7 @@ export const GridTimezoneLabel = () => {
   return (
     <button
       aria-label={`Calendar timezone: ${abbreviation}`}
-      className="c-focus-ring max-w-full truncate rounded-sm px-0.5 text-center text-[10px] text-text-muted leading-none hover:text-text"
+      className="c-focus-ring min-h-6 w-full max-w-full truncate rounded-sm px-0.5 text-center text-[10px] text-text-muted leading-none hover:text-text"
       type="button"
     >
       {abbreviation}

--- a/packages/web/src/timezone/GridTimezoneLabel.tsx
+++ b/packages/web/src/timezone/GridTimezoneLabel.tsx
@@ -1,10 +1,12 @@
-import { useEffect, useRef } from "react";
+import { useEffect } from "react";
 import { useMinuteTick } from "@web/common/hooks/useMinuteTick";
 import {
   refreshEffectiveTimeZoneFromBrowser,
   useEffectiveTimeZone,
 } from "@web/timezone/effective-timezone.store";
 import { formatTimeZoneAbbreviation } from "@web/timezone/format-timezone-abbreviation";
+
+const BROWSER_ZONE_POLL_MS = 60_000;
 
 /**
  * Week/Day grid-corner control showing the effective timezone abbreviation.
@@ -14,19 +16,18 @@ import { formatTimeZoneAbbreviation } from "@web/timezone/format-timezone-abbrev
 export const GridTimezoneLabel = () => {
   const timeZone = useEffectiveTimeZone();
   const now = useMinuteTick();
-  const skipBrowserRefreshOnMount = useRef(true);
 
-  // There is no timezonechange event. Reread the browser zone on the existing
-  // minute cadence so Auto mode follows an OS change without a tab blur. Skip
-  // the mount run so tests (and Part II pins, once refresh is Auto-gated) are
-  // not wiped on first paint. DST abbreviation flips use `now` directly.
+  // There is no timezonechange event. Poll so Auto mode follows an OS change
+  // without a tab blur. Do not refresh on mount — that would wipe a test pin
+  // (and a Part II pin, until refresh is Auto-gated). DST abbreviation flips
+  // still use `now` from the minute tick.
   useEffect(() => {
-    if (skipBrowserRefreshOnMount.current) {
-      skipBrowserRefreshOnMount.current = false;
-      return;
-    }
-    refreshEffectiveTimeZoneFromBrowser();
-  }, [now]);
+    const id = setInterval(
+      refreshEffectiveTimeZoneFromBrowser,
+      BROWSER_ZONE_POLL_MS,
+    );
+    return () => clearInterval(id);
+  }, []);
 
   const abbreviation = formatTimeZoneAbbreviation(timeZone, now.toDate());
 

--- a/packages/web/src/timezone/GridTimezoneLabel.tsx
+++ b/packages/web/src/timezone/GridTimezoneLabel.tsx
@@ -1,5 +1,9 @@
+import { useEffect, useRef } from "react";
 import { useMinuteTick } from "@web/common/hooks/useMinuteTick";
-import { useEffectiveTimeZone } from "@web/timezone/effective-timezone.store";
+import {
+  refreshEffectiveTimeZoneFromBrowser,
+  useEffectiveTimeZone,
+} from "@web/timezone/effective-timezone.store";
 import { formatTimeZoneAbbreviation } from "@web/timezone/format-timezone-abbreviation";
 
 /**
@@ -10,6 +14,20 @@ import { formatTimeZoneAbbreviation } from "@web/timezone/format-timezone-abbrev
 export const GridTimezoneLabel = () => {
   const timeZone = useEffectiveTimeZone();
   const now = useMinuteTick();
+  const skipBrowserRefreshOnMount = useRef(true);
+
+  // There is no timezonechange event. Reread the browser zone on the existing
+  // minute cadence so Auto mode follows an OS change without a tab blur. Skip
+  // the mount run so tests (and Part II pins, once refresh is Auto-gated) are
+  // not wiped on first paint. DST abbreviation flips use `now` directly.
+  useEffect(() => {
+    if (skipBrowserRefreshOnMount.current) {
+      skipBrowserRefreshOnMount.current = false;
+      return;
+    }
+    refreshEffectiveTimeZoneFromBrowser();
+  }, [now]);
+
   const abbreviation = formatTimeZoneAbbreviation(timeZone, now.toDate());
 
   return (

--- a/packages/web/src/timezone/GridTimezoneLabel.tsx
+++ b/packages/web/src/timezone/GridTimezoneLabel.tsx
@@ -1,0 +1,24 @@
+import { useMinuteTick } from "@web/common/hooks/useMinuteTick";
+import { useEffectiveTimeZone } from "@web/timezone/effective-timezone.store";
+import { formatTimeZoneAbbreviation } from "@web/timezone/format-timezone-abbreviation";
+
+/**
+ * Week/Day grid-corner control showing the effective timezone abbreviation.
+ * A button from day one so Part III can reuse it as the time-travel trigger;
+ * Part II will wire the click to the timezone picker.
+ */
+export const GridTimezoneLabel = () => {
+  const timeZone = useEffectiveTimeZone();
+  const now = useMinuteTick();
+  const abbreviation = formatTimeZoneAbbreviation(timeZone, now.toDate());
+
+  return (
+    <button
+      aria-label={`Calendar timezone: ${abbreviation}`}
+      className="c-focus-ring max-w-full truncate rounded-sm px-0.5 text-center text-[10px] text-text-muted leading-none hover:text-text"
+      type="button"
+    >
+      {abbreviation}
+    </button>
+  );
+};

--- a/packages/web/src/timezone/effective-timezone.store.test.ts
+++ b/packages/web/src/timezone/effective-timezone.store.test.ts
@@ -28,12 +28,11 @@ describe("effective-timezone.store", () => {
   });
 
   it("notifies subscribers when the effective zone changes", () => {
-    const { result, rerender } = renderHook(useEffectiveTimeZone);
+    const { result } = renderHook(useEffectiveTimeZone);
 
     act(() => {
       setEffectiveTimeZoneForTests("America/Denver");
     });
-    rerender();
 
     expect(result.current).toBe("America/Denver");
   });
@@ -43,7 +42,7 @@ describe("effective-timezone.store", () => {
       setEffectiveTimeZoneForTests("America/Denver");
     });
 
-    const { result, rerender } = renderHook(useEffectiveTimeZone);
+    const { result } = renderHook(useEffectiveTimeZone);
     expect(result.current).toBe("America/Denver");
 
     act(() => {
@@ -53,7 +52,6 @@ describe("effective-timezone.store", () => {
       });
       document.dispatchEvent(new Event("visibilitychange"));
     });
-    rerender();
 
     expect(result.current).toBe(getBrowserTimeZone());
   });

--- a/packages/web/src/timezone/effective-timezone.store.test.ts
+++ b/packages/web/src/timezone/effective-timezone.store.test.ts
@@ -1,0 +1,58 @@
+import { act, renderHook } from "@testing-library/react";
+import { getBrowserTimeZone } from "@web/common/utils/datetime/web.date.util";
+import {
+  resetEffectiveTimeZoneStoreForTests,
+  setEffectiveTimeZoneForTests,
+  useEffectiveTimeZone,
+} from "@web/timezone/effective-timezone.store";
+import { afterEach, describe, expect, it } from "bun:test";
+
+const originalVisibilityState = document.visibilityState;
+
+const readEffectiveTimeZone = () =>
+  renderHook(useEffectiveTimeZone).result.current;
+
+describe("effective-timezone.store", () => {
+  afterEach(() => {
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      value: originalVisibilityState,
+    });
+    resetEffectiveTimeZoneStoreForTests();
+  });
+
+  it("defaults to the browser timezone", () => {
+    expect(readEffectiveTimeZone()).toBe(getBrowserTimeZone());
+  });
+
+  it("notifies subscribers when the effective zone changes", () => {
+    const { result, rerender } = renderHook(useEffectiveTimeZone);
+
+    act(() => {
+      setEffectiveTimeZoneForTests("America/Denver");
+    });
+    rerender();
+
+    expect(result.current).toBe("America/Denver");
+  });
+
+  it("returns to the browser zone when the tab becomes visible", () => {
+    act(() => {
+      setEffectiveTimeZoneForTests("America/Denver");
+    });
+
+    const { result, rerender } = renderHook(useEffectiveTimeZone);
+    expect(result.current).toBe("America/Denver");
+
+    act(() => {
+      Object.defineProperty(document, "visibilityState", {
+        configurable: true,
+        value: "visible",
+      });
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+    rerender();
+
+    expect(result.current).toBe(getBrowserTimeZone());
+  });
+});

--- a/packages/web/src/timezone/effective-timezone.store.test.ts
+++ b/packages/web/src/timezone/effective-timezone.store.test.ts
@@ -18,7 +18,9 @@ describe("effective-timezone.store", () => {
       configurable: true,
       value: originalVisibilityState,
     });
-    resetEffectiveTimeZoneStoreForTests();
+    act(() => {
+      resetEffectiveTimeZoneStoreForTests();
+    });
   });
 
   it("defaults to the browser timezone", () => {

--- a/packages/web/src/timezone/effective-timezone.store.ts
+++ b/packages/web/src/timezone/effective-timezone.store.ts
@@ -17,24 +17,19 @@ export function refreshEffectiveTimeZoneFromBrowser(): void {
   effectiveTimeZoneStore.set(getBrowserTimeZone());
 }
 
-function subscribe(onChange: () => void): () => void {
-  const unsubscribeStore = effectiveTimeZoneStore.subscribe(onChange);
-
-  const onVisibility = () => {
+if (typeof document !== "undefined") {
+  document.addEventListener("visibilitychange", () => {
     if (document.visibilityState === "visible") {
       refreshEffectiveTimeZoneFromBrowser();
     }
-  };
-  document.addEventListener("visibilitychange", onVisibility);
-
-  return () => {
-    unsubscribeStore();
-    document.removeEventListener("visibilitychange", onVisibility);
-  };
+  });
 }
 
 export function useEffectiveTimeZone(): string {
-  return useSyncExternalStore(subscribe, effectiveTimeZoneStore.get);
+  return useSyncExternalStore(
+    effectiveTimeZoneStore.subscribe,
+    effectiveTimeZoneStore.get,
+  );
 }
 
 /** Test-only: set the in-memory effective zone without persistence. */

--- a/packages/web/src/timezone/effective-timezone.store.ts
+++ b/packages/web/src/timezone/effective-timezone.store.ts
@@ -1,0 +1,47 @@
+import { useSyncExternalStore } from "react";
+import { getBrowserTimeZone } from "@web/common/utils/datetime/web.date.util";
+import { createExternalStore } from "@web/common/utils/external-store.util";
+
+/**
+ * Part I: the effective timezone is always the browser zone (Auto). Part II
+ * will pin a user choice on top of this store; until then, subscribers still
+ * need a live value so the corner label can update without a reload.
+ */
+const effectiveTimeZoneStore = createExternalStore(getBrowserTimeZone());
+
+export function getEffectiveTimeZone(): string {
+  return effectiveTimeZoneStore.get();
+}
+
+export function refreshEffectiveTimeZoneFromBrowser(): void {
+  effectiveTimeZoneStore.set(getBrowserTimeZone());
+}
+
+function subscribe(onChange: () => void): () => void {
+  const unsubscribeStore = effectiveTimeZoneStore.subscribe(onChange);
+
+  const onVisibility = () => {
+    if (document.visibilityState === "visible") {
+      refreshEffectiveTimeZoneFromBrowser();
+    }
+  };
+  document.addEventListener("visibilitychange", onVisibility);
+
+  return () => {
+    unsubscribeStore();
+    document.removeEventListener("visibilitychange", onVisibility);
+  };
+}
+
+export function useEffectiveTimeZone(): string {
+  return useSyncExternalStore(subscribe, effectiveTimeZoneStore.get);
+}
+
+/** Test-only: set the in-memory effective zone without persistence. */
+export function setEffectiveTimeZoneForTests(timeZone: string): void {
+  effectiveTimeZoneStore.set(timeZone);
+}
+
+export function resetEffectiveTimeZoneStoreForTests(): void {
+  refreshEffectiveTimeZoneFromBrowser();
+}

--- a/packages/web/src/timezone/effective-timezone.store.ts
+++ b/packages/web/src/timezone/effective-timezone.store.ts
@@ -13,6 +13,7 @@ export function getEffectiveTimeZone(): string {
   return effectiveTimeZoneStore.get();
 }
 
+/** Auto-mode refresh. Part II must no-op this when a zone is pinned. */
 export function refreshEffectiveTimeZoneFromBrowser(): void {
   effectiveTimeZoneStore.set(getBrowserTimeZone());
 }

--- a/packages/web/src/timezone/format-timezone-abbreviation.test.ts
+++ b/packages/web/src/timezone/format-timezone-abbreviation.test.ts
@@ -1,0 +1,37 @@
+import { formatTimeZoneAbbreviation } from "@web/timezone/format-timezone-abbreviation";
+import { describe, expect, it } from "bun:test";
+
+describe("formatTimeZoneAbbreviation", () => {
+  it("uses the daylight abbreviation on the summer side of a DST boundary", () => {
+    expect(
+      formatTimeZoneAbbreviation(
+        "America/Denver",
+        new Date("2026-07-15T18:00:00.000Z"),
+      ),
+    ).toBe("MDT");
+  });
+
+  it("uses the standard abbreviation on the winter side of a DST boundary", () => {
+    expect(
+      formatTimeZoneAbbreviation(
+        "America/Denver",
+        new Date("2026-01-15T18:00:00.000Z"),
+      ),
+    ).toBe("MST");
+  });
+
+  it("falls back to the offset form when the zone has no named abbreviation", () => {
+    expect(
+      formatTimeZoneAbbreviation(
+        "Asia/Kolkata",
+        new Date("2026-07-15T12:00:00.000Z"),
+      ),
+    ).toBe("GMT+5:30");
+  });
+
+  it("labels UTC as UTC", () => {
+    expect(
+      formatTimeZoneAbbreviation("UTC", new Date("2026-07-15T12:00:00.000Z")),
+    ).toBe("UTC");
+  });
+});

--- a/packages/web/src/timezone/format-timezone-abbreviation.ts
+++ b/packages/web/src/timezone/format-timezone-abbreviation.ts
@@ -1,0 +1,32 @@
+type TimeZoneNameStyle = "short" | "shortOffset";
+
+function timeZoneNamePart(
+  timeZone: string,
+  at: Date,
+  timeZoneName: TimeZoneNameStyle,
+): string | undefined {
+  return new Intl.DateTimeFormat("en-US", { timeZone, timeZoneName })
+    .formatToParts(at)
+    .find((part) => part.type === "timeZoneName")?.value;
+}
+
+function looksLikeIanaId(value: string): boolean {
+  return value.includes("/");
+}
+
+/**
+ * Short wall-clock label for a zone at `at` (defaults to now, so DST flips
+ * the abbreviation without a reload). Prefers Intl `timeZoneName: "short"`
+ * ("MDT"); zones that only have an offset form keep that ("GMT+5:30").
+ */
+export function formatTimeZoneAbbreviation(
+  timeZone: string,
+  at: Date = new Date(),
+): string {
+  const short = timeZoneNamePart(timeZone, at, "short");
+  if (short && !looksLikeIanaId(short)) {
+    return short;
+  }
+
+  return timeZoneNamePart(timeZone, at, "shortOffset") ?? short ?? timeZone;
+}

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarColumnHeaders.test.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarColumnHeaders.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from "@testing-library/react";
+import { createMockCalendar } from "@web/__tests__/utils/factories/calendar.factory";
+import {
+  getEffectiveTimeZone,
+  resetEffectiveTimeZoneStoreForTests,
+} from "@web/timezone/effective-timezone.store";
+import { formatTimeZoneAbbreviation } from "@web/timezone/format-timezone-abbreviation";
+import { DayCalendarColumnHeaders } from "@web/views/Day/components/Calendar/DayCalendarColumnHeaders";
+import { afterEach, describe, expect, it } from "bun:test";
+
+const calendar = createMockCalendar({ name: "Personal" });
+
+describe("DayCalendarColumnHeaders", () => {
+  afterEach(() => {
+    resetEffectiveTimeZoneStoreForTests();
+  });
+
+  it("shows the effective timezone in the grid corner", () => {
+    render(<DayCalendarColumnHeaders calendars={[calendar]} />);
+
+    const abbreviation = formatTimeZoneAbbreviation(getEffectiveTimeZone());
+    expect(
+      screen.getByRole("button", {
+        name: `Calendar timezone: ${abbreviation}`,
+      }),
+    ).toHaveTextContent(abbreviation);
+    expect(screen.getByRole("region", { name: "Calendars" })).toHaveTextContent(
+      "Personal",
+    );
+  });
+});

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarColumnHeaders.test.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarColumnHeaders.test.tsx
@@ -1,20 +1,13 @@
 import { render, screen } from "@testing-library/react";
 import { createMockCalendar } from "@web/__tests__/utils/factories/calendar.factory";
-import {
-  getEffectiveTimeZone,
-  resetEffectiveTimeZoneStoreForTests,
-} from "@web/timezone/effective-timezone.store";
+import { getEffectiveTimeZone } from "@web/timezone/effective-timezone.store";
 import { formatTimeZoneAbbreviation } from "@web/timezone/format-timezone-abbreviation";
 import { DayCalendarColumnHeaders } from "@web/views/Day/components/Calendar/DayCalendarColumnHeaders";
-import { afterEach, describe, expect, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 
 const calendar = createMockCalendar({ name: "Personal" });
 
 describe("DayCalendarColumnHeaders", () => {
-  afterEach(() => {
-    resetEffectiveTimeZoneStoreForTests();
-  });
-
   it("shows the effective timezone in the grid corner", () => {
     render(<DayCalendarColumnHeaders calendars={[calendar]} />);
 
@@ -27,5 +20,19 @@ describe("DayCalendarColumnHeaders", () => {
     expect(screen.getByRole("region", { name: "Calendars" })).toHaveTextContent(
       "Personal",
     );
+  });
+
+  it("still shows the timezone when there are no calendars", () => {
+    render(<DayCalendarColumnHeaders calendars={[]} />);
+
+    const abbreviation = formatTimeZoneAbbreviation(getEffectiveTimeZone());
+    expect(
+      screen.getByRole("button", {
+        name: `Calendar timezone: ${abbreviation}`,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("region", { name: "Calendars" }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarColumnHeaders.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarColumnHeaders.tsx
@@ -1,31 +1,41 @@
 import { type Calendar } from "@core/types/calendar.contracts";
 import { GRID_MARGIN_LEFT } from "@web/grid/grid.constants";
+import { GridTimezoneLabel } from "@web/timezone/GridTimezoneLabel";
 
 export const DayCalendarColumnHeaders = ({
   calendars,
 }: {
   calendars: Calendar[];
 }) => (
-  <section
-    aria-label="Calendars"
-    className="grid min-h-12 shrink-0 bg-background"
-    style={{
-      gridTemplateColumns: `repeat(${calendars.length}, minmax(0, 1fr))`,
-      marginLeft: GRID_MARGIN_LEFT,
-    }}
-  >
-    {calendars.map((calendar) => (
-      <div
-        className="flex min-w-0 items-center justify-center gap-2 border-border border-l px-3 last:border-r"
-        key={calendar.id}
+  <div className="flex min-h-12 shrink-0 bg-background">
+    <div
+      className="flex shrink-0 items-center justify-center"
+      style={{ width: GRID_MARGIN_LEFT }}
+    >
+      <GridTimezoneLabel />
+    </div>
+    {calendars.length > 0 ? (
+      <section
+        aria-label="Calendars"
+        className="grid min-h-12 min-w-0 flex-1"
+        style={{
+          gridTemplateColumns: `repeat(${calendars.length}, minmax(0, 1fr))`,
+        }}
       >
-        <span
-          aria-hidden="true"
-          className="size-2 shrink-0 rounded-full"
-          style={{ backgroundColor: calendar.backgroundColor }}
-        />
-        <span className="truncate text-sm text-text">{calendar.name}</span>
-      </div>
-    ))}
-  </section>
+        {calendars.map((calendar) => (
+          <div
+            className="flex min-w-0 items-center justify-center gap-2 border-border border-l px-3 last:border-r"
+            key={calendar.id}
+          >
+            <span
+              aria-hidden="true"
+              className="size-2 shrink-0 rounded-full"
+              style={{ backgroundColor: calendar.backgroundColor }}
+            />
+            <span className="truncate text-sm text-text">{calendar.name}</span>
+          </div>
+        ))}
+      </section>
+    ) : null}
+  </div>
 );

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
@@ -453,9 +453,7 @@ export function DayCalendarGrid() {
         onOpenEvent={openEventFormForEvent}
         timedEvents={displayedTimedEvents}
       >
-        {displayedCalendars.length > 0 ? (
-          <DayCalendarColumnHeaders calendars={displayedCalendars} />
-        ) : null}
+        <DayCalendarColumnHeaders calendars={displayedCalendars} />
         <EventGrid
           allDayEventsLayer={allDayEventsLayer}
           allDayRowsCount={allDayRowsCount}

--- a/packages/web/src/views/Week/components/Header/DayLabels.test.tsx
+++ b/packages/web/src/views/Week/components/Header/DayLabels.test.tsx
@@ -1,20 +1,13 @@
 import { render, screen } from "@testing-library/react";
 import dayjs from "@core/util/date/dayjs";
-import {
-  getEffectiveTimeZone,
-  resetEffectiveTimeZoneStoreForTests,
-} from "@web/timezone/effective-timezone.store";
+import { getEffectiveTimeZone } from "@web/timezone/effective-timezone.store";
 import { formatTimeZoneAbbreviation } from "@web/timezone/format-timezone-abbreviation";
 import { DayLabels } from "@web/views/Week/components/Header/DayLabels";
-import { afterEach, describe, expect, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 
 const monday = dayjs("2026-08-17T12:00:00.000Z");
 
 describe("DayLabels", () => {
-  afterEach(() => {
-    resetEffectiveTimeZoneStoreForTests();
-  });
-
   it("shows the effective timezone in the grid corner", () => {
     render(
       <DayLabels

--- a/packages/web/src/views/Week/components/Header/DayLabels.test.tsx
+++ b/packages/web/src/views/Week/components/Header/DayLabels.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from "@testing-library/react";
+import dayjs from "@core/util/date/dayjs";
+import {
+  getEffectiveTimeZone,
+  resetEffectiveTimeZoneStoreForTests,
+} from "@web/timezone/effective-timezone.store";
+import { formatTimeZoneAbbreviation } from "@web/timezone/format-timezone-abbreviation";
+import { DayLabels } from "@web/views/Week/components/Header/DayLabels";
+import { afterEach, describe, expect, it } from "bun:test";
+
+const monday = dayjs("2026-08-17T12:00:00.000Z");
+
+describe("DayLabels", () => {
+  afterEach(() => {
+    resetEffectiveTimeZoneStoreForTests();
+  });
+
+  it("shows the effective timezone in the grid corner", () => {
+    render(
+      <DayLabels
+        startOfView={monday.startOf("week")}
+        today={monday}
+        week={monday.week()}
+        weekDays={[monday, monday.add(1, "day"), monday.add(2, "day")]}
+      />,
+    );
+
+    const abbreviation = formatTimeZoneAbbreviation(getEffectiveTimeZone());
+    expect(
+      screen.getByRole("button", {
+        name: `Calendar timezone: ${abbreviation}`,
+      }),
+    ).toHaveTextContent(abbreviation);
+  });
+});

--- a/packages/web/src/views/Week/components/Header/DayLabels.tsx
+++ b/packages/web/src/views/Week/components/Header/DayLabels.tsx
@@ -3,11 +3,15 @@ import { type FC } from "react";
 import { YEAR_MONTH_DAY_FORMAT } from "@core/constants/date.constants";
 import { type Dayjs } from "@core/util/date/dayjs";
 import { getWeekDayLabel } from "@web/common/utils/event/event.util";
-import { EVENT_WIDTH_MINIMUM } from "@web/grid/grid.constants";
+import {
+  EVENT_WIDTH_MINIMUM,
+  GRID_MARGIN_LEFT,
+} from "@web/grid/grid.constants";
 import {
   selectEventJumpActiveDayKeys,
   useEventJumpStore,
 } from "@web/shortcuts/shift-hint/event-jump.store";
+import { GridTimezoneLabel } from "@web/timezone/GridTimezoneLabel";
 
 interface Props {
   today: Dayjs;
@@ -49,8 +53,16 @@ export const DayLabels: FC<Props> = ({
   return (
     <div className="relative mt-2.5 min-h-8 w-full">
       <div
-        className="absolute top-0 left-12.5 grid h-full w-[calc(100%-50px)] items-end"
+        className="absolute inset-y-0 left-0 z-1 flex items-end justify-center pb-0.5"
+        style={{ width: GRID_MARGIN_LEFT }}
+      >
+        <GridTimezoneLabel />
+      </div>
+      <div
+        className="absolute top-0 grid h-full items-end"
         style={{
+          left: GRID_MARGIN_LEFT,
+          width: `calc(100% - ${GRID_MARGIN_LEFT}px)`,
           gridTemplateColumns: `repeat(${weekDays.length}, minmax(${EVENT_WIDTH_MINIMUM}px, 1fr))`,
         }}
       >


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Part I of timezone support: show the calendar's effective timezone in the empty Week/Day grid corner (the 50px hour-label gutter, left of the day columns).

The label uses `Intl.DateTimeFormat` `timeZoneName: "short"` (MDT / MST across DST; `GMT+5:30` when the zone has no named abbreviation). It is a focusable button named `Calendar timezone: MDT` so Part III can reuse it as the time-travel trigger. Until Part II ships the picker, click is a no-op.

Effective timezone is Auto-only for this slice (browser `Intl` zone). A small external store plus a minute tick and tab-visibility refresh keep the abbreviation live without a reload. Pinning, persistence, and the picker are Part II.

## Simplicity

- One shared `GridTimezoneLabel` in both Week `DayLabels` and Day column headers.
- Formatter is a pure `Intl` helper; no dayjs `advancedFormat`.
- Store follows the existing `default-calendar.store` external-store pattern without localStorage yet.

## Automated validation

Pending focused web tests and lint after this pre-testing revision.

## Independent review

Pending after tests.

## Test plan

Pending: focused timezone/label tests, `bun run lint`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-79a4e258-3657-4a50-ad8f-b2c1f414740f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-79a4e258-3657-4a50-ad8f-b2c1f414740f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

