### PR TITLE
fix(sync): refresh stale foreground connections

### DIFF
--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -1,6 +1,7 @@
 import { CONFIG } from "@backend/common/constants/config.constants";
 import mongoService from "@backend/common/services/mongo.service";
 import { initExpressServer } from "@backend/servers/express/express.server";
+import { foregroundSyncRefresh } from "@backend/servers/sse/foreground-sync-refresh";
 import { syncChangeFeedBridge } from "@backend/servers/sse/sync-change-feed.bridge";
 import { logger } from "./init"; //must be first import
 import { stopPostHogLogs } from "./logging/posthog-logs";
@@ -29,6 +30,7 @@ async function start() {
     // locally connected. Started here (not at module import) so a test
     // importing the bridge for its types never triggers a live network poll.
     syncChangeFeedBridge.start();
+    foregroundSyncRefresh.start();
   } catch (error) {
     logger.error("Problems encountered during startup", error);
 
@@ -50,6 +52,7 @@ async function closeHttpServer(): Promise<void> {
 async function gracefulShutdown(): Promise<void> {
   try {
     syncChangeFeedBridge.stop();
+    foregroundSyncRefresh.stop();
     await closeHttpServer();
     await mongoService.stop();
     await stopPostHogLogs();

--- a/packages/backend/src/common/services/sync-service/sync-service.client.test.ts
+++ b/packages/backend/src/common/services/sync-service/sync-service.client.test.ts
@@ -20,6 +20,7 @@ import {
   CALENDARS_PATH,
   CONNECTIONS_PATH,
   EVENTS_FULL_PATH,
+  FOREGROUND_REFRESH_PATH,
 } from "@sync/server/connection.routes";
 import { PRINCIPAL_PATH } from "@sync/server/principal.routes";
 import {
@@ -610,6 +611,30 @@ describe("SyncServiceClient", () => {
     });
     if (!verdict.ok) throw new Error(`verify failed: ${verdict.reason}`);
     expect(verdict.context.principalId).toBe(who.principalId);
+  });
+
+  it("sends foreground principals in one service-authenticated batch", async () => {
+    const principalIds = [objectId(), objectId()];
+    const { fn, calls } = fakeFetch(async () => ({
+      status: 200,
+      json: async () => ({ enqueued: 1, inFlight: 0, resources: 2 }),
+    }));
+
+    const result = await client(fn).refreshForegroundConnections(
+      principalIds as never,
+    );
+
+    expect(result.ok).toBe(true);
+    const sent = calls[0];
+    expect(sent?.url).toBe(`${BASE_URL}${FOREGROUND_REFRESH_PATH}`);
+    expect(JSON.parse(sent?.body ?? "{}")).toEqual({ principalIds });
+    expect(
+      verifyServiceRequest({
+        secret: SECRET,
+        headers: sent?.headers ?? {},
+        now: NOW,
+      }).ok,
+    ).toBe(true);
   });
 
   it("adopts a server-exchanged Google authorization with a signed POST", async () => {

--- a/packages/backend/src/common/services/sync-service/sync-service.client.ts
+++ b/packages/backend/src/common/services/sync-service/sync-service.client.ts
@@ -25,6 +25,7 @@ import {
   ConnectionListResponseSchema,
   type ConnectionRefreshResponse,
   ConnectionRefreshResponseSchema,
+  type ForegroundRefreshRequest,
   type GoogleConnectionAdoptionRequest,
   type GoogleConnectionAdoptionResponse,
   GoogleConnectionAdoptionResponseSchema,
@@ -51,6 +52,8 @@ const CHANGES_ALL_PATH = "/internal/changes/all";
 const CONNECTIONS_PATH = "/internal/connections";
 const CONNECTIONS_BEGIN_PATH = "/internal/connections/begin";
 const CONNECTIONS_REFRESH_PATH = "/internal/connections/refresh";
+const CONNECTIONS_FOREGROUND_REFRESH_PATH =
+  "/internal/connections/foreground-refresh";
 const ADOPT_GOOGLE_AUTHORIZATION_PATH =
   "/internal/connections/adopt-google-authorization";
 const EVENTS_FULL_PATH = "/internal/events/full";
@@ -289,6 +292,19 @@ export class SyncServiceClient {
     });
   }
 
+  refreshForegroundConnections(
+    principalIds: ForegroundRefreshRequest["principalIds"],
+    correlationId?: string,
+  ): Promise<SyncClientResult<ConnectionRefreshResponse>> {
+    return this.#requestUnscoped({
+      method: "POST",
+      path: CONNECTIONS_FOREGROUND_REFRESH_PATH,
+      body: { principalIds },
+      schema: ConnectionRefreshResponseSchema,
+      correlationId,
+    });
+  }
+
   // A page of full-fidelity event rows (content + schedule + series linkage) for
   // the given calendars and range, scoped to the signed principal. Backs the
   // browser calendar read — each row carries what the app needs to render AND
@@ -462,9 +478,10 @@ export class SyncServiceClient {
   // claim — see signServiceRequest — so it can never be confused with, or
   // used to replay, a per-principal-signed request.
   async #requestUnscoped<T>(input: {
-    method: "GET";
+    method: "GET" | "POST";
     path: string;
     query?: URLSearchParams;
+    body?: unknown;
     schema: z.ZodType<T>;
     correlationId?: string;
     timeoutMs?: number;

--- a/packages/backend/src/servers/sse/foreground-sync-refresh.test.ts
+++ b/packages/backend/src/servers/sse/foreground-sync-refresh.test.ts
@@ -1,0 +1,114 @@
+import { faker } from "@faker-js/faker";
+import {
+  ForegroundSyncRefresh,
+  type ForegroundSyncRefreshDeps,
+} from "@backend/servers/sse/foreground-sync-refresh";
+
+class FakeScheduler {
+  pending: Array<{ delayMs: number; tick: () => void }> = [];
+
+  schedule = (tick: () => void, delayMs: number): { clear: () => void } => {
+    const entry = { delayMs, tick };
+    this.pending.push(entry);
+    return {
+      clear: () => {
+        this.pending = this.pending.filter((item) => item !== entry);
+      },
+    };
+  };
+
+  async fireNext(): Promise<void> {
+    const entry = this.pending.shift();
+    if (!entry) throw new Error("no tick scheduled");
+    entry.tick();
+    await Bun.sleep(0);
+  }
+}
+
+describe("ForegroundSyncRefresh", () => {
+  it("refreshes each connected principal once per backend tick", async () => {
+    const users = [
+      faker.database.mongodbObjectId(),
+      faker.database.mongodbObjectId(),
+    ];
+    const calls: string[] = [];
+    const scheduler = new FakeScheduler();
+    const deps: ForegroundSyncRefreshDeps = {
+      sse: { connectedUserIds: () => users },
+      client: {
+        refreshForegroundConnections: async (principalIds) => {
+          calls.push(...principalIds);
+          return {
+            ok: true,
+            value: { enqueued: 0, inFlight: 0, resources: 0 },
+            correlationId: "correlation-id",
+          };
+        },
+      },
+    };
+    const refresh = new ForegroundSyncRefresh(deps, {
+      intervalMs: 30_000,
+      schedule: scheduler.schedule,
+    });
+
+    refresh.start();
+    expect(scheduler.pending.map((entry) => entry.delayMs)).toEqual([30_000]);
+    await scheduler.fireNext();
+
+    expect(calls).toEqual(users);
+    expect(scheduler.pending.map((entry) => entry.delayMs)).toEqual([30_000]);
+    refresh.stop();
+    expect(scheduler.pending).toEqual([]);
+  });
+
+  it("does no Sync work when nobody is connected", async () => {
+    const scheduler = new FakeScheduler();
+    let calls = 0;
+    const refresh = new ForegroundSyncRefresh(
+      {
+        sse: { connectedUserIds: () => [] },
+        client: {
+          refreshForegroundConnections: async () => {
+            calls += 1;
+            throw new Error("unexpected call");
+          },
+        },
+      },
+      { intervalMs: 10, schedule: scheduler.schedule },
+    );
+
+    refresh.start();
+    await scheduler.fireNext();
+    expect(calls).toBe(0);
+    refresh.stop();
+  });
+
+  it("chunks large connected populations to the Sync contract bound", async () => {
+    const scheduler = new FakeScheduler();
+    const users = Array.from({ length: 501 }, () =>
+      faker.database.mongodbObjectId(),
+    );
+    const batchSizes: number[] = [];
+    const refresh = new ForegroundSyncRefresh(
+      {
+        sse: { connectedUserIds: () => users },
+        client: {
+          refreshForegroundConnections: async (principalIds) => {
+            batchSizes.push(principalIds.length);
+            return {
+              ok: true,
+              value: { enqueued: 0, inFlight: 0, resources: 0 },
+              correlationId: "correlation-id",
+            };
+          },
+        },
+      },
+      { intervalMs: 10, schedule: scheduler.schedule },
+    );
+
+    refresh.start();
+    await scheduler.fireNext();
+    expect(batchSizes).toEqual([500, 1]);
+    refresh.stop();
+  });
+});

--- a/packages/backend/src/servers/sse/foreground-sync-refresh.ts
+++ b/packages/backend/src/servers/sse/foreground-sync-refresh.ts
@@ -1,0 +1,113 @@
+import { Logger } from "@core/logger/winston.logger";
+import { PrincipalIdSchema } from "@core/types/sync/identity.contracts";
+import { type SyncServiceClient } from "@backend/common/services/sync-service/sync-service.client";
+import { getSyncServiceClient } from "@backend/common/services/sync-service/sync-service.factory";
+import { sseServer } from "@backend/servers/sse/sse.server";
+
+const logger = Logger("app:sse.foreground-sync-refresh");
+// Tick more often than Sync's 30s resource-staleness guard so a change that
+// lands just after a successful pull still gets a fallback attempt comfortably
+// inside the 60s foreground bound (plus queue/change-feed latency).
+const DEFAULT_INTERVAL_MS = 15_000;
+const MAX_PRINCIPALS_PER_REQUEST = 500;
+
+export interface ForegroundSyncRefreshDeps {
+  client: Pick<SyncServiceClient, "refreshForegroundConnections">;
+  sse: Pick<typeof sseServer, "connectedUserIds">;
+}
+
+export interface ForegroundSyncRefreshOptions {
+  intervalMs?: number;
+  schedule?: (tick: () => void, delayMs: number) => { clear: () => void };
+}
+
+// One backend-owned loop, rather than one timer per tab. Sync performs the
+// per-resource recency check and queue coalescing, so multiple backend replicas
+// remain safe even when they observe the same principal.
+export class ForegroundSyncRefresh {
+  readonly #deps: ForegroundSyncRefreshDeps;
+  readonly #intervalMs: number;
+  readonly #schedule: NonNullable<ForegroundSyncRefreshOptions["schedule"]>;
+  #timer: { clear: () => void } | null = null;
+  #stopped = true;
+
+  constructor(
+    deps: ForegroundSyncRefreshDeps,
+    options: ForegroundSyncRefreshOptions = {},
+  ) {
+    this.#deps = deps;
+    this.#intervalMs = options.intervalMs ?? DEFAULT_INTERVAL_MS;
+    this.#schedule = options.schedule ?? defaultSchedule;
+  }
+
+  start(): void {
+    if (!this.#stopped) return;
+    this.#stopped = false;
+    this.#scheduleNext(this.#intervalMs);
+  }
+
+  stop(): void {
+    this.#stopped = true;
+    this.#timer?.clear();
+    this.#timer = null;
+  }
+
+  #scheduleNext(delayMs: number): void {
+    if (this.#stopped) return;
+    this.#timer = this.#schedule(() => void this.#tick(), delayMs);
+  }
+
+  async #tick(): Promise<void> {
+    if (this.#stopped) return;
+    try {
+      const principalIds = this.#deps.sse
+        .connectedUserIds()
+        .map((userId) => PrincipalIdSchema.parse(userId));
+      if (principalIds.length === 0) return;
+      for (
+        let offset = 0;
+        offset < principalIds.length;
+        offset += MAX_PRINCIPALS_PER_REQUEST
+      ) {
+        const result = await this.#deps.client.refreshForegroundConnections(
+          principalIds.slice(offset, offset + MAX_PRINCIPALS_PER_REQUEST),
+        );
+        if (!result.ok && result.error.kind !== "conflict") {
+          logger.warn(
+            `Foreground sync refresh failed: ${result.error.kind} (${result.error.correlationId})`,
+          );
+        } else if (result.ok && result.value.resources > 0) {
+          logger.info(
+            `Foreground sync refresh checked ${result.value.resources} stale resource(s): enqueued=${result.value.enqueued} inFlight=${result.value.inFlight}`,
+          );
+        }
+      }
+    } catch (error) {
+      logger.error(
+        `Foreground sync refresh tick threw: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    } finally {
+      this.#scheduleNext(this.#intervalMs);
+    }
+  }
+}
+
+function defaultSchedule(
+  tick: () => void,
+  delayMs: number,
+): { clear: () => void } {
+  const timer = setTimeout(tick, delayMs);
+  timer.unref?.();
+  return { clear: () => clearTimeout(timer) };
+}
+
+export const foregroundSyncRefresh = new ForegroundSyncRefresh({
+  client: {
+    refreshForegroundConnections: (principalIds, correlationId) =>
+      getSyncServiceClient().refreshForegroundConnections(
+        principalIds,
+        correlationId,
+      ),
+  },
+  sse: sseServer,
+});

--- a/packages/core/src/types/sync/connection.contracts.ts
+++ b/packages/core/src/types/sync/connection.contracts.ts
@@ -207,6 +207,16 @@ export type ConnectionRefreshResponse = z.infer<
   typeof ConnectionRefreshResponseSchema
 >;
 
+// Content-free batch used by the backend's one foreground freshness loop.
+// Personal Compass tenants use the same ObjectId for tenant + principal, so
+// Sync can safely derive both after the service-authenticated request.
+export const ForegroundRefreshRequestSchema = z.strictObject({
+  principalIds: z.array(PrincipalIdSchema).min(1).max(500),
+});
+export type ForegroundRefreshRequest = z.infer<
+  typeof ForegroundRefreshRequestSchema
+>;
+
 export const CalendarListQuerySchema = z.strictObject({
   // Optional narrowing; principal scope always comes from authenticated
   // context, never from the request body.

--- a/packages/sync/src/domain/connection-refresh.service.db.test.ts
+++ b/packages/sync/src/domain/connection-refresh.service.db.test.ts
@@ -1,6 +1,10 @@
+import { faker } from "@faker-js/faker";
 import { seedProviderCalendar } from "@sync/__tests__/helpers/fixtures";
 import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
-import { refreshPrincipalCalendars } from "@sync/domain/connection-refresh.service";
+import {
+  refreshPrincipalCalendars,
+  refreshStalePrincipalCalendars,
+} from "@sync/domain/connection-refresh.service";
 import { SYNC_COLLECTIONS } from "@sync/storage/collections";
 import { JOB_PRIORITY } from "@sync/storage/contracts/job.contracts";
 import { type ProviderCalendarRecord } from "@sync/storage/contracts/provider-calendar.contracts";
@@ -114,6 +118,111 @@ describe("refreshPrincipalCalendars (db)", () => {
         .countDocuments({
           coalescingKey: `calendarListSync:${calendar.connectionId}`,
         }),
+    ).toBe(1);
+  });
+
+  it("foreground refresh only enqueues ready resources without a recent attempt", async () => {
+    const { resources, jobs, calendars, connections } = deps();
+    const connection = await connections.upsertByProviderAccount({
+      tenantId: faker.database.mongodbObjectId(),
+      principalId: faker.database.mongodbObjectId(),
+      provider: "google",
+      account: {
+        providerAccountId: "foreground-refresh@gmail.com",
+        email: "foreground-refresh@gmail.com",
+        displayName: "Foreground refresh",
+      },
+      capabilities: ["readEvents"],
+      state: "healthy",
+      stateReason: null,
+    });
+    const staleCalendar: ProviderCalendarRecord = await seedProviderCalendar(
+      calendars,
+      {
+        tenantId: connection.tenantId,
+        principalId: connection.principalId,
+        connectionId: connection._id,
+      },
+    );
+    const recentCalendar: ProviderCalendarRecord = await seedProviderCalendar(
+      calendars,
+      {
+        tenantId: staleCalendar.tenantId,
+        principalId: staleCalendar.principalId,
+        connectionId: staleCalendar.connectionId,
+        providerCalendarId: "recent@google.com",
+        primary: false,
+      },
+    );
+    const importingCalendar: ProviderCalendarRecord =
+      await seedProviderCalendar(calendars, {
+        tenantId: staleCalendar.tenantId,
+        principalId: staleCalendar.principalId,
+        connectionId: staleCalendar.connectionId,
+        providerCalendarId: "importing@google.com",
+        primary: false,
+      });
+    const stale = await resources.ensure({
+      tenantId: staleCalendar.tenantId,
+      principalId: staleCalendar.principalId,
+      connectionId: staleCalendar.connectionId,
+      resourceKind: "events",
+      calendarId: staleCalendar._id,
+    });
+    const recent = await resources.ensure({
+      tenantId: recentCalendar.tenantId,
+      principalId: recentCalendar.principalId,
+      connectionId: recentCalendar.connectionId,
+      resourceKind: "events",
+      calendarId: recentCalendar._id,
+    });
+    await resources.ensure({
+      tenantId: importingCalendar.tenantId,
+      principalId: importingCalendar.principalId,
+      connectionId: importingCalendar.connectionId,
+      resourceKind: "events",
+      calendarId: importingCalendar._id,
+    });
+    await resources.setBootstrapState(
+      stale.tenantId,
+      stale.principalId,
+      stale._id,
+      "ready",
+    );
+    await resources.setBootstrapState(
+      recent.tenantId,
+      recent.principalId,
+      recent._id,
+      "ready",
+    );
+    await resources.markAttempt(
+      recent.tenantId,
+      recent.principalId,
+      recent._id,
+      new Date("2026-08-10T11:59:50.000Z"),
+    );
+
+    const tally = await refreshStalePrincipalCalendars(
+      { resources, jobs, connections },
+      stale.tenantId,
+      stale.principalId,
+      new Date("2026-08-10T11:59:30.000Z"),
+      now,
+    );
+
+    expect(tally).toMatchObject({ resources: 1, created: 1 });
+    expect(
+      await storage
+        .db()
+        .collection(SYNC_COLLECTIONS.jobs)
+        .findOne({
+          coalescingKey: `incrementalPull:${stale._id}`,
+        }),
+    ).toMatchObject({ priority: JOB_PRIORITY.user });
+    expect(
+      await storage.db().collection(SYNC_COLLECTIONS.jobs).countDocuments({
+        kind: "incrementalPull",
+      }),
     ).toBe(1);
   });
 });

--- a/packages/sync/src/domain/connection-refresh.service.ts
+++ b/packages/sync/src/domain/connection-refresh.service.ts
@@ -10,10 +10,19 @@ import {
 import { type JobRepository } from "@sync/storage/repositories/job.repository";
 import { type ProviderConnectionRepository } from "@sync/storage/repositories/provider-connection.repository";
 import { type SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
+import { mapWithConcurrency } from "@sync/util/map-with-concurrency";
+
+const FOREGROUND_ENQUEUE_CONCURRENCY = 10;
 
 export interface ConnectionRefreshDeps {
   resources: SyncResourceRepository;
   jobs: JobRepository;
+  connections: Pick<ProviderConnectionRepository, "listByPrincipal">;
+}
+
+export interface ForegroundRefreshDeps {
+  resources: Pick<SyncResourceRepository, "listStaleEventsByPrincipal">;
+  jobs: Pick<JobRepository, "enqueueForeground">;
   connections: Pick<ProviderConnectionRepository, "listByPrincipal">;
 }
 
@@ -102,6 +111,62 @@ export async function refreshPrincipalCalendars(
   );
   for (const outcome of outcomes) {
     tally[outcome] += 1;
+  }
+  return tally;
+}
+
+/**
+ * Bound staleness for a principal actively viewing Compass when a Google push
+ * notification is lost. Unlike the manual refresh path this only touches
+ * ready resources that have not recently attempted a pull; it deliberately
+ * does not rediscover calendars or revive failed jobs every foreground tick.
+ */
+export async function refreshStalePrincipalCalendars(
+  deps: ForegroundRefreshDeps,
+  tenantId: TenantId,
+  principalId: PrincipalId,
+  staleBefore: Date,
+  now: () => Date = () => new Date(),
+): Promise<ConnectionRefreshTally> {
+  const [candidates, connections] = await Promise.all([
+    deps.resources.listStaleEventsByPrincipal(
+      tenantId,
+      principalId,
+      staleBefore,
+    ),
+    deps.connections.listByPrincipal(tenantId, principalId),
+  ]);
+  const refreshableConnectionIds = new Set(
+    connections
+      .filter(
+        (connection) =>
+          connection.state === "healthy" || connection.state === "delayed",
+      )
+      .map((connection) => connection._id),
+  );
+  const resources = candidates.filter((resource) =>
+    refreshableConnectionIds.has(resource.connectionId),
+  );
+  const runAfter = now();
+  const tally: ConnectionRefreshTally = {
+    resources: resources.length,
+    created: 0,
+    boosted: 0,
+    requeuedFailed: 0,
+    inFlight: 0,
+  };
+  const outcomes = await mapWithConcurrency(
+    resources,
+    FOREGROUND_ENQUEUE_CONCURRENCY,
+    async (resource) => {
+      const { outcome } = await deps.jobs.enqueueForeground(
+        resourceJob(resource, "incrementalPull", runAfter, JOB_PRIORITY.user),
+      );
+      return outcome;
+    },
+  );
+  for (const outcome of outcomes) {
+    if (outcome !== "failed") tally[outcome] += 1;
   }
   return tally;
 }

--- a/packages/sync/src/server/connection.routes.db.test.ts
+++ b/packages/sync/src/server/connection.routes.db.test.ts
@@ -13,7 +13,10 @@ import {
 } from "@sync/__tests__/helpers/fixtures";
 import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
 import { createSyncService, type SyncService } from "@sync/app";
-import { signInternalRequest } from "@sync/auth/internal-auth";
+import {
+  signInternalRequest,
+  signServiceRequest,
+} from "@sync/auth/internal-auth";
 import { type SyncConfig } from "@sync/config/sync.config";
 import {
   deriveOAuthStateSecret,
@@ -32,6 +35,7 @@ import {
   CALENDARS_PATH,
   CONNECTIONS_PATH,
   EVENTS_FULL_PATH,
+  FOREGROUND_REFRESH_PATH,
   OAUTH_CALLBACK_PATH,
   REFRESH_PATH,
 } from "@sync/server/connection.routes";
@@ -155,6 +159,15 @@ const signedHeaders = (
       tenantId,
       principalId,
     }),
+  };
+};
+
+const serviceSignedHeaders = (): Record<string, string> => {
+  const timestamp = Date.now();
+  return {
+    "content-type": "application/json",
+    "x-sync-timestamp": String(timestamp),
+    "x-sync-signature": signServiceRequest(SECRET, timestamp),
   };
 };
 
@@ -1636,5 +1649,30 @@ describe("POST /internal/connections/refresh", () => {
     );
     expect(still?.leaseOwner).toBe("worker-1");
     expect(still?.state).toBe("claimed");
+  });
+
+  it("batch foreground refresh enqueues only stale ready resources", async () => {
+    const principalId = objectId();
+    const { resource } = await seedEventsResource(principalId, principalId);
+    await resources.setBootstrapState(
+      resource.tenantId,
+      resource.principalId,
+      resource._id,
+      "ready",
+    );
+    await startService();
+
+    const res = await fetch(`${base}${FOREGROUND_REFRESH_PATH}`, {
+      method: "POST",
+      headers: serviceSignedHeaders(),
+      body: JSON.stringify({ principalIds: [principalId] }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      enqueued: 1,
+      inFlight: 0,
+      resources: 1,
+    });
   });
 });

--- a/packages/sync/src/server/connection.routes.ts
+++ b/packages/sync/src/server/connection.routes.ts
@@ -10,6 +10,7 @@ import {
 import {
   type ConnectionListResponse,
   ConnectionRefreshResponseSchema,
+  ForegroundRefreshRequestSchema,
   GoogleConnectionAdoptionRequestSchema,
   type ProviderCalendar,
   ProviderCalendarSchema,
@@ -26,6 +27,7 @@ import {
   ConnectionIdSchema,
   type PrincipalId,
   type TenantId,
+  TenantIdSchema,
 } from "@core/types/sync/identity.contracts";
 import dayjs from "@core/util/date/dayjs";
 import { type SyncExecutionMode } from "@sync/config/sync.config";
@@ -34,7 +36,10 @@ import {
   type BusyAvailability,
   computeBusyAvailability,
 } from "@sync/domain/busy-query.service";
-import { refreshPrincipalCalendars } from "@sync/domain/connection-refresh.service";
+import {
+  refreshPrincipalCalendars,
+  refreshStalePrincipalCalendars,
+} from "@sync/domain/connection-refresh.service";
 import { type DerivedConnectionState } from "@sync/domain/connection-state";
 import { refreshConnectionState } from "@sync/domain/connection-state-refresh.service";
 import { assembleEventInstances } from "@sync/domain/event-instance-assembly";
@@ -65,6 +70,7 @@ import { ProviderCalendarRepository } from "@sync/storage/repositories/provider-
 import { ProviderConnectionRepository } from "@sync/storage/repositories/provider-connection.repository";
 import { type SyncMongoService } from "@sync/storage/sync-mongo.service";
 import { syncRepositories } from "@sync/storage/sync-repositories";
+import { mapWithConcurrency } from "@sync/util/map-with-concurrency";
 
 const logger = Logger("sync:connection.routes");
 
@@ -74,6 +80,10 @@ export const EVENTS_FULL_PATH = "/internal/events/full";
 export const AVAILABILITY_BUSY_PATH = "/internal/availability/busy";
 export const BEGIN_PATH = "/internal/connections/begin";
 export const REFRESH_PATH = "/internal/connections/refresh";
+export const FOREGROUND_REFRESH_PATH =
+  "/internal/connections/foreground-refresh";
+const FOREGROUND_STALE_AFTER_MS = 30_000;
+const FOREGROUND_PRINCIPAL_CONCURRENCY = 10;
 export const ADOPT_GOOGLE_AUTHORIZATION_PATH =
   "/internal/connections/adopt-google-authorization";
 // Where the provider redirects the browser after consent; `begin` builds the
@@ -422,6 +432,62 @@ export function registerConnectionRoutes(
           "Failed to compute busy availability",
           redactedCause(error),
         );
+        respondInternalError(res);
+      }
+    },
+  );
+
+  // Server-driven safety net for users with an open Compass stream. Push
+  // remains the fast path; this bounds a missed notification without turning
+  // every browser tab into an independent provider poller.
+  app.post(
+    FOREGROUND_REFRESH_PATH,
+    internalRateLimit,
+    deps.serviceAuthMiddleware,
+    async (req, res) => {
+      if (!ensureConnected(deps.mongo, res)) return;
+      if (deps.execution === "passive") {
+        res.status(Status.CONFLICT).json({ error: "provider_work_disabled" });
+        return;
+      }
+
+      try {
+        const parsed = ForegroundRefreshRequestSchema.safeParse(req.body);
+        if (!parsed.success) {
+          res.status(Status.BAD_REQUEST).json({ error: "invalid_request" });
+          return;
+        }
+        const repos = syncRepositories(deps.mongo);
+        const now = new Date((deps.now ?? Date.now)());
+        const tallies = await mapWithConcurrency(
+          parsed.data.principalIds,
+          FOREGROUND_PRINCIPAL_CONCURRENCY,
+          (principalId) =>
+            refreshStalePrincipalCalendars(
+              {
+                resources: repos.syncResources,
+                jobs: repos.jobs,
+                connections: repos.connections,
+              },
+              TenantIdSchema.parse(principalId),
+              principalId,
+              new Date(now.getTime() - FOREGROUND_STALE_AFTER_MS),
+              () => now,
+            ),
+        );
+        const totals = tallies.reduce(
+          (total, tally) => ({
+            enqueued: total.enqueued + tally.created + tally.boosted,
+            inFlight: total.inFlight + tally.inFlight,
+            resources: total.resources + tally.resources,
+          }),
+          { enqueued: 0, inFlight: 0, resources: 0 },
+        );
+        res
+          .status(Status.OK)
+          .json(ConnectionRefreshResponseSchema.parse(totals));
+      } catch (error) {
+        logger.error("Failed foreground refresh batch", redactedCause(error));
         respondInternalError(res);
       }
     },

--- a/packages/sync/src/storage/repositories/job.repository.db.test.ts
+++ b/packages/sync/src/storage/repositories/job.repository.db.test.ts
@@ -289,6 +289,27 @@ describe("JobRepository", () => {
       expect(job.priority).toBe(JOB_PRIORITY.user);
     });
 
+    it("enqueueForeground leaves a terminal job failed", async () => {
+      const coalescingKey = "foreground:failed";
+      const created = await repo.enqueue(
+        enqueue({ coalescingKey, runAfter: past(1000) }),
+      );
+      await repo.claimDueJob("owner", NOW, LEASE_MS);
+      expect(await repo.fail(created._id, "owner")).toBe(true);
+
+      const { job, outcome } = await repo.enqueueForeground(
+        enqueue({
+          coalescingKey,
+          priority: JOB_PRIORITY.user,
+          runAfter: NOW,
+        }),
+      );
+
+      expect(outcome).toBe("failed");
+      expect(job.state).toBe("failed");
+      expect(job.priority).not.toBe(JOB_PRIORITY.user);
+    });
+
     it("enqueueUrgent leaves a claimed row's lease untouched", async () => {
       const coalescingKey = "urgent:claimed";
       await repo.enqueue(enqueue({ coalescingKey, runAfter: past(1000) }));

--- a/packages/sync/src/storage/repositories/job.repository.ts
+++ b/packages/sync/src/storage/repositories/job.repository.ts
@@ -31,6 +31,12 @@ export type EnqueueUrgentOutcome =
   | "requeuedFailed"
   | "inFlight";
 
+export type EnqueueForegroundOutcome =
+  | "created"
+  | "boosted"
+  | "inFlight"
+  | "failed";
+
 // The exact complement of listFailedForRequeue's eligibility filter: {$gte}
 // does not match a missing requeuedCount, so a legacy job counts as eligible
 // there and never as exhausted here. Keep the two in step.
@@ -187,6 +193,59 @@ export class JobRepository {
       return { job: created, outcome: "inFlight" };
     }
 
+    return { job: created, outcome: "created" };
+  }
+
+  // Urgent like a user refresh, except a periodic foreground safety tick must
+  // never revive a terminal job and create an unbounded retry ladder. Races
+  // are harmless: enqueue is coalesced, and the final row decides the outcome.
+  async enqueueForeground(
+    input: JobEnqueue,
+  ): Promise<{ job: JobRecord; outcome: EnqueueForegroundOutcome }> {
+    const fields = JobEnqueueSchema.parse(input);
+    const now = fields.runAfter;
+    const boost = async () => {
+      await this.collection.updateOne(
+        { coalescingKey: fields.coalescingKey, state: "pending" },
+        {
+          $min: { runAfter: now },
+          $max: { priority: fields.priority },
+          $currentDate: { updatedAt: true },
+        },
+      );
+    };
+
+    const existing = await this.collection.findOne({
+      coalescingKey: fields.coalescingKey,
+    });
+    if (existing?.state === "failed") {
+      return { job: JobRecordSchema.parse(existing), outcome: "failed" };
+    }
+    if (existing?.state === "claimed") {
+      return { job: JobRecordSchema.parse(existing), outcome: "inFlight" };
+    }
+    if (existing?.state === "pending") {
+      await boost();
+      const job = await this.collection.findOne({
+        coalescingKey: fields.coalescingKey,
+      });
+      if (!job) throw new Error("Foreground job disappeared after boost");
+      return { job: JobRecordSchema.parse(job), outcome: "boosted" };
+    }
+
+    const created = await this.enqueue(fields);
+    if (created.state === "failed") return { job: created, outcome: "failed" };
+    if (created.state === "claimed") {
+      return { job: created, outcome: "inFlight" };
+    }
+    if (created.priority < fields.priority || created.runAfter > now) {
+      await boost();
+      const job = await this.collection.findOne({
+        coalescingKey: fields.coalescingKey,
+      });
+      if (!job) throw new Error("Foreground job disappeared after late boost");
+      return { job: JobRecordSchema.parse(job), outcome: "boosted" };
+    }
     return { job: created, outcome: "created" };
   }
 

--- a/packages/sync/src/storage/repositories/sync-resource.repository.ts
+++ b/packages/sync/src/storage/repositories/sync-resource.repository.ts
@@ -456,6 +456,30 @@ export class SyncResourceRepository {
     return records.map((r) => SyncResourceRecordSchema.parse(r));
   }
 
+  // Foreground freshness fallback: resources for one currently-connected
+  // principal that have not even attempted a pull since `before`. Attempt
+  // time, rather than success time, prevents a failing provider resource from
+  // being boosted every cycle and bypassing its retry backoff.
+  async listStaleEventsByPrincipal(
+    tenantId: TenantId,
+    principalId: PrincipalId,
+    before: Date,
+    limit = 200,
+  ): Promise<SyncResourceRecord[]> {
+    const records = await this.collection
+      .find({
+        tenantId,
+        principalId,
+        resourceKind: "events",
+        bootstrapState: "ready",
+        $or: [{ lastAttemptAt: { $lt: before } }, { lastAttemptAt: null }],
+      })
+      .sort({ lastAttemptAt: 1 })
+      .limit(limit)
+      .toArray();
+    return records.map((r) => SyncResourceRecordSchema.parse(r));
+  }
+
   // Events resources whose last successful sync is older than `before` (or which
   // never succeeded), oldest first, bounded. This is the reconcile sweep's input
   // — a missed-webhook fallback for connections that CAN still authenticate — so

--- a/packages/sync/src/util/map-with-concurrency.test.ts
+++ b/packages/sync/src/util/map-with-concurrency.test.ts
@@ -1,0 +1,32 @@
+import { mapWithConcurrency } from "@sync/util/map-with-concurrency";
+
+describe("mapWithConcurrency", () => {
+  it("caps work for a maximum-size foreground batch", async () => {
+    let active = 0;
+    let peak = 0;
+    const releases: Array<() => void> = [];
+    const mapped = mapWithConcurrency(
+      Array.from({ length: 500 }, (_, index) => index),
+      10,
+      async (value) => {
+        active += 1;
+        peak = Math.max(peak, active);
+        await new Promise<void>((resolve) => releases.push(resolve));
+        active -= 1;
+        return value * 2;
+      },
+    );
+
+    await Bun.sleep(0);
+    expect(active).toBe(10);
+    while (releases.length > 0 || active > 0) {
+      releases.splice(0).forEach((release) => release());
+      await Bun.sleep(0);
+    }
+
+    const results = await mapped;
+    expect(peak).toBe(10);
+    expect(results).toHaveLength(500);
+    expect(results[499]).toBe(998);
+  });
+});

--- a/packages/sync/src/util/map-with-concurrency.ts
+++ b/packages/sync/src/util/map-with-concurrency.ts
@@ -1,0 +1,22 @@
+export async function mapWithConcurrency<T, R>(
+  values: readonly T[],
+  concurrency: number,
+  map: (value: T) => Promise<R>,
+): Promise<R[]> {
+  if (!Number.isInteger(concurrency) || concurrency < 1) {
+    throw new RangeError("concurrency must be a positive integer");
+  }
+
+  const results = new Array<R>(values.length);
+  let nextIndex = 0;
+  const worker = async () => {
+    while (nextIndex < values.length) {
+      const index = nextIndex++;
+      results[index] = await map(values[index] as T);
+    }
+  };
+  await Promise.all(
+    Array.from({ length: Math.min(concurrency, values.length) }, worker),
+  );
+  return results;
+}


### PR DESCRIPTION
## Summary
- add a backend-owned foreground refresh loop for connected SSE users
- add a signed batch refresh endpoint and stale-resource selection in Sync
- coalesce foreground pulls without reviving terminal failures, with bounded concurrency

## Verification
- bun run test:backend -- ./packages/backend/src/servers/sse/foreground-sync-refresh.test.ts ./packages/backend/src/common/services/sync-service/sync-service.client.test.ts
- bun run test:sync -- ./packages/sync/src/domain/connection-refresh.service.db.test.ts ./packages/sync/src/server/connection.routes.db.test.ts ./packages/sync/src/storage/repositories/job.repository.db.test.ts
- bun test packages/sync/src/util/map-with-concurrency.test.ts
- bunx biome check (15 changed files)