### PR TITLE
fix(web): keep time unchanged when tabbing through picker

### DIFF
--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/TimePicker.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/TimePicker.test.tsx
@@ -12,26 +12,31 @@ const intervalOptions: SelectOption<string>[] = [
   { value: "13:30", label: "1:30 PM" },
 ];
 const dayOptions = getTimeOptions();
+const onePm = { label: "1 PM", value: "1:00 PM" };
 const fiveThirty = { label: "5:30 PM", value: "5:30 PM" };
 
 function Harness({
   initialValue = intervalOptions[0],
   options = intervalOptions,
+  freshOptions = false,
 }: {
   initialValue?: SelectOption<string>;
   options?: SelectOption<string>[];
+  freshOptions?: boolean;
 }) {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [value, setValue] = useState(initialValue);
+  const resolvedOptions = freshOptions ? getTimeOptions() : options;
 
   return (
     <div>
+      <button type="button">Title</button>
       <TimePicker
         aria-label="Start time"
         inputId="startTimePicker"
         isMenuOpen={isMenuOpen}
         onChange={setValue}
-        options={options}
+        options={resolvedOptions}
         setIsMenuOpen={setIsMenuOpen}
         value={value}
       />
@@ -67,16 +72,36 @@ describe("TimePicker", () => {
     expect(screen.getByRole("button", { name: "Description" })).toHaveFocus();
   });
 
-  it("keeps the original value when Tabbing without choosing a new option", async () => {
+  it("keeps the original time when Tabbing through without changing the draft", async () => {
     const user = userEvent.setup();
-    render(<Harness />);
+    render(<Harness initialValue={onePm} options={dayOptions} freshOptions />);
 
-    const combobox = screen.getByRole("combobox", { name: "Start time" });
-    await user.click(combobox);
+    await user.tab();
+    await user.tab();
+    expect(screen.getByRole("combobox", { name: "Start time" })).toHaveFocus();
+
     await user.tab();
 
     expect(screen.getByText("1 PM")).toBeInTheDocument();
-    expect(screen.queryByText("1:30 PM")).not.toBeInTheDocument();
+    expect(screen.queryByText("12 AM")).not.toBeInTheDocument();
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Description" })).toHaveFocus();
+  });
+
+  it("commits the next interval when ArrowDown then Tab", async () => {
+    const user = userEvent.setup();
+    render(<Harness initialValue={onePm} options={dayOptions} />);
+
+    await user.tab();
+    await user.tab();
+    expect(screen.getByRole("combobox", { name: "Start time" })).toHaveFocus();
+    expect(screen.getByRole("listbox")).toBeInTheDocument();
+
+    await user.keyboard("{ArrowDown}");
+    await user.tab();
+
+    expect(screen.getByText("1:15 PM")).toBeInTheDocument();
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Description" })).toHaveFocus();
   });
 
@@ -108,14 +133,16 @@ describe("TimePicker", () => {
     expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
   });
 
-  it("announces that Tab selects the focused option", async () => {
+  it("announces that Tab confirms a newly chosen option or leaves the time unchanged", async () => {
     const user = userEvent.setup();
     render(<Harness />);
 
     await user.click(screen.getByRole("combobox", { name: "Start time" }));
 
     expect(
-      screen.getByText(/press Tab to select the option and exit the menu/i),
+      screen.getByText(
+        /press Tab to confirm a newly chosen option and exit, or to leave the current time unchanged/i,
+      ),
     ).toBeInTheDocument();
   });
 });

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/TimePicker.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/TimePicker.tsx
@@ -36,6 +36,15 @@ const timePickerTextStyles = {
 
 const TIMEPICKER = "timepicker";
 
+const MENU_NAV_KEYS = new Set([
+  "ArrowUp",
+  "ArrowDown",
+  "Home",
+  "End",
+  "PageUp",
+  "PageDown",
+]);
+
 function optionFromFocusedMenu(
   container: HTMLElement | null,
   options: TimeOption[] | undefined,
@@ -64,6 +73,7 @@ export const TimePicker = ({
 }: Props) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const scrollRafRef = useRef<number | null>(null);
+  const userAdjustedRef = useRef(false);
   const layerId = useId();
   useFloatingLayer(`timePicker:${layerId}`, isMenuOpen);
 
@@ -116,6 +126,10 @@ export const TimePicker = ({
         onKeyDown={(e) => {
           const key = e.key;
 
+          if (MENU_NAV_KEYS.has(key)) {
+            userAdjustedRef.current = true;
+          }
+
           if (key === "Enter" || key === "Backspace") {
             e.stopPropagation();
           }
@@ -130,11 +144,14 @@ export const TimePicker = ({
           }
 
           if (key === "Tab") {
-            // Commit the focused option ourselves. react-select's
-            // tabSelectsValue preventDefaults Tab and, with blurInputOnSelect,
-            // leaves focus on the document instead of the next field.
+            // Commit only after the user changed the draft (arrows or
+            // typing). Bare Tab through must leave the current time
+            // alone so keyboard users can move past the pickers.
+            // react-select's tabSelectsValue preventDefaults Tab and,
+            // with blurInputOnSelect, leaves focus on the document
+            // instead of the next field.
             if (e.nativeEvent.isComposing) return;
-            if (!e.shiftKey) {
+            if (!e.shiftKey && userAdjustedRef.current) {
               const option = optionFromFocusedMenu(
                 containerRef.current,
                 selectOptions,
@@ -145,7 +162,13 @@ export const TimePicker = ({
             setIsMenuOpen(false);
           }
         }}
+        onInputChange={(_inputValue, { action }) => {
+          if (action === "input-change") {
+            userAdjustedRef.current = true;
+          }
+        }}
         onMenuOpen={() => {
+          userAdjustedRef.current = false;
           setIsMenuOpen(true);
           scheduleScrollToSelected();
         }}
@@ -166,7 +189,7 @@ export const TimePicker = ({
           }) => {
             switch (context) {
               case "menu":
-                return "Use Up and Down to choose options, press Enter to select the currently focused option, press Escape to exit the menu, press Tab to select the option and exit the menu.";
+                return "Use Up and Down to choose options, press Enter to select the currently focused option, press Escape to exit the menu, press Tab to confirm a newly chosen option and exit, or to leave the current time unchanged.";
               case "input":
                 return isInitialFocus
                   ? `${ariaLabel || "Select"} is focused ${isSearchable ? ",type to refine list" : ""}, press Down to open the menu, ${isMulti ? " press left to focus selected values" : ""}`

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/TimePickers.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/TimePickers.test.tsx
@@ -188,6 +188,27 @@ describe("TimePickers", () => {
     expectDraft("2026-04-24T14:00:00+00:00", "2026-04-24T15:00:00+00:00");
   });
 
+  it("does not change the draft when Tabbing through the time pickers", async () => {
+    const user = userEvent.setup();
+    render(
+      <Harness
+        start={new Date("2026-04-24T13:00:00.000Z")}
+        end={new Date("2026-04-24T14:15:00.000Z")}
+      />,
+    );
+
+    await user.tab();
+    expect(screen.getByRole("combobox", { name: "Start time" })).toHaveFocus();
+    await user.tab();
+    expect(screen.getByRole("combobox", { name: "End time" })).toHaveFocus();
+    await user.tab();
+
+    expect(screen.queryByText("12 AM")).not.toBeInTheDocument();
+    expect(screen.getByText("1 PM")).toBeInTheDocument();
+    expect(screen.getByText("2:15 PM")).toBeInTheDocument();
+    expectDraft("2026-04-24T13:00:00+00:00", "2026-04-24T14:15:00+00:00");
+  });
+
   it("does not reject a later overnight end just because the clock is before start", async () => {
     const user = userEvent.setup();
     render(

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/TimePickers.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/TimePickers.tsx
@@ -15,6 +15,8 @@ import { TimePicker } from "./TimePicker";
 
 export const END_TIME_ORDER_ERROR = "End time must be after start time";
 
+const timeOptions = getTimeOptions();
+
 const isEndBeforeStartOnDummyDay = (startValue: string, endValue: string) => {
   const startAt = dayjs(`2000-01-01 ${startValue}`, YMDHAM_FORMAT);
   const endAt = dayjs(`2000-01-01 ${endValue}`, YMDHAM_FORMAT);
@@ -42,7 +44,6 @@ export const TimePickers: FC<Props> = ({
   setStartTime,
   startTime,
 }) => {
-  const timeOptions = getTimeOptions();
   const [isStartMenuOpen, setIsStartMenuOpen] = useState(false);
   const [isEndMenuOpen, setIsEndMenuOpen] = useState(false);
   const [timeError, setTimeError] = useState<string | null>(null);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Tabbing into an event time picker and then tabbing out no longer rewrites the time (for example 1 PM becoming 12 AM). Forward Tab now commits a focused option only after the user has changed the draft — arrow keys or typing a filter — then still moves focus to the next field. Bare Tab through closes the menu and leaves the original time alone.

Option identities are also hoisted in `TimePickers` so opening the menu does not rebuild the list and drop keyboard focus onto 12 AM.

## Simplicity

No extra simplification commit. The implementation is already a ref plus a module-level `getTimeOptions()` constant.

Retained `userAdjustedRef` because it is an imperative keystroke flag that must survive renders without causing them. Pre-existing `containerRef` and `scrollRafRef` stay for DOM/scroll cleanup. Hover-then-Tab does not commit; that matches the requested "only select after arrows or typing" behavior.

## Automated validation

- `bun run test:web` on TimePicker / TimePickers: 19 pass, 0 fail
- `bun run test:web` (full package): 2341 pass, 0 fail
- `bun run lint`: pass (8 pre-existing warnings, none in the TimePicker files)
- GitHub CI on the PR head: lint, type-check, knip, unit (core/web/backend/sync/scripts), e2e, CodeQL — all success

Manual, anonymous `dev:web` at http://localhost:9080:

- Created a 1 PM event "check mail, msg Larry"
- Tab from title into start time, Tab out: start stayed 1 PM (not 12 AM)
- Shift+Tab back, ArrowDown, Tab: start became 1:15 PM

![Tab into start time still showing 1 PM](https://cursor.com/artifacts/c/art-d3acdd3e-9d64-4578-bf0a-95f84b750132)
![Tab out keeps start time at 1 PM](https://cursor.com/artifacts/c/art-f992dbf4-4658-4e2b-b5d0-74d62072ff8b)
![ArrowDown then Tab selects 1:15 PM](https://cursor.com/artifacts/c/art-6cd23642-2ce7-499e-8fde-9103ed1e7d54)
<a href="https://cursor.com/agents/bc-8e8d005e-c11e-4a51-96b2-984635f59af9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftime_picker_tab_through_keeps_1pm.mp4"><img src="https://cursor.com/artifacts/c/art-fe04538b-bef3-4e18-9f4e-c705d63ac403" alt="time_picker_tab_through_keeps_1pm.mp4" /></a>

## Independent review

Fresh read-only review of `origin/main...HEAD`: no confirmed findings, do not block merge. Uncertain only: hover-then-Tab no longer commits (intentional), and there is no TimePickers-level ArrowDown-then-Tab test (covered at TimePicker unit level).

## Test plan

- `bun run test:web` focused on TimePicker / TimePickers (19 pass)
- `bun run test:web` (2341 pass)
- `bun run lint`
- Manual keyboard walkthrough on anonymous week view (1 PM event, Tab through, then ArrowDown+Tab)
- GitHub Test + CodeQL workflows on the PR

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8e8d005e-c11e-4a51-96b2-984635f59af9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8e8d005e-c11e-4a51-96b2-984635f59af9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

