### PR TITLE
fix: stop a sync blip from storming the backend and filing issues

### DIFF
--- a/packages/backend/src/common/errors/handlers/error.handler.test.ts
+++ b/packages/backend/src/common/errors/handlers/error.handler.test.ts
@@ -1,8 +1,10 @@
 import { BaseError } from "@core/errors/errors.base";
 import { Status } from "@core/errors/status.codes";
+import { AuthError } from "@backend/common/errors/auth/auth.errors";
 import { handleExpressError } from "@backend/common/errors/handlers/error.express.handler";
 import {
   error,
+  logLevelForError,
   toClientErrorPayload,
 } from "@backend/common/errors/handlers/error.handler";
 import { UserError } from "@backend/common/errors/user/user.errors";
@@ -55,6 +57,54 @@ describe("error.handler", () => {
         message: "some-description",
         code: "GOOGLE_ACCOUNT_ALREADY_CONNECTED",
       });
+    });
+  });
+
+  // Only `error`-level logs reach PostHogExceptionTransport, so this is what
+  // decides whether a failure becomes a captured exception (and an
+  // auto-filed GitHub issue) or stays an ordinary server-log warning.
+  describe("logLevelForError", () => {
+    it("warns on an operational 503 instead of capturing an exception", () => {
+      const unreachable = error(
+        AuthError.SyncConnectionUnavailable,
+        "Failed to list calendars from sync (unavailable)",
+      );
+
+      expect(unreachable.statusCode).toBe(Status.SERVICE_UNAVAILABLE);
+      expect(logLevelForError(unreachable)).toBe("warn");
+    });
+
+    it("warns on a retryable MAINTENANCE mutation error", () => {
+      expect(
+        logLevelForError(
+          eventMutationError("MAINTENANCE", "Cloud edits are paused"),
+        ),
+      ).toBe("warn");
+    });
+
+    it("keeps error level for a non-503 operational BaseError", () => {
+      expect(
+        logLevelForError(
+          error(UserError.MissingGoogleRefreshToken, "no refresh token"),
+        ),
+      ).toBe("error");
+    });
+
+    it("keeps error level for a 503 that is NOT operational", () => {
+      expect(
+        logLevelForError(
+          new BaseError(
+            "programmer-error",
+            "unexpected",
+            Status.SERVICE_UNAVAILABLE,
+            false,
+          ),
+        ),
+      ).toBe("error");
+    });
+
+    it("keeps error level for a plain Error", () => {
+      expect(logLevelForError(new Error("boom"))).toBe("error");
     });
   });
 

--- a/packages/backend/src/common/errors/handlers/error.handler.ts
+++ b/packages/backend/src/common/errors/handlers/error.handler.ts
@@ -1,8 +1,27 @@
 import { BaseError } from "@core/errors/errors.base";
+import { Status } from "@core/errors/status.codes";
 import { Logger } from "@core/logger/winston.logger";
 import { type ErrorMetadata } from "@backend/common/types/error.types";
 
 const logger = Logger("app:error.handler");
