### PR TITLE
feat(web): prompt when the pinned timezone differs from the device

### DIFF
--- a/packages/web/src/common/constants/storage.constants.ts
+++ b/packages/web/src/common/constants/storage.constants.ts
@@ -32,7 +32,10 @@ type StorageKey =
   // an id that no longer resolves to a visible item is skipped, not an error.
   | "compass.commands.recent"
   // Pinned calendar timezone. Absent means Auto (follow the browser).
-  | "compass.timezone.default";
+  | "compass.timezone.default"
+  // Browser IANA id the pin-mismatch banner is snoozed for. Absent means the
+  // banner can show. It returns when the browser zone no longer matches.
+  | "compass.timezone.mismatch-snoozed-browser";
 
 export const STORAGE_KEYS: Record<
   | "AUTH"
@@ -53,7 +56,8 @@ export const STORAGE_KEYS: Record<
   | "DEFAULT_CALENDAR_ID"
   | "COLLAPSED_ACCOUNTS"
   | "RECENT_COMMANDS"
-  | "DEFAULT_TIMEZONE",
+  | "DEFAULT_TIMEZONE"
+  | "TIMEZONE_MISMATCH_SNOOZED_BROWSER",
   StorageKey
 > = {
   AUTH: "compass.auth",
@@ -78,4 +82,6 @@ export const STORAGE_KEYS: Record<
   COLLAPSED_ACCOUNTS: "compass.calendars.collapsed-accounts",
   RECENT_COMMANDS: "compass.commands.recent",
   DEFAULT_TIMEZONE: "compass.timezone.default",
+  TIMEZONE_MISMATCH_SNOOZED_BROWSER:
+    "compass.timezone.mismatch-snoozed-browser",
 } as const;

--- a/packages/web/src/common/utils/draft/reposition-draft-by-keyboard.util.test.ts
+++ b/packages/web/src/common/utils/draft/reposition-draft-by-keyboard.util.test.ts
@@ -1,12 +1,24 @@
+import { act } from "react";
 import dayjs from "@core/util/date/dayjs";
 import {
   createGridEventDraft,
   timedGridSchedule,
 } from "@web/events/grid-event-draft.adapter";
+import {
+  resetEffectiveTimeZoneStoreForTests,
+  setPinnedTimeZone,
+} from "@web/timezone/effective-timezone.store";
+import { calendarDateInEffectiveTimeZone } from "@web/timezone/in-time-zone";
 import { repositionDraftByKeyboard } from "./reposition-draft-by-keyboard.util";
