### PR TITLE
fix(ci): surface autofix agent errors on manual dispatch

### DIFF
--- a/.github/workflows/error-autofix.yml
+++ b/.github/workflows/error-autofix.yml
@@ -82,6 +82,14 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: "posthog"
+          # Scoped on purpose. The agent's output carries PostHog query
+          # results and whatever it reads out of the repo, and this repo is
+          # public, so bot-triggered runs stay redacted. But a redacted run
+          # reports API-level failures (an expired token, exhausted quota)
+          # as a bare `is_error: true` with no cause, which is undebuggable
+          # without the real message. An operator dispatching by hand already
+          # has write access, so those runs get the full output.
+          show_full_output: ${{ github.event_name == 'workflow_dispatch' }}
           prompt: |
             Read .github/prompts/error-autofix.md and follow it exactly.
             Mode: ${{ vars.AUTOFIX_MODE }}


### PR DESCRIPTION
## Why

The error-autofix agent has never completed a run. Runs [32202734928](https://github.com/KeepSoftwareSimple/compass-calendar/actions/runs/32202734928), [32522949514](https://github.com/KeepSoftwareSimple/compass-calendar/actions/runs/32522949514) (issue #2824), and [32522949687](https://github.com/KeepSoftwareSimple/compass-calendar/actions/runs/32522949687) (issue #2825) all die the same way:

```
{"type":"system","subtype":"init","message":"Claude Code initialized","model":"claude-sonnet-5"}
{"type":"result","subtype":"success","is_error":true,"duration_ms":1865,
 "num_turns":1,"total_cost_usd":0,"permission_denials_count":0,"modelUsage":{}}
```

Zero cost and an empty `modelUsage` after a single sub-two-second turn means the CLI booted and its very first API request was refused before a token was generated. That narrows the cause to authentication or quota, but not which one, because the actual error string is inside the redacted output and in `claude-execution-output.json`, which is never uploaded.

The likely fix is unrelated to this PR: `CLAUDE_CODE_OAUTH_TOKEN` was last written 2026-07-02, while every other autofix secret was rotated on 2026-08-18, and nothing else in the repo exercises that secret. This PR is about not having to guess next time.

## What

Set `show_full_output` to true for `workflow_dispatch` runs only.

Full output is off by default for a good reason: this repo is public, and the agent's transcript carries PostHog query results plus whatever it reads out of the tree. Issue-triggered runs (the common path, driven by `posthog[bot]`) keep that redaction. Dispatching by hand already requires write access, so an operator debugging a failure gets the real message.

## Testing

The workflow parses and the step's inputs are unchanged apart from the addition:

```
show_full_output: "${{ github.event_name == 'workflow_dispatch' }}"
inputs: claude_code_oauth_token, allowed_bots, show_full_output, prompt, claude_args
```

End-to-end verification needs a dispatch after merge, since re-running a failed run reuses that run's workflow snapshot. Note that preflight already stamped the `autofix` label on #2824 and #2825, so the label has to come off before either can be dispatched again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)