### PR TITLE
refactor(sync,backend): dedupe foreground refresh scheduling and enqueue

### DIFF
--- a/packages/backend/src/__tests__/helpers/fake-scheduler.ts
+++ b/packages/backend/src/__tests__/helpers/fake-scheduler.ts
@@ -1,0 +1,30 @@
+import { type TickScheduler } from "@backend/servers/sse/tick-scheduler";
+
+// Captures every scheduled tick without real timers; a test fires the next
+// one explicitly, so ticks run deterministically and instantly.
+export class FakeScheduler {
+  pending: Array<{ delayMs: number; tick: () => void }> = [];
+
+  schedule: TickScheduler = (tick, delayMs) => {
+    const entry = { delayMs, tick };
+    this.pending.push(entry);
+    return {
+      clear: () => {
+        this.pending = this.pending.filter((e) => e !== entry);
+      },
+    };
+  };
+
+  get delays(): number[] {
+    return this.pending.map((entry) => entry.delayMs);
+  }
+
+  // Run the next scheduled tick, then let the async tick body run to
+  // completion (a macrotask turn drains the microtasks it queued).
+  async fireNext(): Promise<void> {
+    const entry = this.pending.shift();
+    if (!entry) throw new Error("no tick scheduled");
+    entry.tick();
+    await Bun.sleep(0);
+  }
+}

--- a/packages/backend/src/servers/sse/foreground-sync-refresh.test.ts
+++ b/packages/backend/src/servers/sse/foreground-sync-refresh.test.ts
@@ -1,29 +1,9 @@
 import { faker } from "@faker-js/faker";
+import { FakeScheduler } from "@backend/__tests__/helpers/fake-scheduler";
 import {
   ForegroundSyncRefresh,
   type ForegroundSyncRefreshDeps,
 } from "@backend/servers/sse/foreground-sync-refresh";