-import { describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it } from "bun:test";
 
 describe("repositionDraftByKeyboard", () => {
+  afterEach(() => {
+    act(() => {
+      resetEffectiveTimeZoneStoreForTests();
+    });
+  });
+
   it("moves a createShortcut timed draft by 15 minutes with ArrowDown", () => {
     const draft = createGridEventDraft(
       timedGridSchedule(
@@ -78,5 +90,32 @@ describe("repositionDraftByKeyboard", () => {
     expect(dayjs(next?.values.schedule.start).format()).toBe(
       dayjs("2026-05-20T09:15:00.000").format(),
     );
+  });
+
+  it("moves a timed draft that is same-day in the pin but crosses the browser midnight", () => {
+    act(() => {
+      setPinnedTimeZone("America/Chicago");
+    });
+
+    const draft = createGridEventDraft(
+      timedGridSchedule(
+        calendarDateInEffectiveTimeZone("2026-05-20").add(18, "hour").toDate(),
+        calendarDateInEffectiveTimeZone("2026-05-20").add(20, "hour").toDate(),
+      ),
+    );
+
+    const next = repositionDraftByKeyboard({
+      activity: "createShortcut",
+      draft,
+      key: "ArrowDown",
+    });
+
+    expect(next).not.toBeNull();
+    expect(
+      calendarDateInEffectiveTimeZone("2026-05-20")
+        .add(18, "hour")
+        .add(15, "minute")
+        .isSame(next?.values.schedule.start),
+    ).toBe(true);
   });
 });

--- a/packages/web/src/common/utils/draft/reposition-draft-by-keyboard.util.ts
+++ b/packages/web/src/common/utils/draft/reposition-draft-by-keyboard.util.ts
@@ -1,4 +1,3 @@
-import dayjs from "@core/util/date/dayjs";
 import {
   getArrowKeyMovement,
   isTimedEventInsideOneDay,
@@ -9,6 +8,7 @@ import {
 } from "@web/events/event-draft.types";
 import { replaceGridDraftSchedule } from "@web/events/grid-event-draft.adapter";
 import { type Activity_DraftEvent } from "@web/events/stores/draft.store";
+import { inEffectiveTimeZone } from "@web/timezone/in-time-zone";
 
 const canRepositionDraftByKeyboard = (
   activity: Activity_DraftEvent | null | undefined,
@@ -41,8 +41,8 @@ export const repositionDraftByKeyboard = ({
   const movement = getArrowKeyMovement(key, isAllDay);
   if (!movement) return null;
 
-  const start = dayjs(draft.values.schedule.start);
-  const end = dayjs(draft.values.schedule.end);
+  const start = inEffectiveTimeZone(draft.values.schedule.start);
+  const end = inEffectiveTimeZone(draft.values.schedule.end);
   const nextStart = start
     .add(movement.days, "day")
     .add(movement.minutes, "minutes");

--- a/packages/web/src/components/OverlayPanel/OverlayPanel.test.tsx
+++ b/packages/web/src/components/OverlayPanel/OverlayPanel.test.tsx
@@ -81,6 +81,26 @@ describe("OverlayPanel", () => {
     expect(last).toHaveFocus();
   });
 
+  it("does not trap Tab onto tabindex=-1 buttons", async () => {
+    const user = userEvent.setup();
+    render(
+      <OverlayPanel title="Confirm" onDismiss={() => {}}>
+        <button type="button">First</button>
+        <button type="button" tabIndex={-1}>
+          Skipped
+        </button>
+        <button type="button">Last</button>
+      </OverlayPanel>,
+    );
+
+    const first = screen.getByRole("button", { name: "First" });
+    const last = screen.getByRole("button", { name: "Last" });
+    expect(first).toHaveFocus();
+
+    await user.tab();
+    expect(last).toHaveFocus();
+  });
+
   it("skips focus restore when skipFocusRestoreRef is set", () => {
     const skipFocusRestoreRef = { current: false };
     const { rerender } = render(<button type="button">Outside</button>);

--- a/packages/web/src/components/OverlayPanel/OverlayPanel.tsx
+++ b/packages/web/src/components/OverlayPanel/OverlayPanel.tsx
@@ -12,7 +12,7 @@ import { Z_INDEX_MODAL } from "@web/common/constants/web.constants";
 import { useAppLockReason } from "@web/shortcuts/app-lock";
 
 const FOCUSABLE_SELECTOR =
-  'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
+  'a[href]:not([tabindex="-1"]), button:not([disabled]):not([tabindex="-1"]), textarea:not([disabled]):not([tabindex="-1"]), input:not([disabled]):not([tabindex="-1"]), select:not([disabled]):not([tabindex="-1"]), [tabindex]:not([tabindex="-1"])';
 
 const getFocusableElements = (root: HTMLElement) =>
   Array.from(root.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR));

--- a/packages/web/src/events/grid-event-draft.adapter.test.ts
+++ b/packages/web/src/events/grid-event-draft.adapter.test.ts
@@ -1,3 +1,4 @@
+import { act } from "react";
 import { Origin } from "@core/constants/core.constants";
 import {
   type Calendar,
@@ -7,6 +8,11 @@ import { type Event } from "@core/types/event.contracts";
 import dayjs from "@core/util/date/dayjs";
 import { type GridEventDraft } from "@web/events/event-draft.types";
 import {
+  resetEffectiveTimeZoneStoreForTests,
+  setPinnedTimeZone,
+} from "@web/timezone/effective-timezone.store";
+import {
+  allDayGridSchedule,
   createGridEventDraft,
   duplicateGridEventDraft,
   editGridEventDraft,
@@ -401,4 +407,22 @@ test("suppressedSeriesIdForDraft: the base event's own id once a series base's r
   const edited = patchGridDraftRecurrence(draft, ["RRULE:FREQ=DAILY"]);
 
   expect(suppressedSeriesIdForDraft(edited)).toEqual(seriesEvent.id);
+});
+
+test("all-day YMD stays on the pinned calendar day when it is west of the runtime", () => {
+  act(() => {
+    setPinnedTimeZone("America/Chicago");
+  });
+  try {
+    const draft = createGridEventDraft(
+      allDayGridSchedule("2026-05-17", "2026-05-18"),
+    );
+
+    expect(gridEventDraftToGridEvent(draft).startDate).toBe("2026-05-17");
+    expect(gridEventDraftToGridEvent(draft).endDate).toBe("2026-05-18");
+  } finally {
+    act(() => {
+      resetEffectiveTimeZoneStoreForTests();
+    });
+  }
 });

--- a/packages/web/src/events/grid-event-draft.adapter.ts
+++ b/packages/web/src/events/grid-event-draft.adapter.ts
@@ -24,7 +24,10 @@ import {
   type GridScheduleDraft,
 } from "@web/events/event-draft.types";
 import { getEffectiveTimeZone } from "@web/timezone/effective-timezone.store";
-import { inEffectiveTimeZone } from "@web/timezone/in-time-zone";
+import {
+  calendarDateInEffectiveTimeZone,
+  inEffectiveTimeZone,
+} from "@web/timezone/in-time-zone";
 
 function gridScheduleFromEvent(event: Event): GridScheduleDraft | null {
   const { schedule } = event;
@@ -196,18 +199,18 @@ export function timedGridSchedule(start: Date, end: Date): GridScheduleDraft {
   return { kind: "timed", start, end, timeZone: getEffectiveTimeZone() };
 }
 
-// All-day draft Dates are local midnight everywhere (drag creation, form
-// patches, shortcuts). new Date("YYYY-MM-DD") would parse as UTC midnight,
-// which reads as the previous day when formatted back in local time west of
-// UTC — dayjs parses date-only strings as local.
+// All-day draft Dates are midnight in the effective calendar timezone.
+// Parsing YYYY-MM-DD as browser-local midnight, then formatting with
+// inEffectiveTimeZone, shifts the calendar day when the pin is west of the
+// runtime zone.
 export function allDayGridSchedule(
   start: string,
   end: string,
 ): GridScheduleDraft {
   return {
     kind: "allDay",
-    start: dayjs(start).toDate(),
-    end: dayjs(end).toDate(),
+    start: calendarDateInEffectiveTimeZone(start).toDate(),
+    end: calendarDateInEffectiveTimeZone(end).toDate(),
   };
 }
 

--- a/packages/web/src/timezone/TimezoneMismatchBanner.tsx
+++ b/packages/web/src/timezone/TimezoneMismatchBanner.tsx
@@ -1,0 +1,43 @@
+import { timezoneMismatchCopy } from "@web/timezone/timezone-mismatch";
+
+export function TimezoneMismatchBanner({
+  browserZone,
+  calendarZone,
+  onKeep,
+  onSwitch,
+}: {
+  browserZone: string;
+  calendarZone: string;
+  onKeep: () => void;
+  onSwitch: () => void;
+}) {
+  const { keepLabel, message, switchLabel } = timezoneMismatchCopy(
+    browserZone,
+    calendarZone,
+  );
+
+  return (
+    <div
+      className="flex flex-wrap items-center justify-between gap-3 border-border border-b bg-surface-panel px-4 py-2 text-text-muted text-xs"
+      role="status"
+    >
+      <p>{message}</p>
+      <div className="flex shrink-0 gap-2">
+        <button
+          className="c-focus-ring rounded-xs px-2 py-1 font-medium text-text hover:bg-surface-overlay"
+          onClick={onSwitch}
+          type="button"
+        >
+          {switchLabel}
+        </button>
+        <button
+          className="c-focus-ring rounded-xs px-2 py-1 text-text hover:bg-surface-overlay"
+          onClick={onKeep}
+          type="button"
+        >
+          {keepLabel}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/timezone/TimezoneMismatchBanner.tsx
+++ b/packages/web/src/timezone/TimezoneMismatchBanner.tsx
@@ -17,9 +17,9 @@ export function TimezoneMismatchBanner({
   );
 
   return (
-    <div
+    <section
+      aria-label="Timezone mismatch"
       className="flex flex-wrap items-center justify-between gap-3 border-border border-b bg-surface-panel px-4 py-2 text-text-muted text-xs"
-      role="status"
     >
       <p>{message}</p>
       <div className="flex shrink-0 gap-2">
@@ -38,6 +38,6 @@ export function TimezoneMismatchBanner({
           {keepLabel}
         </button>
       </div>
-    </div>
+    </section>
   );
 }

--- a/packages/web/src/timezone/TimezoneMismatchBannerGate.test.tsx
+++ b/packages/web/src/timezone/TimezoneMismatchBannerGate.test.tsx
@@ -1,0 +1,100 @@
+import { act, cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  getPinnedTimeZone,
+  resetEffectiveTimeZoneStoreForTests,
+  setBrowserTimeZoneForTests,
+  setPinnedTimeZone,
+} from "@web/timezone/effective-timezone.store";
+import { TimezoneMismatchBannerGate } from "@web/timezone/TimezoneMismatchBannerGate";
+import { timezoneMismatchCopy } from "@web/timezone/timezone-mismatch";
+import { afterEach, describe, expect, it } from "bun:test";
+import "@testing-library/jest-dom";
+
+afterEach(() => {
+  cleanup();
+  act(() => {
+    resetEffectiveTimeZoneStoreForTests();
+  });
+});
+
+describe("TimezoneMismatchBannerGate", () => {
+  it("does not render in Auto", () => {
+    render(<TimezoneMismatchBannerGate />);
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+  });
+
+  it("does not render when the pin matches the browser", () => {
+    act(() => {
+      setBrowserTimeZoneForTests("America/Denver");
+      setPinnedTimeZone("America/Denver");
+    });
+
+    render(<TimezoneMismatchBannerGate />);
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+  });
+
+  it("prompts to switch or keep when the pin differs from the browser", () => {
+    act(() => {
+      setBrowserTimeZoneForTests("America/Denver");
+      setPinnedTimeZone("America/New_York");
+    });
+
+    const copy = timezoneMismatchCopy("America/Denver", "America/New_York");
+    render(<TimezoneMismatchBannerGate />);
+
+    expect(screen.getByRole("status")).toHaveTextContent(copy.message);
+    expect(
+      screen.getByRole("button", { name: copy.switchLabel }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: copy.keepLabel }),
+    ).toBeInTheDocument();
+  });
+
+  it("pins the browser zone when Switch is chosen", async () => {
+    const user = userEvent.setup();
+    act(() => {
+      setBrowserTimeZoneForTests("America/Denver");
+      setPinnedTimeZone("America/New_York");
+    });
+
+    const copy = timezoneMismatchCopy("America/Denver", "America/New_York");
+    render(<TimezoneMismatchBannerGate />);
+    await user.click(screen.getByRole("button", { name: copy.switchLabel }));
+
+    expect(getPinnedTimeZone()).toBe("America/Denver");
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+  });
+
+  it("snoozes until the browser zone changes when Keep is chosen", async () => {
+    const user = userEvent.setup();
+    act(() => {
+      setBrowserTimeZoneForTests("America/Denver");
+      setPinnedTimeZone("America/New_York");
+    });
+
+    const denverCopy = timezoneMismatchCopy(
+      "America/Denver",
+      "America/New_York",
+    );
+    const { unmount } = render(<TimezoneMismatchBannerGate />);
+    await user.click(
+      screen.getByRole("button", { name: denverCopy.keepLabel }),
+    );
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+
+    unmount();
+    render(<TimezoneMismatchBannerGate />);
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+
+    act(() => {
+      setBrowserTimeZoneForTests("America/Chicago");
+    });
+    const chicagoCopy = timezoneMismatchCopy(
+      "America/Chicago",
+      "America/New_York",
+    );
+    expect(screen.getByRole("status")).toHaveTextContent(chicagoCopy.message);
+  });
+});

--- a/packages/web/src/timezone/TimezoneMismatchBannerGate.test.tsx
+++ b/packages/web/src/timezone/TimezoneMismatchBannerGate.test.tsx
@@ -1,5 +1,6 @@
 import { act, cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
 import {
   getPinnedTimeZone,
   resetEffectiveTimeZoneStoreForTests,
@@ -11,6 +12,9 @@ import { timezoneMismatchCopy } from "@web/timezone/timezone-mismatch";
 import { afterEach, describe, expect, it } from "bun:test";
 import "@testing-library/jest-dom";
 
+const mismatchRegion = () =>
+  screen.queryByRole("region", { name: "Timezone mismatch" });
+
 afterEach(() => {
   cleanup();
   act(() => {
@@ -21,7 +25,7 @@ afterEach(() => {
 describe("TimezoneMismatchBannerGate", () => {
   it("does not render in Auto", () => {
     render(<TimezoneMismatchBannerGate />);
-    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    expect(mismatchRegion()).not.toBeInTheDocument();
   });
 
   it("does not render when the pin matches the browser", () => {
@@ -31,7 +35,7 @@ describe("TimezoneMismatchBannerGate", () => {
     });
 
     render(<TimezoneMismatchBannerGate />);
-    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    expect(mismatchRegion()).not.toBeInTheDocument();
   });
 
   it("prompts to switch or keep when the pin differs from the browser", () => {
@@ -43,7 +47,9 @@ describe("TimezoneMismatchBannerGate", () => {
     const copy = timezoneMismatchCopy("America/Denver", "America/New_York");
     render(<TimezoneMismatchBannerGate />);
 
-    expect(screen.getByRole("status")).toHaveTextContent(copy.message);
+    expect(
+      screen.getByRole("region", { name: "Timezone mismatch" }),
+    ).toHaveTextContent(copy.message);
     expect(
       screen.getByRole("button", { name: copy.switchLabel }),
     ).toBeInTheDocument();
@@ -64,7 +70,7 @@ describe("TimezoneMismatchBannerGate", () => {
     await user.click(screen.getByRole("button", { name: copy.switchLabel }));
 
     expect(getPinnedTimeZone()).toBe("America/Denver");
-    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    expect(mismatchRegion()).not.toBeInTheDocument();
   });
 
   it("snoozes until the browser zone changes when Keep is chosen", async () => {
@@ -82,11 +88,11 @@ describe("TimezoneMismatchBannerGate", () => {
     await user.click(
       screen.getByRole("button", { name: denverCopy.keepLabel }),
     );
-    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    expect(mismatchRegion()).not.toBeInTheDocument();
 
     unmount();
     render(<TimezoneMismatchBannerGate />);
-    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    expect(mismatchRegion()).not.toBeInTheDocument();
 
     act(() => {
       setBrowserTimeZoneForTests("America/Chicago");
@@ -95,6 +101,32 @@ describe("TimezoneMismatchBannerGate", () => {
       "America/Chicago",
       "America/New_York",
     );
-    expect(screen.getByRole("status")).toHaveTextContent(chicagoCopy.message);
+    expect(
+      screen.getByRole("region", { name: "Timezone mismatch" }),
+    ).toHaveTextContent(chicagoCopy.message);
+  });
+
+  it("hides when another tab snoozes the same browser zone", () => {
+    act(() => {
+      setBrowserTimeZoneForTests("America/Denver");
+      setPinnedTimeZone("America/New_York");
+    });
+
+    render(<TimezoneMismatchBannerGate />);
+    expect(mismatchRegion()).toBeInTheDocument();
+
+    act(() => {
+      localStorage.setItem(
+        STORAGE_KEYS.TIMEZONE_MISMATCH_SNOOZED_BROWSER,
+        "America/Denver",
+      );
+      window.dispatchEvent(
+        new StorageEvent("storage", {
+          key: STORAGE_KEYS.TIMEZONE_MISMATCH_SNOOZED_BROWSER,
+        }),
+      );
+    });
+
+    expect(mismatchRegion()).not.toBeInTheDocument();
   });
 });

--- a/packages/web/src/timezone/TimezoneMismatchBannerGate.tsx
+++ b/packages/web/src/timezone/TimezoneMismatchBannerGate.tsx
@@ -1,0 +1,48 @@
+import { useState } from "react";
+import {
+  setPinnedTimeZone,
+  useBrowserTimeZone,
+  usePinnedTimeZone,
+} from "@web/timezone/effective-timezone.store";
+import { TimezoneMismatchBanner } from "@web/timezone/TimezoneMismatchBanner";
+import {
+  getTimezoneMismatchSnoozedBrowser,
+  shouldShowTimezoneMismatch,
+  snoozeTimezoneMismatch,
+} from "@web/timezone/timezone-mismatch";
+
+export function TimezoneMismatchBannerGate() {
+  const pinnedTimeZone = usePinnedTimeZone();
+  const browserTimeZone = useBrowserTimeZone();
+  const [snoozedForBrowser, setSnoozedForBrowser] = useState(
+    getTimezoneMismatchSnoozedBrowser,
+  );
+
+  if (pinnedTimeZone === null) {
+    return null;
+  }
+
+  if (
+    !shouldShowTimezoneMismatch(
+      pinnedTimeZone,
+      browserTimeZone,
+      snoozedForBrowser,
+    )
+  ) {
+    return null;
+  }
+
+  return (
+    <TimezoneMismatchBanner
+      browserZone={browserTimeZone}
+      calendarZone={pinnedTimeZone}
+      onKeep={() => {
+        snoozeTimezoneMismatch(browserTimeZone);
+        setSnoozedForBrowser(browserTimeZone);
+      }}
+      onSwitch={() => {
+        setPinnedTimeZone(browserTimeZone);
+      }}
+    />
+  );
+}

--- a/packages/web/src/timezone/TimezoneMismatchBannerGate.tsx
+++ b/packages/web/src/timezone/TimezoneMismatchBannerGate.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import {
   setPinnedTimeZone,
   useBrowserTimeZone,
@@ -6,17 +5,15 @@ import {
 } from "@web/timezone/effective-timezone.store";
 import { TimezoneMismatchBanner } from "@web/timezone/TimezoneMismatchBanner";
 import {
-  getTimezoneMismatchSnoozedBrowser,
   shouldShowTimezoneMismatch,
   snoozeTimezoneMismatch,
+  useTimezoneMismatchSnoozedBrowser,
 } from "@web/timezone/timezone-mismatch";
 
 export function TimezoneMismatchBannerGate() {
   const pinnedTimeZone = usePinnedTimeZone();
   const browserTimeZone = useBrowserTimeZone();
-  const [snoozedForBrowser, setSnoozedForBrowser] = useState(
-    getTimezoneMismatchSnoozedBrowser,
-  );
+  const snoozedForBrowser = useTimezoneMismatchSnoozedBrowser();
 
   if (pinnedTimeZone === null) {
     return null;
@@ -38,7 +35,6 @@ export function TimezoneMismatchBannerGate() {
       calendarZone={pinnedTimeZone}
       onKeep={() => {
         snoozeTimezoneMismatch(browserTimeZone);
-        setSnoozedForBrowser(browserTimeZone);
       }}
       onSwitch={() => {
         setPinnedTimeZone(browserTimeZone);

--- a/packages/web/src/timezone/TimezoneOptionButton.tsx
+++ b/packages/web/src/timezone/TimezoneOptionButton.tsx
@@ -22,6 +22,7 @@ export function TimezoneOptionButton({
       id={id}
       onClick={onSelect}
       role="option"
+      tabIndex={-1}
       type="button"
     >
       <span className="text-text">{label}</span>

--- a/packages/web/src/timezone/TimezonePickerDialog.test.tsx
+++ b/packages/web/src/timezone/TimezonePickerDialog.test.tsx
@@ -57,7 +57,7 @@ describe("TimezonePickerDialog", () => {
 
     const search = screen.getByRole("combobox", { name: "Search timezones" });
     await user.type(search, "Chicago");
-    await user.keyboard("{ArrowDown}{Enter}");
+    await user.keyboard("{Enter}");
 
     expect(getPinnedTimeZone()).toBe("America/Chicago");
   });
@@ -78,5 +78,21 @@ describe("TimezonePickerDialog", () => {
 
     expect(getPinnedTimeZone()).toBeNull();
     expect(getEffectiveTimeZone()).toBe(getBrowserTimeZone());
+  });
+
+  it("keeps timezone options out of the tab order", async () => {
+    const user = userEvent.setup();
+    render(
+      <TimezonePickerDialog onDismiss={() => timezoneDialogActions.close()} />,
+    );
+
+    const search = screen.getByRole("combobox", { name: "Search timezones" });
+    expect(search).toHaveFocus();
+    for (const option of screen.getAllByRole("option")) {
+      expect(option).toHaveAttribute("tabindex", "-1");
+    }
+
+    await user.tab();
+    expect(search).toHaveFocus();
   });
 });

--- a/packages/web/src/timezone/TimezonePickerDialog.tsx
+++ b/packages/web/src/timezone/TimezonePickerDialog.tsx
@@ -125,8 +125,14 @@ export function TimezonePickerDialog({
           autoComplete="off"
           className="c-focus-ring w-full rounded border border-border bg-surface-overlay px-3 py-2 text-sm text-text outline-none placeholder:text-text-muted"
           onChange={(event) => {
-            setQuery(event.target.value);
-            setActiveId(AUTO_ID);
+            const nextQuery = event.target.value;
+            setQuery(nextQuery);
+            const nextZones = filterTimeZones(catalog, nextQuery);
+            setActiveId(
+              nextQuery.trim().length > 0
+                ? (nextZones[0]?.id ?? AUTO_ID)
+                : AUTO_ID,
+            );
             setVisibleCount(VISIBLE_PAGE);
           }}
           onKeyDown={handleKeyDown}

--- a/packages/web/src/timezone/effective-timezone.store.ts
+++ b/packages/web/src/timezone/effective-timezone.store.ts
@@ -120,13 +120,33 @@ export function usePinnedTimeZone(): string | null {
   return useSyncExternalStore(subscribe, getPinnedTimeZone);
 }
 
+function getStoredBrowserTimeZone(): string {
+  return browserTimeZoneStore.get();
+}
+
+export function useBrowserTimeZone(): string {
+  return useSyncExternalStore(subscribe, getStoredBrowserTimeZone);
+}
+
 /** Test-only: pin in memory (and storage when available) without extra UI. */
 export function setEffectiveTimeZoneForTests(timeZone: string): void {
   setPinnedTimeZone(timeZone);
 }
 
+/** Test-only: set the tracked browser zone without going through Intl. */
+export function setBrowserTimeZoneForTests(timeZone: string): void {
+  if (!isValidTimeZone(timeZone)) {
+    return;
+  }
+  browserTimeZoneStore.set(timeZone);
+  if (pinnedTimeZoneStore.get() === null) {
+    syncEffectiveTimeZone();
+  }
+}
+
 export function resetEffectiveTimeZoneStoreForTests(): void {
   persistentBrowserStore.remove(STORAGE_KEYS.DEFAULT_TIMEZONE);
+  persistentBrowserStore.remove(STORAGE_KEYS.TIMEZONE_MISMATCH_SNOOZED_BROWSER);
   pinnedTimeZoneStore.set(null);
   browserTimeZoneStore.set(getBrowserTimeZone());
   syncEffectiveTimeZone();

--- a/packages/web/src/timezone/effective-timezone.store.ts
+++ b/packages/web/src/timezone/effective-timezone.store.ts
@@ -7,6 +7,7 @@ import {
   subscribeToStorageKey,
 } from "@web/common/utils/external-store.util";
 import { getBrowserTimeZone } from "@web/timezone/browser-timezone";
+import { resetTimezoneMismatchSnoozeForTests } from "@web/timezone/timezone-mismatch";
 
 function isValidTimeZone(value: string): boolean {
   try {
@@ -146,8 +147,8 @@ export function setBrowserTimeZoneForTests(timeZone: string): void {
 
 export function resetEffectiveTimeZoneStoreForTests(): void {
   persistentBrowserStore.remove(STORAGE_KEYS.DEFAULT_TIMEZONE);
-  persistentBrowserStore.remove(STORAGE_KEYS.TIMEZONE_MISMATCH_SNOOZED_BROWSER);
   pinnedTimeZoneStore.set(null);
   browserTimeZoneStore.set(getBrowserTimeZone());
   syncEffectiveTimeZone();
+  resetTimezoneMismatchSnoozeForTests();
 }

--- a/packages/web/src/timezone/timezone-mismatch.test.ts
+++ b/packages/web/src/timezone/timezone-mismatch.test.ts
@@ -1,0 +1,79 @@
+import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
+import { persistentBrowserStore } from "@web/common/storage/browser-key-value.store";
+import {
+  getTimezoneMismatchSnoozedBrowser,
+  shouldShowTimezoneMismatch,
+  snoozeTimezoneMismatch,
+  timezoneMismatchCopy,
+} from "@web/timezone/timezone-mismatch";
+import { describe, expect, it } from "bun:test";
+
+describe("shouldShowTimezoneMismatch", () => {
+  it("hides for Auto even when the browser zone is set", () => {
+    expect(shouldShowTimezoneMismatch(null, "America/Denver", null)).toBe(
+      false,
+    );
+  });
+
+  it("hides when the pin matches the browser", () => {
+    expect(
+      shouldShowTimezoneMismatch("America/Denver", "America/Denver", null),
+    ).toBe(false);
+  });
+
+  it("shows when a pin differs from the browser", () => {
+    expect(
+      shouldShowTimezoneMismatch("America/New_York", "America/Denver", null),
+    ).toBe(true);
+  });
+
+  it("hides while snoozed for the current browser zone", () => {
+    expect(
+      shouldShowTimezoneMismatch(
+        "America/New_York",
+        "America/Denver",
+        "America/Denver",
+      ),
+    ).toBe(false);
+  });
+
+  it("shows again after the browser zone changes", () => {
+    expect(
+      shouldShowTimezoneMismatch(
+        "America/New_York",
+        "America/Chicago",
+        "America/Denver",
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("timezoneMismatchCopy", () => {
+  it("names both cities and abbreviations without an em dash", () => {
+    const copy = timezoneMismatchCopy(
+      "America/Denver",
+      "America/New_York",
+      new Date("2026-08-20T18:00:00.000Z"),
+    );
+
+    expect(copy.message).toBe(
+      "Your device is in Denver time (MDT) but your calendar is showing New York time (EDT).",
+    );
+    expect(copy.message).not.toContain("\u2014");
+    expect(copy.switchLabel).toBe("Switch to MDT");
+    expect(copy.keepLabel).toBe("Keep EDT");
+  });
+});
+
+describe("timezone mismatch snooze", () => {
+  it("persists the browser zone Keep was clicked for", () => {
+    snoozeTimezoneMismatch("America/Denver");
+
+    expect(getTimezoneMismatchSnoozedBrowser()).toBe("America/Denver");
+    expect(
+      persistentBrowserStore.get(
+        STORAGE_KEYS.TIMEZONE_MISMATCH_SNOOZED_BROWSER,
+      ),
+    ).toBe("America/Denver");
+  });
+});

--- a/packages/web/src/timezone/timezone-mismatch.ts
+++ b/packages/web/src/timezone/timezone-mismatch.ts
@@ -1,0 +1,46 @@
+import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
+import { persistentBrowserStore } from "@web/common/storage/browser-key-value.store";
+import { formatTimeZoneAbbreviation } from "@web/timezone/format-timezone-abbreviation";
+import { timeZoneCityName } from "@web/timezone/timezone-catalog";
+
+export function shouldShowTimezoneMismatch(
+  pinnedTimeZone: string | null,
+  browserTimeZone: string,
+  snoozedForBrowser: string | null,
+): boolean {
+  return (
+    pinnedTimeZone !== null &&
+    pinnedTimeZone !== browserTimeZone &&
+    snoozedForBrowser !== browserTimeZone
+  );
+}
+
+export function getTimezoneMismatchSnoozedBrowser(): string | null {
+  return persistentBrowserStore.get(
+    STORAGE_KEYS.TIMEZONE_MISMATCH_SNOOZED_BROWSER,
+  );
+}
+
+export function snoozeTimezoneMismatch(browserTimeZone: string): void {
+  persistentBrowserStore.set(
+    STORAGE_KEYS.TIMEZONE_MISMATCH_SNOOZED_BROWSER,
+    browserTimeZone,
+  );
+}
+
+export function timezoneMismatchCopy(
+  browserZone: string,
+  calendarZone: string,
+  at: Date = new Date(),
+): { keepLabel: string; message: string; switchLabel: string } {
+  const browserCity = timeZoneCityName(browserZone);
+  const calendarCity = timeZoneCityName(calendarZone);
+  const browserAbbr = formatTimeZoneAbbreviation(browserZone, at);
+  const calendarAbbr = formatTimeZoneAbbreviation(calendarZone, at);
+
+  return {
+    keepLabel: `Keep ${calendarAbbr}`,
+    message: `Your device is in ${browserCity} time (${browserAbbr}) but your calendar is showing ${calendarCity} time (${calendarAbbr}).`,
+    switchLabel: `Switch to ${browserAbbr}`,
+  };
+}

--- a/packages/web/src/timezone/timezone-mismatch.ts
+++ b/packages/web/src/timezone/timezone-mismatch.ts
@@ -1,5 +1,10 @@
+import { useSyncExternalStore } from "react";
 import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
 import { persistentBrowserStore } from "@web/common/storage/browser-key-value.store";
+import {
+  createExternalStore,
+  subscribeToStorageKey,
+} from "@web/common/utils/external-store.util";
 import { formatTimeZoneAbbreviation } from "@web/timezone/format-timezone-abbreviation";
 import { timeZoneCityName } from "@web/timezone/timezone-catalog";
 
@@ -15,17 +20,58 @@ export function shouldShowTimezoneMismatch(
   );
 }
 
-export function getTimezoneMismatchSnoozedBrowser(): string | null {
+function readSnoozedBrowser(): string | null {
   return persistentBrowserStore.get(
     STORAGE_KEYS.TIMEZONE_MISMATCH_SNOOZED_BROWSER,
   );
 }
 
-export function snoozeTimezoneMismatch(browserTimeZone: string): void {
-  persistentBrowserStore.set(
+const snoozedBrowserStore = createExternalStore<string | null>(
+  readSnoozedBrowser(),
+);
+
+function refreshSnoozeFromStorage(): void {
+  snoozedBrowserStore.set(readSnoozedBrowser());
+}
+
+export function getTimezoneMismatchSnoozedBrowser(): string | null {
+  return snoozedBrowserStore.get();
+}
+
+export function snoozeTimezoneMismatch(browserTimeZone: string): boolean {
+  const saved = persistentBrowserStore.set(
     STORAGE_KEYS.TIMEZONE_MISMATCH_SNOOZED_BROWSER,
     browserTimeZone,
   );
+  if (saved) {
+    snoozedBrowserStore.set(browserTimeZone);
+  }
+  return saved;
+}
+
+function subscribeSnooze(onChange: () => void): () => void {
+  const unsubscribeStore = snoozedBrowserStore.subscribe(onChange);
+  const unsubscribeStorage = subscribeToStorageKey(
+    STORAGE_KEYS.TIMEZONE_MISMATCH_SNOOZED_BROWSER,
+    refreshSnoozeFromStorage,
+  );
+
+  return () => {
+    unsubscribeStore();
+    unsubscribeStorage();
+  };
+}
+
+export function useTimezoneMismatchSnoozedBrowser(): string | null {
+  return useSyncExternalStore(
+    subscribeSnooze,
+    getTimezoneMismatchSnoozedBrowser,
+  );
+}
+
+export function resetTimezoneMismatchSnoozeForTests(): void {
+  persistentBrowserStore.remove(STORAGE_KEYS.TIMEZONE_MISMATCH_SNOOZED_BROWSER);
+  snoozedBrowserStore.set(null);
 }
 
 export function timezoneMismatchCopy(

--- a/packages/web/src/views/Day/components/Calendar/dayCalendarDraft.util.test.ts
+++ b/packages/web/src/views/Day/components/Calendar/dayCalendarDraft.util.test.ts
@@ -1,11 +1,20 @@
+import { act } from "react";
 import { Origin } from "@core/constants/core.constants";
 import dayjs from "@core/util/date/dayjs";
 import { type GridEvent } from "@web/common/types/web.event.types";
 import { gridEventDefaultPosition } from "@web/common/utils/event/event.util";
-import { createGridEventDraft } from "@web/events/grid-event-draft.adapter";
+import {
+  allDayGridSchedule,
+  createGridEventDraft,
+} from "@web/events/grid-event-draft.adapter";
 import { type GridVisibleDate } from "@web/grid/types/grid.types";
+import {
+  resetEffectiveTimeZoneStoreForTests,
+  setPinnedTimeZone,
+} from "@web/timezone/effective-timezone.store";
+import { calendarDateInEffectiveTimeZone } from "@web/timezone/in-time-zone";
 import { addVisibleDraftEvent } from "./dayCalendarDraft.util";
-import { describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it } from "bun:test";
 
 const visibleDates: GridVisibleDate[] = [
   { key: "2026-05-22", date: dayjs("2026-05-22T00:00:00") },
@@ -23,6 +32,12 @@ const savedTimed = {
 } as GridEvent;
 
 describe("addVisibleDraftEvent", () => {
+  afterEach(() => {
+    act(() => {
+      resetEffectiveTimeZoneStoreForTests();
+    });
+  });
+
   it("does not inject a multi-day timed draft into the timed layer", () => {
     const draft = createGridEventDraft({
       kind: "timed",
@@ -95,5 +110,30 @@ describe("addVisibleDraftEvent", () => {
 
     expect(result).toHaveLength(2);
     expect(result[0]?.startDate).toContain("2026-05-22T22:00:00");
+  });
+
+  it("keeps a pinned all-day draft on its calendar day", () => {
+    act(() => {
+      setPinnedTimeZone("America/Chicago");
+    });
+
+    const draft = createGridEventDraft(
+      allDayGridSchedule("2026-05-22", "2026-05-23"),
+    );
+    const chicagoDay: GridVisibleDate[] = [
+      {
+        key: "2026-05-22",
+        date: calendarDateInEffectiveTimeZone("2026-05-22"),
+      },
+    ];
+
+    const result = addVisibleDraftEvent({
+      draft,
+      events: [],
+      isAllDay: true,
+      visibleDates: chicagoDay,
+    });
+
+    expect(result).toHaveLength(1);
   });
 });

--- a/packages/web/src/views/Day/components/Calendar/dayCalendarDraft.util.ts
+++ b/packages/web/src/views/Day/components/Calendar/dayCalendarDraft.util.ts
@@ -1,4 +1,3 @@
-import dayjs from "@core/util/date/dayjs";
 import { type GridEvent } from "@web/common/types/web.event.types";
 import {
   shouldRenderTimedInAllDayRow,
@@ -14,7 +13,10 @@ import {
   positionAllDayDraftEvent,
 } from "@web/grid/layout/all-day-draft.position";
 import { type GridVisibleDate } from "@web/grid/types/grid.types";
-import { inEffectiveTimeZone } from "@web/timezone/in-time-zone";
+import {
+  calendarDateInEffectiveTimeZone,
+  inEffectiveTimeZone,
+} from "@web/timezone/in-time-zone";
 
 export const addVisibleDraftEvent = ({
   draft,
@@ -106,8 +108,8 @@ export const isDraftVisibleOnDate = (
         inEffectiveTimeZone(schedule.end),
       );
       const visibleDay = visibleDate.startOf("day");
-      const start = dayjs(dates.startDate).startOf("day");
-      const end = dayjs(dates.endDate).startOf("day");
+      const start = calendarDateInEffectiveTimeZone(dates.startDate);
+      const end = calendarDateInEffectiveTimeZone(dates.endDate);
       const inclusiveEnd = end.isAfter(start) ? end.subtract(1, "day") : start;
 
       return (
@@ -121,8 +123,8 @@ export const isDraftVisibleOnDate = (
   }
 
   const visibleDay = visibleDate.startOf("day");
-  const start = dayjs(schedule.start).startOf("day");
-  const end = dayjs(schedule.end).startOf("day");
+  const start = inEffectiveTimeZone(schedule.start).startOf("day");
+  const end = inEffectiveTimeZone(schedule.end).startOf("day");
   const inclusiveEnd = end.isAfter(start) ? end.subtract(1, "day") : start;
 
   return (

--- a/packages/web/src/views/Day/view/DayViewContent.tsx
+++ b/packages/web/src/views/Day/view/DayViewContent.tsx
@@ -24,6 +24,7 @@ import {
 } from "@web/events/stores/view.store";
 import { useCalendarViewShortcuts } from "@web/grid/shortcuts/useCalendarViewShortcuts";
 import { getShortcutMenuSections } from "@web/shortcuts/shortcuts.registry";
+import { TimezoneMismatchBannerGate } from "@web/timezone/TimezoneMismatchBannerGate";
 import { DayCalendarGrid } from "@web/views/Day/components/Calendar/DayCalendarGrid";
 import { Header } from "@web/views/Day/components/Header/Header";
 import { useDayEvents } from "@web/views/Day/hooks/events/useDayEvents";
@@ -125,6 +126,7 @@ export const DayViewContent = memo(() => {
       >
         <Header />
         <CalendarConnectionBannerGate />
+        <TimezoneMismatchBannerGate />
         <DemoEventsBannerGate range={demoEventsRange} />
 
         <div className="flex w-full flex-1 overflow-hidden">

--- a/packages/web/src/views/Week/WeekView.tsx
+++ b/packages/web/src/views/Week/WeekView.tsx
@@ -22,6 +22,7 @@ import {
   viewActions,
 } from "@web/events/stores/view.store";
 import { getShortcutMenuSections } from "@web/shortcuts/shortcuts.registry";
+import { TimezoneMismatchBannerGate } from "@web/timezone/TimezoneMismatchBannerGate";
 import { Dedication } from "@web/views/Week/components/Dedication/Dedication";
 import { DraftProvider } from "@web/views/Week/components/Draft/context/DraftProvider";
 import { Draft } from "@web/views/Week/components/Draft/Draft";
@@ -164,6 +165,7 @@ export const WeekView = () => {
           >
             <Header scrollUtil={scrollUtil} weekProps={weekProps} />
             <CalendarConnectionBannerGate />
+            <TimezoneMismatchBannerGate />
             <DemoEventsBannerGate range={demoEventsRange} />
 
             <WeekGridScrollArea>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Part II.5 of timezone support: when a calendar timezone is pinned and it differs from the browser zone, show a non-blocking banner.

Copy: `Your device is in Denver time (MDT) but your calendar is showing New York time (EDT).`

- Switch to MDT pins the browser zone (calendar follows the device)
- Keep EDT snoozes until the browser IANA zone changes
- Auto users never see the banner (`getPinnedTimeZone() === null`)

Mounted on week and day views next to the existing connection/demo banners.

Also includes Part II follow-up fixes found after merge:

- All-day draft Dates are midnight in the pinned zone, so create/duplicate/save do not shift a day west of the runtime TZ
- Draft keyboard moves use effective-zone day bounds
- Timezone picker Enter selects the top search hit; option rows are not tabbable

## Simplicity

- Visibility is one predicate (`shouldShowTimezoneMismatch`)
- Copy is a pure helper reused by the banner and tests
- Snooze is one storage key plus the same external-store + `storage` event pattern as other device prefs
- Banner and gate are separate files; gate has no `useState` / `useEffect`
- All-day YMD construction reuses `calendarDateInEffectiveTimeZone`

## Automated validation

- Focused mismatch + store tests pass, including a simulated other-tab Keep
- All-day YMD, draft keyboard, picker Enter, and OverlayPanel tabindex tests pass
- `bun run lint` and `bun run type-check` pass
- `TZ=Etc/UTC bun test:web -- --timeout=10000`: 2351 pass, 0 fail on the first II.5 commit; focused suites re-run after follow-up fixes

## Independent review

II.5 review: no high defects. Medium: Keep in one tab left Switch live in another. Fixed in `c3b81b7d`. Low a11y: banner is a labeled `<section>`.

Part II review (post-merge): high all-day draft day-shift and medium picker Enter/tab plus draft keyboard bounds. Fixed in `80642f4f` and `54773544`.

## Test plan

- `timezone-mismatch.test.ts` / `TimezoneMismatchBannerGate.test.tsx`
- `grid-event-draft.adapter.test.ts` (pinned Chicago YMD round-trip)
- `reposition-draft-by-keyboard.util.test.ts` (Chicago evening block)
- `TimezonePickerDialog.test.tsx` (Enter without ArrowDown; options `tabindex=-1`)
- `bun test:web`, `bun run lint`, `bun run type-check`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-79a4e258-3657-4a50-ad8f-b2c1f414740f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-79a4e258-3657-4a50-ad8f-b2c1f414740f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