+
+// An OPERATIONAL 503 is a service-state condition the caller is expected to
+// retry through, not a defect in this process: the sync service is briefly
+// unreachable (AuthError.SyncConnectionUnavailable, e.g. during its own
+// deploy), maintenance mode is on, or Google isn't configured for this
+// instance. PostHogExceptionTransport only listens at `error`, so logging
+// these at `error` captured them as exceptions and — via the error-autofix
+// pipeline — filed GitHub issues for what is really upstream downtime. Log
+// them at `warn` instead: same message and metadata in the server log and
+// OTel, but no exception. A sustained outage still surfaces through the sync
+// service's own error telemetry and the gap in its sync_health_snapshot beat,
+// which is the signal that actually distinguishes "down" from "restarting".
+export const logLevelForError = (error: Error): "warn" | "error" =>
+  error instanceof BaseError &&
+  error.isOperational &&
+  error.statusCode === Status.SERVICE_UNAVAILABLE
+    ? "warn"
+    : "error";
 
 /**
  * Transforms error metadata into a BaseError class
@@ -83,7 +102,7 @@ class ErrorHandler {
       meta.result = error.result;
       meta.errorType = error.code ?? error.constructor.name;
     }
-    logger.error(error.message || String(error), meta);
+    logger[logLevelForError(error)](error.message || String(error), meta);
   }
 
   exitAfterProgrammerError(): void {

--- a/packages/backend/src/common/services/sync-service/sync-connection-begin.test.ts
+++ b/packages/backend/src/common/services/sync-service/sync-connection-begin.test.ts
@@ -45,17 +45,31 @@ describe("beginSyncConnection", () => {
     });
   });
 
-  it("maps every client error kind to a 503 without leaking sync internals", async () => {
-    for (const kind of [
-      "timeout",
-      "unauthorized",
-      "badRequest",
-      "invalidResponse",
-      "unexpectedStatus",
-    ] as const) {
+  // Transient kinds get the retryable 503 (which logLevelForError logs at
+  // `warn`, so a sync restart no longer files a GitHub issue). Everything
+  // else must stay a 502 at `error` level, or a permanently broken sync -
+  // drifted shared secret, broken response contract - would be invisible to
+  // error tracking. Neither branch leaks the kind or status to the browser.
+  it("maps each client error kind to the right opaque status", async () => {
+    const expected = {
+      timeout: Status.SERVICE_UNAVAILABLE,
+      unavailable: Status.SERVICE_UNAVAILABLE,
+      unauthorized: Status.BAD_GATEWAY,
+      badRequest: Status.BAD_GATEWAY,
+      notFound: Status.BAD_GATEWAY,
+      conflict: Status.BAD_GATEWAY,
+      invalidResponse: Status.BAD_GATEWAY,
+      unexpectedStatus: Status.BAD_GATEWAY,
+    } as const;
+
+    for (const [kind, status] of Object.entries(expected)) {
       const client = clientReturning({
         ok: false,
-        error: { kind, status: 409, correlationId: "corr-1" },
+        error: {
+          kind: kind as keyof typeof expected,
+          status: 409,
+          correlationId: "corr-1",
+        },
       });
 
       let thrown: unknown;
@@ -66,7 +80,7 @@ describe("beginSyncConnection", () => {
       }
 
       expect(thrown).toBeInstanceOf(BaseError);
-      expect((thrown as BaseError).statusCode).toBe(Status.SERVICE_UNAVAILABLE);
+      expect((thrown as BaseError).statusCode).toBe(status);
       // The sync error kind/status must not reach the browser-facing message.
       expect((thrown as BaseError).message).not.toContain(kind);
       expect((thrown as BaseError).message).not.toContain("409");

--- a/packages/backend/src/common/services/sync-service/sync-connection-begin.ts
+++ b/packages/backend/src/common/services/sync-service/sync-connection-begin.ts
@@ -15,11 +15,12 @@ const logger = Logger("app:sync-connection-begin");
  * Ask the sync service to start an OAuth authorization flow and return the
  * consent URL the browser should be sent to.
  *
- * Any client failure surfaces as the standard opaque 503 via
- * unwrapSyncResult. The client now reports conflict (409 passive mode) and
- * notFound (404 reconnect-not-found) kinds — visible in the server-side log
- * line — but the browser response stays the single opaque 503 until the
- * reconnect UI can act on the distinction.
+ * Any client failure surfaces as an opaque proxy failure via
+ * unwrapSyncResult: 503 when sync is momentarily unreachable, 502 otherwise.
+ * The client also reports conflict (409 passive mode) and notFound (404
+ * reconnect-not-found) kinds — visible in the server-side log line — but the
+ * browser response stays opaque either way until the reconnect UI can act on
+ * the distinction.
  */
 export async function beginSyncConnection(
   client: Pick<SyncServiceClient, "beginConnection">,

--- a/packages/backend/src/common/services/sync-service/unwrap-sync-result.test.ts
+++ b/packages/backend/src/common/services/sync-service/unwrap-sync-result.test.ts
@@ -31,25 +31,57 @@ describe("unwrapSyncResult", () => {
     });
   });
 
