### PR TITLE
fix(web): hide jump labels for out-of-view events

### DIFF
--- a/docs/acceptance/shortcuts.md
+++ b/docs/acceptance/shortcuts.md
@@ -292,7 +292,7 @@ Pressing `S` shows event-jump chips. Week view chips use day prefixes (`SU`/`M`/
 
 ### Expected Results
 
-- Chips appear on events when `S` is pressed and stay until Esc.
+- Chips appear on events currently visible in the grid when `S` is pressed and stay until Esc. Scrolled-off events keep their jump keys but hide their chips.
 - A day letter highlights that column and focuses the first event; digits refine to `Wn`.
 - Arrow keys keep jump mode on so letter-then-arrows works.
 - Shift alone / Shift+Tab / Shift+J do not toggle jump mode.

--- a/packages/web/src/shortcuts/shift-hint/ShiftHintOverlay.test.tsx
+++ b/packages/web/src/shortcuts/shift-hint/ShiftHintOverlay.test.tsx
@@ -1,0 +1,110 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { ShiftHintOverlay } from "@web/shortcuts/shift-hint/ShiftHintOverlay";
+import { type ActiveShiftHint } from "@web/shortcuts/shift-hint/useShiftHoldEventHints";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+
+const box = (
+  top: number,
+  left: number,
+  bottom: number,
+  right: number,
+): DOMRect =>
+  ({
+    top,
+    left,
+    bottom,
+    right,
+    width: right - left,
+    height: bottom - top,
+    x: left,
+    y: top,
+    toJSON: () => ({}),
+  }) as DOMRect;
+
+const stubRect = (element: HTMLElement, rect: DOMRect) => {
+  element.getBoundingClientRect = () => rect;
+};
+
+const hintFor = (element: HTMLElement, hint = "m1"): ActiveShiftHint => ({
+  eventId: "aaaaaaaaaaaaaaaaaaaaaaaa",
+  hint,
+  dayKey: "2026-08-17",
+  dayPrefix: "m",
+  index: 1,
+  element,
+});
+
+describe("ShiftHintOverlay", () => {
+  let originalInnerHeight: number;
+  let originalInnerWidth: number;
+
+  beforeEach(() => {
+    originalInnerHeight = window.innerHeight;
+    originalInnerWidth = window.innerWidth;
+    Object.defineProperty(window, "innerHeight", {
+      configurable: true,
+      value: 800,
+    });
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value: 1200,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    document.body.replaceChildren();
+    Object.defineProperty(window, "innerHeight", {
+      configurable: true,
+      value: originalInnerHeight,
+    });
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value: originalInnerWidth,
+    });
+  });
+
+  it("renders a chip on an in-view event", () => {
+    const event = document.createElement("div");
+    stubRect(event, box(220, 80, 280, 240));
+    document.body.append(event);
+
+    render(<ShiftHintOverlay hints={[hintFor(event)]} />);
+
+    const chip = screen.getByText("M1", { hidden: true }).parentElement;
+    expect(chip?.style.top).toBe("224px");
+    expect(chip?.style.left).toBe("214px");
+  });
+
+  it("hides the chip when the event is above a clipping scroller", () => {
+    const scroller = document.createElement("div");
+    scroller.style.overflowY = "auto";
+    stubRect(scroller, box(200, 0, 700, 1200));
+
+    const event = document.createElement("div");
+    stubRect(event, box(40, 80, 120, 240));
+    scroller.append(event);
+    document.body.append(scroller);
+
+    render(<ShiftHintOverlay hints={[hintFor(event)]} />);
+
+    expect(screen.queryByText("M1", { hidden: true })).toBeNull();
+  });
+
+  it("anchors a partially clipped event to the visible top-right", () => {
+    const scroller = document.createElement("div");
+    scroller.style.overflowY = "auto";
+    stubRect(scroller, box(200, 0, 700, 1200));
+
+    const event = document.createElement("div");
+    stubRect(event, box(160, 80, 260, 240));
+    scroller.append(event);
+    document.body.append(scroller);
+
+    render(<ShiftHintOverlay hints={[hintFor(event, "su1")]} />);
+
+    const chip = screen.getByText("SU1", { hidden: true }).parentElement;
+    expect(chip?.style.top).toBe("204px");
+    expect(chip?.style.left).toBe("206px");
+  });
+});

