### PR TITLE
feat(web): pin calendar timezone and thread it through the grid

### DIFF
--- a/packages/core/src/util/date/dayjs-compass.plugin.ts
+++ b/packages/core/src/util/date/dayjs-compass.plugin.ts
@@ -140,8 +140,8 @@ function rruleUntilToIsoString(this: typeof dayjs, rrule: string): string {
   return origDateFromUntil;
 }
 
-function setDefaultTimezone(this: typeof dayjs.tz) {
-  const defaultTimezone = this.guess();
+function setDefaultTimezone(this: typeof dayjs.tz, timezone?: string) {
+  const defaultTimezone = timezone ?? this.guess();
 
   Object.assign(this, { defaultTimezone });
 
@@ -167,6 +167,9 @@ export const dayjsCompassPlugin: PluginFunc<never> = (...params) => {
   const setDefault = setDefaultTimezone.bind(dayjsStatic.tz);
 
   setDefault();
+  dayjsStatic.setDefaultTimezone = (timezone: string) => {
+    setDefaultTimezone.call(dayjsStatic.tz, timezone);
+  };
 
   dayjsClass.prototype.next = next;
   dayjsClass.prototype.startOfNextWeek = startOfNextWeek;

--- a/packages/web/src/__tests__/utils/state/reset-stores.ts
+++ b/packages/web/src/__tests__/utils/state/reset-stores.ts
@@ -40,6 +40,7 @@ import {
 } from "@web/settings/settings.store";
 import { useThemeStore } from "@web/settings/theme/theme.store";
 import { resetEffectiveTimeZoneStoreForTests } from "@web/timezone/effective-timezone.store";
+import { useTimezoneDialogStore } from "@web/timezone/timezone-dialog.store";
 import { setWeekInteractionMotionActive } from "@web/views/Week/interaction/state/motion.state";
 
 type StoreReset = () => void;
@@ -63,6 +64,7 @@ const storeResets: StoreReset[] = [
   resetCalendarVisibilityStoreForTests,
   resetDefaultCalendarStoreForTests,
   resetEffectiveTimeZoneStoreForTests,
+  () => useTimezoneDialogStore.setState({ isOpen: false }, true),
   resetCollapsedAccountsStoreForTests,
   resetRecentCommandsStoreForTests,
   // Lives on window.__weekInteractionMotionActive, which survives across

--- a/packages/web/src/common/constants/storage.constants.ts
+++ b/packages/web/src/common/constants/storage.constants.ts
@@ -30,7 +30,9 @@ type StorageKey =
   | "compass.calendars.collapsed-accounts"
   // Recently-used command palette item ids, most recent first. Device-local;
   // an id that no longer resolves to a visible item is skipped, not an error.
-  | "compass.commands.recent";
+  | "compass.commands.recent"
+  // Pinned calendar timezone. Absent means Auto (follow the browser).
+  | "compass.timezone.default";
 
 export const STORAGE_KEYS: Record<
   | "AUTH"
@@ -50,7 +52,8 @@ export const STORAGE_KEYS: Record<
   | "HIDDEN_CALENDAR_IDS"
   | "DEFAULT_CALENDAR_ID"
   | "COLLAPSED_ACCOUNTS"
-  | "RECENT_COMMANDS",
+  | "RECENT_COMMANDS"
+  | "DEFAULT_TIMEZONE",
   StorageKey
 > = {
   AUTH: "compass.auth",
@@ -74,4 +77,5 @@ export const STORAGE_KEYS: Record<
   DEFAULT_CALENDAR_ID: "compass.calendars.default-id",
   COLLAPSED_ACCOUNTS: "compass.calendars.collapsed-accounts",
   RECENT_COMMANDS: "compass.commands.recent",
+  DEFAULT_TIMEZONE: "compass.timezone.default",
 } as const;

--- a/packages/web/src/common/utils/datetime/date.label.test.ts
+++ b/packages/web/src/common/utils/datetime/date.label.test.ts
@@ -1,9 +1,20 @@
+import { act } from "react";
 import { getTimesLabel } from "@web/common/utils/datetime/web.date.util";
+import {
+  resetEffectiveTimeZoneStoreForTests,
+  setPinnedTimeZone,
+} from "@web/timezone/effective-timezone.store";
+import { afterEach, describe, expect, it } from "bun:test";
 
 const meridians = (label: string) =>
   (label.match(/am/gi) || label.match(/pm/gi) || []).length;
 
 describe("Time Labels", () => {
+  afterEach(() => {
+    act(() => {
+      resetEffectiveTimeZoneStoreForTests();
+    });
+  });
   it("removes minutes and am/pm when possible", () => {
     const morningLabel = getTimesLabel(
       "2022-07-06T06:00:00Z",
@@ -56,5 +67,15 @@ describe("Time Labels", () => {
     expect(
       getTimesLabel("2026-07-31T17:00:00+02:00", "2026-07-31T18:30:00+02:00"),
     ).toBe("3 - 4:30 PM");
+  });
+
+  it("localizes the label to a pinned calendar timezone", () => {
+    act(() => {
+      setPinnedTimeZone("America/Chicago");
+    });
+
+    expect(getTimesLabel("2022-07-06T06:00:00Z", "2022-07-06T07:00:00Z")).toBe(
+      "1 - 2 AM",
+    );
   });
 });

--- a/packages/web/src/common/utils/datetime/web.date.util.test.ts
+++ b/packages/web/src/common/utils/datetime/web.date.util.test.ts
@@ -1,5 +1,6 @@
 import { YEAR_MONTH_DAY_FORMAT } from "@core/constants/date.constants";
 import { type CompassEvent } from "@core/types/compass-event.contracts";
+import { TimeZoneSchema } from "@core/types/domain-primitives";
 import dayjs from "@core/util/date/dayjs";
 import {
   computeCurrentEventDateRange,
@@ -613,6 +614,6 @@ describe("mapToBackend timed overnight", () => {
 
     expect(schedule.kind).toBe("timed");
     if (schedule.kind !== "timed") return;
-    expect(schedule.timeZone).toBe("America/Chicago");
+    expect(schedule.timeZone).toBe(TimeZoneSchema.parse("America/Chicago"));
   });
 });

--- a/packages/web/src/common/utils/datetime/web.date.util.test.ts
+++ b/packages/web/src/common/utils/datetime/web.date.util.test.ts
@@ -15,6 +15,7 @@ import {
   toUTCOffset,
   tryMapToBackend,
 } from "@web/common/utils/datetime/web.date.util";
+import { setPinnedTimeZone } from "@web/timezone/effective-timezone.store";
 import { getFormDates } from "@web/views/Forms/EventForm/DateControlsSection/DateTimeSection/form.datetime.util";
 import {
   afterAll,
@@ -596,5 +597,22 @@ describe("mapToBackend timed overnight", () => {
 
     expect(() => mapToBackend(selected)).toThrow();
     expect(tryMapToBackend(selected).ok).toBe(false);
+  });
+
+  it("stamps the pinned timezone on new timed events", () => {
+    setPinnedTimeZone("America/Chicago");
+
+    const day = dayjs("2026-08-11T00:00:00");
+    const schedule = mapToBackend({
+      startDate: day.toDate(),
+      endDate: day.toDate(),
+      startTime: getTimeOptionByValue(day.hour(9).minute(0)),
+      endTime: getTimeOptionByValue(day.hour(10).minute(0)),
+      isAllDay: false,
+    });
+
+    expect(schedule.kind).toBe("timed");
+    if (schedule.kind !== "timed") return;
+    expect(schedule.timeZone).toBe("America/Chicago");
   });
 });

--- a/packages/web/src/common/utils/datetime/web.date.util.ts
+++ b/packages/web/src/common/utils/datetime/web.date.util.ts
@@ -14,6 +14,7 @@ import dayjs, { type Dayjs } from "@core/util/date/dayjs";
 import { ACCEPTED_TIMES } from "@web/common/constants/web.constants";
 import { type SelectOption } from "@web/common/types/component.types";
 import { type TimeOption } from "@web/common/types/util.types";
+import { getEffectiveTimeZone } from "@web/timezone/effective-timezone.store";
 
 interface SelectedDates {
   startDate: Date;
@@ -204,10 +205,7 @@ export const getCalendarHeadingLabel = (
   }
 };
 
-// Browser IANA zone (e.g. "America/Chicago"), used to stamp timed schedules
-// built from local form input (B_G).
-export const getBrowserTimeZone = (): string =>
-  Intl.DateTimeFormat().resolvedOptions().timeZone;
+export { getBrowserTimeZone } from "@web/timezone/browser-timezone";
 
 export const mapToBackend = (s: SelectedDates): EventSchedule => {
   if (s.isAllDay) {
@@ -227,7 +225,7 @@ export const mapToBackend = (s: SelectedDates): EventSchedule => {
     });
   }
 
-  const timeZone = getBrowserTimeZone();
+  const timeZone = getEffectiveTimeZone();
   const { startDate, endDate } = _addTimesToDates(s, timeZone);
 
   return EventScheduleSchema.parse({

--- a/packages/web/src/common/utils/datetime/web.date.util.ts
+++ b/packages/web/src/common/utils/datetime/web.date.util.ts
@@ -15,6 +15,7 @@ import { ACCEPTED_TIMES } from "@web/common/constants/web.constants";
 import { type SelectOption } from "@web/common/types/component.types";
 import { type TimeOption } from "@web/common/types/util.types";
 import { getEffectiveTimeZone } from "@web/timezone/effective-timezone.store";
+import { inEffectiveTimeZone } from "@web/timezone/in-time-zone";
 
 interface SelectedDates {
   startDate: Date;
@@ -297,7 +298,7 @@ const _cleanStartMeridiem = (start: string, end: string) => {
 };
 
 const _getTimeLabel = (date: string) =>
-  getTimeLabel(dayjs(date).format(HOURS_AM_FORMAT));
+  getTimeLabel(inEffectiveTimeZone(date).format(HOURS_AM_FORMAT));
 
 export const computeCurrentEventDateRange = (
   to: {

--- a/packages/web/src/common/utils/draft/draft.util.ts
+++ b/packages/web/src/common/utils/draft/draft.util.ts
@@ -58,13 +58,11 @@ export const createAlldayDraft = (
   const start = today.isBetween(startOfView, endOfView, "day", "[]")
     ? today.startOf("day")
     : startOfView.startOf("day");
-  const startDate = start.format();
-  const endDate = start.add(1, "day").format();
   const draft = createGridEventDraft(
     {
       kind: "allDay",
-      start: new Date(startDate),
-      end: new Date(endDate),
+      start: start.toDate(),
+      end: start.add(1, "day").toDate(),
     },
     undefined,
     calendarId,

--- a/packages/web/src/common/utils/draft/draft.util.ts
+++ b/packages/web/src/common/utils/draft/draft.util.ts
@@ -17,6 +17,7 @@ import {
 import { draftActions } from "@web/events/stores/draft.store";
 import { GRID_TIME_STEP } from "@web/grid/grid.constants";
 import { isDraftRenderedInAllDayRow } from "@web/grid/layout/all-day-draft.position";
+import { getEffectiveTimeZone } from "@web/timezone/effective-timezone.store";
 
 // Keeps a newly-timed event off the very top edge of the scrolled-in
 // viewport rather than glued flush against it.
@@ -53,7 +54,7 @@ export const createAlldayDraft = (
   activity: "createShortcut",
   calendarId: CalendarId | null = null,
 ) => {
-  const today = dayjs();
+  const today = dayjs().tz(getEffectiveTimeZone());
   const start = today.isBetween(startOfView, endOfView, "day", "[]")
     ? today.startOf("day")
     : startOfView.startOf("day");
@@ -73,10 +74,11 @@ export const createAlldayDraft = (
 };
 
 export const getDraftTimes = (isCurrentWeek: boolean, startOfWeek: Dayjs) => {
-  const currentMinute = dayjs().minute();
+  const now = dayjs().tz(getEffectiveTimeZone());
+  const currentMinute = now.minute();
   const nextMinuteInterval = roundToNext(currentMinute, GRID_TIME_STEP);
 
-  const fullStart = isCurrentWeek ? dayjs() : startOfWeek.hour(dayjs().hour());
+  const fullStart = isCurrentWeek ? now : startOfWeek.hour(now.hour());
   const _start = fullStart.minute(nextMinuteInterval).second(0);
 
   const _end = _start.add(1, "hour");

--- a/packages/web/src/common/utils/event/event-nudge.util.ts
+++ b/packages/web/src/common/utils/event/event-nudge.util.ts
@@ -1,7 +1,11 @@
 import { YEAR_MONTH_DAY_FORMAT } from "@core/constants/date.constants";
 import { type CompassEvent } from "@core/types/compass-event.contracts";
-import dayjs, { type Dayjs } from "@core/util/date/dayjs";
+import { type Dayjs } from "@core/util/date/dayjs";
 import { GRID_TIME_STEP } from "@web/grid/grid.constants";
+import {
+  calendarDateInEffectiveTimeZone,
+  inEffectiveTimeZone,
+} from "@web/timezone/in-time-zone";
 
 export interface EventNudgeMovement {
   days: number;
@@ -45,7 +49,7 @@ export const convertAllDayToTimedDates = (
   event: Pick<CompassEvent, "startDate">,
   startMinute: number,
 ): { startDate: string; endDate: string } => {
-  const start = dayjs(event.startDate)
+  const start = calendarDateInEffectiveTimeZone(event.startDate)
     .startOf("day")
     .add(startMinute, "minute");
   return {
@@ -104,10 +108,13 @@ export const nudgeEventDates = (
   if (!event.startDate || !event.endDate) return null;
   if (event.isAllDay && movement.minutes !== 0) return null;
 
-  const nextStart = dayjs(event.startDate)
+  const parse = event.isAllDay
+    ? calendarDateInEffectiveTimeZone
+    : inEffectiveTimeZone;
+  const nextStart = parse(event.startDate)
     .add(movement.days, "day")
     .add(movement.minutes, "minutes");
-  const nextEnd = dayjs(event.endDate)
+  const nextEnd = parse(event.endDate)
     .add(movement.days, "day")
     .add(movement.minutes, "minutes");
 
@@ -158,8 +165,8 @@ const nudgeTimedEdgeDates = (
   edge: EventEdge,
   minutesDelta: number,
 ): { startDate: string; endDate: string; edge: EventEdge } | null => {
-  const start = dayjs(event.startDate);
-  const end = dayjs(event.endDate);
+  const start = inEffectiveTimeZone(event.startDate);
+  const end = inEffectiveTimeZone(event.endDate);
 
   if (edge === "startDate") {
     const candidateStart = start.add(minutesDelta, "minute");
@@ -209,8 +216,12 @@ const nudgeAllDayEdgeDates = (
   edge: EventEdge,
   daysDelta: number,
 ): { startDate: string; endDate: string; edge: EventEdge } => {
-  const startDay = dayjs(event.startDate).startOf("day");
-  const inclusiveEnd = dayjs(event.endDate).startOf("day").subtract(1, "day");
+  const startDay = calendarDateInEffectiveTimeZone(event.startDate).startOf(
+    "day",
+  );
+  const inclusiveEnd = calendarDateInEffectiveTimeZone(event.endDate)
+    .startOf("day")
+    .subtract(1, "day");
 
   if (edge === "startDate") {
     const candidate = startDay.add(daysDelta, "day");

--- a/packages/web/src/common/utils/event/event-nudge.util.ts
+++ b/packages/web/src/common/utils/event/event-nudge.util.ts
@@ -49,7 +49,7 @@ export const convertAllDayToTimedDates = (
   event: Pick<CompassEvent, "startDate">,
   startMinute: number,
 ): { startDate: string; endDate: string } => {
-  const start = calendarDateInEffectiveTimeZone(event.startDate)
+  const start = calendarDateInEffectiveTimeZone(event.startDate ?? "")
     .startOf("day")
     .add(startMinute, "minute");
   return {
@@ -108,13 +108,15 @@ export const nudgeEventDates = (
   if (!event.startDate || !event.endDate) return null;
   if (event.isAllDay && movement.minutes !== 0) return null;
 
+  const startDate = event.startDate;
+  const endDate = event.endDate;
   const parse = event.isAllDay
     ? calendarDateInEffectiveTimeZone
     : inEffectiveTimeZone;
-  const nextStart = parse(event.startDate)
+  const nextStart = parse(startDate)
     .add(movement.days, "day")
     .add(movement.minutes, "minutes");
-  const nextEnd = parse(event.endDate)
+  const nextEnd = parse(endDate)
     .add(movement.days, "day")
     .add(movement.minutes, "minutes");
 
@@ -149,19 +151,21 @@ export const nudgeEventEdgeDates = (
   edge: EventEdge,
   movement: EventNudgeMovement,
 ): { startDate: string; endDate: string; edge: EventEdge } | null => {
-  if (!event.startDate || !event.endDate) return null;
+  const startDate = event.startDate;
+  const endDate = event.endDate;
+  if (!startDate || !endDate) return null;
 
   if (event.isAllDay) {
     if (movement.days === 0) return null;
-    return nudgeAllDayEdgeDates(event, edge, movement.days);
+    return nudgeAllDayEdgeDates({ startDate, endDate }, edge, movement.days);
   }
 
   if (movement.minutes === 0) return null;
-  return nudgeTimedEdgeDates(event, edge, movement.minutes);
+  return nudgeTimedEdgeDates({ startDate, endDate }, edge, movement.minutes);
 };
 
 const nudgeTimedEdgeDates = (
-  event: Pick<CompassEvent, "startDate" | "endDate">,
+  event: { startDate: string; endDate: string },
   edge: EventEdge,
   minutesDelta: number,
 ): { startDate: string; endDate: string; edge: EventEdge } | null => {
@@ -212,7 +216,7 @@ const nudgeTimedEdgeDates = (
 };
 
 const nudgeAllDayEdgeDates = (
-  event: Pick<CompassEvent, "startDate" | "endDate">,
+  event: { startDate: string; endDate: string },
   edge: EventEdge,
   daysDelta: number,
 ): { startDate: string; endDate: string; edge: EventEdge } => {

--- a/packages/web/src/common/utils/grid/grid.util.ts
+++ b/packages/web/src/common/utils/grid/grid.util.ts
@@ -4,6 +4,7 @@ import {
   GRID_EVENT_TITLE_VERTICAL_SLACK_PX,
   TIMED_VISIBLE_HOURS,
 } from "@web/grid/grid.constants";
+import { getEffectiveTimeZone } from "@web/timezone/effective-timezone.store";
 import {
   AFTER_TMRW_MULTIPLE,
   FLEX_EQUAL,
@@ -35,7 +36,8 @@ export const assignEventToRow = (
 };
 
 export const getCurrentMinute = () => {
-  return dayjs().get("hours") * 60 + dayjs().get("minutes");
+  const now = dayjs().tz(getEffectiveTimeZone());
+  return now.get("hours") * 60 + now.get("minutes");
 };
 
 // Timed grid always renders exactly TIMED_VISIBLE_HOURS worth of rows in

--- a/packages/web/src/components/CommandPalette/CommandPalette.test.tsx
+++ b/packages/web/src/components/CommandPalette/CommandPalette.test.tsx
@@ -124,6 +124,7 @@ describe("CommandPalette", () => {
     expect(screen.getByText("Go to Life")).toBeInTheDocument();
     expect(screen.getByText("Create event")).toBeInTheDocument();
     expect(screen.getByText("Create all-day event")).toBeInTheDocument();
+    expect(screen.getByText(/Change default timezone/)).toBeInTheDocument();
     expect(getInput()).toHaveFocus();
     // First option is active by default.
     expect(activeRowText(container)).toBe("Go to Today");

--- a/packages/web/src/components/CommandPalette/CommandPalette.tsx
+++ b/packages/web/src/components/CommandPalette/CommandPalette.tsx
@@ -41,6 +41,7 @@ import {
 } from "@web/settings/settings.store";
 import { useAppLockReason } from "@web/shortcuts/app-lock";
 import { type ViewName } from "@web/shortcuts/shortcuts.constants";
+import { useTimezoneCmdItems } from "@web/timezone/useTimezoneCmdItems";
 import { filterSections, getLabelMatchRanges } from "./command-palette.search";
 import { type CommandItem, type CommandSection } from "./command-palette.types";
 
@@ -295,6 +296,7 @@ export const CommandPalette = ({
   const showAccountsCmdItems = useShowAccountsCmdItems();
   const logoutCmdItems = useLogoutCmdItems();
   const themeCmdItems = useThemeCmdItems();
+  const timezoneCmdItems = useTimezoneCmdItems();
   const { undo, redo, canUndo, canRedo } = useUndoRedo(mutationDependencies);
   const recentCommandIds = useRecentCommandIds();
 
@@ -348,7 +350,12 @@ export const CommandPalette = ({
     {
       id: "settings",
       heading: "Settings",
-      items: [...authCmdItems, ...showAccountsCmdItems, ...logoutCmdItems],
+      items: [
+        ...timezoneCmdItems,
+        ...authCmdItems,
+        ...showAccountsCmdItems,
+        ...logoutCmdItems,
+      ],
     },
     ...getMoreCommandPaletteSections(currentView),
   ];
@@ -391,6 +398,7 @@ export const LifeCommandPalette = ({
   useAppLockReason("commandPalette", open);
   const navigate = useNavigate();
   const themeCmdItems = useThemeCmdItems();
+  const timezoneCmdItems = useTimezoneCmdItems();
 
   if (!open) return null;
 
@@ -411,6 +419,11 @@ export const LifeCommandPalette = ({
           id: "appearance",
           heading: "Appearance",
           items: themeCmdItems,
+        },
+        {
+          id: "settings",
+          heading: "Settings",
+          items: timezoneCmdItems,
         },
         ...getMoreCommandPaletteSections("life"),
       ]}

--- a/packages/web/src/components/CompassProvider/CompassProvider.tsx
+++ b/packages/web/src/components/CompassProvider/CompassProvider.tsx
@@ -18,6 +18,7 @@ import { LogoutConfirmationProvider } from "@web/components/LogoutConfirmation/L
 import { SettingsModal } from "@web/components/Settings/SettingsModal";
 import { RecurrenceScopeOpportunityHost } from "@web/events/recurrence/RecurrenceScopeOpportunityHost";
 import { selectTheme, useThemeStore } from "@web/settings/theme/theme.store";
+import { TimezoneDialogHost } from "@web/timezone/TimezoneDialogHost";
 import { useUndoRedoShortcuts } from "@web/views/Week/hooks/shortcuts/useUndoRedoShortcuts";
 
 /**
@@ -70,6 +71,7 @@ export const CompassRequiredProviders = ({
               <DeleteAccountConfirmationProvider>
                 {children}
                 <SettingsModal />
+                <TimezoneDialogHost />
                 <AboutModal />
               </DeleteAccountConfirmationProvider>
               <ThemeAwareToastContainer />

--- a/packages/web/src/components/Settings/SettingsModal.test.tsx
+++ b/packages/web/src/components/Settings/SettingsModal.test.tsx
@@ -157,7 +157,7 @@ describe("SettingsModal", () => {
 
     expect(screen.getByText("Default timezone")).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "Default timezone" }),
+      screen.getByRole("button", { name: /Default timezone/ }),
     ).toBeInTheDocument();
   });
 

--- a/packages/web/src/components/Settings/SettingsModal.test.tsx
+++ b/packages/web/src/components/Settings/SettingsModal.test.tsx
@@ -152,6 +152,15 @@ describe("SettingsModal", () => {
     expect(screen.queryByText("Settings")).not.toBeInTheDocument();
   });
 
+  it("shows a default timezone control", () => {
+    renderSettings();
+
+    expect(screen.getByText("Default timezone")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Default timezone" }),
+    ).toBeInTheDocument();
+  });
+
   it("lists every connected account with its own status", () => {
     renderSettings({
       connections: [

--- a/packages/web/src/components/Settings/SettingsModal.tsx
+++ b/packages/web/src/components/Settings/SettingsModal.tsx
@@ -49,6 +49,7 @@ import {
 } from "@web/settings/settings.store";
 import { useAppLockReason } from "@web/shortcuts/app-lock";
 import { useSseDegraded } from "@web/sse/hooks/useSseDegraded";
+import { DefaultTimezonePicker } from "@web/timezone/DefaultTimezonePicker";
 
 const OUTLINE_BUTTON_CLASSNAME =
   "c-focus-ring shrink-0 rounded border border-border bg-surface-overlay px-2 py-1 text-xs text-text transition-colors hover:bg-surface-panel disabled:pointer-events-none disabled:opacity-60";
@@ -142,6 +143,7 @@ export const SettingsModal: FC = () => {
           </button>
         </nav>
         <div className="flex min-w-0 flex-1 flex-col gap-4">
+          <DefaultTimezonePicker />
           <DefaultCalendarPicker
             calendars={writableCalendars}
             connections={connections}

--- a/packages/web/src/events/event-draft.parser.ts
+++ b/packages/web/src/events/event-draft.parser.ts
@@ -14,6 +14,7 @@ import {
   type EventScheduleDraft,
   type NewEventRecurrenceDraft,
 } from "@web/events/event-draft.types";
+import { inEffectiveTimeZone } from "@web/timezone/in-time-zone";
 
 export type ParseEventDraftResult =
   | { ok: true; mode: "create"; input: CreateEventInput }
@@ -56,7 +57,7 @@ function isValidTimeZone(timeZone: string): boolean {
 }
 
 function toDateOnlyString(date: Date): string {
-  return dayjs(date).toYearMonthDayString();
+  return inEffectiveTimeZone(date).toYearMonthDayString();
 }
 
 // Formats the instant in the draft's own time zone so the offset matches the

--- a/packages/web/src/events/grid-event-draft.adapter.ts
+++ b/packages/web/src/events/grid-event-draft.adapter.ts
@@ -24,6 +24,7 @@ import {
   type GridScheduleDraft,
 } from "@web/events/event-draft.types";
 import { getEffectiveTimeZone } from "@web/timezone/effective-timezone.store";
+import { inEffectiveTimeZone } from "@web/timezone/in-time-zone";
 
 function gridScheduleFromEvent(event: Event): GridScheduleDraft | null {
   const { schedule } = event;
@@ -620,4 +621,5 @@ const editableDetailsFromEvent = (
 
 // Local, not toISOString: all-day draft Dates are local midnight, so a UTC
 // rendering would shift the day for any non-UTC viewer.
-const toDateOnlyString = (date: Date) => dayjs(date).toYearMonthDayString();
+const toDateOnlyString = (date: Date) =>
+  inEffectiveTimeZone(date).toYearMonthDayString();

--- a/packages/web/src/events/grid-event-draft.adapter.ts
+++ b/packages/web/src/events/grid-event-draft.adapter.ts
@@ -13,7 +13,6 @@ import { type RecurrenceScope } from "@core/types/event-command.contracts";
 import dayjs from "@core/util/date/dayjs";
 import { CompassEventRRule } from "@core/util/event/compass.event.rrule";
 import { type GridEvent } from "@web/common/types/web.event.types";
-import { getBrowserTimeZone } from "@web/common/utils/datetime/web.date.util";
 import { gridEventDefaultPosition } from "@web/common/utils/event/event.util";
 import {
   type ParseEventDraftResult,
@@ -24,6 +23,7 @@ import {
   type GridEventDraft,
   type GridScheduleDraft,
 } from "@web/events/event-draft.types";
+import { getEffectiveTimeZone } from "@web/timezone/effective-timezone.store";
 
 function gridScheduleFromEvent(event: Event): GridScheduleDraft | null {
   const { schedule } = event;
@@ -192,7 +192,7 @@ export function parseGridEventDraft(
 }
 
 export function timedGridSchedule(start: Date, end: Date): GridScheduleDraft {
-  return { kind: "timed", start, end, timeZone: getBrowserTimeZone() };
+  return { kind: "timed", start, end, timeZone: getEffectiveTimeZone() };
 }
 
 // All-day draft Dates are local midnight everywhere (drag creation, form

--- a/packages/web/src/events/queries/event.view-model.ts
+++ b/packages/web/src/events/queries/event.view-model.ts
@@ -2,7 +2,6 @@ import { Origin } from "@core/constants/core.constants";
 import { type EventId } from "@core/types/domain-primitives";
 import { type Event } from "@core/types/event.contracts";
 import { withColor, withColorHex } from "@core/types/event-color.contracts";
-import dayjs from "@core/util/date/dayjs";
 import { type GridEvent } from "@web/common/types/web.event.types";
 import { gridEventDefaultPosition } from "@web/common/utils/event/event.util";
 import {
@@ -10,6 +9,7 @@ import {
   timedMultiDayToAllDayDates,
 } from "@web/common/utils/event/event-nudge.util";
 import { assignEventsToRow } from "@web/common/utils/grid/assign.row";
+import { inEffectiveTimeZone } from "@web/timezone/in-time-zone";
 import { type NormalizedEventQueryData } from "./event.query.types";
 
 // The ONE authoritative spot for a busy event's display title (packet 08
@@ -138,8 +138,8 @@ const timedEventsFrom = (events: Event[], annotations?: EventAnnotations) =>
   gridEventsFrom(events, "timed", annotations).filter((event) => {
     if (!event.startDate || !event.endDate) return true;
     return !shouldRenderTimedInAllDayRow(
-      dayjs(event.startDate),
-      dayjs(event.endDate),
+      inEffectiveTimeZone(event.startDate),
+      inEffectiveTimeZone(event.endDate),
     );
   });
 
@@ -151,11 +151,17 @@ const multiDayTimedAsAllDayFrom = (
     .filter((event) => event.schedule.kind === "timed")
     .filter((event) => {
       const { start, end } = event.schedule;
-      return shouldRenderTimedInAllDayRow(dayjs(start), dayjs(end));
+      return shouldRenderTimedInAllDayRow(
+        inEffectiveTimeZone(start),
+        inEffectiveTimeZone(end),
+      );
     })
     .map((event) => {
       const { start, end } = event.schedule;
-      const dates = timedMultiDayToAllDayDates(dayjs(start), dayjs(end));
+      const dates = timedMultiDayToAllDayDates(
+        inEffectiveTimeZone(start),
+        inEffectiveTimeZone(end),
+      );
       return eventToGridEvent(event, {
         ...annotations,
         scheduleOverride: {

--- a/packages/web/src/grid/components/TimedGrid.tsx
+++ b/packages/web/src/grid/components/TimedGrid.tsx
@@ -33,6 +33,7 @@ import {
   selectEventJumpActiveDayKeys,
   useEventJumpStore,
 } from "@web/shortcuts/shift-hint/event-jump.store";
+import { useEffectiveTimeZone } from "@web/timezone/effective-timezone.store";
 
 interface TimedGridProps {
   columnsId?: string;
@@ -148,7 +149,8 @@ export const TimedGrid: FC<TimedGridProps> = ({
 };
 
 const CalendarTimeColumn = () => {
-  const currentHour = useMinuteTick().hour();
+  const timeZone = useEffectiveTimeZone();
+  const currentHour = useMinuteTick().tz(timeZone).hour();
   const colors = useMemo(() => getColorsByHour(currentHour), [currentHour]);
   const hourLabels = useMemo(() => getHourLabels(), []);
 

--- a/packages/web/src/grid/interaction/commit/cross-row.commit.test.ts
+++ b/packages/web/src/grid/interaction/commit/cross-row.commit.test.ts
@@ -1,11 +1,16 @@
+import { act } from "react";
 import { type GridEvent } from "@web/common/types/web.event.types";
 import { type AllDayDragVisual } from "@web/grid/interaction/types/all-day-drag.types";
 import { type TimedDragVisual } from "@web/grid/interaction/types/timed-drag.types";
 import {
+  resetEffectiveTimeZoneStoreForTests,
+  setPinnedTimeZone,
+} from "@web/timezone/effective-timezone.store";
+import {
   allDayDragVisualToTimedGridEvent,
   timedDragVisualToAllDayGridEvent,
 } from "./cross-row.commit";
-import { describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it } from "bun:test";
 
 // All-day dates are date-only with an exclusive end, so this single-day event
 // on the 13th ends on the 14th.
@@ -65,6 +70,12 @@ const timedDragVisual = (
   ...overrides,
 });
 
+afterEach(() => {
+  act(() => {
+    resetEffectiveTimeZoneStoreForTests();
+  });
+});
+
 describe("allDayDragVisualToTimedGridEvent", () => {
   it("invents a default-length block at the dropped start time on the drop column", () => {
     const result = allDayDragVisualToTimedGridEvent(
@@ -105,6 +116,20 @@ describe("allDayDragVisualToTimedGridEvent", () => {
 
     expect(result._id).toBe("all-day-event");
     expect(result.title).toBe("All-day event");
+  });
+
+  it("interprets drop minutes in the pinned calendar timezone", () => {
+    act(() => {
+      setPinnedTimeZone("America/Chicago");
+    });
+
+    const result = allDayDragVisualToTimedGridEvent(
+      allDayEvent,
+      allDayDragVisual({ dayDate: "2026-05-15", timedStartMinutes: 600 }),
+    );
+
+    expect(result.startDate).toContain("2026-05-15T10:00:00");
+    expect(result.startDate).toMatch(/-05:00$/);
   });
 });
 

--- a/packages/web/src/grid/interaction/commit/cross-row.commit.ts
+++ b/packages/web/src/grid/interaction/commit/cross-row.commit.ts
@@ -1,6 +1,6 @@
 import { YEAR_MONTH_DAY_FORMAT } from "@core/constants/date.constants";
-import dayjs from "@core/util/date/dayjs";
 import { type GridEvent } from "@web/common/types/web.event.types";
+import { calendarDateInEffectiveTimeZone } from "@web/timezone/in-time-zone";
 import { CROSS_ROW_TIMED_DURATION_MIN } from "../math/cross-row.drag";
 import { type AllDayDragVisual } from "../types/all-day-drag.types";
 import { type TimedDragVisual } from "../types/timed-drag.types";
@@ -19,7 +19,7 @@ export const allDayDragVisualToTimedGridEvent = (
   event: GridEvent,
   visual: AllDayDragVisual,
 ): GridEvent => {
-  const day = dayjs(visual.dayDate).startOf("day");
+  const day = calendarDateInEffectiveTimeZone(visual.dayDate);
   const startMinutes = visual.timedStartMinutes ?? 0;
 
   return {
@@ -42,7 +42,7 @@ export const timedDragVisualToAllDayGridEvent = (
   event: GridEvent,
   visual: TimedDragVisual,
 ): GridEvent => {
-  const day = dayjs(visual.dayDate);
+  const day = calendarDateInEffectiveTimeZone(visual.dayDate);
 
   return {
     ...event,

--- a/packages/web/src/grid/interaction/date.test.ts
+++ b/packages/web/src/grid/interaction/date.test.ts
@@ -1,0 +1,24 @@
+import { act } from "react";
+import { getLocalMinutes } from "@web/grid/interaction/date";
+import {
+  resetEffectiveTimeZoneStoreForTests,
+  setPinnedTimeZone,
+} from "@web/timezone/effective-timezone.store";
+import { afterEach, describe, expect, it } from "bun:test";
+
+describe("getLocalMinutes", () => {
+  afterEach(() => {
+    act(() => {
+      resetEffectiveTimeZoneStoreForTests();
+    });
+  });
+
+  it("reads minutes of day in the pinned timezone", () => {
+    act(() => {
+      setPinnedTimeZone("America/Chicago");
+    });
+
+    // 09:00 UTC is 04:00 CDT on 2026-05-20.
+    expect(getLocalMinutes("2026-05-20T09:00:00.000Z")).toBe(4 * 60);
+  });
+});

--- a/packages/web/src/grid/interaction/date.ts
+++ b/packages/web/src/grid/interaction/date.ts
@@ -1,7 +1,8 @@
-import dayjs from "@core/util/date/dayjs";
+import { inEffectiveTimeZone } from "@web/timezone/in-time-zone";
 
+/** Minutes from midnight in the calendar's effective timezone. */
 export const getLocalMinutes = (date: string | undefined) => {
-  const parsed = dayjs(date);
+  const parsed = inEffectiveTimeZone(date ?? new Date());
 
   return parsed.hour() * 60 + parsed.minute();
 };

--- a/packages/web/src/grid/layout/all-day-draft.position.ts
+++ b/packages/web/src/grid/layout/all-day-draft.position.ts
@@ -1,4 +1,3 @@
-import dayjs from "@core/util/date/dayjs";
 import { type GridEvent } from "@web/common/types/web.event.types";
 import {
   shouldRenderTimedInAllDayRow,
@@ -10,6 +9,7 @@ import {
   getGridDraftId,
   gridEventDraftToGridEvent,
 } from "@web/events/grid-event-draft.adapter";
+import { inEffectiveTimeZone } from "@web/timezone/in-time-zone";
 
 export const isDraftRenderedInAllDayRow = (draft: GridEventDraft): boolean => {
   const { schedule } = draft.values;
@@ -17,7 +17,10 @@ export const isDraftRenderedInAllDayRow = (draft: GridEventDraft): boolean => {
   return (
     schedule.kind === "allDay" ||
     (schedule.kind === "timed" &&
-      shouldRenderTimedInAllDayRow(dayjs(schedule.start), dayjs(schedule.end)))
+      shouldRenderTimedInAllDayRow(
+        inEffectiveTimeZone(schedule.start),
+        inEffectiveTimeZone(schedule.end),
+      ))
   );
 };
 
@@ -29,8 +32,8 @@ export const draftToAllDayRowGridEvent = (draft: GridEventDraft): GridEvent => {
   }
 
   const dates = timedMultiDayToAllDayDates(
-    dayjs(schedule.start),
-    dayjs(schedule.end),
+    inEffectiveTimeZone(schedule.start),
+    inEffectiveTimeZone(schedule.end),
   );
 
   return {

--- a/packages/web/src/grid/layout/event.position.test.ts
+++ b/packages/web/src/grid/layout/event.position.test.ts
@@ -1,4 +1,6 @@
+import { act } from "react";
 import dayjs from "@core/util/date/dayjs";
+import { setPinnedTimeZone } from "@web/timezone/effective-timezone.store";
 import {
   getAllDayEventPosition,
   getTimedEventPosition,
@@ -307,5 +309,35 @@ describe("event position", () => {
     );
 
     expect(position.top).toBe(3);
+  });
+
+  it("shifts a timed event's row when the effective timezone is pinned", () => {
+    const utcTop = getTimedEventPosition(
+      {
+        endDate: "2026-05-20T10:00:00.000Z",
+        isAllDay: false,
+        position: { widthMultiplier: 1 },
+        startDate: "2026-05-20T09:00:00.000Z",
+      } as never,
+      { measurements, visibleDates, isDraft: false },
+    ).top;
+
+    act(() => {
+      setPinnedTimeZone("America/Chicago");
+    });
+
+    const chicagoTop = getTimedEventPosition(
+      {
+        endDate: "2026-05-20T10:00:00.000Z",
+        isAllDay: false,
+        position: { widthMultiplier: 1 },
+        startDate: "2026-05-20T09:00:00.000Z",
+      } as never,
+      { measurements, visibleDates, isDraft: false },
+    ).top;
+
+    expect(utcTop).toBe(9 * 60);
+    expect(chicagoTop).toBe(4 * 60);
+    expect(chicagoTop).not.toBe(utcTop);
   });
 });

--- a/packages/web/src/grid/layout/event.position.ts
+++ b/packages/web/src/grid/layout/event.position.ts
@@ -1,4 +1,5 @@
-import dayjs, { type Dayjs } from "@core/util/date/dayjs";
+import { YEAR_MONTH_DAY_FORMAT } from "@core/constants/date.constants";
+import { type Dayjs } from "@core/util/date/dayjs";
 import { type GridEvent } from "@web/common/types/web.event.types";
 import {
   DRAFT_PADDING_BOTTOM,
@@ -14,6 +15,10 @@ import {
   type GridMeasurements,
   type GridVisibleDate,
 } from "@web/grid/types/grid.types";
+import {
+  calendarDateInEffectiveTimeZone,
+  inEffectiveTimeZone,
+} from "@web/timezone/in-time-zone";
 
 export interface EventPositionInput {
   columnIndex?: number;
@@ -26,8 +31,8 @@ export const getTimedEventPosition = (
   event: GridEvent,
   input: EventPositionInput,
 ): EventPosition => {
-  const start = dayjs(event.startDate);
-  const end = dayjs(event.endDate);
+  const start = inEffectiveTimeZone(event.startDate);
+  const end = inEffectiveTimeZone(event.endDate);
   const dateIndex =
     input.columnIndex ?? getVisibleDateIndex(start, input.visibleDates);
   if (dateIndex === null) {
@@ -77,8 +82,8 @@ export const getBusyPeriodPosition = (
   segment: { start: string; end: string },
   input: BusyPeriodPositionInput,
 ): EventPosition => {
-  const start = dayjs(segment.start);
-  const end = dayjs(segment.end);
+  const start = inEffectiveTimeZone(segment.start);
+  const end = inEffectiveTimeZone(segment.end);
   const dateIndex =
     input.columnIndex ?? getVisibleDateIndex(start, input.visibleDates);
   if (dateIndex === null) {
@@ -147,37 +152,59 @@ const getVisibleAllDaySpan = (
   event: GridEvent,
   visibleDates: GridVisibleDate[],
 ) => {
-  const visibleStart = visibleDates[0]?.date.startOf("day");
+  const visibleStart = visibleDates[0]?.date;
   if (!visibleStart) {
     return null;
   }
 
   const visibleEnd =
-    visibleDates[visibleDates.length - 1]?.date.startOf("day") ?? visibleStart;
-  const eventStart = dayjs(event.startDate).startOf("day");
-  const exclusiveEnd = dayjs(event.endDate).startOf("day");
-  const eventEnd = exclusiveEnd.isAfter(eventStart)
-    ? exclusiveEnd.subtract(1, "day")
-    : eventStart;
+    visibleDates[visibleDates.length - 1]?.date ?? visibleStart;
+  const eventStartKey = calendarDayKey(
+    calendarDateInEffectiveTimeZone(event.startDate),
+  );
+  const exclusiveEndKey = calendarDayKey(
+    calendarDateInEffectiveTimeZone(event.endDate),
+  );
+  const eventEndKey =
+    exclusiveEndKey > eventStartKey
+      ? calendarDayKey(
+          calendarDateInEffectiveTimeZone(event.endDate).subtract(1, "day"),
+        )
+      : eventStartKey;
+  const visibleStartKey = calendarDayKey(visibleStart);
+  const visibleEndKey = calendarDayKey(visibleEnd);
 
-  if (eventEnd.isBefore(visibleStart) || eventStart.isAfter(visibleEnd)) {
+  if (eventEndKey < visibleStartKey || eventStartKey > visibleEndKey) {
     return null;
   }
 
-  const start = eventStart.isBefore(visibleStart) ? visibleStart : eventStart;
-  const end = eventEnd.isAfter(visibleEnd) ? visibleEnd : eventEnd;
+  const startKey =
+    eventStartKey < visibleStartKey ? visibleStartKey : eventStartKey;
+  const endKey = eventEndKey > visibleEndKey ? visibleEndKey : eventEndKey;
+  const start = visibleDates.find(
+    ({ date }) => calendarDayKey(date) === startKey,
+  )?.date;
+  const end = visibleDates.find(
+    ({ date }) => calendarDayKey(date) === endKey,
+  )?.date;
+
+  if (!start || !end) {
+    return null;
+  }
 
   return { end, start };
 };
+
+const calendarDayKey = (date: Dayjs) => date.format(YEAR_MONTH_DAY_FORMAT);
 
 const getVisibleDateIndex = (date: Dayjs, visibleDates: GridVisibleDate[]) => {
   if (visibleDates.length === 0) {
     return null;
   }
 
-  const normalizedDate = date.startOf("day");
-  const matchingIndex = visibleDates.findIndex(({ date: visibleDate }) =>
-    visibleDate.isSame(normalizedDate, "day"),
+  const eventDay = calendarDayKey(date);
+  const matchingIndex = visibleDates.findIndex(
+    ({ date: visibleDate }) => calendarDayKey(visibleDate) === eventDay,
   );
 
   if (matchingIndex !== -1) {

--- a/packages/web/src/routers/loaders.test.ts
+++ b/packages/web/src/routers/loaders.test.ts
@@ -132,16 +132,15 @@ describe("loadDateParam", () => {
     expect(result).toMatchObject({ dateString: "2026-05-20" });
   });
 
-  // dayEventQueryRange formats dateInView to build the day's query bounds, so
-  // a UTC-mode value would shift the window off local midnight and drop
-  // evening events from the day view and Up Next card.
-  it("returns local-mode midnight, not UTC", () => {
+  // Midnight in the effective timezone. A UTC-mode parse of a date-only
+  // string would shift the day's query window and drop evening events.
+  it("returns midnight on the requested calendar date", () => {
     const result = loadDateParam({
       params: { dateString: "2026-05-20" },
     });
 
-    expect(result.dateInView.isUTC()).toBe(false);
     expect(result.dateInView.hour()).toBe(0);
+    expect(result.dateInView.format("YYYY-MM-DD")).toBe("2026-05-20");
   });
 });
 

--- a/packages/web/src/routers/loaders.ts
+++ b/packages/web/src/routers/loaders.ts
@@ -5,11 +5,12 @@ import {
   DEFAULT_CALENDAR_ROUTE,
   ROOT_ROUTES,
 } from "@web/common/constants/routes";
+import { getEffectiveTimeZone } from "@web/timezone/effective-timezone.store";
 
 export interface DayLoaderData {
-  // Local-mode, not UTC: dayEventQueryRange formats this to build the day's
-  // query bounds, so a UTC-mode value would shift the window off local
-  // midnight and drop evening events.
+  // Midnight in the effective timezone: dayEventQueryRange formats this to
+  // build the day's query bounds, so a UTC-mode parse of a date-only string
+  // would shift the window and drop evening events.
   dateInView: Dayjs;
   dateString: string;
 }
@@ -30,7 +31,7 @@ export async function loadAuthenticated() {
 }
 
 export function loadTodayData(): DayLoaderData {
-  const dateInView = dayjs();
+  const dateInView = dayjs().tz(getEffectiveTimeZone());
   const dateFormat = dayjs.DateFormat.YEAR_MONTH_DAY_FORMAT;
 
   return { dateInView, dateString: dateInView.format(dateFormat) };
@@ -94,9 +95,6 @@ export function loadDateParam({
 }): DayLoaderData {
   return {
     dateString: params.dateString,
-    dateInView: dayjs(
-      params.dateString,
-      dayjs.DateFormat.YEAR_MONTH_DAY_FORMAT,
-    ),
+    dateInView: dayjs.tz(params.dateString, getEffectiveTimeZone()),
   };
 }

--- a/packages/web/src/timezone/DefaultTimezonePicker.tsx
+++ b/packages/web/src/timezone/DefaultTimezonePicker.tsx
@@ -1,0 +1,37 @@
+import { settingsActions } from "@web/settings/settings.store";
+import {
+  useEffectiveTimeZone,
+  usePinnedTimeZone,
+} from "@web/timezone/effective-timezone.store";
+import { formatTimeZoneAbbreviation } from "@web/timezone/format-timezone-abbreviation";
+import { timeZoneCityName } from "@web/timezone/timezone-catalog";
+import { timezoneDialogActions } from "@web/timezone/timezone-dialog.store";
+
+export function DefaultTimezonePicker() {
+  const timeZone = useEffectiveTimeZone();
+  const pinnedTimeZone = usePinnedTimeZone();
+  const abbreviation = formatTimeZoneAbbreviation(timeZone);
+  const label =
+    pinnedTimeZone === null
+      ? `Auto (${abbreviation})`
+      : `${timeZoneCityName(timeZone)} (${abbreviation})`;
+
+  return (
+    <div>
+      <p className="mb-1 text-sm text-text" id="default-timezone-label">
+        Default timezone
+      </p>
+      <button
+        aria-labelledby="default-timezone-label"
+        className="c-focus-ring w-full rounded border border-border bg-surface-overlay px-2 py-1 text-left text-sm text-text hover:bg-surface-panel"
+        onClick={() => {
+          settingsActions.closeSettings();
+          timezoneDialogActions.open();
+        }}
+        type="button"
+      >
+        {label}
+      </button>
+    </div>
+  );
+}

--- a/packages/web/src/timezone/DefaultTimezonePicker.tsx
+++ b/packages/web/src/timezone/DefaultTimezonePicker.tsx
@@ -18,11 +18,9 @@ export function DefaultTimezonePicker() {
 
   return (
     <div>
-      <p className="mb-1 text-sm text-text" id="default-timezone-label">
-        Default timezone
-      </p>
+      <p className="mb-1 text-sm text-text">Default timezone</p>
       <button
-        aria-labelledby="default-timezone-label"
+        aria-label={`Default timezone: ${label}`}
         className="c-focus-ring w-full rounded border border-border bg-surface-overlay px-2 py-1 text-left text-sm text-text hover:bg-surface-panel"
         onClick={() => {
           settingsActions.closeSettings();

--- a/packages/web/src/timezone/GridTimezoneLabel.test.tsx
+++ b/packages/web/src/timezone/GridTimezoneLabel.test.tsx
@@ -1,13 +1,20 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { act } from "react";
-import { getBrowserTimeZone } from "@web/common/utils/datetime/web.date.util";
+import * as browserTimezone from "@web/timezone/browser-timezone";
 import {
   getEffectiveTimeZone,
+  resetEffectiveTimeZoneStoreForTests,
   setEffectiveTimeZoneForTests,
+  setPinnedTimeZone,
 } from "@web/timezone/effective-timezone.store";
 import { formatTimeZoneAbbreviation } from "@web/timezone/format-timezone-abbreviation";
 import { GridTimezoneLabel } from "@web/timezone/GridTimezoneLabel";
+import {
+  selectTimezoneDialogOpen,
+  timezoneDialogActions,
+  useTimezoneDialogStore,
+} from "@web/timezone/timezone-dialog.store";
 import { describe, expect, it, spyOn } from "bun:test";
 
 describe("GridTimezoneLabel", () => {
@@ -55,7 +62,23 @@ describe("GridTimezoneLabel", () => {
     ).toHaveTextContent("GMT+5:30");
   });
 
-  it("rereads the browser timezone on the poll interval", () => {
+  it("opens the timezone picker", async () => {
+    const user = userEvent.setup();
+    render(<GridTimezoneLabel />);
+
+    await user.click(
+      screen.getByRole("button", { name: /Calendar timezone:/ }),
+    );
+
+    expect(selectTimezoneDialogOpen(useTimezoneDialogStore.getState())).toBe(
+      true,
+    );
+    act(() => {
+      timezoneDialogActions.close();
+    });
+  });
+
+  it("keeps a pinned zone across the browser poll", () => {
     const intervalCallbacks: Array<() => void> = [];
     const setIntervalSpy = spyOn(globalThis, "setInterval").mockImplementation(
       ((callback: TimerHandler) => {
@@ -71,34 +94,71 @@ describe("GridTimezoneLabel", () => {
     ).mockImplementation(() => {});
 
     try {
-      const browserZone = getBrowserTimeZone();
-      expect(browserZone).not.toBe("Pacific/Kiritimati");
-
       act(() => {
         setEffectiveTimeZoneForTests("Pacific/Kiritimati");
       });
 
       render(<GridTimezoneLabel />);
-      expect(
-        screen.getByRole("button", {
-          name: `Calendar timezone: ${formatTimeZoneAbbreviation("Pacific/Kiritimati")}`,
-        }),
-      ).toBeInTheDocument();
-
       act(() => {
         for (const callback of intervalCallbacks) {
           callback();
         }
       });
 
-      expect(getEffectiveTimeZone()).toBe(browserZone);
-      const browserAbbreviation = formatTimeZoneAbbreviation(browserZone);
+      expect(getEffectiveTimeZone()).toBe("Pacific/Kiritimati");
       expect(
         screen.getByRole("button", {
-          name: `Calendar timezone: ${browserAbbreviation}`,
+          name: `Calendar timezone: ${formatTimeZoneAbbreviation("Pacific/Kiritimati")}`,
         }),
-      ).toHaveTextContent(browserAbbreviation);
+      ).toBeInTheDocument();
     } finally {
+      setIntervalSpy.mockRestore();
+      clearIntervalSpy.mockRestore();
+    }
+  });
+
+  it("rereads the browser timezone on the poll interval in Auto mode", () => {
+    const intervalCallbacks: Array<() => void> = [];
+    const setIntervalSpy = spyOn(globalThis, "setInterval").mockImplementation(
+      ((callback: TimerHandler) => {
+        if (typeof callback === "function") {
+          intervalCallbacks.push(() => callback());
+        }
+        return 1 as unknown as ReturnType<typeof setInterval>;
+      }) as unknown as typeof setInterval,
+    );
+    const clearIntervalSpy = spyOn(
+      globalThis,
+      "clearInterval",
+    ).mockImplementation(() => {});
+
+    act(() => {
+      resetEffectiveTimeZoneStoreForTests();
+      setPinnedTimeZone(null);
+    });
+    expect(getEffectiveTimeZone()).not.toBe("Pacific/Kiritimati");
+
+    const browserSpy = spyOn(
+      browserTimezone,
+      "getBrowserTimeZone",
+    ).mockReturnValue("Pacific/Kiritimati");
+
+    try {
+      render(<GridTimezoneLabel />);
+      act(() => {
+        for (const callback of intervalCallbacks) {
+          callback();
+        }
+      });
+
+      expect(getEffectiveTimeZone()).toBe("Pacific/Kiritimati");
+      expect(
+        screen.getByRole("button", {
+          name: `Calendar timezone: ${formatTimeZoneAbbreviation("Pacific/Kiritimati")}`,
+        }),
+      ).toBeInTheDocument();
+    } finally {
+      browserSpy.mockRestore();
       setIntervalSpy.mockRestore();
       clearIntervalSpy.mockRestore();
     }

--- a/packages/web/src/timezone/GridTimezoneLabel.tsx
+++ b/packages/web/src/timezone/GridTimezoneLabel.tsx
@@ -5,13 +5,14 @@ import {
   useEffectiveTimeZone,
 } from "@web/timezone/effective-timezone.store";
 import { formatTimeZoneAbbreviation } from "@web/timezone/format-timezone-abbreviation";
+import { timezoneDialogActions } from "@web/timezone/timezone-dialog.store";
 
 const BROWSER_ZONE_POLL_MS = 60_000;
 
 /**
  * Week/Day grid-corner control showing the effective timezone abbreviation.
  * A button from day one so Part III can reuse it as the time-travel trigger;
- * Part II will wire the click to the timezone picker.
+ * until then it opens the timezone picker.
  */
 export const GridTimezoneLabel = () => {
   const timeZone = useEffectiveTimeZone();
@@ -19,8 +20,8 @@ export const GridTimezoneLabel = () => {
 
   // There is no timezonechange event. Poll so Auto mode follows an OS change
   // without a tab blur. Do not refresh on mount — that would wipe a test pin
-  // (and a Part II pin, until refresh is Auto-gated). DST abbreviation flips
-  // still use `now` from the minute tick.
+  // before Auto-gating can keep it. DST abbreviation flips still use `now`
+  // from the minute tick.
   useEffect(() => {
     const id = setInterval(
       refreshEffectiveTimeZoneFromBrowser,
@@ -35,6 +36,7 @@ export const GridTimezoneLabel = () => {
     <button
       aria-label={`Calendar timezone: ${abbreviation}`}
       className="c-focus-ring min-h-6 w-full max-w-full truncate rounded-sm px-0.5 text-center text-[10px] text-text-muted leading-none hover:text-text"
+      onClick={() => timezoneDialogActions.open()}
       type="button"
     >
       {abbreviation}

--- a/packages/web/src/timezone/TimezoneDialogHost.tsx
+++ b/packages/web/src/timezone/TimezoneDialogHost.tsx
@@ -1,19 +1,20 @@
-import { restoreCommandPaletteFocus } from "@web/components/Feedback/FeedbackDialogHost";
 import { TimezonePickerDialog } from "@web/timezone/TimezonePickerDialog";
 import {
   selectTimezoneDialogOpen,
+  selectTimezoneDialogRestoreFocus,
   timezoneDialogActions,
   useTimezoneDialogStore,
 } from "@web/timezone/timezone-dialog.store";
 
 export function TimezoneDialogHost() {
   const isOpen = useTimezoneDialogStore(selectTimezoneDialogOpen);
+  const restoreFocus = useTimezoneDialogStore(selectTimezoneDialogRestoreFocus);
   if (!isOpen) return null;
 
   return (
     <TimezonePickerDialog
       onDismiss={timezoneDialogActions.close}
-      restoreFocus={restoreCommandPaletteFocus}
+      restoreFocus={restoreFocus}
     />
   );
 }

--- a/packages/web/src/timezone/TimezoneDialogHost.tsx
+++ b/packages/web/src/timezone/TimezoneDialogHost.tsx
@@ -1,0 +1,19 @@
+import { restoreCommandPaletteFocus } from "@web/components/Feedback/FeedbackDialogHost";
+import { TimezonePickerDialog } from "@web/timezone/TimezonePickerDialog";
+import {
+  selectTimezoneDialogOpen,
+  timezoneDialogActions,
+  useTimezoneDialogStore,
+} from "@web/timezone/timezone-dialog.store";
+
+export function TimezoneDialogHost() {
+  const isOpen = useTimezoneDialogStore(selectTimezoneDialogOpen);
+  if (!isOpen) return null;
+
+  return (
+    <TimezonePickerDialog
+      onDismiss={timezoneDialogActions.close}
+      restoreFocus={restoreCommandPaletteFocus}
+    />
+  );
+}

--- a/packages/web/src/timezone/TimezoneOptionButton.tsx
+++ b/packages/web/src/timezone/TimezoneOptionButton.tsx
@@ -1,0 +1,31 @@
+export function TimezoneOptionButton({
+  active,
+  description,
+  id,
+  label,
+  onSelect,
+  selected,
+}: {
+  active: boolean;
+  description: string;
+  id: string;
+  label: string;
+  onSelect: () => void;
+  selected: boolean;
+}) {
+  return (
+    <button
+      aria-selected={selected}
+      className={`flex w-full flex-col items-start rounded-sm px-3 py-2 text-left text-sm ${
+        active ? "bg-surface-overlay" : ""
+      } ${selected ? "text-text" : "text-text-muted"} hover:bg-surface-overlay hover:text-text`}
+      id={id}
+      onClick={onSelect}
+      role="option"
+      type="button"
+    >
+      <span className="text-text">{label}</span>
+      <span className="text-text-muted text-xs">{description}</span>
+    </button>
+  );
+}

--- a/packages/web/src/timezone/TimezonePickerDialog.test.tsx
+++ b/packages/web/src/timezone/TimezonePickerDialog.test.tsx
@@ -38,6 +38,17 @@ describe("TimezonePickerDialog", () => {
     expect(getPinnedTimeZone()).toBe("America/Chicago");
   });
 
+  it("does not mount the full IANA catalog on first paint", () => {
+    render(
+      <TimezonePickerDialog onDismiss={() => timezoneDialogActions.close()} />,
+    );
+
+    const options = screen.getAllByRole("option");
+    expect(options[0]).toHaveAccessibleName(/Use browser timezone \(Auto\)/);
+    expect(options.length).toBeGreaterThan(1);
+    expect(options.length).toBeLessThan(80);
+  });
+
   it("pins the highlighted search result on Enter", async () => {
     const user = userEvent.setup();
     render(

--- a/packages/web/src/timezone/TimezonePickerDialog.test.tsx
+++ b/packages/web/src/timezone/TimezonePickerDialog.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { act } from "react";
+import { getBrowserTimeZone } from "@web/common/utils/datetime/web.date.util";
+import {
+  getEffectiveTimeZone,
+  getPinnedTimeZone,
+  resetEffectiveTimeZoneStoreForTests,
+  setPinnedTimeZone,
+} from "@web/timezone/effective-timezone.store";
+import { TimezonePickerDialog } from "@web/timezone/TimezonePickerDialog";
+import { timezoneDialogActions } from "@web/timezone/timezone-dialog.store";
+import { afterEach, describe, expect, it } from "bun:test";
+
+describe("TimezonePickerDialog", () => {
+  afterEach(() => {
+    act(() => {
+      resetEffectiveTimeZoneStoreForTests();
+    });
+  });
+
+  it("lists Auto first and pins a searched city", async () => {
+    const user = userEvent.setup();
+    render(
+      <TimezonePickerDialog onDismiss={() => timezoneDialogActions.close()} />,
+    );
+
+    expect(
+      screen.getByRole("option", { name: /Use browser timezone \(Auto\)/ }),
+    ).toBeInTheDocument();
+
+    await user.type(
+      screen.getByRole("searchbox", { name: "Search timezones" }),
+      "Chi",
+    );
+
+    await user.click(screen.getByRole("option", { name: /Chicago/ }));
+    expect(getPinnedTimeZone()).toBe("America/Chicago");
+  });
+
+  it("returns to Auto from the first row", async () => {
+    const user = userEvent.setup();
+    act(() => {
+      setPinnedTimeZone("America/New_York");
+    });
+
+    render(
+      <TimezonePickerDialog onDismiss={() => timezoneDialogActions.close()} />,
+    );
+
+    await user.click(
+      screen.getByRole("option", { name: /Use browser timezone \(Auto\)/ }),
+    );
+
+    expect(getPinnedTimeZone()).toBeNull();
+    expect(getEffectiveTimeZone()).toBe(getBrowserTimeZone());
+  });
+});

--- a/packages/web/src/timezone/TimezonePickerDialog.test.tsx
+++ b/packages/web/src/timezone/TimezonePickerDialog.test.tsx
@@ -30,7 +30,7 @@ describe("TimezonePickerDialog", () => {
     ).toBeInTheDocument();
 
     await user.type(
-      screen.getByRole("searchbox", { name: "Search timezones" }),
+      screen.getByRole("combobox", { name: "Search timezones" }),
       "Chi",
     );
 
@@ -55,7 +55,7 @@ describe("TimezonePickerDialog", () => {
       <TimezonePickerDialog onDismiss={() => timezoneDialogActions.close()} />,
     );
 
-    const search = screen.getByRole("searchbox", { name: "Search timezones" });
+    const search = screen.getByRole("combobox", { name: "Search timezones" });
     await user.type(search, "Chicago");
     await user.keyboard("{ArrowDown}{Enter}");
 

--- a/packages/web/src/timezone/TimezonePickerDialog.test.tsx
+++ b/packages/web/src/timezone/TimezonePickerDialog.test.tsx
@@ -38,6 +38,19 @@ describe("TimezonePickerDialog", () => {
     expect(getPinnedTimeZone()).toBe("America/Chicago");
   });
 
+  it("pins the highlighted search result on Enter", async () => {
+    const user = userEvent.setup();
+    render(
+      <TimezonePickerDialog onDismiss={() => timezoneDialogActions.close()} />,
+    );
+
+    const search = screen.getByRole("searchbox", { name: "Search timezones" });
+    await user.type(search, "Chicago");
+    await user.keyboard("{ArrowDown}{Enter}");
+
+    expect(getPinnedTimeZone()).toBe("America/Chicago");
+  });
+
   it("returns to Auto from the first row", async () => {
     const user = userEvent.setup();
     act(() => {

--- a/packages/web/src/timezone/TimezonePickerDialog.tsx
+++ b/packages/web/src/timezone/TimezonePickerDialog.tsx
@@ -62,7 +62,7 @@ export function TimezonePickerDialog({
     setActiveId(optionIds[nextIndex] ?? AUTO_ID);
   };
 
-  const handleKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {
+  const handleKeyDown = (event: ReactKeyboardEvent<HTMLElement>) => {
     if (event.key === "ArrowDown") {
       event.preventDefault();
       moveActive(1);
@@ -89,7 +89,7 @@ export function TimezonePickerDialog({
       variant="modal"
       widthClassName="w-[480px]"
     >
-      <div className="flex w-full flex-col gap-3" onKeyDown={handleKeyDown}>
+      <div className="flex w-full flex-col gap-3">
         <input
           ref={searchRef}
           aria-autocomplete="list"
@@ -102,6 +102,7 @@ export function TimezonePickerDialog({
             setQuery(event.target.value);
             setActiveId(AUTO_ID);
           }}
+          onKeyDown={handleKeyDown}
           placeholder="Search city, region, or abbreviation"
           type="search"
           value={query}

--- a/packages/web/src/timezone/TimezonePickerDialog.tsx
+++ b/packages/web/src/timezone/TimezonePickerDialog.tsx
@@ -1,0 +1,170 @@
+import {
+  type KeyboardEvent as ReactKeyboardEvent,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { getBrowserTimeZone } from "@web/common/utils/datetime/web.date.util";
+import { OverlayPanel } from "@web/components/OverlayPanel/OverlayPanel";
+import {
+  setPinnedTimeZone,
+  useEffectiveTimeZone,
+  usePinnedTimeZone,
+} from "@web/timezone/effective-timezone.store";
+import { formatTimeZoneAbbreviation } from "@web/timezone/format-timezone-abbreviation";
+import {
+  buildTimeZoneList,
+  filterTimeZones,
+  sortTimeZonesByOffsetDistance,
+} from "@web/timezone/timezone-catalog";
+
+const AUTO_ID = "auto";
+
+interface TimezonePickerDialogProps {
+  onDismiss: () => void;
+  restoreFocus?: () => void;
+}
+
+export function TimezonePickerDialog({
+  onDismiss,
+  restoreFocus,
+}: TimezonePickerDialogProps) {
+  const effectiveTimeZone = useEffectiveTimeZone();
+  const pinnedTimeZone = usePinnedTimeZone();
+  const searchRef = useRef<HTMLInputElement>(null);
+  const listId = useId();
+  const [query, setQuery] = useState("");
+  const [activeId, setActiveId] = useState(pinnedTimeZone ?? AUTO_ID);
+  const now = useMemo(() => new Date(), []);
+  const zones = useMemo(() => {
+    const list = buildTimeZoneList(now);
+    const sorted = sortTimeZonesByOffsetDistance(list, effectiveTimeZone);
+    return filterTimeZones(sorted, query);
+  }, [effectiveTimeZone, now, query]);
+
+  const browserZone = getBrowserTimeZone();
+  const browserAbbreviation = formatTimeZoneAbbreviation(browserZone, now);
+  const isAuto = pinnedTimeZone === null;
+  const optionIds = [AUTO_ID, ...zones.map((zone) => zone.id)];
+
+  const selectZone = (timeZone: string | null) => {
+    setPinnedTimeZone(timeZone);
+    onDismiss();
+  };
+
+  const moveActive = (delta: number) => {
+    const currentIndex = optionIds.indexOf(activeId);
+    const nextIndex = Math.min(
+      optionIds.length - 1,
+      Math.max(0, (currentIndex === -1 ? 0 : currentIndex) + delta),
+    );
+    setActiveId(optionIds[nextIndex] ?? AUTO_ID);
+  };
+
+  const handleKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      moveActive(1);
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault();
+      moveActive(-1);
+    } else if (event.key === "Enter") {
+      event.preventDefault();
+      if (activeId === AUTO_ID) {
+        selectZone(null);
+      } else {
+        selectZone(activeId);
+      }
+    }
+  };
+
+  return (
+    <OverlayPanel
+      title="Change default timezone"
+      onDismiss={onDismiss}
+      restoreFocus={restoreFocus}
+      initialFocusRef={searchRef}
+      align="start"
+      variant="modal"
+      widthClassName="w-[480px]"
+    >
+      <div className="flex w-full flex-col gap-3" onKeyDown={handleKeyDown}>
+        <input
+          ref={searchRef}
+          aria-autocomplete="list"
+          aria-controls={listId}
+          aria-activedescendant={`${listId}-${activeId}`}
+          aria-label="Search timezones"
+          autoComplete="off"
+          className="c-focus-ring w-full rounded border border-border bg-surface-overlay px-3 py-2 text-sm text-text outline-none placeholder:text-text-muted"
+          onChange={(event) => {
+            setQuery(event.target.value);
+            setActiveId(AUTO_ID);
+          }}
+          placeholder="Search city, region, or abbreviation"
+          type="search"
+          value={query}
+        />
+        <div
+          aria-label="Timezones"
+          className="max-h-80 overflow-y-auto"
+          id={listId}
+          role="listbox"
+        >
+          <TimezoneOptionButton
+            active={activeId === AUTO_ID}
+            description={`Currently ${browserAbbreviation}`}
+            id={`${listId}-${AUTO_ID}`}
+            label={`Use browser timezone (Auto)`}
+            onSelect={() => selectZone(null)}
+            selected={isAuto}
+          />
+          {zones.map((zone) => (
+            <TimezoneOptionButton
+              active={activeId === zone.id}
+              description={zone.secondary}
+              id={`${listId}-${zone.id}`}
+              key={zone.id}
+              label={zone.city}
+              onSelect={() => selectZone(zone.id)}
+              selected={!isAuto && zone.id === effectiveTimeZone}
+            />
+          ))}
+        </div>
+      </div>
+    </OverlayPanel>
+  );
+}
+
+function TimezoneOptionButton({
+  active,
+  description,
+  id,
+  label,
+  onSelect,
+  selected,
+}: {
+  active: boolean;
+  description: string;
+  id: string;
+  label: string;
+  onSelect: () => void;
+  selected: boolean;
+}) {
+  return (
+    <button
+      aria-selected={selected}
+      className={`flex w-full flex-col items-start rounded-sm px-3 py-2 text-left text-sm ${
+        active ? "bg-surface-overlay" : ""
+      } ${selected ? "text-text" : "text-text-muted"} hover:bg-surface-overlay hover:text-text`}
+      id={id}
+      onClick={onSelect}
+      role="option"
+      type="button"
+    >
+      <span className="text-text">{label}</span>
+      <span className="text-text-muted text-xs">{description}</span>
+    </button>
+  );
+}

--- a/packages/web/src/timezone/TimezonePickerDialog.tsx
+++ b/packages/web/src/timezone/TimezonePickerDialog.tsx
@@ -1,6 +1,7 @@
 import {
   type KeyboardEvent as ReactKeyboardEvent,
   type UIEvent as ReactUIEvent,
+  useEffect,
   useId,
   useMemo,
   useRef,
@@ -57,6 +58,12 @@ export function TimezonePickerDialog({
   const optionIds = [AUTO_ID, ...zones.map((zone) => zone.id)];
   const visibleZones = zones.slice(0, visibleCount);
 
+  useEffect(() => {
+    document
+      .getElementById(`${listId}-${activeId}`)
+      ?.scrollIntoView({ block: "nearest" });
+  }, [activeId, listId]);
+
   const selectZone = (timeZone: string | null) => {
     setPinnedTimeZone(timeZone);
     onDismiss();
@@ -108,10 +115,13 @@ export function TimezonePickerDialog({
       <div className="flex w-full flex-col gap-3">
         <input
           ref={searchRef}
+          aria-activedescendant={`${listId}-${activeId}`}
           aria-autocomplete="list"
           aria-controls={listId}
-          aria-activedescendant={`${listId}-${activeId}`}
+          aria-expanded={true}
+          aria-haspopup="listbox"
           aria-label="Search timezones"
+          role="combobox"
           autoComplete="off"
           className="c-focus-ring w-full rounded border border-border bg-surface-overlay px-3 py-2 text-sm text-text outline-none placeholder:text-text-muted"
           onChange={(event) => {

--- a/packages/web/src/timezone/TimezonePickerDialog.tsx
+++ b/packages/web/src/timezone/TimezonePickerDialog.tsx
@@ -1,18 +1,20 @@
 import {
   type KeyboardEvent as ReactKeyboardEvent,
+  type UIEvent as ReactUIEvent,
   useId,
   useMemo,
   useRef,
   useState,
 } from "react";
-import { getBrowserTimeZone } from "@web/common/utils/datetime/web.date.util";
 import { OverlayPanel } from "@web/components/OverlayPanel/OverlayPanel";
+import { getBrowserTimeZone } from "@web/timezone/browser-timezone";
 import {
   setPinnedTimeZone,
   useEffectiveTimeZone,
   usePinnedTimeZone,
 } from "@web/timezone/effective-timezone.store";
 import { formatTimeZoneAbbreviation } from "@web/timezone/format-timezone-abbreviation";
+import { TimezoneOptionButton } from "@web/timezone/TimezoneOptionButton";
 import {
   buildTimeZoneList,
   filterTimeZones,
@@ -20,6 +22,7 @@ import {
 } from "@web/timezone/timezone-catalog";
 
 const AUTO_ID = "auto";
+const VISIBLE_PAGE = 40;
 
 interface TimezonePickerDialogProps {
   onDismiss: () => void;
@@ -36,17 +39,23 @@ export function TimezonePickerDialog({
   const listId = useId();
   const [query, setQuery] = useState("");
   const [activeId, setActiveId] = useState(pinnedTimeZone ?? AUTO_ID);
+  const [visibleCount, setVisibleCount] = useState(VISIBLE_PAGE);
   const now = useMemo(() => new Date(), []);
-  const zones = useMemo(() => {
-    const list = buildTimeZoneList(now);
-    const sorted = sortTimeZonesByOffsetDistance(list, effectiveTimeZone);
-    return filterTimeZones(sorted, query);
-  }, [effectiveTimeZone, now, query]);
+  const catalog = useMemo(
+    () =>
+      sortTimeZonesByOffsetDistance(buildTimeZoneList(now), effectiveTimeZone),
+    [effectiveTimeZone, now],
+  );
+  const zones = useMemo(
+    () => filterTimeZones(catalog, query),
+    [catalog, query],
+  );
 
   const browserZone = getBrowserTimeZone();
   const browserAbbreviation = formatTimeZoneAbbreviation(browserZone, now);
   const isAuto = pinnedTimeZone === null;
   const optionIds = [AUTO_ID, ...zones.map((zone) => zone.id)];
+  const visibleZones = zones.slice(0, visibleCount);
 
   const selectZone = (timeZone: string | null) => {
     setPinnedTimeZone(timeZone);
@@ -60,6 +69,7 @@ export function TimezonePickerDialog({
       Math.max(0, (currentIndex === -1 ? 0 : currentIndex) + delta),
     );
     setActiveId(optionIds[nextIndex] ?? AUTO_ID);
+    setVisibleCount((count) => (nextIndex > count ? nextIndex : count));
   };
 
   const handleKeyDown = (event: ReactKeyboardEvent<HTMLElement>) => {
@@ -77,6 +87,12 @@ export function TimezonePickerDialog({
         selectZone(activeId);
       }
     }
+  };
+
+  const handleListScroll = (event: ReactUIEvent<HTMLDivElement>) => {
+    const list = event.currentTarget;
+    if (list.scrollTop + list.clientHeight < list.scrollHeight - 24) return;
+    setVisibleCount((count) => Math.min(zones.length, count + VISIBLE_PAGE));
   };
 
   return (
@@ -101,6 +117,7 @@ export function TimezonePickerDialog({
           onChange={(event) => {
             setQuery(event.target.value);
             setActiveId(AUTO_ID);
+            setVisibleCount(VISIBLE_PAGE);
           }}
           onKeyDown={handleKeyDown}
           placeholder="Search city, region, or abbreviation"
@@ -111,6 +128,7 @@ export function TimezonePickerDialog({
           aria-label="Timezones"
           className="max-h-80 overflow-y-auto"
           id={listId}
+          onScroll={handleListScroll}
           role="listbox"
         >
           <TimezoneOptionButton
@@ -121,7 +139,7 @@ export function TimezonePickerDialog({
             onSelect={() => selectZone(null)}
             selected={isAuto}
           />
-          {zones.map((zone) => (
+          {visibleZones.map((zone) => (
             <TimezoneOptionButton
               active={activeId === zone.id}
               description={zone.secondary}
@@ -135,37 +153,5 @@ export function TimezonePickerDialog({
         </div>
       </div>
     </OverlayPanel>
-  );
-}
-
-function TimezoneOptionButton({
-  active,
-  description,
-  id,
-  label,
-  onSelect,
-  selected,
-}: {
-  active: boolean;
-  description: string;
-  id: string;
-  label: string;
-  onSelect: () => void;
-  selected: boolean;
-}) {
-  return (
-    <button
-      aria-selected={selected}
-      className={`flex w-full flex-col items-start rounded-sm px-3 py-2 text-left text-sm ${
-        active ? "bg-surface-overlay" : ""
-      } ${selected ? "text-text" : "text-text-muted"} hover:bg-surface-overlay hover:text-text`}
-      id={id}
-      onClick={onSelect}
-      role="option"
-      type="button"
-    >
-      <span className="text-text">{label}</span>
-      <span className="text-text-muted text-xs">{description}</span>
-    </button>
   );
 }

--- a/packages/web/src/timezone/browser-timezone.ts
+++ b/packages/web/src/timezone/browser-timezone.ts
@@ -1,0 +1,4 @@
+/** Browser IANA zone (e.g. "America/Chicago"). Isolated so the store can read it without importing date utils that depend on the store. */
+export function getBrowserTimeZone(): string {
+  return Intl.DateTimeFormat().resolvedOptions().timeZone;
+}

--- a/packages/web/src/timezone/effective-timezone.store.test.ts
+++ b/packages/web/src/timezone/effective-timezone.store.test.ts
@@ -1,8 +1,12 @@
 import { act, renderHook } from "@testing-library/react";
+import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
+import { persistentBrowserStore } from "@web/common/storage/browser-key-value.store";
 import { getBrowserTimeZone } from "@web/common/utils/datetime/web.date.util";
 import {
+  getEffectiveTimeZone,
+  getPinnedTimeZone,
   resetEffectiveTimeZoneStoreForTests,
-  setEffectiveTimeZoneForTests,
+  setPinnedTimeZone,
   useEffectiveTimeZone,
 } from "@web/timezone/effective-timezone.store";
 import { afterEach, describe, expect, it } from "bun:test";
@@ -25,25 +29,95 @@ describe("effective-timezone.store", () => {
 
   it("defaults to the browser timezone", () => {
     expect(readEffectiveTimeZone()).toBe(getBrowserTimeZone());
+    expect(getPinnedTimeZone()).toBeNull();
   });
 
-  it("notifies subscribers when the effective zone changes", () => {
+  it("pins a zone until Auto is restored", () => {
     const { result } = renderHook(useEffectiveTimeZone);
 
     act(() => {
-      setEffectiveTimeZoneForTests("America/Denver");
+      setPinnedTimeZone("America/Denver");
+    });
+
+    expect(result.current).toBe("America/Denver");
+    expect(getPinnedTimeZone()).toBe("America/Denver");
+
+    act(() => {
+      setPinnedTimeZone(null);
+    });
+
+    expect(result.current).toBe(getBrowserTimeZone());
+    expect(getPinnedTimeZone()).toBeNull();
+  });
+
+  it("pins even when the zone matches the browser", () => {
+    const browserZone = getBrowserTimeZone();
+    act(() => {
+      setPinnedTimeZone(browserZone);
+    });
+
+    expect(getPinnedTimeZone()).toBe(browserZone);
+    expect(getEffectiveTimeZone()).toBe(browserZone);
+  });
+
+  it("persists a pin and hydrates it from storage", () => {
+    act(() => {
+      setPinnedTimeZone("Pacific/Auckland");
+    });
+
+    expect(persistentBrowserStore.get(STORAGE_KEYS.DEFAULT_TIMEZONE)).toBe(
+      "Pacific/Auckland",
+    );
+
+    act(() => {
+      resetEffectiveTimeZoneStoreForTests();
+    });
+    expect(getPinnedTimeZone()).toBeNull();
+
+    persistentBrowserStore.set(
+      STORAGE_KEYS.DEFAULT_TIMEZONE,
+      "Pacific/Auckland",
+    );
+    const { result } = renderHook(useEffectiveTimeZone);
+
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent("storage", {
+          key: STORAGE_KEYS.DEFAULT_TIMEZONE,
+          newValue: "Pacific/Auckland",
+        }),
+      );
+    });
+
+    expect(result.current).toBe("Pacific/Auckland");
+  });
+
+  it("rejects an invalid IANA zone", () => {
+    expect(setPinnedTimeZone("Not/AZone")).toBe(false);
+    expect(getPinnedTimeZone()).toBeNull();
+  });
+
+  it("keeps a pinned zone when the tab becomes visible", () => {
+    act(() => {
+      setPinnedTimeZone("America/Denver");
+    });
+
+    const { result } = renderHook(useEffectiveTimeZone);
+    expect(result.current).toBe("America/Denver");
+
+    act(() => {
+      Object.defineProperty(document, "visibilityState", {
+        configurable: true,
+        value: "visible",
+      });
+      document.dispatchEvent(new Event("visibilitychange"));
     });
 
     expect(result.current).toBe("America/Denver");
   });
 
-  it("returns to the browser zone when the tab becomes visible", () => {
-    act(() => {
-      setEffectiveTimeZoneForTests("America/Denver");
-    });
-
+  it("returns to the browser zone when Auto and the tab becomes visible", () => {
     const { result } = renderHook(useEffectiveTimeZone);
-    expect(result.current).toBe("America/Denver");
 
     act(() => {
       Object.defineProperty(document, "visibilityState", {

--- a/packages/web/src/timezone/effective-timezone.store.ts
+++ b/packages/web/src/timezone/effective-timezone.store.ts
@@ -1,21 +1,96 @@
 import { useSyncExternalStore } from "react";
-import { getBrowserTimeZone } from "@web/common/utils/datetime/web.date.util";
-import { createExternalStore } from "@web/common/utils/external-store.util";
+import dayjs from "@core/util/date/dayjs";
+import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
+import { persistentBrowserStore } from "@web/common/storage/browser-key-value.store";
+import {
+  createExternalStore,
+  subscribeToStorageKey,
+} from "@web/common/utils/external-store.util";
+import { getBrowserTimeZone } from "@web/timezone/browser-timezone";
 
-/**
- * Part I: the effective timezone is always the browser zone (Auto). Part II
- * will pin a user choice on top of this store; until then, subscribers still
- * need a live value so the corner label can update without a reload.
- */
-const effectiveTimeZoneStore = createExternalStore(getBrowserTimeZone());
-
-export function getEffectiveTimeZone(): string {
-  return effectiveTimeZoneStore.get();
+function isValidTimeZone(value: string): boolean {
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone: value });
+    return true;
+  } catch {
+    return false;
+  }
 }
 
-/** Auto-mode refresh. Part II must no-op this when a zone is pinned. */
+function readPinnedTimeZone(): string | null {
+  const raw = persistentBrowserStore.get(STORAGE_KEYS.DEFAULT_TIMEZONE);
+  if (!raw || raw.trim().length === 0 || !isValidTimeZone(raw)) {
+    return null;
+  }
+  return raw;
+}
+
+const pinnedTimeZoneStore = createExternalStore<string | null>(
+  readPinnedTimeZone(),
+);
+const browserTimeZoneStore = createExternalStore(getBrowserTimeZone());
+
+function applyDayjsDefault(timeZone: string): void {
+  dayjs.setDefaultTimezone(timeZone);
+}
+
+function currentEffectiveTimeZone(): string {
+  return pinnedTimeZoneStore.get() ?? browserTimeZoneStore.get();
+}
+
+function syncEffectiveTimeZone(): void {
+  applyDayjsDefault(currentEffectiveTimeZone());
+}
+
+syncEffectiveTimeZone();
+
+function refreshPinnedFromStorage(): void {
+  pinnedTimeZoneStore.set(readPinnedTimeZone());
+  syncEffectiveTimeZone();
+}
+
+export function getPinnedTimeZone(): string | null {
+  return pinnedTimeZoneStore.get();
+}
+
+export function isTimeZonePinned(): boolean {
+  return pinnedTimeZoneStore.get() !== null;
+}
+
+export function getEffectiveTimeZone(): string {
+  return currentEffectiveTimeZone();
+}
+
+/**
+ * Refresh the tracked browser zone. The effective zone only follows this
+ * value in Auto mode (no pin).
+ */
 export function refreshEffectiveTimeZoneFromBrowser(): void {
-  effectiveTimeZoneStore.set(getBrowserTimeZone());
+  browserTimeZoneStore.set(getBrowserTimeZone());
+  if (pinnedTimeZoneStore.get() === null) {
+    syncEffectiveTimeZone();
+  }
+}
+
+/**
+ * Pin an IANA zone, or pass null to return to Auto. Returns false when the
+ * storage write fails, leaving the previous preference in place.
+ */
+export function setPinnedTimeZone(timeZone: string | null): boolean {
+  if (timeZone !== null && !isValidTimeZone(timeZone)) {
+    return false;
+  }
+
+  const saved =
+    timeZone === null
+      ? persistentBrowserStore.remove(STORAGE_KEYS.DEFAULT_TIMEZONE)
+      : persistentBrowserStore.set(STORAGE_KEYS.DEFAULT_TIMEZONE, timeZone);
+
+  if (saved) {
+    pinnedTimeZoneStore.set(timeZone);
+    syncEffectiveTimeZone();
+  }
+  return saved;
 }
 
 if (typeof document !== "undefined") {
@@ -26,18 +101,37 @@ if (typeof document !== "undefined") {
   });
 }
 
-export function useEffectiveTimeZone(): string {
-  return useSyncExternalStore(
-    effectiveTimeZoneStore.subscribe,
-    effectiveTimeZoneStore.get,
+function subscribe(onChange: () => void): () => void {
+  const unsubscribePinned = pinnedTimeZoneStore.subscribe(onChange);
+  const unsubscribeBrowser = browserTimeZoneStore.subscribe(onChange);
+  const unsubscribeStorage = subscribeToStorageKey(
+    STORAGE_KEYS.DEFAULT_TIMEZONE,
+    refreshPinnedFromStorage,
   );
+
+  return () => {
+    unsubscribePinned();
+    unsubscribeBrowser();
+    unsubscribeStorage();
+  };
 }
 
-/** Test-only: set the in-memory effective zone without persistence. */
+export function useEffectiveTimeZone(): string {
+  return useSyncExternalStore(subscribe, getEffectiveTimeZone);
+}
+
+export function usePinnedTimeZone(): string | null {
+  return useSyncExternalStore(subscribe, getPinnedTimeZone);
+}
+
+/** Test-only: pin in memory (and storage when available) without extra UI. */
 export function setEffectiveTimeZoneForTests(timeZone: string): void {
-  effectiveTimeZoneStore.set(timeZone);
+  setPinnedTimeZone(timeZone);
 }
 
 export function resetEffectiveTimeZoneStoreForTests(): void {
-  refreshEffectiveTimeZoneFromBrowser();
+  persistentBrowserStore.remove(STORAGE_KEYS.DEFAULT_TIMEZONE);
+  pinnedTimeZoneStore.set(null);
+  browserTimeZoneStore.set(getBrowserTimeZone());
+  syncEffectiveTimeZone();
 }

--- a/packages/web/src/timezone/effective-timezone.store.ts
+++ b/packages/web/src/timezone/effective-timezone.store.ts
@@ -53,10 +53,6 @@ export function getPinnedTimeZone(): string | null {
   return pinnedTimeZoneStore.get();
 }
 
-export function isTimeZonePinned(): boolean {
-  return pinnedTimeZoneStore.get() !== null;
-}
-
 export function getEffectiveTimeZone(): string {
   return currentEffectiveTimeZone();
 }

--- a/packages/web/src/timezone/in-time-zone.ts
+++ b/packages/web/src/timezone/in-time-zone.ts
@@ -1,0 +1,18 @@
+import dayjs from "@core/util/date/dayjs";
+import { getEffectiveTimeZone } from "@web/timezone/effective-timezone.store";
+
+/** Reinterpret an instant in the calendar's effective timezone. */
+export function inEffectiveTimeZone(
+  input: string | number | Date | dayjs.Dayjs,
+  timeZone: string = getEffectiveTimeZone(),
+): dayjs.Dayjs {
+  return dayjs(input).tz(timeZone);
+}
+
+/** Parse a date-only (`YYYY-MM-DD`) value as midnight in the effective zone. */
+export function calendarDateInEffectiveTimeZone(
+  ymd: string,
+  timeZone: string = getEffectiveTimeZone(),
+): dayjs.Dayjs {
+  return dayjs.tz(ymd, timeZone);
+}

--- a/packages/web/src/timezone/timezone-catalog.test.ts
+++ b/packages/web/src/timezone/timezone-catalog.test.ts
@@ -22,6 +22,18 @@ describe("timezone-catalog", () => {
     expect(america.every((zone) => zone.id.includes("America"))).toBe(true);
   });
 
+  it("formats offset labels as strings, not objects", () => {
+    const chicago = zones.find((zone) => zone.id === "America/Chicago");
+    expect(chicago).toBeTruthy();
+    if (!chicago) return;
+
+    expect(chicago.offset).toMatch(/GMT/);
+    expect(chicago.secondary).not.toContain("[object Object]");
+    expect(
+      chicago.keywords.every((keyword) => typeof keyword === "string"),
+    ).toBe(true);
+  });
+
   it("sorts the current zone first, then by offset distance", () => {
     const sorted = sortTimeZonesByOffsetDistance(zones, "America/Denver");
     expect(sorted[0]?.id).toBe("America/Denver");

--- a/packages/web/src/timezone/timezone-catalog.test.ts
+++ b/packages/web/src/timezone/timezone-catalog.test.ts
@@ -1,0 +1,42 @@
+import {
+  buildTimeZoneList,
+  filterTimeZones,
+  sortTimeZonesByOffsetDistance,
+} from "@web/timezone/timezone-catalog";
+import { describe, expect, it } from "bun:test";
+
+const at = new Date("2026-07-15T18:00:00.000Z");
+
+describe("timezone-catalog", () => {
+  const zones = buildTimeZoneList(at);
+
+  it("filters by city, abbreviation, and region", () => {
+    const chicago = filterTimeZones(zones, "Chi").map((zone) => zone.id);
+    expect(chicago).toContain("America/Chicago");
+
+    const edt = filterTimeZones(zones, "EDT").map((zone) => zone.id);
+    expect(edt.some((id) => id.startsWith("America/"))).toBe(true);
+
+    const america = filterTimeZones(zones, "America");
+    expect(america.length).toBeGreaterThan(10);
+    expect(america.every((zone) => zone.id.includes("America"))).toBe(true);
+  });
+
+  it("sorts the current zone first, then by offset distance", () => {
+    const sorted = sortTimeZonesByOffsetDistance(zones, "America/Denver");
+    expect(sorted[0]?.id).toBe("America/Denver");
+
+    const denver = zones.find((zone) => zone.id === "America/Denver");
+    const chicago = zones.find((zone) => zone.id === "America/Chicago");
+    const tokyo = zones.find((zone) => zone.id === "Asia/Tokyo");
+    expect(denver && chicago && tokyo).toBeTruthy();
+    if (!denver || !chicago || !tokyo) return;
+
+    const chicagoIndex = sorted.findIndex(
+      (zone) => zone.id === "America/Chicago",
+    );
+    const tokyoIndex = sorted.findIndex((zone) => zone.id === "Asia/Tokyo");
+    expect(chicagoIndex).toBeGreaterThan(0);
+    expect(chicagoIndex).toBeLessThan(tokyoIndex);
+  });
+});

--- a/packages/web/src/timezone/timezone-catalog.ts
+++ b/packages/web/src/timezone/timezone-catalog.ts
@@ -47,15 +47,21 @@ function formatOffsetLabel(timeZone: string, at: Date): string {
   );
 }
 
-let cachedZones: string[] | null = null;
+let cachedZoneIds: string[] | null = null;
+let cachedList: { minute: number; items: TimeZoneListItem[] } | null = null;
 
 function supportedTimeZones(): string[] {
-  cachedZones ??= Intl.supportedValuesOf("timeZone");
-  return cachedZones;
+  cachedZoneIds ??= Intl.supportedValuesOf("timeZone");
+  return cachedZoneIds;
 }
 
 export function buildTimeZoneList(at: Date = new Date()): TimeZoneListItem[] {
-  return supportedTimeZones().map((id) => {
+  const minute = Math.floor(at.getTime() / 60_000);
+  if (cachedList?.minute === minute) {
+    return cachedList.items;
+  }
+
+  const items = supportedTimeZones().map((id) => {
     const city = timeZoneCityName(id);
     const region = regionFromIanaId(id);
     const abbreviation = formatTimeZoneAbbreviation(id, at);
@@ -71,6 +77,8 @@ export function buildTimeZoneList(at: Date = new Date()): TimeZoneListItem[] {
       keywords: [id, region, abbreviation, offset],
     };
   });
+  cachedList = { minute, items };
+  return items;
 }
 
 export function sortTimeZonesByOffsetDistance(

--- a/packages/web/src/timezone/timezone-catalog.ts
+++ b/packages/web/src/timezone/timezone-catalog.ts
@@ -22,29 +22,22 @@ function regionFromIanaId(id: string): string {
   return slash === -1 ? id : id.slice(0, slash);
 }
 
-function offsetMinutesAt(timeZone: string, at: Date): number {
-  const parts = new Intl.DateTimeFormat("en-US", {
-    timeZone,
-    timeZoneName: "shortOffset",
-    hour: "numeric",
-  }).formatToParts(at);
-  const raw = parts.find((part) => part.type === "timeZoneName")?.value ?? "";
+function offsetAt(
+  timeZone: string,
+  at: Date,
+): { minutes: number; label: string } {
+  const raw =
+    new Intl.DateTimeFormat("en-US", { timeZone, timeZoneName: "shortOffset" })
+      .formatToParts(at)
+      .find((part) => part.type === "timeZoneName")?.value ?? "";
   const match = raw.match(/([+-])(\d{1,2})(?::?(\d{2}))?/);
   if (!match) {
-    return 0;
+    return { minutes: 0, label: raw };
   }
   const sign = match[1] === "-" ? -1 : 1;
   const hours = Number(match[2]);
   const minutes = Number(match[3] ?? "0");
-  return sign * (hours * 60 + minutes);
-}
-
-function formatOffsetLabel(timeZone: string, at: Date): string {
-  return (
-    new Intl.DateTimeFormat("en-US", { timeZone, timeZoneName: "shortOffset" })
-      .formatToParts(at)
-      .find((part) => part.type === "timeZoneName")?.value ?? ""
-  );
+  return { minutes: sign * (hours * 60 + minutes), label: raw };
 }
 
 let cachedZoneIds: string[] | null = null;
@@ -65,16 +58,16 @@ export function buildTimeZoneList(at: Date = new Date()): TimeZoneListItem[] {
     const city = timeZoneCityName(id);
     const region = regionFromIanaId(id);
     const abbreviation = formatTimeZoneAbbreviation(id, at);
-    const offset = formatOffsetLabel(id, at);
+    const offset = offsetAt(id, at);
     return {
       id,
       city,
       region,
       abbreviation,
-      offset,
-      offsetMinutes: offsetMinutesAt(id, at),
-      secondary: [abbreviation, offset].filter(Boolean).join(", "),
-      keywords: [id, region, abbreviation, offset],
+      offset: offset.label,
+      offsetMinutes: offset.minutes,
+      secondary: [abbreviation, offset.label].filter(Boolean).join(", "),
+      keywords: [id, region, abbreviation, offset.label],
     };
   });
   cachedList = { minute, items };

--- a/packages/web/src/timezone/timezone-catalog.ts
+++ b/packages/web/src/timezone/timezone-catalog.ts
@@ -1,0 +1,116 @@
+import { scoreCommandItem } from "@web/components/CommandPalette/command-palette.search";
+import { formatTimeZoneAbbreviation } from "@web/timezone/format-timezone-abbreviation";
+
+export interface TimeZoneListItem {
+  id: string;
+  city: string;
+  region: string;
+  abbreviation: string;
+  offset: string;
+  offsetMinutes: number;
+  secondary: string;
+  keywords: string[];
+}
+
+export function timeZoneCityName(id: string): string {
+  const last = id.split("/").pop() ?? id;
+  return last.replaceAll("_", " ");
+}
+
+function regionFromIanaId(id: string): string {
+  const slash = id.indexOf("/");
+  return slash === -1 ? id : id.slice(0, slash);
+}
+
+function offsetMinutesAt(timeZone: string, at: Date): number {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    timeZoneName: "shortOffset",
+    hour: "numeric",
+  }).formatToParts(at);
+  const raw = parts.find((part) => part.type === "timeZoneName")?.value ?? "";
+  const match = raw.match(/([+-])(\d{1,2})(?::?(\d{2}))?/);
+  if (!match) {
+    return 0;
+  }
+  const sign = match[1] === "-" ? -1 : 1;
+  const hours = Number(match[2]);
+  const minutes = Number(match[3] ?? "0");
+  return sign * (hours * 60 + minutes);
+}
+
+function formatOffsetLabel(timeZone: string, at: Date): string {
+  return (
+    new Intl.DateTimeFormat("en-US", { timeZone, timeZoneName: "shortOffset" })
+      .formatToParts(at)
+      .find((part) => part.type === "timeZoneName")?.value ?? ""
+  );
+}
+
+let cachedZones: string[] | null = null;
+
+function supportedTimeZones(): string[] {
+  cachedZones ??= Intl.supportedValuesOf("timeZone");
+  return cachedZones;
+}
+
+export function buildTimeZoneList(at: Date = new Date()): TimeZoneListItem[] {
+  return supportedTimeZones().map((id) => {
+    const city = timeZoneCityName(id);
+    const region = regionFromIanaId(id);
+    const abbreviation = formatTimeZoneAbbreviation(id, at);
+    const offset = formatOffsetLabel(id, at);
+    return {
+      id,
+      city,
+      region,
+      abbreviation,
+      offset,
+      offsetMinutes: offsetMinutesAt(id, at),
+      secondary: [abbreviation, offset].filter(Boolean).join(", "),
+      keywords: [id, region, abbreviation, offset],
+    };
+  });
+}
+
+export function sortTimeZonesByOffsetDistance(
+  zones: TimeZoneListItem[],
+  currentTimeZone: string,
+): TimeZoneListItem[] {
+  const current = zones.find((zone) => zone.id === currentTimeZone);
+  const currentOffset = current?.offsetMinutes ?? 0;
+
+  return [...zones].sort((left, right) => {
+    if (left.id === currentTimeZone) return -1;
+    if (right.id === currentTimeZone) return 1;
+
+    const leftDistance = Math.abs(left.offsetMinutes - currentOffset);
+    const rightDistance = Math.abs(right.offsetMinutes - currentOffset);
+    if (leftDistance !== rightDistance) {
+      return leftDistance - rightDistance;
+    }
+    return left.city.localeCompare(right.city);
+  });
+}
+
+export function filterTimeZones(
+  zones: TimeZoneListItem[],
+  query: string,
+): TimeZoneListItem[] {
+  const trimmed = query.trim();
+  if (trimmed.length === 0) {
+    return zones;
+  }
+
+  return zones
+    .map((zone) => ({
+      zone,
+      score: scoreCommandItem(
+        { label: zone.city, keywords: zone.keywords },
+        trimmed,
+      ),
+    }))
+    .filter((entry) => entry.score > 0)
+    .sort((left, right) => right.score - left.score)
+    .map((entry) => entry.zone);
+}

--- a/packages/web/src/timezone/timezone-dialog.store.ts
+++ b/packages/web/src/timezone/timezone-dialog.store.ts
@@ -2,6 +2,7 @@ import { create } from "zustand";
 
 interface TimezoneDialogState {
   isOpen: boolean;
+  restoreFocus?: () => void;
 }
 
 export const useTimezoneDialogStore = create<TimezoneDialogState>()(() => ({
@@ -9,9 +10,17 @@ export const useTimezoneDialogStore = create<TimezoneDialogState>()(() => ({
 }));
 
 export const timezoneDialogActions = {
-  open: () => useTimezoneDialogStore.setState({ isOpen: true }),
-  close: () => useTimezoneDialogStore.setState({ isOpen: false }),
+  open: (restoreFocus?: () => void) =>
+    useTimezoneDialogStore.setState({ isOpen: true, restoreFocus }),
+  close: () =>
+    useTimezoneDialogStore.setState({
+      isOpen: false,
+      restoreFocus: undefined,
+    }),
 };
 
 export const selectTimezoneDialogOpen = (state: TimezoneDialogState) =>
   state.isOpen;
+
+export const selectTimezoneDialogRestoreFocus = (state: TimezoneDialogState) =>
+  state.restoreFocus;

--- a/packages/web/src/timezone/timezone-dialog.store.ts
+++ b/packages/web/src/timezone/timezone-dialog.store.ts
@@ -1,0 +1,17 @@
+import { create } from "zustand";
+
+interface TimezoneDialogState {
+  isOpen: boolean;
+}
+
+export const useTimezoneDialogStore = create<TimezoneDialogState>()(() => ({
+  isOpen: false,
+}));
+
+export const timezoneDialogActions = {
+  open: () => useTimezoneDialogStore.setState({ isOpen: true }),
+  close: () => useTimezoneDialogStore.setState({ isOpen: false }),
+};
+
+export const selectTimezoneDialogOpen = (state: TimezoneDialogState) =>
+  state.isOpen;

--- a/packages/web/src/timezone/useTimezoneCmdItems.test.ts
+++ b/packages/web/src/timezone/useTimezoneCmdItems.test.ts
@@ -1,0 +1,44 @@
+import { renderHook } from "@testing-library/react";
+import { act } from "react";
+import {
+  resetEffectiveTimeZoneStoreForTests,
+  setPinnedTimeZone,
+} from "@web/timezone/effective-timezone.store";
+import { formatTimeZoneAbbreviation } from "@web/timezone/format-timezone-abbreviation";
+import {
+  selectTimezoneDialogOpen,
+  timezoneDialogActions,
+  useTimezoneDialogStore,
+} from "@web/timezone/timezone-dialog.store";
+import { useTimezoneCmdItems } from "@web/timezone/useTimezoneCmdItems";
+import { afterEach, describe, expect, it } from "bun:test";
+
+describe("useTimezoneCmdItems", () => {
+  afterEach(() => {
+    act(() => {
+      resetEffectiveTimeZoneStoreForTests();
+      timezoneDialogActions.close();
+    });
+  });
+
+  it("labels the command with the current zone abbreviation", () => {
+    act(() => {
+      setPinnedTimeZone("America/Denver");
+    });
+
+    const { result } = renderHook(() => useTimezoneCmdItems());
+    expect(result.current[0]?.label).toBe(
+      `Change default timezone (${formatTimeZoneAbbreviation("America/Denver")})`,
+    );
+  });
+
+  it("opens the timezone picker", () => {
+    const { result } = renderHook(() => useTimezoneCmdItems());
+    act(() => {
+      result.current[0]?.onClick?.();
+    });
+    expect(selectTimezoneDialogOpen(useTimezoneDialogStore.getState())).toBe(
+      true,
+    );
+  });
+});

--- a/packages/web/src/timezone/useTimezoneCmdItems.test.ts
+++ b/packages/web/src/timezone/useTimezoneCmdItems.test.ts
@@ -32,7 +32,7 @@ describe("useTimezoneCmdItems", () => {
     );
   });
 
-  it("opens the timezone picker", () => {
+  it("opens the timezone picker from the command palette restore path", () => {
     const { result } = renderHook(() => useTimezoneCmdItems());
     act(() => {
       result.current[0]?.onClick?.();

--- a/packages/web/src/timezone/useTimezoneCmdItems.ts
+++ b/packages/web/src/timezone/useTimezoneCmdItems.ts
@@ -1,0 +1,20 @@
+import { GlobeIcon } from "@phosphor-icons/react";
+import { type CommandItem } from "@web/components/CommandPalette/command-palette.types";
+import { useEffectiveTimeZone } from "@web/timezone/effective-timezone.store";
+import { formatTimeZoneAbbreviation } from "@web/timezone/format-timezone-abbreviation";
+import { timezoneDialogActions } from "@web/timezone/timezone-dialog.store";
+
+export function useTimezoneCmdItems(): CommandItem[] {
+  const timeZone = useEffectiveTimeZone();
+  const abbreviation = formatTimeZoneAbbreviation(timeZone);
+
+  return [
+    {
+      id: "change-default-timezone",
+      label: `Change default timezone (${abbreviation})`,
+      icon: GlobeIcon,
+      keywords: ["timezone", "time zone", "tz", abbreviation],
+      onClick: () => timezoneDialogActions.open(),
+    },
+  ];
+}

--- a/packages/web/src/timezone/useTimezoneCmdItems.ts
+++ b/packages/web/src/timezone/useTimezoneCmdItems.ts
@@ -1,5 +1,6 @@
 import { GlobeIcon } from "@phosphor-icons/react";
 import { type CommandItem } from "@web/components/CommandPalette/command-palette.types";
+import { restoreCommandPaletteFocus } from "@web/components/Feedback/FeedbackDialogHost";
 import { useEffectiveTimeZone } from "@web/timezone/effective-timezone.store";
 import { formatTimeZoneAbbreviation } from "@web/timezone/format-timezone-abbreviation";
 import { timezoneDialogActions } from "@web/timezone/timezone-dialog.store";
@@ -14,7 +15,7 @@ export function useTimezoneCmdItems(): CommandItem[] {
       label: `Change default timezone (${abbreviation})`,
       icon: GlobeIcon,
       keywords: ["timezone", "time zone", "tz", abbreviation],
-      onClick: () => timezoneDialogActions.open(),
+      onClick: () => timezoneDialogActions.open(restoreCommandPaletteFocus),
     },
   ];
 }

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
@@ -7,7 +7,6 @@ import {
 import { YEAR_MONTH_DAY_FORMAT } from "@core/constants/date.constants";
 import { type Calendar } from "@core/types/calendar.contracts";
 import { type CalendarId } from "@core/types/domain-primitives";
-import dayjs from "@core/util/date/dayjs";
 import { shouldShowContextualLoadError } from "@web/api/util/api.util";
 import { useConnectGoogle } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle";
 import {
@@ -50,6 +49,7 @@ import { useDateInView } from "@web/views/Day/hooks/navigation/useDateInView";
 import { useDateNavigation } from "@web/views/Day/hooks/navigation/useDateNavigation";
 import { useDayEventNudgeShortcuts } from "@web/views/Day/hooks/shortcuts/useDayEventNudgeShortcuts";
 import { DayInteractionCoordinator } from "@web/views/Day/interaction/DayInteractionCoordinator";
+import { useToday } from "@web/views/Week/hooks/useToday";
 import { DayCalendarBusyPeriodsLayer } from "./DayCalendarBusyPeriods";
 import { DayCalendarColumnHeaders } from "./DayCalendarColumnHeaders";
 import { useDayCalendarContextMenu } from "./DayCalendarContextMenu";
@@ -86,7 +86,7 @@ const isDayInteractionMotionActive = () => false;
 export function DayCalendarGrid() {
   const dateInView = useDateInView();
   const { navigateToDate } = useDateNavigation();
-  const today = useMemo(() => dayjs(), []);
+  const { today } = useToday();
   const { data: calendars = [], isPending: isCalendarsPending } =
     useCalendarsQuery();
   // Seed shortcuts with the form's default create target, not day-column order.
@@ -293,13 +293,13 @@ export function DayCalendarGrid() {
     () =>
       openShortcutDraft(() =>
         createTimedDraft(
-          dateInView.isSame(dayjs(), "day"),
+          dateInView.isSame(today, "day"),
           dateInView,
           "createShortcut",
           defaultTargetCalendarId,
         ),
       ),
-    [dateInView, defaultTargetCalendarId, openShortcutDraft],
+    [dateInView, defaultTargetCalendarId, openShortcutDraft, today],
   );
 
   // Form stays closed so Shift+Arrow can keep repositioning; Enter opens it.
@@ -309,14 +309,14 @@ export function DayCalendarGrid() {
       openShortcutDraft(
         () =>
           createTimedDraft(
-            dateInView.isSame(dayjs(), "day"),
+            dateInView.isSame(today, "day"),
             dateInView,
             "keyboardPlace",
             defaultTargetCalendarId,
           ),
         false,
       ),
-    [dateInView, defaultTargetCalendarId, openShortcutDraft],
+    [dateInView, defaultTargetCalendarId, openShortcutDraft, today],
   );
   const { getEditSequenceAnchor, shiftHints } = useDayEventNudgeShortcuts({
     allDayEvents: displayedAllDayEvents,

--- a/packages/web/src/views/Day/components/Calendar/dayCalendarDraft.util.ts
+++ b/packages/web/src/views/Day/components/Calendar/dayCalendarDraft.util.ts
@@ -14,6 +14,7 @@ import {
   positionAllDayDraftEvent,
 } from "@web/grid/layout/all-day-draft.position";
 import { type GridVisibleDate } from "@web/grid/types/grid.types";
+import { inEffectiveTimeZone } from "@web/timezone/in-time-zone";
 
 export const addVisibleDraftEvent = ({
   draft,
@@ -95,11 +96,14 @@ export const isDraftVisibleOnDate = (
 
   if (schedule.kind === "timed") {
     if (
-      shouldRenderTimedInAllDayRow(dayjs(schedule.start), dayjs(schedule.end))
+      shouldRenderTimedInAllDayRow(
+        inEffectiveTimeZone(schedule.start),
+        inEffectiveTimeZone(schedule.end),
+      )
     ) {
       const dates = timedMultiDayToAllDayDates(
-        dayjs(schedule.start),
-        dayjs(schedule.end),
+        inEffectiveTimeZone(schedule.start),
+        inEffectiveTimeZone(schedule.end),
       );
       const visibleDay = visibleDate.startOf("day");
       const start = dayjs(dates.startDate).startOf("day");
@@ -113,7 +117,7 @@ export const isDraftVisibleOnDate = (
       );
     }
 
-    return dayjs(schedule.start).isSame(visibleDate, "day");
+    return inEffectiveTimeZone(schedule.start).isSame(visibleDate, "day");
   }
 
   const visibleDay = visibleDate.startOf("day");

--- a/packages/web/src/views/Day/context/DateNavigationContext.tsx
+++ b/packages/web/src/views/Day/context/DateNavigationContext.tsx
@@ -1,8 +1,15 @@
 import { useMatch, useNavigate } from "@tanstack/react-router";
-import { createContext, type PropsWithChildren, useCallback } from "react";
+import {
+  createContext,
+  type PropsWithChildren,
+  useCallback,
+  useMemo,
+} from "react";
 import dayjs, { type Dayjs } from "@core/util/date/dayjs";
 import { ROOT_ROUTES, ROUTE_IDS } from "@web/common/constants/routes";
 import { type DayLoaderData, loadTodayData } from "@web/routers/loaders";
+import { useEffectiveTimeZone } from "@web/timezone/effective-timezone.store";
+import { calendarDateInEffectiveTimeZone } from "@web/timezone/in-time-zone";
 
 interface DateNavigationContextProps extends DayLoaderData {
   navigateToDate: (date: Dayjs) => void;
@@ -28,7 +35,12 @@ export function DateNavigationProvider({ children }: PropsWithChildren) {
     shouldThrow: false,
   })?.loaderData as DayLoaderData | undefined;
 
-  const { dateInView, dateString } = routeData ?? loadTodayData();
+  const { dateString } = routeData ?? loadTodayData();
+  const timeZone = useEffectiveTimeZone();
+  const dateInView = useMemo(
+    () => calendarDateInEffectiveTimeZone(dateString, timeZone),
+    [dateString, timeZone],
+  );
 
   const navigateToDate = useCallback(
     (date: dayjs.Dayjs) => {

--- a/packages/web/src/views/Day/hooks/navigation/useDateInView.ts
+++ b/packages/web/src/views/Day/hooks/navigation/useDateInView.ts
@@ -1,10 +1,15 @@
 import { useContext, useMemo } from "react";
 import dayjs from "@core/util/date/dayjs";
+import { useEffectiveTimeZone } from "@web/timezone/effective-timezone.store";
 import { DateNavigationContext } from "@web/views/Day/context/DateNavigationContext";
 
 export function useDateInView(): dayjs.Dayjs {
   const context = useContext(DateNavigationContext);
   const dateInView = context?.dateInView;
+  const timeZone = useEffectiveTimeZone();
 
-  return useMemo(() => dateInView ?? dayjs(), [dateInView]);
+  return useMemo(
+    () => dateInView ?? dayjs().tz(timeZone),
+    [dateInView, timeZone],
+  );
 }

--- a/packages/web/src/views/Day/view/DayViewContent.tsx
+++ b/packages/web/src/views/Day/view/DayViewContent.tsx
@@ -1,5 +1,4 @@
 import { memo, useCallback, useMemo, useRef } from "react";
-import dayjs from "@core/util/date/dayjs";
 import { ID_MAIN } from "@web/common/constants/web.constants";
 import { useHorizontalNavigation } from "@web/common/hooks/useHorizontalNavigation";
 import { emitViewCommand } from "@web/common/utils/dom/view-command-bus";
@@ -32,6 +31,7 @@ import { useDateInView } from "@web/views/Day/hooks/navigation/useDateInView";
 import { useDateNavigation } from "@web/views/Day/hooks/navigation/useDateNavigation";
 import { focusFirstDayCalendarEvent } from "@web/views/Day/interaction/day-event.focus";
 import { Dedication } from "@web/views/Week/components/Dedication/Dedication";
+import { useToday } from "@web/views/Week/hooks/useToday";
 
 export const DayViewContent = memo(() => {
   const isSidebarOpen = useViewStore(selectIsSidebarOpen);
@@ -42,7 +42,8 @@ export const DayViewContent = memo(() => {
   const mainRef = useRef<HTMLDivElement | null>(null);
 
   const dateInView = useDateInView();
-  const isViewingToday = dateInView.isSame(dayjs(), "day");
+  const { today } = useToday();
+  const isViewingToday = dateInView.isSame(today, "day");
 
   const {
     navigateToDate,
@@ -71,9 +72,6 @@ export const DayViewContent = memo(() => {
   );
 
   const handleGoToToday = useCallback(() => {
-    // Compare dates in the same timezone to avoid timezone issues
-    // Both dates are in local timezone, ensuring accurate day comparison
-    const today = dayjs().startOf("day");
     const isViewingToday = dateInView.isSame(today, "day");
 
     if (isViewingToday) {
@@ -81,7 +79,7 @@ export const DayViewContent = memo(() => {
     } else {
       navigateToToday();
     }
-  }, [dateInView, navigateToToday]);
+  }, [dateInView, navigateToToday, today]);
 
   const handleCreateTimedEvent = useCallback(() => {
     emitViewCommand("CREATE_TIMED_DRAFT");

--- a/packages/web/src/views/Week/components/Header/Header.tsx
+++ b/packages/web/src/views/Week/components/Header/Header.tsx
@@ -1,7 +1,7 @@
 import { type FC } from "react";
-import dayjs from "@core/util/date/dayjs";
 import { getCalendarHeadingLabel } from "@web/common/utils/datetime/web.date.util";
 import { CalendarHeader } from "@web/components/CalendarHeader/CalendarHeader";
+import { useToday } from "@web/views/Week/hooks/useToday";
 import { type Util_Scroll } from "../../hooks/grid/useScroll";
 import { type WeekProps } from "../../hooks/useWeek";
 
@@ -11,11 +11,12 @@ interface Props {
 }
 export const Header: FC<Props> = ({ scrollUtil, weekProps }) => {
   const { scrollToNow } = scrollUtil;
+  const { today } = useToday();
 
   const headerLabel = getCalendarHeadingLabel(
     weekProps.component.startOfView,
     weekProps.component.endOfView,
-    dayjs(),
+    today,
   );
 
   const onTodayClick = () => {

--- a/packages/web/src/views/Week/hooks/useToday.test.ts
+++ b/packages/web/src/views/Week/hooks/useToday.test.ts
@@ -1,5 +1,6 @@
 import { renderHook } from "@testing-library/react";
 import { act } from "react";
+import { setPinnedTimeZone } from "@web/timezone/effective-timezone.store";
 import { useToday } from "@web/views/Week/hooks/useToday";
 import {
   afterEach,
@@ -57,5 +58,16 @@ describe("useToday", () => {
 
     expect(result.current.today.isSame("2026-02-06", "day")).toBe(true);
     expect(result.current.todayIndex).toBe(result.current.today.get("day"));
+  });
+
+  it("uses the pinned timezone for the calendar day", () => {
+    setSystemTime(new Date("2026-02-06T01:00:00.000Z"));
+    act(() => {
+      setPinnedTimeZone("America/Denver");
+    });
+
+    const { result } = renderHook(() => useToday());
+
+    expect(result.current.today.format("YYYY-MM-DD")).toBe("2026-02-05");
   });
 });

--- a/packages/web/src/views/Week/hooks/useToday.ts
+++ b/packages/web/src/views/Week/hooks/useToday.ts
@@ -1,19 +1,27 @@
-import { useRef } from "react";
+import { useMemo, useRef } from "react";
 import { type Dayjs } from "@core/util/date/dayjs";
 import { useMinuteTick } from "@web/common/hooks/useMinuteTick";
+import { useEffectiveTimeZone } from "@web/timezone/effective-timezone.store";
 
 // A fresh dayjs() every render permanently invalidates every memo/comparator
 // downstream that takes `today` as a dependency (weekProps, grid layout,
 // etc.), since it never equals the previous render's instance even though
 // the calendar day hasn't changed. Keep the same reference across renders
 // within a day; only swap it (checked once a minute, via the shared tick)
-// when the day rolls over.
+// when the day rolls over or the effective timezone changes.
 export const useToday = () => {
   const tick = useMinuteTick();
-  const todayRef = useRef<Dayjs>(tick);
+  const timeZone = useEffectiveTimeZone();
+  const zonedTick = useMemo(() => tick.tz(timeZone), [tick, timeZone]);
+  const todayRef = useRef<Dayjs>(zonedTick);
+  const timeZoneRef = useRef(timeZone);
 
-  if (!todayRef.current.isSame(tick, "day")) {
-    todayRef.current = tick;
+  if (
+    timeZoneRef.current !== timeZone ||
+    !todayRef.current.isSame(zonedTick, "day")
+  ) {
+    todayRef.current = zonedTick.startOf("day");
+    timeZoneRef.current = timeZone;
   }
 
   const today = todayRef.current;

--- a/packages/web/src/views/Week/hooks/useWeek.test.tsx
+++ b/packages/web/src/views/Week/hooks/useWeek.test.tsx
@@ -1,6 +1,7 @@
 import { act } from "react";
 import dayjs from "@core/util/date/dayjs";
 import { renderHook } from "@web/__tests__/__mocks__/mock.render";
+import { getEffectiveTimeZone } from "@web/timezone/effective-timezone.store";
 import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
 
 const DATE_FORMAT = dayjs.DateFormat.YEAR_MONTH_DAY_FORMAT;
@@ -253,9 +254,10 @@ describe("useWeek", () => {
     expect(result.current.query.startOfView.format(DATE_FORMAT)).toBe(
       "2026-08-06",
     );
-    // WEEK_DAY_COUNT days from the anchor → exclusive end is the following midnight.
+    // WEEK_DAY_COUNT days from the anchor → exclusive end is the following
+    // midnight in the effective calendar timezone.
     expect(result.current.query.endOfView.format()).toBe(
-      dayjs("2026-08-13", DATE_FORMAT).startOf("day").format(),
+      dayjs.tz("2026-08-13", getEffectiveTimeZone()).startOf("day").format(),
     );
   });
 });

--- a/packages/web/src/views/Week/hooks/useWeek.ts
+++ b/packages/web/src/views/Week/hooks/useWeek.ts
@@ -7,6 +7,7 @@ import { weekEventsQueryOptions } from "@web/events/queries/event.query.options"
 import { usePrefetchAdjacentEvents } from "@web/events/queries/usePrefetchAdjacentEvents";
 import { useWeekEventsQuery } from "@web/events/queries/useWeekEventsQuery";
 import { viewActions } from "@web/events/stores/view.store";
+import { useEffectiveTimeZone } from "@web/timezone/effective-timezone.store";
 import { WEEK_DAY_COUNT } from "@web/views/Week/util/week-window.util";
 import { type Category_View } from "@web/views/Week/week-view.types";
 
@@ -29,13 +30,14 @@ export const useWeek = (
   // Bare /week has no dateString. Default to today when only one day is
   // visible, otherwise the week-aligned start. Once navigation writes a
   // dateString, that drives the anchor at every width.
+  const timeZone = useEffectiveTimeZone();
   const defaultAnchorDate =
     visibleDayCount === 1 ? today : today.startOf("week");
   const anchorDateString =
     params?.dateString ?? defaultAnchorDate.format(DATE_FORMAT);
   const anchor = useMemo(
-    () => dayjs(anchorDateString, DATE_FORMAT),
-    [anchorDateString],
+    () => dayjs.tz(anchorDateString, timeZone),
+    [anchorDateString, timeZone],
   );
   const setAnchor = useCallback(
     (date: Dayjs) =>

--- a/packages/web/src/views/Week/interaction/adapter/commit/timed.commit.ts
+++ b/packages/web/src/views/Week/interaction/adapter/commit/timed.commit.ts
@@ -1,4 +1,3 @@
-import dayjs from "@core/util/date/dayjs";
 import { type GridEvent } from "@web/common/types/web.event.types";
 import {
   hasTimedDragVisualMoved,
@@ -6,6 +5,10 @@ import {
 } from "@web/grid/interaction/commit/timed-moved";
 import { type TimedDragVisual } from "@web/grid/interaction/types/timed-drag.types";
 import { type TimedResizeVisual } from "@web/grid/interaction/types/timed-resize.types";
+import {
+  calendarDateInEffectiveTimeZone,
+  inEffectiveTimeZone,
+} from "@web/timezone/in-time-zone";
 
 export { hasTimedDragVisualMoved, hasTimedResizeVisualMoved };
 
@@ -15,7 +18,9 @@ export const timedDragVisualToGridEvent = (
 ): GridEvent => {
   // The column under the drag knows its own date, so the target day is
   // assigned absolutely; time-of-day rides on the visual's minutes.
-  const movedDay = dayjs(visual.dayDate).startOf("day");
+  const movedDay = /^\d{4}-\d{2}-\d{2}$/.test(visual.dayDate)
+    ? calendarDateInEffectiveTimeZone(visual.dayDate)
+    : inEffectiveTimeZone(event.startDate).startOf("day");
 
   return {
     ...event,
@@ -28,7 +33,7 @@ export const timedResizeVisualToGridEvent = (
   event: GridEvent,
   visual: TimedResizeVisual,
 ): GridEvent => {
-  const resizedDay = dayjs(event.startDate).startOf("day");
+  const resizedDay = inEffectiveTimeZone(event.startDate).startOf("day");
 
   return {
     ...event,

--- a/packages/web/src/views/Week/util/week-window.util.test.ts
+++ b/packages/web/src/views/Week/util/week-window.util.test.ts
@@ -1,4 +1,9 @@
+import { act } from "react";
 import dayjs from "@core/util/date/dayjs";
+import {
+  resetEffectiveTimeZoneStoreForTests,
+  setPinnedTimeZone,
+} from "@web/timezone/effective-timezone.store";
 import {
   anchorDateForWindowOffset,
   computeVisibleDayCount,
@@ -7,13 +12,19 @@ import {
   isTimedEventInVisibleDays,
   WEEK_DAY_COUNT,
 } from "@web/views/Week/util/week-window.util";
-import { describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it } from "bun:test";
 
 // Sunday-start week used across the tests
 const weekStart = dayjs("2026-06-28T00:00:00.000");
 const weekDay = (index: number) => weekStart.add(index, "day");
 const windowDays = (offset: number, count: number) =>
   [...Array(count)].map((_, index) => weekDay(offset + index));
+
+afterEach(() => {
+  act(() => {
+    resetEffectiveTimeZoneStoreForTests();
+  });
+});
 
 describe("computeVisibleDayCount", () => {
   it("fits the full week on wide tracks", () => {
@@ -117,5 +128,27 @@ describe("isAllDayEventInVisibleDays", () => {
   it("does not leak the exclusive end date into the next day", () => {
     // Ends (exclusively) on Friday: hidden in a Fri..Sat window
     expect(isAllDayEventInVisibleDays(multiDay, windowDays(5, 2))).toBe(false);
+  });
+
+  it("keeps a date-only all-day event on the pinned calendar day", () => {
+    act(() => {
+      setPinnedTimeZone("America/Chicago");
+    });
+    const chicagoWeek = Array.from({ length: 7 }, (_, index) =>
+      dayjs.tz("2026-05-17", "America/Chicago").add(index, "day"),
+    );
+
+    expect(
+      isAllDayEventInVisibleDays(
+        { startDate: "2026-05-17", endDate: "2026-05-18" },
+        chicagoWeek,
+      ),
+    ).toBe(true);
+    expect(
+      isAllDayEventInVisibleDays(
+        { startDate: "2026-05-24", endDate: "2026-05-25" },
+        chicagoWeek,
+      ),
+    ).toBe(false);
   });
 });

--- a/packages/web/src/views/Week/util/week-window.util.ts
+++ b/packages/web/src/views/Week/util/week-window.util.ts
@@ -1,9 +1,13 @@
-import dayjs, { type Dayjs } from "@core/util/date/dayjs";
+import { type Dayjs } from "@core/util/date/dayjs";
 import { type GridEvent } from "@web/common/types/web.event.types";
 import {
   DAY_COLUMN_MIN_USABLE_WIDTH,
   GRID_MARGIN_LEFT,
 } from "@web/grid/grid.constants";
+import {
+  calendarDateInEffectiveTimeZone,
+  inEffectiveTimeZone,
+} from "@web/timezone/in-time-zone";
 
 export const WEEK_DAY_COUNT = 7;
 
@@ -64,7 +68,7 @@ export const isTimedEventInVisibleDays = (
   event: EventDates,
   visibleDays: Dayjs[],
 ) => {
-  const start = dayjs(event.startDate);
+  const start = inEffectiveTimeZone(event.startDate);
   return visibleDays.some((day) => day.isSame(start, "day"));
 };
 
@@ -83,8 +87,12 @@ export const isAllDayEventInVisibleDays = (
     return false;
   }
 
-  const eventStart = dayjs(event.startDate).startOf("day");
-  const exclusiveEnd = dayjs(event.endDate).startOf("day");
+  const eventStart = calendarDateInEffectiveTimeZone(event.startDate).startOf(
+    "day",
+  );
+  const exclusiveEnd = calendarDateInEffectiveTimeZone(event.endDate).startOf(
+    "day",
+  );
   const eventEnd = exclusiveEnd.isAfter(eventStart)
     ? exclusiveEnd.subtract(1, "day")
     : eventStart;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Part II of timezone support: pin a calendar timezone and actually use it.

Effective timezone is the pinned IANA zone when the user has picked one, otherwise the browser zone (Auto). Changing the zone never mutates event data; only wall-clock presentation shifts.

Entry points:
- Command palette: `Change default timezone (MDT)`
- Settings: Default timezone row
- Grid-corner button from Part I (#2814, merged)

The picker lists Auto first, then the full IANA catalog (city + abbreviation/offset), filtered with the existing palette scorer. Empty-query order is offset-distance from the current zone. The choice persists per device (`compass.timezone.default`).

The option list is windowed (40 rows, grows on scroll or arrow keys) so jsdom and first paint do not mount hundreds of buttons. The catalog is built once per picker open, not on every keystroke.

Grid positioning, the now-line, week/day bounds, and new-event `schedule.timeZone` all read the effective zone.

Follow-up plumbing threads the effective zone through all-day week visibility, timed/cross-row drag minutes, card labels, all-day draft calendar dates, and day-view `dateInView`. Picker focus restore is limited to the command-palette path.

## Simplicity

- Pin vs Auto is two stores (pinned + browser) with one `getEffectiveTimeZone()`
- Picker reuses OverlayPanel, the feedback-dialog host pattern, and `scoreCommandItem`
- Instant vs date-only parsing is two helpers (`inEffectiveTimeZone` / `calendarDateInEffectiveTimeZone`) instead of sprinkling `.tz()` at every call site
- Catalog offset minutes and label share one `offsetAt()` helper
- Catalog build is cached per minute; filter/sort are separate from Intl construction
- Option rows live in `TimezoneOptionButton.tsx` (one component per file)

## Automated validation

- Focused timezone tests pass, including first-paint option count and combobox search
- All-day week visibility, drag minutes, card labels, and catalog offset-label tests pass
- `bun run lint` passes (pre-existing warnings only)
- `bun run type-check` passes
- `TZ=Etc/UTC bun test:web -- --timeout=10000`: 2339 pass, 0 fail (44.9s)
- GitHub CI on `d3087fe6` is green (lint, type-check, knip, unit suites, e2e, CodeQL)

## Independent review

Prior review confirmed hang (full catalog mount) and high-severity plumbing gaps: all-day events parsed as browser-local, drag minutes in browser-local, stale day-view `dateInView` after pin, all-day create date shift, card labels, palette-only focus restore, and combobox ARIA. Those are fixed in `d3087fe6`. Fresh review of the final diff is in progress.

## Test plan

- Timezone picker/catalog/store/label tests
- Picker then DayCalendarGrid hang regression
- Week-window pinned all-day visibility
- Timed/cross-row drag minutes in the pinned zone
- `bun test:web`, `bun run lint`, `bun run type-check`
- Manual: anonymous week view at http://localhost:9080 — corner UTC, search Chicago, pin, return to Auto

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-79a4e258-3657-4a50-ad8f-b2c1f414740f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-79a4e258-3657-4a50-ad8f-b2c1f414740f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