-  it("throws a 503 that hides the sync-internal error kind and status", () => {
-    const result: SyncClientResult<void> = {
-      ok: false,
-      error: { kind: "unauthorized", status: 401, correlationId: "corr-1" },
-    };
-
+  const unwrapError = (result: SyncClientResult<void>): BaseError => {
     let thrown: unknown;
     try {
       unwrapSyncResult(result, deps);
     } catch (e) {
       thrown = e;
     }
-
     expect(thrown).toBeInstanceOf(BaseError);
-    expect((thrown as BaseError).statusCode).toBe(Status.SERVICE_UNAVAILABLE);
-    expect((thrown as BaseError).result).toBe(deps.userMessage);
-    // Neither the internal description nor the client payload leaks the
-    // sync-internal error kind or status.
-    expect((thrown as BaseError).message).not.toContain("unauthorized");
-    expect((thrown as BaseError).message).not.toContain("401");
+    return thrown as BaseError;
+  };
+
+  it("throws the retryable 503 when sync is momentarily unreachable", () => {
+    const thrown = unwrapError({
+      ok: false,
+      error: { kind: "unavailable", status: 503, correlationId: "corr-1" },
+    });
+
+    expect(thrown.statusCode).toBe(Status.SERVICE_UNAVAILABLE);
+    expect(thrown.isOperational).toBe(true);
+    expect(thrown.result).toBe(deps.userMessage);
+  });
+
+  // A 503 is downgraded to a `warn` by logLevelForError so a sync restart
+  // stops filing GitHub issues, which is only safe because a kind that means
+  // "sync is genuinely broken" never lands on it. Flattening every kind to
+  // 503 would hide a drifted internalAuthToken (`unauthorized`) or a broken
+  // response contract (`invalidResponse`) from error tracking permanently.
+  it("throws a 502, not the retryable 503, for a non-transient kind", () => {
+    for (const kind of [
+      "unauthorized",
+      "invalidResponse",
+      "unexpectedStatus",
+    ] as const) {
+      const thrown = unwrapError({
+        ok: false,
+        error: { kind, status: 401, correlationId: "corr-1" },
+      });
+
+      expect(thrown.statusCode).toBe(Status.BAD_GATEWAY);
+      expect(thrown.code).toBe("SYNC_PROXY_FAILURE");
+    }
+  });
+
+  it("hides the sync-internal error kind and status from the client", () => {
+    const thrown = unwrapError({
+      ok: false,
+      error: { kind: "unauthorized", status: 401, correlationId: "corr-1" },
+    });
+
+    expect(thrown.result).toBe(deps.userMessage);
+    expect(thrown.message).not.toContain("unauthorized");
+    expect(thrown.message).not.toContain("401");
   });
 });

--- a/packages/backend/src/common/services/sync-service/unwrap-sync-result.ts
+++ b/packages/backend/src/common/services/sync-service/unwrap-sync-result.ts
@@ -1,15 +1,23 @@
 import { type Logger } from "@core/logger/winston.logger";