-
-class FakeScheduler {
-  pending: Array<{ delayMs: number; tick: () => void }> = [];
-
-  schedule = (tick: () => void, delayMs: number): { clear: () => void } => {
-    const entry = { delayMs, tick };
-    this.pending.push(entry);
-    return {
-      clear: () => {
-        this.pending = this.pending.filter((item) => item !== entry);
-      },
-    };
-  };
-
-  async fireNext(): Promise<void> {
-    const entry = this.pending.shift();
-    if (!entry) throw new Error("no tick scheduled");
-    entry.tick();
-    await Bun.sleep(0);
-  }
-}
 
 describe("ForegroundSyncRefresh", () => {
   it("refreshes each connected principal once per backend tick", async () => {
@@ -52,11 +32,11 @@ describe("ForegroundSyncRefresh", () => {
     });
 
     refresh.start();
-    expect(scheduler.pending.map((entry) => entry.delayMs)).toEqual([30_000]);
+    expect(scheduler.delays).toEqual([30_000]);
     await scheduler.fireNext();
 
     expect(calls).toEqual(users);
-    expect(scheduler.pending.map((entry) => entry.delayMs)).toEqual([30_000]);
+    expect(scheduler.delays).toEqual([30_000]);
     refresh.stop();
     expect(scheduler.pending).toEqual([]);
   });

--- a/packages/backend/src/servers/sse/foreground-sync-refresh.ts
+++ b/packages/backend/src/servers/sse/foreground-sync-refresh.ts
@@ -3,6 +3,10 @@ import { PrincipalIdSchema } from "@core/types/sync/identity.contracts";
 import { type SyncServiceClient } from "@backend/common/services/sync-service/sync-service.client";
 import { getSyncServiceClient } from "@backend/common/services/sync-service/sync-service.factory";
 import { sseServer } from "@backend/servers/sse/sse.server";
+import {
+  defaultSchedule,
+  type TickScheduler,
+} from "@backend/servers/sse/tick-scheduler";
 
 const logger = Logger("app:sse.foreground-sync-refresh");
 // Tick more often than Sync's 30s resource-staleness guard so a change that
@@ -16,9 +20,9 @@ export interface ForegroundSyncRefreshDeps {
   sse: Pick<typeof sseServer, "connectedUserIds">;
 }
 
-export interface ForegroundSyncRefreshOptions {
+interface ForegroundSyncRefreshOptions {
   intervalMs?: number;
-  schedule?: (tick: () => void, delayMs: number) => { clear: () => void };
+  schedule?: TickScheduler;
 }
 
 // One backend-owned loop, rather than one timer per tab. Sync performs the
@@ -27,8 +31,10 @@ export interface ForegroundSyncRefreshOptions {
 export class ForegroundSyncRefresh {
   readonly #deps: ForegroundSyncRefreshDeps;
   readonly #intervalMs: number;
-  readonly #schedule: NonNullable<ForegroundSyncRefreshOptions["schedule"]>;
+  readonly #schedule: TickScheduler;
   #timer: { clear: () => void } | null = null;
+  // Distinct from #timer: during an in-flight tick the handle has already
+  // fired, so only this flag can stop the finally-block from rescheduling.
   #stopped = true;
 
   constructor(
@@ -92,16 +98,9 @@ export class ForegroundSyncRefresh {
   }
 }
 
-function defaultSchedule(
-  tick: () => void,
-  delayMs: number,
-): { clear: () => void } {
-  const timer = setTimeout(tick, delayMs);
-  timer.unref?.();
-  return { clear: () => clearTimeout(timer) };
-}
-
 export const foregroundSyncRefresh = new ForegroundSyncRefresh({
+  // Deferred rather than resolved eagerly: getSyncServiceClient() reads global
+  // CONFIG, and this singleton is constructed at module import time.
   client: {
     refreshForegroundConnections: (principalIds, correlationId) =>
       getSyncServiceClient().refreshForegroundConnections(

--- a/packages/backend/src/servers/sse/sync-change-feed.bridge.test.ts
+++ b/packages/backend/src/servers/sse/sync-change-feed.bridge.test.ts
@@ -1,39 +1,13 @@
 import { faker } from "@faker-js/faker";
 import { type CalendarId, type EventId } from "@core/types/domain-primitives";
 import { type ServerMessage } from "@core/types/server-message.contracts";
+import { FakeScheduler } from "@backend/__tests__/helpers/fake-scheduler";
 import {
   SyncChangeFeedBridge,
   type SyncChangeFeedBridgeDeps,
 } from "@backend/servers/sse/sync-change-feed.bridge";
 
 const objectId = () => faker.database.mongodbObjectId();
-
-// Captures every scheduled tick without real timers; a test fires the next
-// one explicitly, so ticks run deterministically and instantly.
-class FakeScheduler {
-  pending: Array<{ delayMs: number; tick: () => void }> = [];
-
-  schedule = (tick: () => void, delayMs: number): { clear: () => void } => {
-    const entry = { delayMs, tick };
-    this.pending.push(entry);
-    return {
-      clear: () => {
-        this.pending = this.pending.filter((e) => e !== entry);
-      },
-    };
-  };
-
-  // Run the next scheduled tick (and await any promise it kicks off).
-  async fireNext(): Promise<void> {
-    const entry = this.pending.shift();
-    if (!entry) throw new Error("no tick scheduled");
-    entry.tick();
-    // Let the async #tick body run to its next await point and back.
-    await Promise.resolve();
-    await Promise.resolve();
-    await Promise.resolve();
-  }
-}
 
 class FakeClient {
   calls: Array<string | null> = [];

--- a/packages/backend/src/servers/sse/sync-change-feed.bridge.ts
+++ b/packages/backend/src/servers/sse/sync-change-feed.bridge.ts
@@ -7,6 +7,10 @@ import {
   syncInvalidationToServerMessages,
   UNKNOWN_CALENDAR_ID,
 } from "@backend/servers/sse/sync-invalidation.to-server-message";
+import {
+  defaultSchedule,
+  type TickScheduler,
+} from "@backend/servers/sse/tick-scheduler";
 
 const logger = Logger("app:sse.sync-change-feed");
 
@@ -28,7 +32,7 @@ export interface SyncChangeFeedBridgeOptions {
   pollIntervalMs?: number;
   errorBackoffMs?: number;
   // Injectable timer so tests can drive ticks deterministically.
-  schedule?: (tick: () => void, delayMs: number) => { clear: () => void };
+  schedule?: TickScheduler;
 }
 
 // Polls Sync's single, global (cross-tenant) change feed with ONE shared
@@ -47,10 +51,7 @@ export class SyncChangeFeedBridge {
   readonly #sse: SyncChangeFeedBridgeDeps["sse"];
   readonly #pollIntervalMs: number;
   readonly #errorBackoffMs: number;
-  readonly #schedule: (
-    tick: () => void,
-    delayMs: number,
-  ) => { clear: () => void };
+  readonly #schedule: TickScheduler;
 
   #cursor: ChangeFeedCursor | null = null;
   #stopped = true;
@@ -144,17 +145,6 @@ export class SyncChangeFeedBridge {
     this.#cursor = page.nextCursor;
     this.#scheduleNext(this.#pollIntervalMs);
   }
-}
-
-// Real timer used when the caller injects none. .unref() keeps it from
-// holding the process open in tests or graceful shutdown.
-function defaultSchedule(
-  tick: () => void,
-  delayMs: number,
-): { clear: () => void } {
-  const timer = setTimeout(tick, delayMs);
-  timer.unref?.();
-  return { clear: () => clearTimeout(timer) };
 }
 
 // Constructed but NOT started here: this module is imported for its types by

--- a/packages/backend/src/servers/sse/tick-scheduler.ts
+++ b/packages/backend/src/servers/sse/tick-scheduler.ts
@@ -1,0 +1,14 @@
+// Injectable timer seam shared by the SSE-side background loops, so tests can
+// drive ticks deterministically instead of waiting on wall-clock timers.
+export type TickScheduler = (
+  tick: () => void,
+  delayMs: number,
+) => { clear: () => void };
+
+// Real timer used when the caller injects none. .unref() keeps it from
+// holding the process open in tests or graceful shutdown.
+export const defaultSchedule: TickScheduler = (tick, delayMs) => {
+  const timer = setTimeout(tick, delayMs);
+  timer.unref?.();
+  return { clear: () => clearTimeout(timer) };
+};

--- a/packages/sync/src/domain/connection-refresh.service.ts
+++ b/packages/sync/src/domain/connection-refresh.service.ts
@@ -1,6 +1,7 @@
 import {
   type PrincipalId,
   type TenantId,
+  TenantIdSchema,
 } from "@core/types/sync/identity.contracts";
 import {
   calendarListSyncJob,
@@ -12,6 +13,13 @@ import { type ProviderConnectionRepository } from "@sync/storage/repositories/pr
 import { type SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
 import { mapWithConcurrency } from "@sync/util/map-with-concurrency";
 
+// A resource pulled this recently does not need a fallback nudge; see
+// listStaleEventsByPrincipal for why this compares attempt, not success, time.
+const FOREGROUND_STALE_AFTER_MS = 30_000;
+// Bounds on the two nested fan-outs below. Their product is the ceiling on
+// simultaneous enqueue workflows for one batch, and therefore on the Mongo
+// load a foreground tick can put behind webhook-driven work.
+const FOREGROUND_PRINCIPAL_CONCURRENCY = 10;
 const FOREGROUND_ENQUEUE_CONCURRENCY = 10;
 
 export interface ConnectionRefreshDeps {
@@ -34,6 +42,25 @@ export type ConnectionRefreshTally = {
   inFlight: number;
 };
 
+const emptyTally = (): ConnectionRefreshTally => ({
+  resources: 0,
+  created: 0,
+  boosted: 0,
+  requeuedFailed: 0,
+  inFlight: 0,
+});
+
+// Both refresh endpoints report the same three numbers. Foreground never
+// revives a failed job, so its requeuedFailed is structurally 0 and this stays
+// a faithful total for either caller.
+export function toConnectionRefreshResponse(tally: ConnectionRefreshTally) {
+  return {
+    enqueued: tally.created + tally.boosted + tally.requeuedFailed,
+    inFlight: tally.inFlight,
+    resources: tally.resources,
+  };
+}
+
 /**
  * Enqueue (or boost) an incremental pull for every events resource owned by
  * the principal. Uses enqueueUrgent so a repeat Refresh pulls runAfter forward
@@ -54,11 +81,8 @@ export async function refreshPrincipalCalendars(
   ]);
   const runAfter = now();
   const tally: ConnectionRefreshTally = {
+    ...emptyTally(),
     resources: resources.length,
-    created: 0,
-    boosted: 0,
-    requeuedFailed: 0,
-    inFlight: 0,
   };
 
   // Revive every failed job (of any kind) for each connection this refresh
@@ -149,11 +173,8 @@ export async function refreshStalePrincipalCalendars(
   );
   const runAfter = now();
   const tally: ConnectionRefreshTally = {
+    ...emptyTally(),
     resources: resources.length,
-    created: 0,
-    boosted: 0,
-    requeuedFailed: 0,
-    inFlight: 0,
   };
   const outcomes = await mapWithConcurrency(
     resources,
@@ -169,4 +190,40 @@ export async function refreshStalePrincipalCalendars(
     if (outcome !== "failed") tally[outcome] += 1;
   }
   return tally;
+}
+
+/**
+ * One foreground tick's worth of work: refresh every principal the backend
+ * reports as holding an open Compass stream, and fold the per-principal
+ * tallies into one. Both fan-outs are capped, so a maximum-size batch can
+ * never put more than PRINCIPAL x ENQUEUE enqueue workflows on Mongo at once.
+ */
+export async function refreshStaleForegroundPrincipals(
+  deps: ForegroundRefreshDeps,
+  principalIds: readonly PrincipalId[],
+  now: Date,
+): Promise<ConnectionRefreshTally> {
+  const staleBefore = new Date(now.getTime() - FOREGROUND_STALE_AFTER_MS);
+  const tallies = await mapWithConcurrency(
+    principalIds,
+    FOREGROUND_PRINCIPAL_CONCURRENCY,
+    (principalId) =>
+      refreshStalePrincipalCalendars(
+        deps,
+        // A personal Compass tenant is keyed by the principal's own ObjectId.
+        TenantIdSchema.parse(principalId),
+        principalId,
+        staleBefore,
+        () => now,
+      ),
+  );
+  const total = emptyTally();
+  for (const tally of tallies) {
+    total.resources += tally.resources;
+    total.created += tally.created;
+    total.boosted += tally.boosted;
+    total.requeuedFailed += tally.requeuedFailed;
+    total.inFlight += tally.inFlight;
+  }
+  return total;
 }

--- a/packages/sync/src/server/connection.routes.ts
+++ b/packages/sync/src/server/connection.routes.ts
@@ -27,7 +27,6 @@ import {
   ConnectionIdSchema,
   type PrincipalId,
   type TenantId,
-  TenantIdSchema,
 } from "@core/types/sync/identity.contracts";
 import dayjs from "@core/util/date/dayjs";
 import { type SyncExecutionMode } from "@sync/config/sync.config";
@@ -38,7 +37,8 @@ import {
 } from "@sync/domain/busy-query.service";
 import {
   refreshPrincipalCalendars,
-  refreshStalePrincipalCalendars,
+  refreshStaleForegroundPrincipals,
+  toConnectionRefreshResponse,
 } from "@sync/domain/connection-refresh.service";
 import { type DerivedConnectionState } from "@sync/domain/connection-state";
 import { refreshConnectionState } from "@sync/domain/connection-state-refresh.service";
@@ -70,7 +70,6 @@ import { ProviderCalendarRepository } from "@sync/storage/repositories/provider-
 import { ProviderConnectionRepository } from "@sync/storage/repositories/provider-connection.repository";
 import { type SyncMongoService } from "@sync/storage/sync-mongo.service";
 import { syncRepositories } from "@sync/storage/sync-repositories";
-import { mapWithConcurrency } from "@sync/util/map-with-concurrency";
 
 const logger = Logger("sync:connection.routes");
 
@@ -82,8 +81,6 @@ export const BEGIN_PATH = "/internal/connections/begin";
 export const REFRESH_PATH = "/internal/connections/refresh";
 export const FOREGROUND_REFRESH_PATH =
   "/internal/connections/foreground-refresh";
-const FOREGROUND_STALE_AFTER_MS = 30_000;
-const FOREGROUND_PRINCIPAL_CONCURRENCY = 10;
 export const ADOPT_GOOGLE_AUTHORIZATION_PATH =
   "/internal/connections/adopt-google-authorization";
 // Where the provider redirects the browser after consent; `begin` builds the
@@ -451,41 +448,30 @@ export function registerConnectionRoutes(
         return;
       }
 
+      const parsed = ForegroundRefreshRequestSchema.safeParse(req.body);
+      if (!parsed.success) {
+        res.status(Status.BAD_REQUEST).json({ error: "invalid_request" });
+        return;
+      }
+
       try {
-        const parsed = ForegroundRefreshRequestSchema.safeParse(req.body);
-        if (!parsed.success) {
-          res.status(Status.BAD_REQUEST).json({ error: "invalid_request" });
-          return;
-        }
         const repos = syncRepositories(deps.mongo);
-        const now = new Date((deps.now ?? Date.now)());
-        const tallies = await mapWithConcurrency(
+        const tally = await refreshStaleForegroundPrincipals(
+          {
+            resources: repos.syncResources,
+            jobs: repos.jobs,
+            connections: repos.connections,
+          },
           parsed.data.principalIds,
-          FOREGROUND_PRINCIPAL_CONCURRENCY,
-          (principalId) =>
-            refreshStalePrincipalCalendars(
-              {
-                resources: repos.syncResources,
-                jobs: repos.jobs,
-                connections: repos.connections,
-              },
-              TenantIdSchema.parse(principalId),
-              principalId,
-              new Date(now.getTime() - FOREGROUND_STALE_AFTER_MS),
-              () => now,
-            ),
-        );
-        const totals = tallies.reduce(
-          (total, tally) => ({
-            enqueued: total.enqueued + tally.created + tally.boosted,
-            inFlight: total.inFlight + tally.inFlight,
-            resources: total.resources + tally.resources,
-          }),
-          { enqueued: 0, inFlight: 0, resources: 0 },
+          new Date((deps.now ?? Date.now)()),
         );
         res
           .status(Status.OK)
-          .json(ConnectionRefreshResponseSchema.parse(totals));
+          .json(
+            ConnectionRefreshResponseSchema.parse(
+              toConnectionRefreshResponse(tally),
+            ),
+          );
       } catch (error) {
         logger.error("Failed foreground refresh batch", redactedCause(error));
         respondInternalError(res);
@@ -662,20 +648,19 @@ export function registerConnectionRoutes(
           auth.principalId,
           () => new Date((deps.now ?? Date.now)()),
         );
-        const enqueued = tally.created + tally.boosted + tally.requeuedFailed;
         logger.info(
           `Refresh calendars for ${auth.tenantId}/${auth.principalId}: ` +
             `resources=${tally.resources} created=${tally.created} ` +
             `boosted=${tally.boosted} requeuedFailed=${tally.requeuedFailed} ` +
             `inFlight=${tally.inFlight}`,
         );
-        res.status(Status.OK).json(
-          ConnectionRefreshResponseSchema.parse({
-            enqueued,
-            inFlight: tally.inFlight,
-            resources: tally.resources,
-          }),
-        );
+        res
+          .status(Status.OK)
+          .json(
+            ConnectionRefreshResponseSchema.parse(
+              toConnectionRefreshResponse(tally),
+            ),
+          );
       } catch (error) {
         logger.error(
           `Failed to refresh calendars for ${auth.tenantId}/${auth.principalId}`,

--- a/packages/sync/src/storage/repositories/job.repository.ts
+++ b/packages/sync/src/storage/repositories/job.repository.ts
@@ -31,11 +31,7 @@ export type EnqueueUrgentOutcome =
   | "requeuedFailed"
   | "inFlight";
 
-export type EnqueueForegroundOutcome =
-  | "created"
-  | "boosted"
-  | "inFlight"
-  | "failed";
+type EnqueueForegroundOutcome = "created" | "boosted" | "inFlight" | "failed";
 
 // The exact complement of listFailedForRequeue's eligibility filter: {$gte}
 // does not match a missing requeuedCount, so a legacy job counts as eligible
@@ -106,34 +102,18 @@ export class JobRepository {
   ): Promise<{ job: JobRecord; outcome: EnqueueUrgentOutcome }> {
     const fields = JobEnqueueSchema.parse(input);
     const now = fields.runAfter;
-
-    const requireByKey = async (
-      outcome: EnqueueUrgentOutcome,
-      missing: string,
-    ) => {
-      const job = await this.collection.findOne({
-        coalescingKey: fields.coalescingKey,
-      });
-      if (!job) throw new Error(missing);
-      return { job: JobRecordSchema.parse(job), outcome };
-    };
-
     const boostPending = () =>
-      this.collection.updateOne(
-        { coalescingKey: fields.coalescingKey, state: "pending" },
-        {
-          $min: { runAfter: now },
-          $max: { priority: fields.priority },
-          $currentDate: { updatedAt: true },
-        },
-      );
+      this.#boostPending(fields.coalescingKey, now, fields.priority);
 
-    // pending → boost. $min pulls a future runAfter back without robbing an
-    // older job of its place; $max can never demote. Wart: this short-circuits
-    // retry backoff, but attempt is untouched so the ladder still terminates.
+    // pending → boost. Wart: this short-circuits retry backoff, but attempt is
+    // untouched so the ladder still terminates.
     const boosted = await boostPending();
     if (boosted.matchedCount === 1) {
-      return requireByKey("boosted", "Boosted job disappeared after update");
+      return this.#requireByKey(
+        fields.coalescingKey,
+        "boosted",
+        "Boosted job disappeared after update",
+      );
     }
 
     // failed → revive. Frees the coalescing key that durable failures hold
@@ -157,7 +137,8 @@ export class JobRepository {
       },
     );
     if (revived.matchedCount === 1) {
-      return requireByKey(
+      return this.#requireByKey(
+        fields.coalescingKey,
         "requeuedFailed",
         "Revived job disappeared after update",
       );
@@ -186,7 +167,11 @@ export class JobRepository {
         created.runAfter.getTime() > now.getTime())
     ) {
       await boostPending();
-      return requireByKey("boosted", "Job disappeared after late boost");
+      return this.#requireByKey(
+        fields.coalescingKey,
+        "boosted",
+        "Job disappeared after late boost",
+      );
     }
 
     if (created.state === "claimed") {
@@ -204,17 +189,19 @@ export class JobRepository {
   ): Promise<{ job: JobRecord; outcome: EnqueueForegroundOutcome }> {
     const fields = JobEnqueueSchema.parse(input);
     const now = fields.runAfter;
-    const boost = async () => {
-      await this.collection.updateOne(
-        { coalescingKey: fields.coalescingKey, state: "pending" },
-        {
-          $min: { runAfter: now },
-          $max: { priority: fields.priority },
-          $currentDate: { updatedAt: true },
-        },
+    const boostPending = async (missing: string) => {
+      await this.#boostPending(fields.coalescingKey, now, fields.priority);
+      return this.#requireByKey(
+        fields.coalescingKey,
+        "boosted" as const,
+        missing,
       );
     };
 
+    // Read first, then branch. Unlike enqueueUrgent this path has no failed →
+    // revive write, so a blind boost/revive pair would cost two extra round
+    // trips per resource on the common no-existing-row path — and this runs
+    // for every stale resource of every connected principal.
     const existing = await this.collection.findOne({
       coalescingKey: fields.coalescingKey,
     });
@@ -225,28 +212,49 @@ export class JobRepository {
       return { job: JobRecordSchema.parse(existing), outcome: "inFlight" };
     }
     if (existing?.state === "pending") {
-      await boost();
-      const job = await this.collection.findOne({
-        coalescingKey: fields.coalescingKey,
-      });
-      if (!job) throw new Error("Foreground job disappeared after boost");
-      return { job: JobRecordSchema.parse(job), outcome: "boosted" };
+      return boostPending("Foreground job disappeared after boost");
     }
 
+    // The row may have appeared, been claimed, or failed since the read above.
+    // enqueue() coalesces on the unique key, so the row it returns — not the
+    // stale read — decides the outcome. By elimination the remaining state is
+    // pending, which the late boost brings up to user priority.
     const created = await this.enqueue(fields);
     if (created.state === "failed") return { job: created, outcome: "failed" };
     if (created.state === "claimed") {
       return { job: created, outcome: "inFlight" };
     }
     if (created.priority < fields.priority || created.runAfter > now) {
-      await boost();
-      const job = await this.collection.findOne({
-        coalescingKey: fields.coalescingKey,
-      });
-      if (!job) throw new Error("Foreground job disappeared after late boost");
-      return { job: JobRecordSchema.parse(job), outcome: "boosted" };
+      return boostPending("Foreground job disappeared after late boost");
     }
     return { job: created, outcome: "created" };
+  }
+
+  // The one boost write behind both urgent enqueue paths. $min pulls a future
+  // runAfter back without robbing an older job of its place; $max can never
+  // demote. Guarded on `pending`, so it can never disturb a claimed row's
+  // lease or resurrect a failed one.
+  #boostPending(coalescingKey: string, runAfter: Date, priority: number) {
+    return this.collection.updateOne(
+      { coalescingKey, state: "pending" },
+      {
+        $min: { runAfter },
+        $max: { priority },
+        $currentDate: { updatedAt: true },
+      },
+    );
+  }
+
+  // Re-read a coalesced row after a blind, state-guarded write. The row is
+  // expected to exist, so absence is an invariant break, not a miss.
+  async #requireByKey<O extends string>(
+    coalescingKey: string,
+    outcome: O,
+    missing: string,
+  ): Promise<{ job: JobRecord; outcome: O }> {
+    const job = await this.collection.findOne({ coalescingKey });
+    if (!job) throw new Error(missing);
+    return { job: JobRecordSchema.parse(job), outcome };
   }
 
   async findById(


### PR DESCRIPTION
Simplification pass over the foreground sync refresh fallback shipped in #2815. No behavior change: same freshness guarantee, service authentication, passive-mode handling, concurrency caps, and failed-job semantics.

## What changed

- **One tick scheduler instead of two.** `defaultSchedule` was byte-identical in `foreground-sync-refresh.ts` and `sync-change-feed.bridge.ts`, and the inline `(tick, delayMs) => {clear}` type was spelled out four times. Both now share `servers/sse/tick-scheduler.ts`.
- **The endpoint handler shed its orchestration.** The staleness window, principal concurrency, tenant derivation and tally fold moved out of the route and into `refreshStaleForegroundPrincipals` in the domain service. The route kept service auth, the passive-mode 409, and strict Zod parse, all ahead of any domain call.
- **One tally-to-response mapper** shared by the manual and foreground refresh endpoints. Foreground never revives a failed job, so its `requeuedFailed` is structurally 0 and the shared total stays faithful for both callers.
- **Single-sourced the race-critical enqueue writes.** The boost update document and the coalesced re-read now live in `JobRepository#boostPending` / `#requireByKey`, shared by `enqueueUrgent` and `enqueueForeground` instead of a copy each.
- **Narrowed two exports** (`EnqueueForegroundOutcome`, `ForegroundSyncRefreshOptions`) to their own modules, and **shared the `FakeScheduler` test helper** across both SSE suites.

Duplicated units: `defaultSchedule` 2 -> 1, `FakeScheduler` 2 -> 1, boost update doc 2 -> 1, refetch-or-throw 4 -> 1, tally-to-response 2 -> 1.

## What was deliberately not done

- **`enqueueForeground` was not merged into `enqueueUrgent`.** They use different orderings for a real reason: urgent is write-first, foreground is read-first. Unifying onto write-first costs foreground two extra round trips per resource on the common no-existing-row path, which is the hot path at up to 100 concurrent workers. Unifying onto read-first would change `enqueueUrgent`'s race labelling. Only the identical pieces are shared, and a comment now records why.
- **`mapWithConcurrency` was kept.** Its test is the only direct regression guard on the concurrency cap.
- **The per-principal queries were not bulk-ified.** `listStaleEventsByPrincipal` carries a per-principal `limit = 200`; a single `$in` query with one limit would let one busy principal starve the rest.

## Invariants preserved

- Google push notifications remain the preferred fast path; no browser polling, no per-tab timers, SSE unchanged.
- Service-level authentication, strict Zod validation, and the 500-principal batch cap are unchanged.
- Only `bootstrapState: "ready"` event resources are selected, still keyed on `lastAttemptAt` rather than last-success so failing resources keep their retry backoff.
- Only healthy or delayed connections are refreshed.
- A periodic foreground tick still cannot revive a terminally failed job. This is enforced by the type system, not just by inspection: `"requeuedFailed"` is not a member of `EnqueueForegroundOutcome`.
- Concurrency stays bounded. Ceiling for a 500-principal request is unchanged at 100 simultaneous Mongo operations (10 principals x 10 resource workers; the read and enqueue phases do not overlap within a principal).
- Scheduler lifecycle unchanged: `start()`/`stop()` idempotent, `.unref()` retained, and stopping during an in-flight tick still suppresses the reschedule via the `#stopped` guard in `#scheduleNext`.

## Line accounting

Production lines went **up** by 53 (net +379 -> +432 against the pre-#2815 base); test lines fell by 16. Of 182 production lines added, 33 are comments and 7 blank, and a large share of the rest is code moved from the route into the domain. The justification is duplication removal and clearer ownership, not size.

## Validation

- `bun run type-check` — passes clean (this change crosses core/backend/sync contracts)
- `bun run test:sync` — 971 pass, 0 fail
- `bun run test:backend` — 355 pass, 1 skip, 0 fail
- `bun run test:core` — 551 pass, 0 fail
- `bun run lint` — 0 errors; the 8 warnings are pre-existing and in unrelated `packages/web` / `self-host` files
- `git diff --check` — clean

No tests were weakened, skipped, or deleted; the test-line reduction is entirely the deduplicated `FakeScheduler`.

An independent read-only review was run over the final diff, instructed to falsify the "behavior unchanged" claim across nine specific axes. It found nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)