### PR TITLE
chore: bypass permissions by default for cloud sessions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "permissions": {
-    "defaultMode": "acceptEdits",
+    "defaultMode": "bypassPermissions",
     "allow": [
       "Bash(bun run test:*)",
       "Bash(bun run lint)",


### PR DESCRIPTION
Cloud sessions only see committed settings, so the personal allowlists in `~/.claude/settings.json` and the gitignored `.claude/settings.local.json` never reach them. That left cloud sessions running under `acceptEdits` and prompting for routine commands.

Sets `permissions.defaultMode` to `bypassPermissions` in `.claude/settings.json`.

The `deny` list is unaffected and still takes precedence: `git push --force`, `git reset --hard`, `rm -rf`, and `.env` reads/edits remain hard blocks.

Note: this applies to local sessions and to anyone who clones the repo, not just cloud. Individual machines can opt back out via `"defaultMode": "acceptEdits"` in their gitignored `.claude/settings.local.json`, which overrides this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)