-import { AuthError } from "@backend/common/errors/auth/auth.errors";
-import { error } from "@backend/common/errors/handlers/error.handler";
+import { throwSyncProxyFailure } from "./sync-proxy-error";
 import { type SyncClientResult } from "./sync-service.client";
 
 type LoggerInstance = ReturnType<typeof Logger>;
 
 /**
- * Unwrap a sync client call: return its value, or throw the single opaque
- * 503 (SyncConnectionUnavailable) every sync-delegated endpoint throws on
+ * Unwrap a sync client call: return its value, or throw an opaque proxy
  * failure - the specific kind and correlation id are logged server-side, but
  * nothing sync-internal (status codes, identity) reaches the browser.
+ *
+ * Discriminates the kind exactly the way the read/proxy path already does
+ * (throwSyncProxyFailure): only timeout/unavailable are the retryable 503,
+ * everything else is a 502. Flattening every kind to 503 was safe while all
+ * of them logged at `error`, but the log level now follows the status
+ * (logLevelForError downgrades operational 503s to `warn` so a sync restart
+ * stops filing GitHub issues). A permanently broken sync - drifted
+ * internalAuthToken, broken response contract - reports `unauthorized` or
+ * `invalidResponse`, and under the flattened 503 it would have logged at
+ * `warn` forever with no exception captured at all.
  */
 export function unwrapSyncResult<T>(
   result: SyncClientResult<T>,
@@ -21,5 +29,5 @@ export function unwrapSyncResult<T>(
     `${deps.logMessage} (${result.error.kind}) ` +
       `[correlationId=${result.error.correlationId}]`,
   );
-  throw error(AuthError.SyncConnectionUnavailable, deps.userMessage);
+  throwSyncProxyFailure(result.error.kind, deps.userMessage);
 }