--- a/packages/web/src/shortcuts/shift-hint/ShiftHintOverlay.test.tsx
+++ b/packages/web/src/shortcuts/shift-hint/ShiftHintOverlay.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, render } from "@testing-library/react";
 import { ShiftHintOverlay } from "@web/shortcuts/shift-hint/ShiftHintOverlay";
 import { type ActiveShiftHint } from "@web/shortcuts/shift-hint/useShiftHoldEventHints";
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
@@ -33,6 +33,11 @@ const hintFor = (element: HTMLElement, hint = "m1"): ActiveShiftHint => ({
   index: 1,
   element,
 });
+
+const overlayRoot = () => document.querySelector("[data-shift-event-hints]");
+
+const overlayChip = () =>
+  overlayRoot()?.firstElementChild as HTMLElement | null;
 
 describe("ShiftHintOverlay", () => {
   let originalInnerHeight: number;
@@ -71,9 +76,9 @@ describe("ShiftHintOverlay", () => {
 
     render(<ShiftHintOverlay hints={[hintFor(event)]} />);
 
-    const chip = screen.getByText("M1", { hidden: true }).parentElement;
-    expect(chip?.style.top).toBe("224px");
-    expect(chip?.style.left).toBe("214px");
+    expect(overlayRoot()?.textContent).toBe("M1");
+    expect(overlayChip()?.style.top).toBe("224px");
+    expect(overlayChip()?.style.left).toBe("214px");
   });
 
   it("hides the chip when the event is above a clipping scroller", () => {
@@ -88,7 +93,7 @@ describe("ShiftHintOverlay", () => {
 
     render(<ShiftHintOverlay hints={[hintFor(event)]} />);
 
-    expect(screen.queryByText("M1", { hidden: true })).toBeNull();
+    expect(overlayRoot()?.textContent).toBe("");
   });
 
   it("anchors a partially clipped event to the visible top-right", () => {
@@ -103,8 +108,8 @@ describe("ShiftHintOverlay", () => {
 
     render(<ShiftHintOverlay hints={[hintFor(event, "su1")]} />);
 
-    const chip = screen.getByText("SU1", { hidden: true }).parentElement;
-    expect(chip?.style.top).toBe("204px");
-    expect(chip?.style.left).toBe("206px");
+    expect(overlayChip()?.textContent).toBe("SU1");
+    expect(overlayChip()?.style.top).toBe("204px");
+    expect(overlayChip()?.style.left).toBe("206px");
   });
 });

--- a/packages/web/src/shortcuts/shift-hint/ShiftHintOverlay.tsx
+++ b/packages/web/src/shortcuts/shift-hint/ShiftHintOverlay.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 import { Z_INDEX_TOOLTIP } from "@web/common/constants/web.constants";
 import { ShortcutHint } from "@web/components/Shortcuts/ShortcutHint";
+import { getVisibleHintRect } from "@web/shortcuts/shift-hint/shift-hint-visible-rect";
 import { type ActiveShiftHint } from "@web/shortcuts/shift-hint/useShiftHoldEventHints";
 
 /**
@@ -36,16 +37,10 @@ export function ShiftHintOverlay({ hints }: { hints: ActiveShiftHint[] }) {
       style={{ zIndex: Z_INDEX_TOOLTIP }}
     >
       {hints.map((hint) => {
-        const rect = hint.element.getBoundingClientRect();
-        // Skip off-screen cards instead of clamping chips into a corner pile.
-        if (
-          rect.width === 0 ||
-          rect.height === 0 ||
-          rect.bottom <= 0 ||
-          rect.right <= 0 ||
-          rect.top >= window.innerHeight ||
-          rect.left >= window.innerWidth
-        ) {
+        const visible = getVisibleHintRect(hint.element);
+        // Skip cards clipped by the window or a grid scroller so chips do
+        // not pile up on the header when the event is scrolled out of view.
+        if (!visible) {
           return null;
         }
 
@@ -58,8 +53,8 @@ export function ShiftHintOverlay({ hints }: { hints: ActiveShiftHint[] }) {
             key={`${hint.eventId}:${hint.hint}`}
             className="absolute"
             style={{
-              top: rect.top + 4,
-              left: Math.max(4, rect.right - chipWidth),
+              top: visible.top + 4,
+              left: Math.max(4, visible.right - chipWidth),
             }}
           >
             <ShortcutHint>{label}</ShortcutHint>

--- a/packages/web/src/shortcuts/shift-hint/shift-hint-visible-rect.test.ts
+++ b/packages/web/src/shortcuts/shift-hint/shift-hint-visible-rect.test.ts
@@ -1,0 +1,183 @@
+import {
+  getVisibleHintRect,
+  intersectHintRects,
+  MIN_VISIBLE_HINT_SIZE_PX,
+} from "@web/shortcuts/shift-hint/shift-hint-visible-rect";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+
+const box = (
+  top: number,
+  left: number,
+  bottom: number,
+  right: number,
+): DOMRect =>
+  ({
+    top,
+    left,
+    bottom,
+    right,
+    width: right - left,
+    height: bottom - top,
+    x: left,
+    y: top,
+    toJSON: () => ({}),
+  }) as DOMRect;
+
+const stubRect = (element: HTMLElement, rect: DOMRect) => {
+  element.getBoundingClientRect = () => rect;
+};
+
+describe("intersectHintRects", () => {
+  it("returns the overlap when both axes clear the minimum size", () => {
+    expect(
+      intersectHintRects(
+        { top: 0, left: 0, bottom: 100, right: 100 },
+        { top: 40, left: 40, bottom: 80, right: 90 },
+      ),
+    ).toEqual({ top: 40, left: 40, bottom: 80, right: 90 });
+  });
+
+  it("returns null when the overlap is thinner than the minimum", () => {
+    expect(
+      intersectHintRects(
+        { top: 0, left: 0, bottom: 100, right: 100 },
+        {
+          top: 100 - (MIN_VISIBLE_HINT_SIZE_PX - 1),
+          left: 0,
+          bottom: 200,
+          right: 100,
+        },
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("getVisibleHintRect", () => {
+  let originalInnerHeight: number;
+  let originalInnerWidth: number;
+
+  beforeEach(() => {
+    originalInnerHeight = window.innerHeight;
+    originalInnerWidth = window.innerWidth;
+    Object.defineProperty(window, "innerHeight", {
+      configurable: true,
+      value: 800,
+    });
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value: 1200,
+    });
+  });
+
+  afterEach(() => {
+    document.body.replaceChildren();
+    Object.defineProperty(window, "innerHeight", {
+      configurable: true,
+      value: originalInnerHeight,
+    });
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value: originalInnerWidth,
+    });
+  });
+
+  it("returns the event rect when it is fully in the viewport", () => {
+    const event = document.createElement("div");
+    stubRect(event, box(80, 40, 140, 200));
+    document.body.append(event);
+
+    expect(getVisibleHintRect(event)).toEqual({
+      top: 80,
+      left: 40,
+      bottom: 140,
+      right: 200,
+    });
+  });
+
+  it("returns null when the event is fully above an overflow-y-auto parent", () => {
+    const scroller = document.createElement("div");
+    scroller.style.overflowY = "auto";
+    stubRect(scroller, box(200, 0, 700, 1200));
+
+    const event = document.createElement("div");
+    stubRect(event, box(40, 80, 120, 240));
+    scroller.append(event);
+    document.body.append(scroller);
+
+    expect(getVisibleHintRect(event)).toBeNull();
+  });
+
+  it("returns null when the event is fully below an overflow-y-auto parent", () => {
+    const scroller = document.createElement("div");
+    scroller.style.overflowY = "auto";
+    stubRect(scroller, box(200, 0, 700, 1200));
+
+    const event = document.createElement("div");
+    stubRect(event, box(720, 80, 780, 240));
+    scroller.append(event);
+    document.body.append(scroller);
+
+    expect(getVisibleHintRect(event)).toBeNull();
+  });
+
+  it("returns null when the event is fully left of an overflow-x-auto parent", () => {
+    const scroller = document.createElement("div");
+    scroller.style.overflowX = "auto";
+    stubRect(scroller, box(0, 200, 800, 800));
+
+    const event = document.createElement("div");
+    stubRect(event, box(80, 20, 140, 120));
+    scroller.append(event);
+    document.body.append(scroller);
+
+    expect(getVisibleHintRect(event)).toBeNull();
+  });
+
+  it("returns the visible sliver when a parent clips the event top", () => {
+    const scroller = document.createElement("div");
+    scroller.style.overflowY = "auto";
+    stubRect(scroller, box(200, 0, 700, 1200));
+
+    const event = document.createElement("div");
+    stubRect(event, box(160, 80, 260, 240));
+    scroller.append(event);
+    document.body.append(scroller);
+
+    expect(getVisibleHintRect(event)).toEqual({
+      top: 200,
+      left: 80,
+      bottom: 260,
+      right: 240,
+    });
+  });
+
+  it("returns null when only a sliver thinner than the minimum is visible", () => {
+    const scroller = document.createElement("div");
+    scroller.style.overflowY = "auto";
+    stubRect(scroller, box(200, 0, 700, 1200));
+
+    const event = document.createElement("div");
+    stubRect(
+      event,
+      box(200 - (MIN_VISIBLE_HINT_SIZE_PX - 1), 80, 200 + 1, 240),
+    );
+    scroller.append(event);
+    document.body.append(scroller);
+
+    expect(getVisibleHintRect(event)).toBeNull();
+  });
+
+  it("does not treat the event card's own overflow-hidden as a clipper", () => {
+    const event = document.createElement("div");
+    event.style.overflow = "hidden";
+    stubRect(event, box(80, 40, 140, 200));
+    document.body.append(event);
+
+    expect(getVisibleHintRect(event)).toEqual({
+      top: 80,
+      left: 40,
+      bottom: 140,
+      right: 200,
+    });
+  });
+});

--- a/packages/web/src/shortcuts/shift-hint/shift-hint-visible-rect.ts
+++ b/packages/web/src/shortcuts/shift-hint/shift-hint-visible-rect.ts
@@ -1,0 +1,84 @@
+/** Smallest visible sliver that still reads as "this event". */
+export const MIN_VISIBLE_HINT_SIZE_PX = 8;
+
+const CLIPPING_OVERFLOW = new Set(["auto", "scroll", "hidden", "clip"]);
+
+export type HintRect = {
+  top: number;
+  left: number;
+  bottom: number;
+  right: number;
+};
+
+const isClippingOverflow = (value: string): boolean =>
+  CLIPPING_OVERFLOW.has(value);
+
+export const intersectHintRects = (
+  a: HintRect,
+  b: HintRect,
+): HintRect | null => {
+  const top = Math.max(a.top, b.top);
+  const left = Math.max(a.left, b.left);
+  const bottom = Math.min(a.bottom, b.bottom);
+  const right = Math.min(a.right, b.right);
+  if (
+    bottom - top < MIN_VISIBLE_HINT_SIZE_PX ||
+    right - left < MIN_VISIBLE_HINT_SIZE_PX
+  ) {
+    return null;
+  }
+  return { top, left, bottom, right };
+};
+
+const toHintRect = (rect: DOMRectReadOnly): HintRect => ({
+  top: rect.top,
+  left: rect.left,
+  bottom: rect.bottom,
+  right: rect.right,
+});
+
+const clipRectForAncestor = (node: HTMLElement): HintRect | null => {
+  const style = getComputedStyle(node);
+  const clipsX = isClippingOverflow(style.overflowX);
+  const clipsY = isClippingOverflow(style.overflowY);
+  if (!clipsX && !clipsY) return null;
+
+  const rect = node.getBoundingClientRect();
+  return {
+    top: clipsY ? rect.top : Number.NEGATIVE_INFINITY,
+    left: clipsX ? rect.left : Number.NEGATIVE_INFINITY,
+    bottom: clipsY ? rect.bottom : Number.POSITIVE_INFINITY,
+    right: clipsX ? rect.right : Number.POSITIVE_INFINITY,
+  };
+};
+
+/**
+ * Visible portion of an event card after viewport and overflow-ancestor
+ * clipping. Walks parents so the card's own overflow-hidden does not hide
+ * the portaled chip. Returns null when too little of the card is in view.
+ */
+export const getVisibleHintRect = (element: HTMLElement): HintRect | null => {
+  const rect = element.getBoundingClientRect();
+  if (rect.width === 0 || rect.height === 0) return null;
+
+  let visible: HintRect | null = intersectHintRects(toHintRect(rect), {
+    top: 0,
+    left: 0,
+    bottom: window.innerHeight,
+    right: window.innerWidth,
+  });
+  if (!visible) return null;
+
+  for (
+    let node: HTMLElement | null = element.parentElement;
+    node;
+    node = node.parentElement
+  ) {
+    const clip = clipRectForAncestor(node);
+    if (!clip) continue;
+    visible = intersectHintRects(visible, clip);
+    if (!visible) return null;
+  }
+
+  return visible;
+};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Event-jump chips (`M1`, `SU2`, …) are portaled to `document.body`, so the timed grid’s `overflow-y-auto` never clipped them. Morning events scrolled above the viewport still had in-window bounding boxes, and their chips piled up on the date header.

This change intersects each event rect with the viewport and overflow-clipping ancestors, hides the chip when too little of the event is visible, and anchors remaining chips to the visible top-right. Jump-key assignment is unchanged: scrolled-off events stay reachable via their existing shortcuts.

## Simplicity

No extra abstraction beyond a small clip-rect helper. Assignment and keyboard matching are untouched. The overlay’s existing scroll/resize `useEffect` + layout tick stays: nested timed-grid scroll does not change `hints`, so chips would otherwise freeze at the coordinates from the `S` press.

## Automated validation

- `bun run test:web -- packages/web/src/shortcuts/shift-hint/shift-hint-visible-rect.test.ts packages/web/src/shortcuts/shift-hint/ShiftHintOverlay.test.tsx` — 12 pass, 0 fail
- `bun run test:web` — 2371 pass, 0 fail
- `bun run type-check` — pass (overlay tests query the portal attribute; `getByText({ hidden: true })` is not in this RTL `SelectorMatcherOptions`)
- `bun run lint` — clean for this diff (8 pre-existing warnings elsewhere)

Manual week view at http://localhost:9080/week (anonymous IndexedDB, demo events): press `s` at the 11am–11pm scroll, no orphaned morning chips at column tops; scroll up and chips appear on Gym / Morning standup; scroll down and they hide; `r` then `1` still jumps to Thursday’s off-screen Gym.

![Jump chips only on visible events](https://cursor.com/artifacts/c/art-14e4f727-1a29-4d39-a35c-0dae5cb0dca3)
![Jump to Thursday morning Gym](https://cursor.com/artifacts/c/art-56be733c-0572-4d71-8dc5-64ac66d5c713)
<a href="https://cursor.com/agents/bc-cced97fc-1dc1-4957-a8b2-5130e15df41a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fjump_chips_hide_when_events_scroll_out.mp4"><img src="https://cursor.com/artifacts/c/art-34cb31fd-4698-49c3-993a-d831af205e8f" alt="jump_chips_hide_when_events_scroll_out.mp4" /></a>

## Independent review

Fresh read-only review of the branch vs `origin/main`: approve, no confirmed findings. Overlay layout tick confirmed necessary. Uncertain only: sliver unit test overlap is 1px rather than 7px (still null); overlay tests do not dispatch a nested scroll event (same render path the tick uses).

## Test plan

- `bun run test:web -- packages/web/src/shortcuts/shift-hint/shift-hint-visible-rect.test.ts packages/web/src/shortcuts/shift-hint/ShiftHintOverlay.test.tsx`
- `bun run test:web`
- `bun run type-check`
- `bun run lint`
- Manual: week view, press `s`, scroll timed grid so morning events leave view; chips hide; jump keys still focus and scroll the event into view.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cced97fc-1dc1-4957-a8b2-5130e15df41a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cced97fc-1dc1-4957-a8b2-5130e15df41a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