--- a/packages/web/src/api/query-client.test.ts
+++ b/packages/web/src/api/query-client.test.ts
@@ -34,9 +34,19 @@ describe("createCompassQueryClient", () => {
     const unsubscribes: Array<() => void> = [];
     for (let i = 0; i < 16; i++) {
       const observer = new QueryObserver(client, options as never);
-      unsubscribes.push(observer.subscribe(() => {}));
-      // Let the in-flight fetch settle, the way a progressive mount does.
-      await new Promise((resolve) => setTimeout(resolve, 5));
+      // Mount progressively, and wait for the query to be genuinely settled
+      // before the next observer subscribes. A fixed sleep would let a slow
+      // worker leave the fetch in flight, where the later observers dedupe
+      // into it and the test reports 1 fetch whether or not retryOnMount is
+      // set - passing for the wrong reason, and silently stopping guarding.
+      await new Promise<void>((resolve) => {
+        unsubscribes.push(
+          observer.subscribe((result) => {
+            if (result.isError && result.fetchStatus === "idle") resolve();
+          }),
+        );
+        if (observer.getCurrentResult().fetchStatus === "idle") resolve();
+      });
     }
     unsubscribes.forEach((unsubscribe) => unsubscribe());
 

--- a/packages/web/src/api/query-client.test.ts
+++ b/packages/web/src/api/query-client.test.ts
@@ -1,3 +1,4 @@
+import { QueryObserver } from "@tanstack/react-query";
 import { createCompassQueryClient } from "./query-client";
 import { describe, expect, test } from "bun:test";
 
@@ -7,8 +8,39 @@ describe("createCompassQueryClient", () => {
     const defaults = client.getDefaultOptions();
 
     expect(defaults.queries?.retry).toBe(false);
+    expect(defaults.queries?.retryOnMount).toBe(false);
     expect(defaults.queries?.staleTime).toBe(0);
     expect(defaults.mutations?.retry).toBe(false);
+  });
+
+  // calendarQueryKeys.all alone is read by 16 components. They mount at
+  // slightly different moments, so each failed fetch has already resolved
+  // before the next observer subscribes and TanStack's in-flight dedupe never
+  // fires - with retryOnMount left on, one unreachable backend produced one
+  // request per call site (prod saw exactly 16 GET /calendars in 1.3s during
+  // the 2026-08-21 sync restart).
+  test("an errored query is fetched once, not once per mounting observer", async () => {
+    let fetches = 0;
+    const client = createCompassQueryClient();
+    const options = {
+      queryKey: ["calendars"],
+      queryFn: async () => {
+        fetches += 1;
+        throw new Error("backend unavailable");
+      },
+      staleTime: 60_000,
+    };
+
+    const unsubscribes: Array<() => void> = [];
+    for (let i = 0; i < 16; i++) {
+      const observer = new QueryObserver(client, options as never);
+      unsubscribes.push(observer.subscribe(() => {}));
+      // Let the in-flight fetch settle, the way a progressive mount does.
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+    unsubscribes.forEach((unsubscribe) => unsubscribe());
+
+    expect(fetches).toBe(1);
   });
 
   test("creates isolated query caches", () => {

--- a/packages/web/src/api/query-client.ts
+++ b/packages/web/src/api/query-client.ts
@@ -5,6 +5,17 @@ export const createCompassQueryClient = () =>
     defaultOptions: {
       queries: {
         retry: false,
+        // `retry: false` alone still leaves ONE automatic retry path open:
+        // every newly-mounting observer of an already-errored query refires
+        // it. Queries here are read by many components at once (16 call
+        // sites share calendarQueryKeys.all), and because each failed fetch
+        // resolves before the next observer mounts, TanStack's in-flight
+        // dedupe never catches them - a single unreachable backend turned
+        // one page load into 16 sequential GET /calendars, which is exactly
+        // the burst prod saw during the 2026-08-21 sync restart. Recovery
+        // stays explicit: the "Retry" buttons on the calendar list and grid,
+        // SSE-reopen invalidation, and any key change all still refetch.
+        retryOnMount: false,
         staleTime: 0,
       },
       mutations: {


### PR DESCRIPTION
Closes #2824
Closes #2825

## What happened

Both issues were auto-filed from **one production incident**, not two bugs. The sync service was unreachable from the backend for roughly four minutes on 2026-08-21 (~20:18 to ~20:22 UTC), right after the 1.1.250 deploy. Its own `sync_health_snapshot` beat gaps over exactly that window. Sync recovered on its own and the errors have not recurred: 21 total occurrences, 1 user, zero in the preceding 14 days.

The errors were honest, then. But two real defects made a four-minute blip much louder than it was.

## 1. 16x request amplification on an errored query

Production logged **exactly 16** `GET /calendars` failures in 1.3s from a single page load. That matches the 16 components that call `useCalendarsQuery()`.

`retry: false` was already set, but `retryOnMount` defaults to `true`, and it is an independent retry path: any newly-mounting observer of an already-errored query refires it. Because each failed fetch resolved (~85ms) before the next observer subscribed, TanStack's in-flight dedupe never fired, so the 16 call sites serialized into 16 requests.

Setting `retryOnMount: false` alongside the existing `retry: false` collapses that to one request. Recovery stays explicit and intact: the "Retry" buttons on the calendar list and grid, SSE-reopen invalidation, and any query-key change all still refetch.

## 2. Retryable 503s captured as code defects

`PostHogExceptionTransport` is constructed with `{ level: "error" }`, so `logger.error` vs `logger.warn` in `errorHandler.log` is literally the switch between "tracked exception + auto-filed GitHub issue" and "ordinary server-log line."

Every operational 503 reaching `handleExpressError` was landing on the `error` side. But an operational 503 is a service-state condition the caller is expected to retry through, not a defect in this process: sync briefly unreachable, maintenance mode on, or Google not configured for the instance. These now log at `warn` -- same message and metadata in the server log and OTel, no exception. A sustained outage still surfaces through the sync service's own error telemetry and the gap in its health beat, which is the signal that actually distinguishes "down" from "restarting".

## Verification

- Both new tests fail without their fix (confirmed by reverting `retryOnMount`).
- The pre-existing `handleExpressError` MAINTENANCE test now visibly emits `[warn]` instead of `[error]`, which proves the routing end-to-end rather than just the predicate.
- `bun run test:web` -- 2360 pass, 0 fail
- `bun run test:backend` -- 358 pass, 0 fail
- `bun run type-check` and `biome check` clean

## Left alone

Four `POST /auth/google/sync/refresh` failures also fired in that window despite the browser-wide refresh coordinator, which dedupes in-flight requests but resets to idle the instant one rejects. Much smaller leak than the calendar one, and the trigger could not be pinned from telemetry alone. Worth revisiting if it reappears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)